### PR TITLE
feat: ID/PW 회원가입 및 로그인 구현

### DIFF
--- a/src/features/auth/api/credentials.ts
+++ b/src/features/auth/api/credentials.ts
@@ -1,0 +1,41 @@
+import { api } from "@/shared/lib/axios"
+
+import type {
+  ChangePasswordRequest,
+  IdPwLoginRequest,
+  IdPwLoginResponse,
+  LoginIdAvailabilityResponse,
+  RegisterCredentialsRequest,
+} from "@/features/auth/model/types"
+
+export async function loginWithIdPw(
+  payload: IdPwLoginRequest,
+): Promise<IdPwLoginResponse> {
+  const { data } = await api.post<IdPwLoginResponse>(
+    "/v1/auth/login/id-pw",
+    payload,
+  )
+  return data
+}
+
+export async function registerCredentials(
+  payload: RegisterCredentialsRequest,
+): Promise<void> {
+  await api.post("/v1/auth/credentials", payload)
+}
+
+export async function checkLoginIdAvailability(
+  loginId: string,
+): Promise<LoginIdAvailabilityResponse> {
+  const { data } = await api.get<LoginIdAvailabilityResponse>(
+    "/v1/auth/login-id/availability",
+    { params: { loginId } },
+  )
+  return data
+}
+
+export async function changePassword(
+  payload: ChangePasswordRequest,
+): Promise<void> {
+  await api.patch("/v1/auth/password", payload)
+}

--- a/src/features/auth/api/register.ts
+++ b/src/features/auth/api/register.ts
@@ -5,11 +5,11 @@ import type {
   RegisterResponse,
 } from "@/features/auth/model/types"
 
-export async function registerMember(
+export async function registerMemberByOAuth(
   payload: RegisterMemberRequest,
 ): Promise<RegisterResponse> {
   const { data } = await api.post<RegisterResponse>(
-    "/v1/member/register",
+    "/v1/member/register/oauth",
     payload,
   )
   return data

--- a/src/features/auth/api/register.ts
+++ b/src/features/auth/api/register.ts
@@ -1,6 +1,7 @@
 import { api } from "@/shared/lib/axios"
 
 import type {
+  IdPwRegisterMemberRequest,
   RegisterMemberRequest,
   RegisterResponse,
 } from "@/features/auth/model/types"
@@ -10,6 +11,16 @@ export async function registerMemberByOAuth(
 ): Promise<RegisterResponse> {
   const { data } = await api.post<RegisterResponse>(
     "/v1/member/register/oauth",
+    payload,
+  )
+  return data
+}
+
+export async function registerMemberByIdPw(
+  payload: IdPwRegisterMemberRequest,
+): Promise<RegisterResponse> {
+  const { data } = await api.post<RegisterResponse>(
+    "/v1/member/register/id-pw",
     payload,
   )
   return data

--- a/src/features/auth/model/registerSchema.ts
+++ b/src/features/auth/model/registerSchema.ts
@@ -19,5 +19,11 @@ export const termsSchema = z.object({
     .min(1, "필수 약관에 동의해주세요."),
 })
 
+export const idPwCredentialsSchema = z.object({
+  loginId: z.string().min(1, "아이디를 입력해주세요."),
+  rawPassword: z.string().min(1, "비밀번호를 입력해주세요."),
+})
+
 export type BasicInfoFormData = z.infer<typeof basicInfoSchema>
 export type TermsFormData = z.infer<typeof termsSchema>
+export type IdPwCredentialsFormData = z.infer<typeof idPwCredentialsSchema>

--- a/src/features/auth/model/types.ts
+++ b/src/features/auth/model/types.ts
@@ -80,3 +80,29 @@ export interface SchoolNameItem {
 export interface SchoolNameListResponse {
   schools: SchoolNameItem[]
 }
+
+export interface IdPwLoginRequest {
+  loginId: string
+  password: string
+}
+
+export interface IdPwLoginResponse {
+  memberId: number
+  accessToken: string
+  refreshToken: string
+}
+
+export interface RegisterCredentialsRequest {
+  loginId: string
+  password: string
+}
+
+export interface LoginIdAvailabilityResponse {
+  loginId: string
+  available: boolean
+}
+
+export interface ChangePasswordRequest {
+  currentPassword: string
+  newPassword: string
+}

--- a/src/features/auth/model/types.ts
+++ b/src/features/auth/model/types.ts
@@ -107,3 +107,13 @@ export interface ChangePasswordRequest {
   currentPassword: string
   newPassword: string
 }
+
+export interface IdPwRegisterMemberRequest {
+  loginId: string
+  rawPassword: string
+  name: string
+  nickname: string
+  emailVerificationToken: string
+  schoolId: number
+  termsAgreements: TermConsentStatus[]
+}

--- a/src/features/auth/model/types.ts
+++ b/src/features/auth/model/types.ts
@@ -56,6 +56,7 @@ export interface RegisterMemberRequest {
   emailVerificationToken: string
   schoolId: number
   termsAgreements: TermConsentStatus[]
+  appleRefreshToken?: string
 }
 
 export interface RegisterResponse {

--- a/src/features/auth/store/signupStore.ts
+++ b/src/features/auth/store/signupStore.ts
@@ -1,10 +1,14 @@
 import { create } from "zustand"
 
-export type SignupStep = "email" | "basic-info" | "terms"
+export type SignupMode = "oauth" | "id-pw"
+export type SignupStep = "credentials" | "email" | "basic-info" | "terms"
 
 interface SignupState {
+  mode: SignupMode
   step: SignupStep
   oAuthVerificationToken: string
+  loginId: string
+  rawPassword: string
   emailVerificationId: number | null
   emailVerificationToken: string
   name: string
@@ -18,13 +22,18 @@ interface SignupState {
     nickname: string
     schoolId: number
   }) => void
+  setCredentials: (data: { loginId: string; rawPassword: string }) => void
   init: (oAuthVerificationToken: string) => void
+  initIdPw: () => void
   reset: () => void
 }
 
 const initialState = {
+  mode: "oauth" as SignupMode,
   step: "email" as SignupStep,
   oAuthVerificationToken: "",
+  loginId: "",
+  rawPassword: "",
   emailVerificationId: null,
   emailVerificationToken: "",
   name: "",
@@ -39,7 +48,20 @@ export const useSignupStore = create<SignupState>((set) => ({
   setEmailVerificationToken: (token) => set({ emailVerificationToken: token }),
   setBasicInfo: (data) =>
     set({ name: data.name, nickname: data.nickname, schoolId: data.schoolId }),
+  setCredentials: (data) =>
+    set({ loginId: data.loginId, rawPassword: data.rawPassword }),
   init: (oAuthVerificationToken) =>
-    set({ ...initialState, oAuthVerificationToken }),
+    set({
+      ...initialState,
+      mode: "oauth",
+      step: "email",
+      oAuthVerificationToken,
+    }),
+  initIdPw: () =>
+    set({
+      ...initialState,
+      mode: "id-pw",
+      step: "credentials",
+    }),
   reset: () => set(initialState),
 }))

--- a/src/features/auth/ui/SignupStepIdPwCredentials.tsx
+++ b/src/features/auth/ui/SignupStepIdPwCredentials.tsx
@@ -1,0 +1,143 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useState } from "react"
+import { useForm } from "react-hook-form"
+
+import { useToastStore } from "@/components/toast/useToastStore"
+import { checkLoginIdAvailability } from "@/features/auth/api/credentials"
+import {
+  type IdPwCredentialsFormData,
+  idPwCredentialsSchema,
+} from "@/features/auth/model/registerSchema"
+import { useSignupStore } from "@/features/auth/store/signupStore"
+import { Button } from "@/shared/ui/Button"
+
+export function SignupStepIdPwCredentials() {
+  const { setStep, setCredentials } = useSignupStore()
+  const addToast = useToastStore((s) => s.addToast)
+  const [isChecking, setIsChecking] = useState(false)
+  const [checkedLoginId, setCheckedLoginId] = useState<string | null>(null)
+  const [isAvailable, setIsAvailable] = useState(false)
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<IdPwCredentialsFormData>({
+    resolver: zodResolver(idPwCredentialsSchema),
+    mode: "onSubmit",
+  })
+
+  const loginId = watch("loginId")
+
+  const handleCheckAvailability = async () => {
+    const currentLoginId = loginId?.trim()
+    if (!currentLoginId) return
+    setIsChecking(true)
+    try {
+      const res = await checkLoginIdAvailability(currentLoginId)
+      setCheckedLoginId(currentLoginId)
+      setIsAvailable(res.available)
+      addToast({
+        message: res.available
+          ? `"${currentLoginId}" 사용 가능한 아이디입니다.`
+          : `"${currentLoginId}" 이미 사용 중인 아이디입니다.`,
+        color: res.available ? "primary" : "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } catch {
+      addToast({
+        message: "중복 확인에 실패했습니다. 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } finally {
+      setIsChecking(false)
+    }
+  }
+
+  const isIdCheckedAndAvailable = isAvailable && checkedLoginId === loginId
+
+  const onSubmit = (data: IdPwCredentialsFormData) => {
+    setCredentials({ loginId: data.loginId, rawPassword: data.rawPassword })
+    setStep("email")
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="flex w-full max-w-[360px] flex-col gap-6"
+    >
+      <div className="flex flex-col gap-1">
+        <p className="text-heading-3-bold">계정 정보</p>
+        <p className="text-label-2-medium text-teal-gray-400">
+          로그인에 사용할 아이디와 비밀번호를 입력해주세요.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <label className="text-label-2-medium">아이디</label>
+          <div className="flex gap-2">
+            <input
+              {...register("loginId")}
+              type="text"
+              placeholder="아이디를 입력해주세요."
+              className="border-teal-gray-200 text-body-2-medium flex-1 rounded-lg border px-4 py-3 outline-none focus:border-teal-600"
+            />
+            <Button
+              type="button"
+              variant="weak"
+              color="primary"
+              size="m"
+              onClick={() => void handleCheckAvailability()}
+              disabled={!loginId?.trim()}
+              isLoading={isChecking}
+            >
+              중복확인
+            </Button>
+          </div>
+          {errors.loginId && (
+            <p className="text-label-2-medium text-red-500">
+              {errors.loginId.message}
+            </p>
+          )}
+          {isIdCheckedAndAvailable && (
+            <p className="text-label-2-medium text-teal-600">
+              사용 가능한 아이디입니다.
+            </p>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-label-2-medium">비밀번호</label>
+          <input
+            {...register("rawPassword")}
+            type="password"
+            placeholder="비밀번호를 입력해주세요."
+            className="border-teal-gray-200 text-body-2-medium w-full rounded-lg border px-4 py-3 outline-none focus:border-teal-600"
+          />
+          {errors.rawPassword && (
+            <p className="text-label-2-medium text-red-500">
+              {errors.rawPassword.message}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <Button
+        type="submit"
+        variant="fill"
+        color="primary"
+        className="w-full"
+        disabled={!isIdCheckedAndAvailable}
+      >
+        다음
+      </Button>
+    </form>
+  )
+}

--- a/src/features/auth/ui/SignupStepTerms.tsx
+++ b/src/features/auth/ui/SignupStepTerms.tsx
@@ -2,7 +2,10 @@ import { useNavigate } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
-import { registerMemberByOAuth } from "@/features/auth/api/register"
+import {
+  registerMemberByIdPw,
+  registerMemberByOAuth,
+} from "@/features/auth/api/register"
 import { getTermsByType } from "@/features/auth/api/terms"
 import { useSignupStore } from "@/features/auth/store/signupStore"
 import { Button } from "@/shared/ui/Button"
@@ -32,7 +35,10 @@ export function SignupStepTerms() {
   const navigate = useNavigate()
   const addToast = useToastStore((s) => s.addToast)
   const {
+    mode,
     oAuthVerificationToken,
+    loginId,
+    rawPassword,
     emailVerificationToken,
     name,
     nickname,
@@ -103,14 +109,25 @@ export function SignupStepTerms() {
 
     setIsSubmitting(true)
     try {
-      const res = await registerMemberByOAuth({
-        oAuthVerificationToken,
-        emailVerificationToken,
-        name,
-        nickname,
-        schoolId,
-        termsAgreements,
-      })
+      const res =
+        mode === "id-pw"
+          ? await registerMemberByIdPw({
+              loginId,
+              rawPassword,
+              emailVerificationToken,
+              name,
+              nickname,
+              schoolId,
+              termsAgreements,
+            })
+          : await registerMemberByOAuth({
+              oAuthVerificationToken,
+              emailVerificationToken,
+              name,
+              nickname,
+              schoolId,
+              termsAgreements,
+            })
       localStorage.setItem("access_token", res.accessToken)
       localStorage.setItem("refresh_token", res.refreshToken)
       sessionStorage.removeItem("oauth_verification_token")

--- a/src/features/auth/ui/SignupStepTerms.tsx
+++ b/src/features/auth/ui/SignupStepTerms.tsx
@@ -2,7 +2,7 @@ import { useNavigate } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
-import { registerMember } from "@/features/auth/api/register"
+import { registerMemberByOAuth } from "@/features/auth/api/register"
 import { getTermsByType } from "@/features/auth/api/terms"
 import { useSignupStore } from "@/features/auth/store/signupStore"
 import { Button } from "@/shared/ui/Button"
@@ -103,7 +103,7 @@ export function SignupStepTerms() {
 
     setIsSubmitting(true)
     try {
-      const res = await registerMember({
+      const res = await registerMemberByOAuth({
         oAuthVerificationToken,
         emailVerificationToken,
         name,

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -36,6 +36,7 @@ import { Route as MatchingRoundsRouteImport } from './routes/matching/rounds'
 import { Route as MatchingNoticePublishRouteImport } from './routes/matching/notice-publish'
 import { Route as MatchingApplicationsRouteImport } from './routes/matching/applications'
 import { Route as MatchingProjectsIndexRouteImport } from './routes/matching/projects/index'
+import { Route as TestSignupIdPwRouteImport } from './routes/test/signup/id-pw'
 import { Route as MatchingProjectsNewRouteImport } from './routes/matching/projects/new'
 import { Route as MatchingNoticePublishNoticeIdRouteImport } from './routes/matching/notice-publish.$noticeId'
 import { Route as AuthCallbackKakaoRouteImport } from './routes/auth/callback/kakao'
@@ -182,6 +183,11 @@ const MatchingProjectsIndexRoute = MatchingProjectsIndexRouteImport.update({
   path: '/projects/',
   getParentRoute: () => MatchingRouteRoute,
 } as any)
+const TestSignupIdPwRoute = TestSignupIdPwRouteImport.update({
+  id: '/test/signup/id-pw',
+  path: '/test/signup/id-pw',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MatchingProjectsNewRoute = MatchingProjectsNewRouteImport.update({
   id: '/projects/new',
   path: '/projects/new',
@@ -266,6 +272,7 @@ export interface FileRoutesByFullPath {
   '/auth/callback/kakao': typeof AuthCallbackKakaoRoute
   '/matching/notice-publish/$noticeId': typeof MatchingNoticePublishNoticeIdRoute
   '/matching/projects/new': typeof MatchingProjectsNewRoute
+  '/test/signup/id-pw': typeof TestSignupIdPwRoute
   '/matching/projects/': typeof MatchingProjectsIndexRoute
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/announce/': typeof MatchingProjectsAnnounceIndexRoute
@@ -302,6 +309,7 @@ export interface FileRoutesByTo {
   '/auth/callback/kakao': typeof AuthCallbackKakaoRoute
   '/matching/notice-publish/$noticeId': typeof MatchingNoticePublishNoticeIdRoute
   '/matching/projects/new': typeof MatchingProjectsNewRoute
+  '/test/signup/id-pw': typeof TestSignupIdPwRoute
   '/matching/projects': typeof MatchingProjectsIndexRoute
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/announce': typeof MatchingProjectsAnnounceIndexRoute
@@ -341,6 +349,7 @@ export interface FileRoutesById {
   '/auth/callback/kakao': typeof AuthCallbackKakaoRoute
   '/matching/notice-publish/$noticeId': typeof MatchingNoticePublishNoticeIdRoute
   '/matching/projects/new': typeof MatchingProjectsNewRoute
+  '/test/signup/id-pw': typeof TestSignupIdPwRoute
   '/matching/projects/': typeof MatchingProjectsIndexRoute
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/announce/': typeof MatchingProjectsAnnounceIndexRoute
@@ -381,6 +390,7 @@ export interface FileRouteTypes {
     | '/auth/callback/kakao'
     | '/matching/notice-publish/$noticeId'
     | '/matching/projects/new'
+    | '/test/signup/id-pw'
     | '/matching/projects/'
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/announce/'
@@ -417,6 +427,7 @@ export interface FileRouteTypes {
     | '/auth/callback/kakao'
     | '/matching/notice-publish/$noticeId'
     | '/matching/projects/new'
+    | '/test/signup/id-pw'
     | '/matching/projects'
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/announce'
@@ -455,6 +466,7 @@ export interface FileRouteTypes {
     | '/auth/callback/kakao'
     | '/matching/notice-publish/$noticeId'
     | '/matching/projects/new'
+    | '/test/signup/id-pw'
     | '/matching/projects/'
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/announce/'
@@ -487,6 +499,7 @@ export interface RootRouteChildren {
   AuthCallbackAppleRoute: typeof AuthCallbackAppleRoute
   AuthCallbackGoogleRoute: typeof AuthCallbackGoogleRoute
   AuthCallbackKakaoRoute: typeof AuthCallbackKakaoRoute
+  TestSignupIdPwRoute: typeof TestSignupIdPwRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -680,6 +693,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MatchingProjectsIndexRouteImport
       parentRoute: typeof MatchingRouteRoute
     }
+    '/test/signup/id-pw': {
+      id: '/test/signup/id-pw'
+      path: '/test/signup/id-pw'
+      fullPath: '/test/signup/id-pw'
+      preLoaderRoute: typeof TestSignupIdPwRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/matching/projects/new': {
       id: '/matching/projects/new'
       path: '/projects/new'
@@ -842,6 +862,7 @@ const rootRouteChildren: RootRouteChildren = {
   AuthCallbackAppleRoute: AuthCallbackAppleRoute,
   AuthCallbackGoogleRoute: AuthCallbackGoogleRoute,
   AuthCallbackKakaoRoute: AuthCallbackKakaoRoute,
+  TestSignupIdPwRoute: TestSignupIdPwRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/test/login.tsx
+++ b/src/routes/test/login.tsx
@@ -9,12 +9,6 @@ import {
   loginWithIdPw,
   registerCredentials,
 } from "@/features/auth/api/credentials"
-import { loginWithApple } from "@/features/auth/api/socialLogin"
-import {
-  isApplePopupCancelled,
-  signInWithApple,
-} from "@/features/auth/lib/appleSignIn"
-import { handleLoginResponse } from "@/features/auth/lib/handleLoginResponse"
 import { redirectToOAuth } from "@/features/auth/lib/oauthRedirect"
 import { useAuthStore } from "@/features/auth/store/authStore"
 import UmcLogo from "@/shared/assets/icon/logo/UmcLogo"
@@ -38,17 +32,6 @@ function LoginPage() {
       type: "default",
       duration: 3000,
     })
-  }
-
-  const handleAppleSignIn = async () => {
-    try {
-      const { authorizationCode } = await signInWithApple()
-      const res = await loginWithApple({ authorizationCode })
-      handleLoginResponse(res)
-    } catch (error) {
-      if (isApplePopupCancelled(error)) return
-      showToast("Apple 로그인에 실패했습니다. 다시 시도해주세요.", "red")
-    }
   }
 
   return (
@@ -93,7 +76,7 @@ function LoginPage() {
           color="neutral"
           size="xl"
           className="w-full"
-          onClick={() => void handleAppleSignIn()}
+          onClick={() => redirectToOAuth("APPLE")}
         >
           <span className="flex items-center gap-2">
             <AppleIcon size={20} />

--- a/src/routes/test/login.tsx
+++ b/src/routes/test/login.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, Link } from "@tanstack/react-router"
 import { Chrome, MessageCircle } from "lucide-react"
 import { useState } from "react"
 
@@ -220,6 +220,15 @@ function IdPwLoginSection({ onSuccess, onError }: IdPwLoginSectionProps) {
       >
         로그인
       </Button>
+      <p className="text-label-2-medium text-teal-gray-400 text-center">
+        계정이 없으신가요?{" "}
+        <Link
+          to="/test/signup/id-pw"
+          className="text-teal-600 underline underline-offset-2"
+        >
+          회원가입
+        </Link>
+      </p>
     </form>
   )
 }

--- a/src/routes/test/login.tsx
+++ b/src/routes/test/login.tsx
@@ -1,7 +1,14 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { Chrome, MessageCircle } from "lucide-react"
+import { useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
+import {
+  changePassword,
+  checkLoginIdAvailability,
+  loginWithIdPw,
+  registerCredentials,
+} from "@/features/auth/api/credentials"
 import { loginWithApple } from "@/features/auth/api/socialLogin"
 import {
   isApplePopupCancelled,
@@ -9,6 +16,7 @@ import {
 } from "@/features/auth/lib/appleSignIn"
 import { handleLoginResponse } from "@/features/auth/lib/handleLoginResponse"
 import { redirectToOAuth } from "@/features/auth/lib/oauthRedirect"
+import { useAuthStore } from "@/features/auth/store/authStore"
 import UmcLogo from "@/shared/assets/icon/logo/UmcLogo"
 import { Button } from "@/shared/ui/Button"
 
@@ -18,6 +26,19 @@ export const Route = createFileRoute("/test/login")({
 
 function LoginPage() {
   const addToast = useToastStore((s) => s.addToast)
+  const isAuthed = useAuthStore((s) => s.isAuthed)
+  const setTokens = useAuthStore((s) => s.setTokens)
+  const clearAuth = useAuthStore((s) => s.clear)
+
+  const showToast = (message: string, color: "primary" | "red" = "primary") => {
+    addToast({
+      message,
+      color,
+      variant: "deep",
+      type: "default",
+      duration: 3000,
+    })
+  }
 
   const handleAppleSignIn = async () => {
     try {
@@ -26,18 +47,12 @@ function LoginPage() {
       handleLoginResponse(res)
     } catch (error) {
       if (isApplePopupCancelled(error)) return
-      addToast({
-        message: "Apple 로그인에 실패했습니다. 다시 시도해주세요.",
-        color: "red",
-        variant: "deep",
-        type: "default",
-        duration: 3000,
-      })
+      showToast("Apple 로그인에 실패했습니다. 다시 시도해주세요.", "red")
     }
   }
 
   return (
-    <main className="flex min-h-[80vh] flex-col items-center justify-center gap-8 px-4">
+    <main className="flex min-h-[80vh] flex-col items-center justify-center gap-10 px-4 py-10">
       <div className="flex flex-col items-center gap-3">
         <UmcLogo className="h-8 w-auto text-teal-600" />
         <p className="text-heading-2-bold text-teal-gray-900">
@@ -47,6 +62,7 @@ function LoginPage() {
           임시 페이지 — 디자인 확정 후 교체 예정
         </p>
       </div>
+
       <div className="flex w-full max-w-90 flex-col gap-3">
         <Button
           variant="weak"
@@ -85,8 +101,326 @@ function LoginPage() {
           </span>
         </Button>
       </div>
+
+      <div className="flex w-full max-w-90 items-center gap-3">
+        <span className="bg-teal-gray-200 h-px flex-1" />
+        <span className="text-label-2-medium text-teal-gray-400">또는</span>
+        <span className="bg-teal-gray-200 h-px flex-1" />
+      </div>
+
+      <IdPwLoginSection
+        onSuccess={(memberId, accessToken, refreshToken) => {
+          setTokens({ memberId, accessToken, refreshToken })
+          showToast(`ID/PW 로그인 성공 (memberId: ${memberId})`, "primary")
+        }}
+        onError={(message) => showToast(message, "red")}
+      />
+
+      {isAuthed && (
+        <section className="flex w-full max-w-90 flex-col gap-6 border-t pt-8">
+          <p className="text-subtitle-3-semibold text-teal-gray-800">
+            인증된 사용자 도구
+          </p>
+
+          <LoginIdAvailabilitySection
+            onResult={(loginId, available) =>
+              showToast(
+                `${loginId}: ${available ? "사용 가능" : "사용 불가"}`,
+                available ? "primary" : "red",
+              )
+            }
+            onError={(message) => showToast(message, "red")}
+          />
+
+          <RegisterCredentialsSection
+            onSuccess={() => showToast("자격증명 등록 성공", "primary")}
+            onError={(message) => showToast(message, "red")}
+          />
+
+          <ChangePasswordSection
+            onSuccess={() => showToast("비밀번호 변경 성공", "primary")}
+            onError={(message) => showToast(message, "red")}
+          />
+
+          <Button
+            variant="weak"
+            color="neutral"
+            size="m"
+            className="w-full"
+            onClick={() => {
+              clearAuth()
+              showToast("로그아웃 완료")
+            }}
+          >
+            로그아웃
+          </Button>
+        </section>
+      )}
     </main>
   )
+}
+
+interface IdPwLoginSectionProps {
+  onSuccess: (
+    memberId: number,
+    accessToken: string,
+    refreshToken: string,
+  ) => void
+  onError: (message: string) => void
+}
+
+function IdPwLoginSection({ onSuccess, onError }: IdPwLoginSectionProps) {
+  const [loginId, setLoginId] = useState("")
+  const [password, setPassword] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!loginId || !password) return
+    setIsLoading(true)
+    try {
+      const res = await loginWithIdPw({ loginId, password })
+      onSuccess(res.memberId, res.accessToken, res.refreshToken)
+      setPassword("")
+    } catch (error) {
+      onError(extractErrorMessage(error, "ID/PW 로그인에 실패했습니다."))
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <form
+      onSubmit={(e) => void handleSubmit(e)}
+      className="flex w-full max-w-90 flex-col gap-3"
+    >
+      <p className="text-label-1-semibold text-teal-gray-700">ID/PW 로그인</p>
+      <input
+        type="text"
+        placeholder="loginId"
+        value={loginId}
+        onChange={(e) => setLoginId(e.target.value)}
+        className="border-teal-gray-200 text-body-2-medium rounded-md border px-3 py-2 outline-none focus:border-teal-500"
+      />
+      <input
+        type="password"
+        placeholder="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="border-teal-gray-200 text-body-2-medium rounded-md border px-3 py-2 outline-none focus:border-teal-500"
+      />
+      <Button
+        type="submit"
+        variant="fill"
+        color="primary"
+        size="m"
+        className="w-full"
+        disabled={!loginId || !password}
+        isLoading={isLoading}
+      >
+        로그인
+      </Button>
+    </form>
+  )
+}
+
+interface LoginIdAvailabilitySectionProps {
+  onResult: (loginId: string, available: boolean) => void
+  onError: (message: string) => void
+}
+
+function LoginIdAvailabilitySection({
+  onResult,
+  onError,
+}: LoginIdAvailabilitySectionProps) {
+  const [loginId, setLoginId] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleCheck = async () => {
+    if (!loginId) return
+    setIsLoading(true)
+    try {
+      const res = await checkLoginIdAvailability(loginId)
+      onResult(res.loginId, res.available)
+    } catch (error) {
+      onError(extractErrorMessage(error, "ID 가용성 확인에 실패했습니다."))
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <p className="text-label-1-semibold text-teal-gray-700">
+        로그인 ID 가용성 확인
+      </p>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          placeholder="loginId"
+          value={loginId}
+          onChange={(e) => setLoginId(e.target.value)}
+          className="border-teal-gray-200 text-body-2-medium flex-1 rounded-md border px-3 py-2 outline-none focus:border-teal-500"
+        />
+        <Button
+          type="button"
+          variant="weak"
+          color="primary"
+          size="m"
+          onClick={() => void handleCheck()}
+          disabled={!loginId}
+          isLoading={isLoading}
+        >
+          확인
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+interface RegisterCredentialsSectionProps {
+  onSuccess: () => void
+  onError: (message: string) => void
+}
+
+function RegisterCredentialsSection({
+  onSuccess,
+  onError,
+}: RegisterCredentialsSectionProps) {
+  const [loginId, setLoginId] = useState("")
+  const [password, setPassword] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!loginId || !password) return
+    setIsLoading(true)
+    try {
+      await registerCredentials({ loginId, password })
+      onSuccess()
+      setLoginId("")
+      setPassword("")
+    } catch (error) {
+      onError(extractErrorMessage(error, "자격증명 등록에 실패했습니다."))
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <form
+      onSubmit={(e) => void handleSubmit(e)}
+      className="flex w-full flex-col gap-2"
+    >
+      <p className="text-label-1-semibold text-teal-gray-700">
+        자격증명 최초 등록
+      </p>
+      <input
+        type="text"
+        placeholder="loginId"
+        value={loginId}
+        onChange={(e) => setLoginId(e.target.value)}
+        className="border-teal-gray-200 text-body-2-medium rounded-md border px-3 py-2 outline-none focus:border-teal-500"
+      />
+      <input
+        type="password"
+        placeholder="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        className="border-teal-gray-200 text-body-2-medium rounded-md border px-3 py-2 outline-none focus:border-teal-500"
+      />
+      <Button
+        type="submit"
+        variant="weak"
+        color="primary"
+        size="m"
+        className="w-full"
+        disabled={!loginId || !password}
+        isLoading={isLoading}
+      >
+        등록
+      </Button>
+    </form>
+  )
+}
+
+interface ChangePasswordSectionProps {
+  onSuccess: () => void
+  onError: (message: string) => void
+}
+
+function ChangePasswordSection({
+  onSuccess,
+  onError,
+}: ChangePasswordSectionProps) {
+  const [currentPassword, setCurrentPassword] = useState("")
+  const [newPassword, setNewPassword] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!currentPassword || !newPassword) return
+    setIsLoading(true)
+    try {
+      await changePassword({ currentPassword, newPassword })
+      onSuccess()
+      setCurrentPassword("")
+      setNewPassword("")
+    } catch (error) {
+      onError(extractErrorMessage(error, "비밀번호 변경에 실패했습니다."))
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <form
+      onSubmit={(e) => void handleSubmit(e)}
+      className="flex w-full flex-col gap-2"
+    >
+      <p className="text-label-1-semibold text-teal-gray-700">비밀번호 변경</p>
+      <input
+        type="password"
+        placeholder="currentPassword"
+        value={currentPassword}
+        onChange={(e) => setCurrentPassword(e.target.value)}
+        className="border-teal-gray-200 text-body-2-medium rounded-md border px-3 py-2 outline-none focus:border-teal-500"
+      />
+      <input
+        type="password"
+        placeholder="newPassword"
+        value={newPassword}
+        onChange={(e) => setNewPassword(e.target.value)}
+        className="border-teal-gray-200 text-body-2-medium rounded-md border px-3 py-2 outline-none focus:border-teal-500"
+      />
+      <Button
+        type="submit"
+        variant="weak"
+        color="primary"
+        size="m"
+        className="w-full"
+        disabled={!currentPassword || !newPassword}
+        isLoading={isLoading}
+      >
+        변경
+      </Button>
+    </form>
+  )
+}
+
+function extractErrorMessage(error: unknown, fallback: string): string {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "response" in error &&
+    typeof (error as { response?: { data?: { message?: string } } })
+      .response === "object"
+  ) {
+    const message = (error as { response?: { data?: { message?: string } } })
+      .response?.data?.message
+    if (message) return message
+  }
+  return fallback
 }
 
 function AppleIcon({ size }: { size: number }) {

--- a/src/routes/test/signup/id-pw.tsx
+++ b/src/routes/test/signup/id-pw.tsx
@@ -1,36 +1,30 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 import { useEffect } from "react"
 
 import { useSignupStore } from "@/features/auth/store/signupStore"
 import { SignupStepBasicInfo } from "@/features/auth/ui/SignupStepBasicInfo"
 import { SignupStepEmail } from "@/features/auth/ui/SignupStepEmail"
+import { SignupStepIdPwCredentials } from "@/features/auth/ui/SignupStepIdPwCredentials"
 import { SignupStepTerms } from "@/features/auth/ui/SignupStepTerms"
 import UmcLogo from "@/shared/assets/icon/logo/UmcLogo"
 
-export const Route = createFileRoute("/signup")({
-  component: SignupPage,
+export const Route = createFileRoute("/test/signup/id-pw")({
+  component: IdPwSignupPage,
 })
 
-const STEP_LABELS: Record<string, string> = {
-  email: "1 / 3",
-  "basic-info": "2 / 3",
-  terms: "3 / 3",
+const STEP_LABELS = {
+  credentials: "1 / 4",
+  email: "2 / 4",
+  "basic-info": "3 / 4",
+  terms: "4 / 4",
 }
 
-function SignupPage() {
-  const navigate = useNavigate()
-  const { step, oAuthVerificationToken, init } = useSignupStore()
+function IdPwSignupPage() {
+  const { step, initIdPw } = useSignupStore()
 
   useEffect(() => {
-    const token = sessionStorage.getItem("oauth_verification_token")
-    if (!token) {
-      void navigate({ to: "/test/login" })
-      return
-    }
-    if (!oAuthVerificationToken) {
-      init(token)
-    }
-  }, [oAuthVerificationToken, navigate, init])
+    initIdPw()
+  }, [initIdPw])
 
   return (
     <main className="flex min-h-[80vh] flex-col items-center justify-center gap-8 px-4">
@@ -41,6 +35,7 @@ function SignupPage() {
           임시 페이지 — 디자인 확정 후 교체 예정 ({STEP_LABELS[step]})
         </p>
       </div>
+      {step === "credentials" && <SignupStepIdPwCredentials />}
       {step === "email" && <SignupStepEmail />}
       {step === "basic-info" && <SignupStepBasicInfo />}
       {step === "terms" && <SignupStepTerms />}


### PR DESCRIPTION
## 📸 작업 내용

ID/PW 기반 단독 회원가입 흐름을 구현하고, OAuth 회원가입 엔드포인트를 신규 스펙으로 마이그레이션했습니다.

- ID/PW 인증 API 함수 추가 (`loginWithIdPw`, `checkLoginIdAvailability`, `registerCredentials`, `changePassword`)
- OAuth 회원가입 엔드포인트 마이그레이션: `/v1/member/register` → `/v1/member/register/oauth`
- ID/PW 단독 회원가입 라우트 추가 (`/test/signup/id-pw`): 자격증명 → 이메일 인증 → 기본 정보 → 약관 동의 4단계
- `signupStore`에 `mode` 필드 추가로 OAuth / ID/PW 두 가입 흐름을 하나의 컴포넌트 셋으로 처리
- Apple 로그인 방식 변경: JS SDK 팝업 → 백엔드 OAuth2 Redirect

## 🎞️ 주요 코드 설명

### signupStore mode 분기

```TypeScript
export type SignupMode = "oauth" | "id-pw"
export type SignupStep = "credentials" | "email" | "basic-info" | "terms"

// ID/PW 가입 초기화
initIdPw: () => set({ ...initialState, mode: "id-pw", step: "credentials" })
```

- 기존 `SignupStepEmail`, `SignupStepBasicInfo`, `SignupStepTerms` 컴포넌트를 수정 없이 재사용
- `SignupStepTerms`에서 `mode`로 분기하여 `registerMemberByOAuth` / `registerMemberByIdPw` 호출

### ID/PW 자격증명 step

```TypeScript
// SignupStepIdPwCredentials.tsx
// loginId 중복확인 통과 여부를 로컬 state로 관리
// 중복확인 미통과 시 "다음" 버튼 비활성화
const [isLoginIdAvailable, setIsLoginIdAvailable] = useState(false)
```

- `checkLoginIdAvailability` 호출 후 사용 가능 여부를 상태로 보관
- loginId 수정 시 중복확인 상태 초기화

### Apple 로그인 redirect 방식

```TypeScript
// before: Apple JS SDK 팝업
onClick={() => void handleAppleSignIn()}

// after: 백엔드 OAuth2 redirect (Google/Kakao와 동일 패턴)
onClick={() => redirectToOAuth("APPLE")}
```

## 🖥️ 구현화면

|           /test/login 회원가입 링크            |           /test/signup/id-pw 자격증명 step            |
| :--------------------------------------------: | :---------------------------------------------------: |
| <img src = "" width ="250"> | <img src = "" width ="250"> |

## 🔗 연결된 이슈

- Connected: #이슈번호

## 💬 기타 더 이야기해볼 점

- `feat/id-pw-auth-api`, `feat/oauth-register-migration` 브랜치의 커밋이 이 PR에 포함되어 있습니다. 두 브랜치가 develop에 먼저 머지되면 이 PR의 diff가 의도한 변경사항만 남도록 정리됩니다.
- Apple `appleRefreshToken` 응답 처리는 백엔드 팀 확인 후 별도 PR로 진행 예정입니다.