### PR TITLE
feat: 공용 컴포넌트 헤더 구현

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,0 +1,58 @@
+import { Link, useLocation } from "@tanstack/react-router"
+
+import DownChevronIcon from "@/shared/assets/icon/chevron/SideBar/DownChevronIcon"
+import UmcLogo from "@/shared/assets/icon/logo/UmcLogo"
+import ProfileIcon from "@/shared/assets/icon/people/ProfileIcon"
+import { cn } from "@/shared/lib/utils"
+
+interface NavItem {
+  label: string
+  to: string
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { label: "데모데이 매칭", to: "/matching" },
+  { label: "관리자 페이지", to: "/admin" },
+]
+
+export default function Header() {
+  const location = useLocation()
+
+  return (
+    <header className="bg-teal-gray-100 border-teal-gray-200 flex h-18 w-full items-center border-b">
+      <Link to="/" className="flex items-center pl-10">
+        <UmcLogo className="text-teal-gray-700 h-5.5 w-17.5" />
+      </Link>
+
+      <nav className="ml-20 flex items-center gap-12">
+        {NAV_ITEMS.map((item) => {
+          const isActive = location.pathname.startsWith(item.to)
+          return (
+            <Link
+              key={item.to}
+              to={item.to}
+              className={cn(
+                "whitespace-nowrap",
+                isActive
+                  ? "text-heading-7-semibold text-teal-500"
+                  : "text-subtitle-2-medium text-teal-gray-600",
+              )}
+            >
+              {item.label}
+            </Link>
+          )
+        })}
+      </nav>
+
+      <div className="ml-auto flex items-center gap-12 pr-7">
+        <button className="flex items-center gap-0.5" type="button">
+          <span className="text-body-1-medium text-teal-gray-600">
+            문의사항
+          </span>
+          <DownChevronIcon className="size-5" />
+        </button>
+        <ProfileIcon className="size-10" />
+      </div>
+    </header>
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as MatchingRouteRouteImport } from './routes/matching/route'
+import { Route as AdminRouteRouteImport } from './routes/admin/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as MatchingIndexRouteImport } from './routes/matching/index'
 import { Route as TestTooltipRouteImport } from './routes/test/tooltip'
@@ -25,6 +26,11 @@ import { Route as MatchingProjectsAnnounceRouteImport } from './routes/matching/
 const MatchingRouteRoute = MatchingRouteRouteImport.update({
   id: '/matching',
   path: '/matching',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AdminRouteRoute = AdminRouteRouteImport.update({
+  id: '/admin',
+  path: '/admin',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -86,6 +92,7 @@ const MatchingProjectsAnnounceRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/admin': typeof AdminRouteRoute
   '/matching': typeof MatchingRouteRouteWithChildren
   '/matching/applications': typeof MatchingApplicationsRoute
   '/matching/rounds': typeof MatchingRoundsRoute
@@ -100,6 +107,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/admin': typeof AdminRouteRoute
   '/matching/applications': typeof MatchingApplicationsRoute
   '/matching/rounds': typeof MatchingRoundsRoute
   '/test/button': typeof TestButtonRoute
@@ -114,6 +122,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/admin': typeof AdminRouteRoute
   '/matching': typeof MatchingRouteRouteWithChildren
   '/matching/applications': typeof MatchingApplicationsRoute
   '/matching/rounds': typeof MatchingRoundsRoute
@@ -130,6 +139,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/admin'
     | '/matching'
     | '/matching/applications'
     | '/matching/rounds'
@@ -144,6 +154,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/admin'
     | '/matching/applications'
     | '/matching/rounds'
     | '/test/button'
@@ -157,6 +168,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/admin'
     | '/matching'
     | '/matching/applications'
     | '/matching/rounds'
@@ -172,6 +184,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AdminRouteRoute: typeof AdminRouteRoute
   MatchingRouteRoute: typeof MatchingRouteRouteWithChildren
   TestButtonRoute: typeof TestButtonRoute
   TestChipRoute: typeof TestChipRoute
@@ -186,6 +199,13 @@ declare module '@tanstack/react-router' {
       path: '/matching'
       fullPath: '/matching'
       preLoaderRoute: typeof MatchingRouteRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/admin': {
+      id: '/admin'
+      path: '/admin'
+      fullPath: '/admin'
+      preLoaderRoute: typeof AdminRouteRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -292,6 +312,7 @@ const MatchingRouteRouteWithChildren = MatchingRouteRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AdminRouteRoute: AdminRouteRoute,
   MatchingRouteRoute: MatchingRouteRouteWithChildren,
   TestButtonRoute: TestButtonRoute,
   TestChipRoute: TestChipRoute,

--- a/src/routes/admin/route.tsx
+++ b/src/routes/admin/route.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import Header from "@/components/header/Header"
+
+export const Route = createFileRoute("/admin")({
+  component: AdminPage,
+})
+
+function AdminPage() {
+  return (
+    <main className="h-full min-h-screen w-full">
+      <Header />
+      <div className="flex min-h-[calc(100vh-4.5rem)] items-center justify-center">
+        <p className="text-heading-5-semibold text-teal-gray-400">준비중</p>
+      </div>
+    </main>
+  )
+}

--- a/src/routes/matching/route.tsx
+++ b/src/routes/matching/route.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
 
+import Header from "@/components/header/Header"
 import SideBar from "@/components/sidebar/SideBar"
 import { MatchingSegmentRegion } from "@/shared/ui/segment/MatchingSegmentRegion"
 
@@ -10,9 +11,7 @@ export const Route = createFileRoute("/matching")({
 function MatchingLayout() {
   return (
     <main className="h-full min-h-screen w-full">
-      <div className="bg-teal-gray-100 flex h-18 w-full items-center pl-10">
-        {/* 추후 헤더 컴포넌트로 교체 */}
-      </div>
+      <Header />
       <div className="flex w-full">
         <SideBar />
         <div className="flex min-w-0 flex-1 flex-col">

--- a/src/shared/assets/icon/logo/UmcLogo.tsx
+++ b/src/shared/assets/icon/logo/UmcLogo.tsx
@@ -1,0 +1,25 @@
+import type { SVGProps } from "react"
+
+const UmcLogo = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 70 22"
+    {...props}
+  >
+    <path
+      fill="currentColor"
+      d="M20.462 0H1.077C.482 0 0 .493 0 1.1V11c0 6.074 4.822 11 10.77 11 5.946 0 10.769-4.926 10.769-11V1.1C21.539.493 21.056 0 20.462 0Z"
+    />
+    <path
+      fill="currentColor"
+      d="M44.693 0c-5.352 0-9.692 3.331-9.692 8.8 0-5.469-4.34-8.8-9.693-8.8-.594 0-1.077.493-1.077 1.1v19.8c0 .607.483 1.1 1.077 1.1h19.385c.595 0 1.077-.493 1.077-1.1V1.1c0-.607-.482-1.1-1.077-1.1Z"
+    />
+    <path
+      fill="currentColor"
+      d="M70 20.9V1.1C70 .493 69.518 0 68.923 0H59.23c-5.946 0-10.769 4.926-10.769 11s4.823 11 10.77 11h9.692c.595 0 1.077-.493 1.077-1.1Z"
+    />
+  </svg>
+)
+
+export default UmcLogo

--- a/src/shared/assets/icon/people/ProfileIcon.tsx
+++ b/src/shared/assets/icon/people/ProfileIcon.tsx
@@ -1,0 +1,18 @@
+import type { SVGProps } from "react"
+
+const ProfileIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 40 40"
+    {...props}
+  >
+    <circle cx={20} cy={20} r={20} fill="#E9ECEC" />
+    <path
+      fill="#9CA3A3"
+      d="M12.889 15.111a7.111 7.111 0 1 1 14.222 0 7.111 7.111 0 0 1-14.222 0ZM12.889 25.778A8.889 8.889 0 0 0 4 34.667 5.333 5.333 0 0 0 9.333 40h21.334A5.333 5.333 0 0 0 36 34.667a8.889 8.889 0 0 0-8.889-8.889h-14.222Z"
+    />
+  </svg>
+)
+
+export default ProfileIcon


### PR DESCRIPTION
## 📸 작업 내용

> 공용 컴포넌트로 쓰이는 헤더를 구현했습니다. 

## 🎞️ 주요 코드 설명

<!-- 코드 설명, 없다면 생략해도 됩니다! -->

> 네비게이션 active 상태 처리

### `Header.tsx`

```TypeScript
const NAV_ITEMS: NavItem[] = [                                                                                        
    { label: "데모데이 매칭", to: "/matching" },
    { label: "관리자 페이지", to: "/admin" },
  ]

  // ...

  const isActive = location.pathname.startsWith(item.to)
  return (
    <Link
      key={item.to}
      to={item.to}
      className={cn(
        "whitespace-nowrap",
        isActive
          ? "text-heading-7-semibold text-teal-500"
          : "text-subtitle-2-medium text-teal-gray-600",
      )}
    >
```
- useLocation으로 현재 경로를 가져와 startsWith로 활성 탭을 판별
- NAV_ITEMS 배열로 관리해 추후 탭 추가 시 배열에만 항목 추가하면 됨
- 활성/비활성 상태에 따라 디자인 시스템 타이포그래피 토큰 분기 적용 (text-heading-7-semibold / text-subtitle-2-medium)


## 🖥️ 구현화면

> localhost 캡쳐 사진을 첨부해 주세요.

|           스크린샷            |           GIF </br>(색이 누렇게 보이는건 GIF로 변환하면서 생긴 이슈 같습니다,, </br> 신경 안 쓰셔도 됩니다~!)            |
| :-------------------------: | :-------------------------: |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/64e35366-9565-40ca-8051-94c6d73e5fc4" /> | <img width="400" alt="Screen Recording 2026-04-20 at 6 07 57 PM" src="https://github.com/user-attachments/assets/dcc799ad-23bf-4b0f-9424-29f5c3d95a5c" /> |


## 🔗 연결된 이슈
- closed #18 

## 📚 참고자료

<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

## 💬 기타 더 이야기해볼 점
프로필 이미지에 대해 디자이너분과 얘기 중입니다! 해결되면 머지 하겠습니다~

화이팅!!
<img width="300" alt="image" src="https://github.com/user-attachments/assets/ffe9005a-302d-4bf6-9eaf-dffcfd683698" />
