### PR TITLE
fix: API 응답 envelope unwrap 처리

### DIFF
--- a/src/features/auth/api/credentials.ts
+++ b/src/features/auth/api/credentials.ts
@@ -7,15 +7,16 @@ import type {
   LoginIdAvailabilityResponse,
   RegisterCredentialsRequest,
 } from "@/features/auth/model/types"
+import type { ApiResponse } from "@/shared/lib/apiResponse"
 
 export async function loginWithIdPw(
   payload: IdPwLoginRequest,
 ): Promise<IdPwLoginResponse> {
-  const { data } = await api.post<IdPwLoginResponse>(
+  const { data } = await api.post<ApiResponse<IdPwLoginResponse>>(
     "/v1/auth/login/id-pw",
     payload,
   )
-  return data
+  return data.result
 }
 
 export async function registerCredentials(
@@ -27,11 +28,11 @@ export async function registerCredentials(
 export async function checkLoginIdAvailability(
   loginId: string,
 ): Promise<LoginIdAvailabilityResponse> {
-  const { data } = await api.get<LoginIdAvailabilityResponse>(
+  const { data } = await api.get<ApiResponse<LoginIdAvailabilityResponse>>(
     "/v1/auth/login-id/availability",
     { params: { loginId } },
   )
-  return data
+  return data.result
 }
 
 export async function changePassword(

--- a/src/features/auth/api/emailVerification.ts
+++ b/src/features/auth/api/emailVerification.ts
@@ -7,15 +7,16 @@ import type {
   SendEmailVerificationRequest,
   SendEmailVerificationResponse,
 } from "@/features/auth/model/types"
+import type { ApiResponse } from "@/shared/lib/apiResponse"
 
 export async function sendEmailVerification(
   payload: SendEmailVerificationRequest,
 ): Promise<SendEmailVerificationResponse> {
-  const { data } = await api.post<SendEmailVerificationResponse>(
+  const { data } = await api.post<ApiResponse<SendEmailVerificationResponse>>(
     "/v1/auth/email-verification",
     payload,
   )
-  return data
+  return data.result
 }
 
 export async function resendEmailVerification(
@@ -27,9 +28,8 @@ export async function resendEmailVerification(
 export async function completeEmailVerification(
   payload: CompleteEmailVerificationRequest,
 ): Promise<CompleteEmailVerificationResponse> {
-  const { data } = await api.post<CompleteEmailVerificationResponse>(
-    "/v1/auth/email-verification/code",
-    payload,
-  )
-  return data
+  const { data } = await api.post<
+    ApiResponse<CompleteEmailVerificationResponse>
+  >("/v1/auth/email-verification/code", payload)
+  return data.result
 }

--- a/src/features/auth/api/me.ts
+++ b/src/features/auth/api/me.ts
@@ -1,5 +1,7 @@
 import { api } from "@/shared/lib/axios"
 
+import type { ApiResponse } from "@/shared/lib/apiResponse"
+
 export interface MemberInfoResponse {
   id: number
   name: string
@@ -12,6 +14,7 @@ export interface MemberInfoResponse {
 }
 
 export async function getMyInfo(): Promise<MemberInfoResponse> {
-  const { data } = await api.get<MemberInfoResponse>("/v1/member/me")
-  return data
+  const { data } =
+    await api.get<ApiResponse<MemberInfoResponse>>("/v1/member/me")
+  return data.result
 }

--- a/src/features/auth/api/register.ts
+++ b/src/features/auth/api/register.ts
@@ -5,23 +5,24 @@ import type {
   RegisterMemberRequest,
   RegisterResponse,
 } from "@/features/auth/model/types"
+import type { ApiResponse } from "@/shared/lib/apiResponse"
 
 export async function registerMemberByOAuth(
   payload: RegisterMemberRequest,
 ): Promise<RegisterResponse> {
-  const { data } = await api.post<RegisterResponse>(
+  const { data } = await api.post<ApiResponse<RegisterResponse>>(
     "/v1/member/register/oauth",
     payload,
   )
-  return data
+  return data.result
 }
 
 export async function registerMemberByIdPw(
   payload: IdPwRegisterMemberRequest,
 ): Promise<RegisterResponse> {
-  const { data } = await api.post<RegisterResponse>(
+  const { data } = await api.post<ApiResponse<RegisterResponse>>(
     "/v1/member/register/id-pw",
     payload,
   )
-  return data
+  return data.result
 }

--- a/src/features/auth/api/school.ts
+++ b/src/features/auth/api/school.ts
@@ -1,8 +1,10 @@
 import { api } from "@/shared/lib/axios"
 
 import type { SchoolNameListResponse } from "@/features/auth/model/types"
+import type { ApiResponse } from "@/shared/lib/apiResponse"
 
 export async function getAllSchools(): Promise<SchoolNameListResponse> {
-  const { data } = await api.get<SchoolNameListResponse>("/v1/schools/all")
-  return data
+  const { data } =
+    await api.get<ApiResponse<SchoolNameListResponse>>("/v1/schools/all")
+  return data.result
 }

--- a/src/features/auth/api/socialLogin.ts
+++ b/src/features/auth/api/socialLogin.ts
@@ -6,33 +6,34 @@ import type {
   KakaoLoginRequest,
   OAuthLoginResponse,
 } from "@/features/auth/model/types"
+import type { ApiResponse } from "@/shared/lib/apiResponse"
 
 export async function loginWithGoogle(
   payload: GoogleLoginRequest,
 ): Promise<OAuthLoginResponse> {
-  const { data } = await api.post<OAuthLoginResponse>(
+  const { data } = await api.post<ApiResponse<OAuthLoginResponse>>(
     "/v1/auth/login/google",
     payload,
   )
-  return data
+  return data.result
 }
 
 export async function loginWithKakao(
   payload: KakaoLoginRequest,
 ): Promise<OAuthLoginResponse> {
-  const { data } = await api.post<OAuthLoginResponse>(
+  const { data } = await api.post<ApiResponse<OAuthLoginResponse>>(
     "/v1/auth/login/kakao",
     payload,
   )
-  return data
+  return data.result
 }
 
 export async function loginWithApple(
   payload: AppleLoginRequest,
 ): Promise<OAuthLoginResponse> {
-  const { data } = await api.post<OAuthLoginResponse>(
+  const { data } = await api.post<ApiResponse<OAuthLoginResponse>>(
     "/v1/auth/login/apple",
     payload,
   )
-  return data
+  return data.result
 }

--- a/src/features/auth/api/terms.ts
+++ b/src/features/auth/api/terms.ts
@@ -1,10 +1,13 @@
 import { api } from "@/shared/lib/axios"
 
 import type { TermResponse, TermType } from "@/features/auth/model/types"
+import type { ApiResponse } from "@/shared/lib/apiResponse"
 
 export async function getTermsByType(
   termType: TermType,
 ): Promise<TermResponse> {
-  const { data } = await api.get<TermResponse>(`/v1/terms/type/${termType}`)
-  return data
+  const { data } = await api.get<ApiResponse<TermResponse>>(
+    `/v1/terms/type/${termType}`,
+  )
+  return data.result
 }

--- a/src/features/auth/api/token.ts
+++ b/src/features/auth/api/token.ts
@@ -1,5 +1,7 @@
 import { api } from "@/shared/lib/axios"
 
+import type { ApiResponse } from "@/shared/lib/apiResponse"
+
 interface RenewAccessTokenRequest {
   refreshToken: string
 }
@@ -12,9 +14,9 @@ interface RenewAccessTokenResponse {
 export async function renewAccessToken(
   refreshToken: string,
 ): Promise<RenewAccessTokenResponse> {
-  const { data } = await api.post<RenewAccessTokenResponse>(
+  const { data } = await api.post<ApiResponse<RenewAccessTokenResponse>>(
     "/v1/auth/token/renew",
     { refreshToken } satisfies RenewAccessTokenRequest,
   )
-  return data
+  return data.result
 }

--- a/src/shared/lib/apiResponse.ts
+++ b/src/shared/lib/apiResponse.ts
@@ -1,0 +1,6 @@
+export interface ApiResponse<T> {
+  success: boolean
+  code: string
+  message: string
+  result: T
+}

--- a/src/shared/lib/axios.ts
+++ b/src/shared/lib/axios.ts
@@ -2,6 +2,8 @@ import axios from "axios"
 
 import type { AxiosRequestConfig } from "axios"
 
+import type { ApiResponse } from "@/shared/lib/apiResponse"
+
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
   timeout: 10000,
@@ -71,17 +73,20 @@ api.interceptors.response.use(
     originalRequest._retry = true
 
     try {
-      const { data } = await api.post<{
-        accessToken: string
-        refreshToken: string
-      }>("/v1/auth/token/renew", { refreshToken })
-      localStorage.setItem("access_token", data.accessToken)
-      localStorage.setItem("refresh_token", data.refreshToken)
-      api.defaults.headers.common.Authorization = `Bearer ${data.accessToken}`
-      drainQueue(data.accessToken)
+      const { data } = await api.post<
+        ApiResponse<{
+          accessToken: string
+          refreshToken: string
+        }>
+      >("/v1/auth/token/renew", { refreshToken })
+      const { accessToken, refreshToken: newRefreshToken } = data.result
+      localStorage.setItem("access_token", accessToken)
+      localStorage.setItem("refresh_token", newRefreshToken)
+      api.defaults.headers.common.Authorization = `Bearer ${accessToken}`
+      drainQueue(accessToken)
       originalRequest.headers = {
         ...originalRequest.headers,
-        Authorization: `Bearer ${data.accessToken}`,
+        Authorization: `Bearer ${accessToken}`,
       }
       return api(originalRequest)
     } catch (refreshError) {


### PR DESCRIPTION
## 📸 작업 내용

`/test/signup/id-pw`에서 ID 중복확인이 항상 "이미 사용 중인 아이디입니다"로 표시되어 가입 진행이 불가능한 버그를 수정합니다.

- **원인**: 백엔드는 모든 응답을 `{success, code, message, result}` envelope으로 감싸는데, 프론트의 auth API 함수들은 envelope을 그대로 반환해 실제 데이터(`available`, `accessToken`, `emailVerificationId` 등)에 접근 불가
- **영향 범위**: `src/features/auth/api/` 하위 13개 함수 + `src/shared/lib/axios.ts` 토큰 갱신 호출 1곳
- **수정**: 공통 `ApiResponse<T>` 타입을 정의하고 각 호출에서 `data.result`로 명시 unwrap

## 🎞️ 주요 코드 설명

### envelope 타입 정의

```TypeScript
// src/shared/lib/apiResponse.ts
export interface ApiResponse<T> {
  success: boolean
  code: string
  message: string
  result: T
}
```

### unwrap 적용 (예시)

```TypeScript
// before: data.available 이 undefined → falsy → 항상 "이미 사용 중"
const { data } = await api.get<LoginIdAvailabilityResponse>(...)
return data

// after: data.result.available 정상 추출
const { data } = await api.get<ApiResponse<LoginIdAvailabilityResponse>>(...)
return data.result
```

### 실제 백엔드 응답 (관측)

```
GET /v1/auth/login-id/availability?loginId=testuser123
{"success":true,"code":"COMMON200","message":"성공입니다.","result":{"loginId":"testuser123","available":true}}
```

기존 코드는 `data.available`(undefined)을 falsy로 판정하여 사용 가능한 ID도 모두 사용 중으로 잘못 표시.

## 🖥️ 구현화면

> 수정 전: 어떤 ID를 입력해도 "이미 사용 중인 아이디입니다" 토스트
> 수정 후: 사용 가능 ID는 "사용 가능한 아이디입니다" 표시 + "다음" 버튼 활성화

## 🔗 연결된 이슈

- Connected: #33 

## 💬 기타 더 이야기해볼 점

- ID 형식(영문/숫자/._- 5~20자) 클라이언트 zod 검증은 별건 PR로 추가 권장. 현재는 형식 위반 시 백엔드 400 응답이 catch 블록의 generic 메시지로만 표시됨.
- `auth/api` 외 다른 features의 API 호출(`await api.*`)은 grep 결과 없음. 새 API 함수 추가 시 동일 패턴(`ApiResponse<T>` 사용) 권장.