### PR TITLE
feat: 팀 매칭, 프로젝트 설정 공지사항 UI 개선

### DIFF
--- a/src/features/notice/ui/NoticeCard.tsx
+++ b/src/features/notice/ui/NoticeCard.tsx
@@ -153,37 +153,38 @@ export function NoticeCard({
             animate={{ height: "auto", opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
             transition={{ duration: 0.35, ease: "easeInOut" }}
-            className="overflow-hidden pb-4"
           >
-            <div
-              id={contentId}
-              className="shadow-inner-neutral-2 bg-teal-gray-50 text-teal-gray-900 rounded-[12px] px-8 pt-6 pb-7.5"
-            >
-              {/* TODO: 공지 API 응답 형식에 맞추어 수정 */}
-              {children}
+            <div className="overflow-hidden pb-4">
+              <div
+                id={contentId}
+                className="shadow-inner-neutral-2 bg-teal-gray-50 text-teal-gray-900 rounded-[12px] px-8 pt-6 pb-7.5"
+              >
+                {/* TODO: 공지 API 응답 형식에 맞추어 수정 */}
+                {children}
 
-              {canManage ? (
-                <div className="flex items-center justify-end gap-2 pt-8">
-                  <Button
-                    type="button"
-                    variant="weak"
-                    color="neutral"
-                    size="m"
-                    onClick={handleDeleteClick}
-                  >
-                    삭제
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="weak"
-                    color="primary"
-                    size="m"
-                    onClick={onEdit}
-                  >
-                    수정
-                  </Button>
-                </div>
-              ) : null}
+                {canManage ? (
+                  <div className="flex items-center justify-end gap-2 pt-8">
+                    <Button
+                      type="button"
+                      variant="weak"
+                      color="neutral"
+                      size="m"
+                      onClick={handleDeleteClick}
+                    >
+                      삭제
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="weak"
+                      color="primary"
+                      size="m"
+                      onClick={onEdit}
+                    >
+                      수정
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
             </div>
           </motion.div>
         ) : null}

--- a/src/features/notice/ui/NoticeCardList.tsx
+++ b/src/features/notice/ui/NoticeCardList.tsx
@@ -16,6 +16,7 @@ interface NoticeCardListProps {
   notices: NoticeItem[]
   page: number
   canManage?: boolean
+  focusedNoticeId?: string | null
   onDeleteNotice?: (noticeId: string) => void
   onEditNotice?: (noticeId: string) => void
 }
@@ -24,6 +25,7 @@ export function NoticeCardList({
   notices,
   page,
   canManage = false,
+  focusedNoticeId,
   onDeleteNotice,
   onEditNotice,
 }: NoticeCardListProps) {
@@ -32,6 +34,31 @@ export function NoticeCardList({
   useEffect(() => {
     setExpandedIndex(null)
   }, [page])
+
+  useEffect(() => {
+    if (!focusedNoticeId) return
+
+    const targetIndex = notices.findIndex(
+      (notice) => notice.id === focusedNoticeId,
+    )
+
+    if (targetIndex < 0) return
+
+    setExpandedIndex(targetIndex)
+  }, [focusedNoticeId, notices])
+
+  useEffect(() => {
+    if (!focusedNoticeId) return
+
+    const targetButton = document.querySelector<HTMLElement>(
+      `[data-notice-id="${focusedNoticeId}"]`,
+    )
+
+    if (!targetButton) return
+
+    targetButton.focus()
+    targetButton.scrollIntoView({ block: "center", behavior: "smooth" })
+  }, [expandedIndex, focusedNoticeId, notices])
 
   return (
     <div className="flex w-full flex-col">
@@ -52,6 +79,7 @@ export function NoticeCardList({
               variant={cardVariant}
               canManage={canManage}
               expanded={isExpanded}
+              data-notice-id={notice.id}
               onExpandedChange={(nextExpanded) => {
                 setExpandedIndex(nextExpanded ? index : null)
               }}

--- a/src/features/notice/ui/NoticePublishForm.tsx
+++ b/src/features/notice/ui/NoticePublishForm.tsx
@@ -179,7 +179,7 @@ export function NoticePublishForm({
             value={noticeContent}
             onChange={handleContentChange}
             placeholder="내용을 입력하세요."
-            maxLength={2000}
+            maxLength={MAX_CHARS}
             className="bg-teal-gray-50 shadow-inner-neutral-2 data-[state=focus]:bg-teal-gray-50 flex flex-col gap-4 px-8 pt-6 pb-7.5"
           />
         </div>

--- a/src/features/notice/ui/NoticePublishForm.tsx
+++ b/src/features/notice/ui/NoticePublishForm.tsx
@@ -10,6 +10,7 @@ import { Modal } from "@/shared/ui/Modal"
 import { TextQuestionField } from "@/shared/ui/question-field/TextQuestionField"
 
 const MAX_CHARS = 2000
+const NOTICE_COMPLETION_STORAGE_KEY = "notice:completion-target"
 
 interface NoticePublishFormProps {
   variant: "publish" | "edit"
@@ -81,6 +82,18 @@ export function NoticePublishForm({
     setTimeout(() => {
       setIsLoading(false)
       setIsDone(true)
+      const completionNoticeId = noticeId ?? crypto.randomUUID()
+
+      sessionStorage.setItem(
+        NOTICE_COMPLETION_STORAGE_KEY,
+        JSON.stringify({
+          id: completionNoticeId,
+          title: noticeTitle,
+          chip: isRequired ? "필독" : undefined,
+          mode: variant,
+        }),
+      )
+
       setIsCompletionModalOpen(true)
       console.log(
         variant === "edit" ? "Updating notice:" : "Publishing notice:",
@@ -103,6 +116,10 @@ export function NoticePublishForm({
     variant === "edit"
       ? "공지 수정이 완료되었습니다."
       : "공지가 등록되었습니다."
+
+  const handleCompletionGoBack = () => {
+    window.history.back()
+  }
 
   return (
     <>
@@ -194,7 +211,7 @@ export function NoticePublishForm({
                   color="primary"
                   size="s"
                   className="rounded-[10px]"
-                  onClick={handleBackClick}
+                  onClick={handleCompletionGoBack}
                 >
                   보러가기
                 </Button>

--- a/src/features/notice/ui/NoticePublishForm.tsx
+++ b/src/features/notice/ui/NoticePublishForm.tsx
@@ -1,5 +1,5 @@
 import { useBlocker } from "@tanstack/react-router"
-import { useLayoutEffect, useRef, useState } from "react"
+import { useState } from "react"
 
 import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
 import LeftChevronIcon from "@/shared/assets/icon/chevron/NoticePublish/LeftChevronIcon"
@@ -7,6 +7,7 @@ import WarningTriangleIcon from "@/shared/assets/icon/infomation/WarningTriangle
 import { Button } from "@/shared/ui/Button"
 import { Checkbox } from "@/shared/ui/input/checkbox/Checkbox"
 import { Modal } from "@/shared/ui/Modal"
+import { TextQuestionField } from "@/shared/ui/question-field/TextQuestionField"
 
 const MAX_CHARS = 2000
 
@@ -62,9 +63,9 @@ export function NoticePublishForm({
     }
   }
 
-  const handleContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    if (e.target.value.length <= MAX_CHARS) {
-      setNoticeContent(e.target.value)
+  const handleContentChange = (value: string) => {
+    if (value.length <= MAX_CHARS) {
+      setNoticeContent(value)
     }
   }
 
@@ -104,15 +105,6 @@ export function NoticePublishForm({
     variant === "edit"
       ? "공지 수정이 완료되었습니다."
       : "공지가 등록되었습니다."
-
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
-
-  useLayoutEffect(() => {
-    const el = textareaRef.current
-    if (!el) return
-    el.style.height = "360px"
-    el.style.height = `${el.scrollHeight}px`
-  }, [noticeContent])
 
   return (
     <>
@@ -168,19 +160,13 @@ export function NoticePublishForm({
             </div>
           </div>
 
-          <div className="bg-teal-gray-50 shadow-inner-neutral-2 flex w-full flex-col gap-4 rounded-[12px] px-8 pt-6 pb-7.5">
-            <textarea
-              ref={textareaRef}
-              className="placeholder-teal-gray-400 text-body-1-regular text-teal-gray-900 min-h-90 resize-none focus:outline-none"
-              placeholder="내용을 입력하세요"
-              value={noticeContent}
-              onChange={handleContentChange}
-              maxLength={MAX_CHARS}
-            />
-            <div className="text-body-2-medium text-teal-gray-400 text-right">
-              {noticeContent.length} / {MAX_CHARS}자
-            </div>
-          </div>
+          <TextQuestionField
+            value={noticeContent}
+            onChange={handleContentChange}
+            placeholder="내용을 입력하세요."
+            maxLength={2000}
+            className="bg-teal-gray-50 shadow-inner-neutral-2 data-[state=focus]:bg-teal-gray-50 flex flex-col gap-4 px-8 pt-6 pb-7.5"
+          />
         </div>
       </section>
 

--- a/src/features/notice/ui/NoticePublishForm.tsx
+++ b/src/features/notice/ui/NoticePublishForm.tsx
@@ -206,7 +206,12 @@ export function NoticePublishForm({
         </Modal.Portal>
       </Modal.Root>
 
-      <Modal.Root open={isLeaveModalOpen}>
+      <Modal.Root
+        open={isLeaveModalOpen}
+        onOpenChange={(open) => {
+          if (!open) handleLeaveCancel()
+        }}
+      >
         <Modal.Portal>
           <Modal.Overlay tone="light" />
           <Modal.Content className="shadow-drop-neutral-1 flex w-115 max-w-[calc(100vw-32px)] flex-col gap-8 rounded-[9.2px] border border-neutral-200 bg-white px-6 py-6 focus:outline-none">

--- a/src/features/notice/ui/NoticePublishForm.tsx
+++ b/src/features/notice/ui/NoticePublishForm.tsx
@@ -22,16 +22,14 @@ export function NoticePublishForm({
 }: NoticePublishFormProps) {
   const [noticeContent, setNoticeContent] = useState("")
   const [noticeTitle, setNoticeTitle] = useState("")
-  const [isNotificationEnabled, setIsNotificationEnabled] = useState(false)
+  const [isRequired, setIsRequired] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [isDone, setIsDone] = useState(false)
   const [isCompletionModalOpen, setIsCompletionModalOpen] = useState(false)
 
   const hasPendingChanges =
     !isDone &&
-    (noticeTitle.trim() !== "" ||
-      noticeContent.trim() !== "" ||
-      isNotificationEnabled)
+    (noticeTitle.trim() !== "" || noticeContent.trim() !== "" || isRequired)
 
   const {
     proceed: proceedLeave,
@@ -69,8 +67,8 @@ export function NoticePublishForm({
     }
   }
 
-  const handleNotificationToggle = () => {
-    setIsNotificationEnabled((prev) => !prev)
+  const handleRequiredToggle = () => {
+    setIsRequired((prev) => !prev)
   }
 
   // TODO: API 연결 후 수정
@@ -90,7 +88,7 @@ export function NoticePublishForm({
           noticeId,
           title: noticeTitle,
           content: noticeContent,
-          isNotificationEnabled,
+          isRequired,
         },
       )
     }, 1000)
@@ -137,13 +135,13 @@ export function NoticePublishForm({
             <div className="flex items-center gap-5">
               <div className="flex items-center gap-2">
                 <Checkbox
-                  checked={isNotificationEnabled}
-                  onChange={handleNotificationToggle}
+                  checked={isRequired}
+                  onChange={handleRequiredToggle}
                   variant="primary"
-                  aria-label="알림 발송"
+                  aria-label="필독"
                 />
                 <span className="text-body-1-medium text-teal-gray-600">
-                  알림 발송
+                  필독
                 </span>
               </div>
 

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
 import {
@@ -21,6 +21,14 @@ interface AnnounceSearch {
 const DEFAULT_CHAPTER: Chapter = "Chromium"
 const DEFAULT_PAGE = 1
 const NOTICE_PAGE_SIZE = 10
+const NOTICE_COMPLETION_STORAGE_KEY = "notice:completion-target"
+
+type PendingNotice = {
+  id: string
+  title: string
+  chip?: string
+  mode: "publish" | "edit"
+}
 
 function isChapter(value: unknown): value is Chapter {
   return (
@@ -39,6 +47,23 @@ function parsePage(value: unknown): number {
   return Number.isFinite(parsedPage) && parsedPage > 0
     ? Math.floor(parsedPage)
     : DEFAULT_PAGE
+}
+
+function readPendingNotice() {
+  if (typeof window === "undefined") {
+    return null
+  }
+
+  const rawValue = sessionStorage.getItem(NOTICE_COMPLETION_STORAGE_KEY)
+  if (!rawValue) return null
+
+  sessionStorage.removeItem(NOTICE_COMPLETION_STORAGE_KEY)
+
+  try {
+    return JSON.parse(rawValue) as PendingNotice
+  } catch {
+    return null
+  }
 }
 
 // TODO: 공지 API 응답 형식에 맞추어 수정
@@ -116,9 +141,31 @@ function TeamMatchingAnnouncePage() {
   const { chapter, page } = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
   const addToast = useToastStore((state) => state.addToast)
-  const [notices, setNotices] = useState(INITIAL_NOTICES)
+  const [pendingNotice] = useState(readPendingNotice)
+  const [notices, setNotices] = useState(() => {
+    if (!pendingNotice) return INITIAL_NOTICES
+
+    if (pendingNotice.mode === "edit") {
+      return INITIAL_NOTICES.map((notice) =>
+        notice.id === pendingNotice.id
+          ? { ...notice, title: pendingNotice.title, chip: pendingNotice.chip }
+          : notice,
+      )
+    }
+
+    return [
+      {
+        id: pendingNotice.id,
+        title: pendingNotice.title,
+        date: "0000.00.00",
+        chip: pendingNotice.chip,
+      },
+      ...INITIAL_NOTICES,
+    ]
+  })
   const totalPages = Math.max(1, Math.ceil(notices.length / NOTICE_PAGE_SIZE))
   const safePage = Math.min(Math.max(1, page), totalPages)
+  const focusedNoticeId = pendingNotice?.id ?? null
   const paginatedNotices = notices.slice(
     (safePage - 1) * NOTICE_PAGE_SIZE,
     safePage * NOTICE_PAGE_SIZE,
@@ -163,6 +210,24 @@ function TeamMatchingAnnouncePage() {
     })
   }
 
+  useEffect(() => {
+    if (!focusedNoticeId) return
+
+    const targetIndex = notices.findIndex(
+      (notice) => notice.id === focusedNoticeId,
+    )
+
+    if (targetIndex < 0) return
+
+    const targetPage = Math.floor(targetIndex / NOTICE_PAGE_SIZE) + 1
+    if (targetPage !== safePage) {
+      navigate({
+        search: (prev) => ({ ...prev, page: targetPage }),
+        replace: true,
+      })
+    }
+  }, [focusedNoticeId, navigate, notices, safePage])
+
   return (
     <section className="w-full pt-8">
       <div className="border-teal-gray-100 flex min-h-213 w-full flex-col items-center justify-between rounded-[12px] border bg-white px-8.5 pt-8 pb-10">
@@ -204,6 +269,7 @@ function TeamMatchingAnnouncePage() {
               notices={paginatedNotices}
               page={safePage}
               canManage={canManage}
+              focusedNoticeId={focusedNoticeId}
               onDeleteNotice={handleNoticeDeleteClick}
               onEditNotice={handleNoticeEditClick}
             />

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -172,7 +172,7 @@ function TeamMatchingAnnouncePage() {
               공지
             </span>
             <p className="text-body-2-regular text-teal-gray-600">
-              우리 지부의 공지를 조회합니다.
+              팀 매칭에 대한 지부별 공지를 모든 챌린저에게 안내합니다.
             </p>
           </div>
 

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
 import {
@@ -21,6 +21,14 @@ interface AnnounceSearch {
 const DEFAULT_CHAPTER: Chapter = "Chromium"
 const DEFAULT_PAGE = 1
 const NOTICE_PAGE_SIZE = 10
+const NOTICE_COMPLETION_STORAGE_KEY = "notice:completion-target"
+
+type PendingNotice = {
+  id: string
+  title: string
+  chip?: string
+  mode: "publish" | "edit"
+}
 
 function isChapter(value: unknown): value is Chapter {
   return (
@@ -39,6 +47,23 @@ function parsePage(value: unknown): number {
   return Number.isFinite(parsedPage) && parsedPage > 0
     ? Math.floor(parsedPage)
     : DEFAULT_PAGE
+}
+
+function readPendingNotice() {
+  if (typeof window === "undefined") {
+    return null
+  }
+
+  const rawValue = sessionStorage.getItem(NOTICE_COMPLETION_STORAGE_KEY)
+  if (!rawValue) return null
+
+  sessionStorage.removeItem(NOTICE_COMPLETION_STORAGE_KEY)
+
+  try {
+    return JSON.parse(rawValue) as PendingNotice
+  } catch {
+    return null
+  }
 }
 
 // TODO: 공지 API 응답 형식에 맞추어 수정
@@ -76,9 +101,31 @@ function ProjectSettingsAnnouncePage() {
   const { chapter, page } = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
   const addToast = useToastStore((state) => state.addToast)
-  const [notices, setNotices] = useState(INITIAL_NOTICES)
+  const [pendingNotice] = useState(readPendingNotice)
+  const [notices, setNotices] = useState(() => {
+    if (!pendingNotice) return INITIAL_NOTICES
+
+    if (pendingNotice.mode === "edit") {
+      return INITIAL_NOTICES.map((notice) =>
+        notice.id === pendingNotice.id
+          ? { ...notice, title: pendingNotice.title, chip: pendingNotice.chip }
+          : notice,
+      )
+    }
+
+    return [
+      {
+        id: pendingNotice.id,
+        title: pendingNotice.title,
+        date: "0000.00.00",
+        chip: pendingNotice.chip,
+      },
+      ...INITIAL_NOTICES,
+    ]
+  })
   const totalPages = Math.max(1, Math.ceil(notices.length / NOTICE_PAGE_SIZE))
   const safePage = Math.min(Math.max(1, page), totalPages)
+  const focusedNoticeId = pendingNotice?.id ?? null
   const paginatedNotices = notices.slice(
     (safePage - 1) * NOTICE_PAGE_SIZE,
     safePage * NOTICE_PAGE_SIZE,
@@ -125,6 +172,24 @@ function ProjectSettingsAnnouncePage() {
     })
   }
 
+  useEffect(() => {
+    if (!focusedNoticeId) return
+
+    const targetIndex = notices.findIndex(
+      (notice) => notice.id === focusedNoticeId,
+    )
+
+    if (targetIndex < 0) return
+
+    const targetPage = Math.floor(targetIndex / NOTICE_PAGE_SIZE) + 1
+    if (targetPage !== safePage) {
+      navigate({
+        search: (prev) => ({ ...prev, page: targetPage }),
+        replace: true,
+      })
+    }
+  }, [focusedNoticeId, navigate, notices, safePage])
+
   return (
     <section className="w-full pt-8">
       <div className="border-teal-gray-100 flex min-h-213 w-full flex-col items-center justify-between rounded-[12px] border bg-white px-8.5 pt-8 pb-10">
@@ -166,6 +231,7 @@ function ProjectSettingsAnnouncePage() {
               notices={paginatedNotices}
               page={safePage}
               canManage={canManage}
+              focusedNoticeId={focusedNoticeId}
               onDeleteNotice={handleNoticeDeleteClick}
               onEditNotice={handleNoticeEditClick}
             />

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -134,7 +134,7 @@ function ProjectSettingsAnnouncePage() {
               공지
             </span>
             <p className="text-body-2-regular text-teal-gray-600">
-              우리 지부의 공지를 조회합니다.
+              프로젝트 설정에 대한 지부별 공지를 PM 챌린저에게 안내합니다.
             </p>
           </div>
 


### PR DESCRIPTION
## 📸 작업 내용

- [x] 공지 작성/수정 페이지에서 "알림 발송" 체크박스를 "필독" 체크박스로 변경
- [x] 공지 작성 중 나가기 모달에서 딤드를 누르면 모달이 꺼지도록 수정
- [x] 공지 입력란 공용 컴포넌트로 대체
- [x] 공지 작성/수정 완료 모달에서 "보러가기" 버튼 클릭 시 해당 공지 카드 열기 + 포커스
- [x] 공지 카드 아코디언 닫을 때 끊김 해결

## 🎞️ 주요 코드 설명


## 🖥️ 구현화면


## 🔗 연결된 이슈

- Connected: #43 