### PR TITLE
[FEAT] 챌린저 상벌점 부여 및 챌린저 기록 코드 생성용 백오피스 제작

### DIFF
--- a/docs/2026-05-06_챌린저_관리_FE_업무보고서.md
+++ b/docs/2026-05-06_챌린저_관리_FE_업무보고서.md
@@ -1,0 +1,238 @@
+# 챌린저 관리 FE 업무 보고서
+
+> 작성일: 2026-05-06
+> 담당: FE
+> 참조 문서: [챌린저\_관리\_FE_API\_가이드.md](챌린저_관리_FE_API_가이드.md)
+
+---
+
+## 1. 개요
+
+운영진용 **챌린저 관리** 두 페이지를 신규 도메인 `features/challenger/` 로 추가했다.
+
+| 페이지             | 경로                        | 기능                                                        |
+| ------------------ | --------------------------- | ----------------------------------------------------------- |
+| 챌린저 상벌점 부여 | `/admin/challenger-points`  | 회원 검색 → 챌린저 기록 선택 → 상세/내역 조회 → 상벌점 부여 |
+| 챌린저 기록 코드   | `/admin/challenger-records` | 9기 이전 활동 이력의 6자리 코드 발급 + 코드 조회            |
+
+이번 작업은 두 단계로 진행되었다.
+
+1. **1차 구현** — 회원 검색 / 회원 프로필 / 챌린저 상세 / 상벌점 부여 / 코드 발급/조회 플로우 골격 완성, TypeScript/Lint/Build 통과.
+2. **2차 가이드 정합화** — [챌린저\_관리\_FE_API\_가이드.md](챌린저_관리_FE_API_가이드.md) 와 1차 결과물을 1:1 비교하여 백엔드 계약 위반 항목을 수정. 본 보고서의 §3 에서 다룬다.
+
+---
+
+## 2. 사용한 API 엔드포인트
+
+가이드 문서의 두 플로우 (A: 운영진 흐름, B: 코드 기반 흐름) 에서 본 페이지가 호출하는 엔드포인트만 정리.
+
+### 2.1 플로우 A — 상벌점 부여
+
+| 가이드 # | Method · Path                               | FE 함수                                                                      | 사용 위치                                                                                                                 |
+| -------- | ------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| A-1      | `GET /v1/member/search`                     | [`searchMembers`](../src/features/challenger/api/member.ts)                  | [`MemberSearchPanel`](../src/features/challenger/ui/grant-points/MemberSearchPanel.tsx) — keyword 디바운스 검색           |
+| A-2      | `GET /v1/member/profile/{memberId}`         | [`getMemberProfile`](../src/features/challenger/api/member.ts)               | [`MemberRecordList`](../src/features/challenger/ui/grant-points/MemberRecordList.tsx) — `challengerRecords` 배열 표시     |
+| A-3      | `GET /v1/challenger/{challengerId}`         | [`getChallengerInfo`](../src/features/challenger/api/challenger.ts)          | [`ChallengerRecordDetail`](../src/features/challenger/ui/grant-points/ChallengerRecordDetail.tsx) — 상벌점 내역 포함 상세 |
+| A-4      | `POST /v1/challenger/{challengerId}/points` | [`grantChallengerPoints`](../src/features/challenger/api/challengerPoint.ts) | [`GrantPointsForm`](../src/features/challenger/ui/grant-points/GrantPointsForm.tsx) — 부여 후 A-3 invalidate              |
+
+> A-5/A-6 (사유 수정·삭제), A-보조-1/2 (challenger 직접 검색) 은 본 작업 범위 밖. 추후 동일 디렉터리에 함수 추가 가능.
+
+### 2.2 플로우 B — 코드 발급/조회
+
+| 가이드 # | Method · Path                              | FE 함수                                                                           | 사용 위치                                                                            |
+| -------- | ------------------------------------------ | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| B-3      | `POST /v1/challenger-record`               | [`createChallengerRecord`](../src/features/challenger/api/challengerRecord.ts)    | [`CreateRecordForm`](../src/features/challenger/ui/record-code/CreateRecordForm.tsx) |
+| B-6      | `GET /v1/challenger-record/code/{code}`    | [`getChallengerRecordByCode`](../src/features/challenger/api/challengerRecord.ts) | [`LookupRecordForm`](../src/features/challenger/ui/record-code/LookupRecordForm.tsx) |
+| 보조     | `GET /v1/gisu/all`                         | [`getAllGisu`](../src/features/challenger/api/organization.ts)                    | 코드 발급 폼의 기수 드롭다운                                                         |
+| 보조     | `GET /v1/chapters/with-schools?gisuId=...` | [`getChaptersWithSchools`](../src/features/challenger/api/organization.ts)        | 지부 ↔ 학교 cascade 드롭다운                                                         |
+
+> B-1/B-2 (현재 기수 챌린저 직접 등록), B-4 (bulk 코드), B-5 (회원이 코드 사용), B-7 (id 로 조회), B-부록 (제명/파트변경/하드삭제) 는 범위 밖.
+
+---
+
+## 3. 가이드 문서 정합화 — 1차 → 2차 변경사항
+
+[챌린저\_관리\_FE_API\_가이드.md](챌린저_관리_FE_API_가이드.md) 와 1차 구현을 비교한 결과 **3건의 백엔드 계약 위반과 2건의 표시 정확도 이슈** 가 있었다. 모두 2차 작업에서 수정.
+
+### 3.1 🔴 `pointValue` 를 optional 로 (가이드 A-4)
+
+가이드:
+
+> `pointValue` | integer | ⛔ optional | **null 이면 `pointType` 의 기본 점수 사용**. 명시 시 그 값으로 덮어씀 (`CUSTOM` 등 자체 제도용).
+
+**1차 (잘못됨):** `pointValue` 를 zod 스키마에서 필수 + `0 != v` 로 강제. 운영자가 매번 -2, -4 같은 값을 외워서 입력해야 했음. 또한 `BLOG_CHALLENGE` 의 기본값 `+3.0` 같은 소수점 기본값을 활용할 길이 없었음.
+
+**2차 (수정):**
+
+- [`model/types.ts`](../src/features/challenger/model/types.ts) `GrantChallengerPointRequest.pointValue: number | null | undefined` 로 변경.
+- [`model/grantPointSchema.ts`](../src/features/challenger/model/grantPointSchema.ts) `.optional()` + `superRefine` 으로 **`CUSTOM` 일 때만 필수**.
+- [`ui/grant-points/GrantPointsForm.tsx`](../src/features/challenger/ui/grant-points/GrantPointsForm.tsx)
+  - 점수 입력 필드 라벨을 동적으로 변경 — 일반 유형은 "점수 덮어쓰기 (선택)", `CUSTOM` 은 "점수" + 필수 표시.
+  - 입력값 비우면 `field.onChange(undefined)` → 페이로드 전송 시 `pointValue: null`.
+  - 적용될 점수 미리보기 카드(teal-50 배경) 추가 — 기본값 + 덮어쓴 값 모두 즉시 반영.
+
+### 3.2 🔴 `description` 을 required 로 (가이드 A-4)
+
+가이드 표: `description | string | ✅ | 부여 사유` (필수)
+
+**1차 (잘못됨):** `.optional()` 처리. 빈 문자열로도 제출 가능 → 백엔드에서 400 가능성, 운영 책임 추적 불가.
+
+**2차 (수정):** [`model/grantPointSchema.ts`](../src/features/challenger/model/grantPointSchema.ts) 에서 `.min(1, "부여 사유를 입력해주세요.")` + `.max(200)` 로 변경. 폼의 라벨도 "설명" → "부여 사유" + 필수 표시.
+
+### 3.3 🟡 `points` 우선, `challengerPoints` 는 deprecated (가이드 A-2)
+
+가이드:
+
+> `challengerPoints` 는 deprecated 필드로 `points` 와 동일한 값. FE 에서는 `points` 를 사용할 것.
+
+**1차 (잘못됨):**
+
+```ts
+const points = data.challengerPoints ?? data.points ?? []
+```
+
+deprecated 필드를 우선 참조.
+
+**2차 (수정):** [`ui/grant-points/ChallengerRecordDetail.tsx`](../src/features/challenger/ui/grant-points/ChallengerRecordDetail.tsx) 순서를 뒤집고 인용 코멘트 추가:
+
+```ts
+// 가이드 문서 A-2 / A-3: `challengerPoints` 는 deprecated, `points` 사용 권장
+const points = data.points ?? data.challengerPoints ?? []
+```
+
+[`model/types.ts`](../src/features/challenger/model/types.ts) 의 `challengerPoints` 필드에도 `@deprecated` JSDoc 표기.
+
+### 3.4 🟡 PointType 기본 점수 메타 데이터 추가
+
+가이드 0.4 표는 18개 `PointType` 각각의 기본 점수 (-10 ~ +3) 를 정의한다. 1차에서는 이 정보가 FE 에 없어 운영자가 어떤 점수가 부여될지 알 수 없었음.
+
+**2차 추가:** [`model/enums.ts`](../src/features/challenger/model/enums.ts)
+
+```ts
+export const POINT_TYPE_META: Record<PointType, {
+  defaultPoint: number       // 기본 점수
+  requiresOverride?: boolean // CUSTOM 만 true
+  fallbackLabel?: string     // 큐레이션에서 빠진 항목용 라벨
+}> = { ... }
+
+export function formatSignedPoint(value: number): string { ... }
+```
+
+부여 폼에서:
+
+- 유형 선택 시 hint 로 **"기본 점수 -2점이 적용됩니다."** 표시
+- 적용될 점수 미리보기 카드(부호별 색상) 노출
+- `CUSTOM` 선택 시 **"기타 유형은 아래에서 점수를 직접 입력해야 합니다."** 안내
+
+### 3.5 🟡 Public View 마스킹을 타입에 반영 (가이드 A-2)
+
+가이드:
+
+> 다른 회원 조회 시에는 보안상 `email`, `status`, `memberStatus` 가 모두 `null` 로 마스킹되며, 각 challengerRecord 의 `points` 도 빈 배열로 비워진다.
+
+**1차 (잘못됨):** [`model/types.ts`](../src/features/challenger/model/types.ts) 의 해당 필드들이 non-nullable 로 선언되어 타입이 거짓말을 했다 — 운영진이 타인을 보는 본 페이지는 정확히 마스킹이 발생하는 케이스.
+
+**2차 (수정):**
+
+- `MemberInfoResponse.email`, `.status`, `.profile`, `.profileImageLink`, `ChallengerInfoResponse.email`, `.memberStatus`, `.status`, `.profileImageLink` 모두 `| null` 로 변경.
+- 각 필드에 "Public View 에서는 null 로 마스킹됨" JSDoc 코멘트.
+- [`ChallengerRecordDetail`](../src/features/challenger/ui/grant-points/ChallengerRecordDetail.tsx) 의 이메일 표시를 `data.email ?? "—"` 로 안전화.
+
+### 3.6 🟢 부수 정리
+
+- `formatSignedPoint(-2)` → `"-2"`, `formatSignedPoint(3)` → `"+3"` 헬퍼 추가하고 detail 의 점수 표기 통일.
+- `POINT_TYPE_LABEL` 을 `POINT_TYPE_OPTIONS` 큐레이션 라벨 우선 + `POINT_TYPE_META.fallbackLabel` 폴백 구조로 변경. 결과적으로 dropdown 에서 가린 `BEST_WORKBOOK` (legacy) 도 과거 기록 표시에서 라벨이 깨지지 않음.
+
+---
+
+## 4. 신규 파일 구조
+
+```
+src/features/challenger/
+├── api/
+│   ├── challenger.ts            # GET /v1/challenger/{id}
+│   ├── challengerPoint.ts       # POST /v1/challenger/{id}/points
+│   ├── challengerRecord.ts      # POST /v1/challenger-record, GET /v1/challenger-record/code/{code}
+│   ├── member.ts                # GET /v1/member/search, /v1/member/profile/{id}
+│   └── organization.ts          # GET /v1/gisu/all, /v1/chapters/with-schools, /v1/schools/all
+├── model/
+│   ├── createRecordSchema.ts    # zod — 코드 발급 폼
+│   ├── enums.ts                 # PART/POINT_TYPE/ROLE_TYPE 메타 + formatSignedPoint
+│   ├── grantPointSchema.ts      # zod — 상벌점 부여 폼 (CUSTOM 분기 포함)
+│   └── types.ts                 # request/response 타입 (Public View nullable 반영)
+├── ui/
+│   ├── grant-points/
+│   │   ├── ChallengerRecordDetail.tsx
+│   │   ├── GrantPointsForm.tsx
+│   │   ├── GrantPointsPage.tsx
+│   │   ├── MemberRecordList.tsx
+│   │   └── MemberSearchPanel.tsx
+│   ├── record-code/
+│   │   ├── CreateRecordForm.tsx
+│   │   ├── GeneratedCodeCard.tsx
+│   │   ├── LookupRecordForm.tsx
+│   │   └── RecordCodePage.tsx
+│   └── shared/
+│       ├── Dropdown.tsx         # 폼용 select 드롭다운 (FilterDropdown 과 별개)
+│       ├── FieldRow.tsx         # 라벨 + 컨트롤 + hint/error 슬롯
+│       └── SectionCard.tsx      # 페이지 섹션 카드
+└── index.ts                     # barrel — GrantPointsPage, RecordCodePage
+
+src/routes/admin/
+├── route.tsx                    # 레이아웃 (Header + sub-nav + Outlet)
+├── index.tsx                    # /admin/challenger-points 로 redirect
+├── challenger-points.tsx        # 페이지 1 라우트
+└── challenger-records.tsx       # 페이지 2 라우트
+```
+
+기존 `routes/admin/route.tsx` 는 "준비중" 한 줄짜리 페이지였는데, 두 페이지를 호스팅하는 segment layout 으로 전환하면서 `<Outlet />` + sub-nav 구조로 재작성. `/admin` 으로 직접 진입하면 `/admin/challenger-points` 로 리다이렉트.
+
+---
+
+## 5. 아키텍처 준수 체크리스트
+
+[ARCHITECTURE.md](../ARCHITECTURE.md) 기준:
+
+- ✅ HTTP 호출은 모두 `@/shared/lib/axios` 의 `api` 인스턴스 사용 + `ApiResponse<T>` unwrap
+- ✅ 라우트 파일은 `createFileRoute(...) + 페이지 컴포넌트 호출` 만 (얇은 어댑터)
+- ✅ 도메인 컴포넌트 (`Dropdown`, `FieldRow`, `SectionCard`) 는 `features/challenger/ui/shared/` 에 격리. 기존 `shared/ui/` 는 건드리지 않음
+- ✅ 타입은 `model/types.ts`, zod 스키마는 `model/*Schema.ts`
+- ✅ 모든 색상·타이포그래피는 디자인 토큰 utility (`teal-*`, `text-*`) — 임의 hex 없음
+- ✅ ESLint perfectionist import 정렬 통과
+- ✅ `index.ts` barrel 에서 외부 공개 심볼만 export (`GrantPointsPage`, `RecordCodePage`)
+- ✅ Toast 는 기존 `useToastStore` 재사용
+
+---
+
+## 6. 검증 결과
+
+| 검증        | 명령                                                        | 결과                                                                                            |
+| ----------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| TypeScript  | `pnpm exec tsc -b --noEmit`                                 | ✅ EXIT 0                                                                                       |
+| ESLint      | `pnpm exec eslint src/features/challenger src/routes/admin` | ✅ EXIT 0 (warning 0)                                                                           |
+| Vite Build  | `pnpm exec vite build`                                      | ✅ 성공, `challenger-points` / `challenger-records` 청크 분리 확인                              |
+| 라우트 트리 | `routeTree.gen.ts`                                          | ✅ `/admin`, `/admin/`, `/admin/challenger-points`, `/admin/challenger-records` 4개 라우트 등록 |
+
+---
+
+## 7. 알려진 제약 / 후속 과제
+
+1. **A-5 / A-6 미구현**: 부여된 상벌점의 사유 수정 / 삭제. `points[]` 의 각 row 옆에 액션 버튼 + 작은 모달로 추가 가능 (CtaModal 패턴).
+2. **A-1 페이지네이션 미연결**: 현재 `MemberSearchPanel` 은 `page=0&size=10` 만 호출. 무한스크롤 또는 "더 보기" 버튼 필요 여부 검토 필요.
+3. **드롭다운 reset 우회**: `CreateRecordForm` 에서 기수 변경 시 chapter/school 을 리셋하기 위해 `setValue("chapterId", undefined as unknown as number)` 사용 중. zod 스키마는 `number` 필수라 타입상 우회. 동작에는 문제 없으나 향후 zod schema 를 `.optional()` + 제출 직전에 `.refine` 으로 검증하는 형태로 깔끔히 정리 가능.
+4. **권한 처리**: 가이드의 `@CheckAccess(...)` 권한은 백엔드가 401/403 으로 응답하는 형태로 위임. FE 는 토큰 인터셉터 (`shared/lib/axios.ts`) 가 토큰 갱신 + 실패 시 로그인 리다이렉트만 처리하므로, 권한 부족 시의 사용자 친화 메시지는 추후 별도 핸들링 필요.
+5. **B-부록 미구현**: 챌린저 비활성화 / 파트 변경 / 하드 삭제는 본 페이지의 스코프 외. `ChallengerRecordDetail` 에 향후 추가 가능.
+
+---
+
+## 8. 변경 요약 (Diff Stat)
+
+```
+추가: src/features/challenger/  (api 5, model 4, ui 12, index 1) — 22 files
+수정: src/routes/admin/route.tsx (준비중 페이지 → 레이아웃)
+추가: src/routes/admin/{index,challenger-points,challenger-records}.tsx
+자동생성: src/routeTree.gen.ts (TanStack Router)
+추가: docs/2026-05-06_챌린저_관리_FE_업무보고서.md (본 문서)
+```
+
+총 신규 파일: 26 (route 3, route-gen 1, feature 22). 기존 수정: `routes/admin/route.tsx` 1개.

--- a/docs/2026-05-06_챌린저_관리_FE_업무보고서.md
+++ b/docs/2026-05-06_챌린저_관리_FE_업무보고서.md
@@ -12,8 +12,8 @@
 
 | 페이지             | 경로                        | 기능                                                        |
 | ------------------ | --------------------------- | ----------------------------------------------------------- |
-| 챌린저 상벌점 부여 | `/admin/challenger-points`  | 회원 검색 → 챌린저 기록 선택 → 상세/내역 조회 → 상벌점 부여 |
-| 챌린저 기록 코드   | `/admin/challenger-records` | 9기 이전 활동 이력의 6자리 코드 발급 + 코드 조회            |
+| 챌린저 상벌점 부여 | `/admin/challenger/points`  | 회원 검색 → 챌린저 기록 선택 → 상세/내역 조회 → 상벌점 부여 |
+| 챌린저 기록 코드   | `/admin/challenger/records` | 9기 이전 활동 이력의 6자리 코드 발급 + 코드 조회            |
 
 이번 작업은 두 단계로 진행되었다.
 
@@ -180,12 +180,13 @@ src/features/challenger/
 
 src/routes/admin/
 ├── route.tsx                    # 레이아웃 (Header + sub-nav + Outlet)
-├── index.tsx                    # /admin/challenger-points 로 redirect
-├── challenger-points.tsx        # 페이지 1 라우트
-└── challenger-records.tsx       # 페이지 2 라우트
+├── index.tsx                    # /admin/challenger/points 로 redirect
+└── challenger/
+    ├── points.tsx               # 페이지 1 라우트
+    └── records.tsx              # 페이지 2 라우트
 ```
 
-기존 `routes/admin/route.tsx` 는 "준비중" 한 줄짜리 페이지였는데, 두 페이지를 호스팅하는 segment layout 으로 전환하면서 `<Outlet />` + sub-nav 구조로 재작성. `/admin` 으로 직접 진입하면 `/admin/challenger-points` 로 리다이렉트.
+기존 `routes/admin/route.tsx` 는 "준비중" 한 줄짜리 페이지였는데, 두 페이지를 호스팅하는 segment layout 으로 전환하면서 `<Outlet />` + sub-nav 구조로 재작성. `/admin` 으로 직접 진입하면 `/admin/challenger/points` 로 리다이렉트.
 
 ---
 
@@ -210,8 +211,8 @@ src/routes/admin/
 | ----------- | ----------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | TypeScript  | `pnpm exec tsc -b --noEmit`                                 | ✅ EXIT 0                                                                                       |
 | ESLint      | `pnpm exec eslint src/features/challenger src/routes/admin` | ✅ EXIT 0 (warning 0)                                                                           |
-| Vite Build  | `pnpm exec vite build`                                      | ✅ 성공, `challenger-points` / `challenger-records` 청크 분리 확인                              |
-| 라우트 트리 | `routeTree.gen.ts`                                          | ✅ `/admin`, `/admin/`, `/admin/challenger-points`, `/admin/challenger-records` 4개 라우트 등록 |
+| Vite Build  | `pnpm exec vite build`                                      | ✅ 성공, `challenger/points` / `challenger/records` 청크 분리 확인                              |
+| 라우트 트리 | `routeTree.gen.ts`                                          | ✅ `/admin`, `/admin/`, `/admin/challenger/points`, `/admin/challenger/records` 4개 라우트 등록 |
 
 ---
 
@@ -230,7 +231,7 @@ src/routes/admin/
 ```
 추가: src/features/challenger/  (api 5, model 4, ui 12, index 1) — 22 files
 수정: src/routes/admin/route.tsx (준비중 페이지 → 레이아웃)
-추가: src/routes/admin/{index,challenger-points,challenger-records}.tsx
+추가: src/routes/admin/index.tsx, src/routes/admin/challenger/{points,records}.tsx
 자동생성: src/routeTree.gen.ts (TanStack Router)
 추가: docs/2026-05-06_챌린저_관리_FE_업무보고서.md (본 문서)
 ```

--- a/docs/챌린저_관리_FE_API_가이드.md
+++ b/docs/챌린저_관리_FE_API_가이드.md
@@ -1,0 +1,918 @@
+# 챌린저 관리 FE API 가이드
+
+> 작성일: 2026-05-06
+>
+> 본 문서는 두 가지 플로우에 사용되는 백엔드 API의 request/response 스펙을 FE 관점에서 정리한 것입니다.
+>
+> - **플로우 A — 운영진 흐름**: 회원 검색 → 회원의 챌린저 기록 조회 → 특정 챌린저 기록 상세 → 상벌점 부여
+> - **플로우 B — 챌린저 기록 부여 및 정보 조회**: 6자리 코드 발급/사용/조회 + 신규 챌린저 등록
+
+---
+
+## 0. 공통 사항
+
+### 0.1 Base URL & 인증
+
+- 모든 엔드포인트는 `/api/v1/...` 접두사를 가진다.
+- `[Public]` 으로 표시되지 않은 엔드포인트는 모두 **Authorization 헤더 필수**.
+  ```
+  Authorization: Bearer {accessToken}
+  ```
+- 본 문서의 모든 엔드포인트는 인증 필요 (Public 없음).
+
+### 0.2 응답 래핑 (`ApiResponse`)
+
+[GlobalResponseWrapper.java](src/main/java/com/umc/product/global/response/GlobalResponseWrapper.java) 에 의해 **모든 컨트롤러 응답은 자동으로 다음 형태로 래핑**된다.
+
+**성공 응답:**
+
+```json
+{
+  "success": true,
+  "code": "COMMON-200",
+  "message": "성공입니다.",
+  "result": <컨트롤러가 리턴한 값>
+}
+```
+
+**실패 응답 (에러):**
+
+```json
+{
+  "success": false,
+  "code": "CHALLENGER-0001",
+  "message": "챌린저를 찾을 수 없습니다.",
+  "result": null
+}
+```
+
+> 본 문서의 "Response" 섹션에는 **`result` 안에 들어가는 값만** 기술한다. FE 에서는 항상 `response.result` 로 접근해야 한다.
+
+### 0.3 페이지네이션 형식
+
+#### Offset 기반 (`PageResponse<T>`)
+
+[PageResponse.java](src/main/java/com/umc/product/global/response/PageResponse.java)
+
+```json
+{
+  "content": [
+    /* T[] */
+  ],
+  "page": 0,
+  "size": 20,
+  "totalElements": 153,
+  "totalPages": 8,
+  "hasNext": true,
+  "hasPrevious": false
+}
+```
+
+- 요청 쿼리: `?page=0&size=20&sort=id,desc` (Spring `Pageable` 표준)
+
+#### Cursor 기반 (`CursorResponse<T>`)
+
+[CursorResponse.java](src/main/java/com/umc/product/global/response/CursorResponse.java)
+
+```json
+{
+  "content": [
+    /* T[] */
+  ],
+  "nextCursor": 12345,
+  "hasNext": true
+}
+```
+
+- 요청 쿼리: `?cursor=12345&size=20` (`cursor` 미전달 시 첫 페이지). `size` 기본 20, 최대 50.
+
+### 0.4 주요 Enum
+
+| Enum                         | 값                                                                                                                                                                                                                                                  |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ChallengerPart`             | `PLAN`, `DESIGN`, `WEB`, `ANDROID`, `IOS`, `NODEJS`, `SPRINGBOOT`, `ADMIN`                                                                                                                                                                          |
+| `ChallengerStatus`           | `ACTIVE`, `GRADUATED`, `EXPELLED`, `WITHDRAWN`                                                                                                                                                                                                      |
+| `MemberStatus`               | `ACTIVE`, `INACTIVE`, `WITHDRAWN`                                                                                                                                                                                                                   |
+| `ChallengerRoleType`         | `SUPER_ADMIN` / `CENTRAL_PRESIDENT` / `CENTRAL_VICE_PRESIDENT` / `CENTRAL_OPERATING_TEAM_MEMBER` / `CENTRAL_EDUCATION_TEAM_MEMBER` / `CHAPTER_PRESIDENT` / `SCHOOL_PRESIDENT` / `SCHOOL_VICE_PRESIDENT` / `SCHOOL_PART_LEADER` / `SCHOOL_ETC_ADMIN` |
+| `ChallengerDeactivationType` | `WITHDRAW` (탈부), `EXPEL` (제명)                                                                                                                                                                                                                   |
+| `OrganizationType`           | `CENTRAL`, `CHAPTER`, `SCHOOL`                                                                                                                                                                                                                      |
+
+#### `PointType` (상벌점 유형) — [PointType.java](src/main/java/com/umc/product/challenger/domain/enums/PointType.java)
+
+각 유형은 **고정 점수**를 가지지만, 요청 시 `pointValue` 를 함께 보내면 **그 값으로 덮어쓸 수 있다** (`pointValue` null 이면 아래 표의 기본값 사용).
+
+| Enum 값                          | 기본 점수 | 설명                              |
+| -------------------------------- | --------: | --------------------------------- |
+| `BLOG_CHALLENGE`                 |      +3.0 | 블로그 챌린지 참여 (매주 최대 +3) |
+| `BEST_WORKBOOK_V2`               |      +2.0 | 베스트 워크북 (10기~)             |
+| `UMC_EVENT_REVIEW`               |      +1.0 | 행사 리뷰어                       |
+| `PEER_REVIEW_SUBMISSION`         |      +1.0 | PeerReview 작성                   |
+| `OUT`                            |      +1.0 | 아웃                              |
+| `WARNING`                        |       0.0 | 경고                              |
+| `CUSTOM`                         |       0.0 | 자체 제도 운영 (ex. 가천대)       |
+| `BEST_WORKBOOK`                  |      -0.5 | 베스트 워크북 (~9기, 레거시)      |
+| `STUDY_LATE`                     |      -2.0 | 스터디 무단 지각                  |
+| `STUDY_ABSENT`                   |      -4.0 | 스터디 무단 불참                  |
+| `EVENT_LATE`                     |      -2.0 | 행사 무단 지각                    |
+| `EVENT_EARLY_LEAVE`              |      -2.0 | 행사 중도 퇴실                    |
+| `EVENT_LATE_CANCEL`              |      -4.0 | 행사 기간 외 취소                 |
+| `EVENT_NO_SHOW`                  |     -10.0 | 노쇼 (무단 결석)                  |
+| `NO_WORKBOOK_MISSION`            |      -4.0 | 과제 미수행                       |
+| `PART_LEAD_FEEDBACK_LATE`        |      -4.0 | 기간 외 피드백                    |
+| `SCHOOL_CORE_MEETING_ABSENT`     |      -4.0 | 회의 무단 불참                    |
+| `SCHOOL_CORE_TASK_NOT_COMPLETED` |      -4.0 | 업무 무단 불이행                  |
+
+---
+
+# 플로우 A — 운영진 흐름
+
+운영진이 회원을 검색해서 특정 회원의 챌린저 기록(기수별 활동 이력)을 확인하고, 해당 챌린저 기록에 상벌점을 부여하는 흐름.
+
+```
+[A-1] 회원 검색
+    ↓ memberId 획득
+[A-2] 회원 정보 조회 (챌린저 기록 목록 포함)
+    ↓ challengerId 선택
+[A-3] 챌린저 기록 상세 조회 (상벌점 목록 포함)
+    ↓
+[A-4] 상벌점 부여 / [A-5] 사유 수정 / [A-6] 삭제
+```
+
+---
+
+## A-1. 회원 검색 — `[MEMBER-103]`
+
+[MemberQueryController.java:50-59](src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java#L50-L59)
+
+이름 / 닉네임 / 이메일 / 학교명을 키워드로 검색하고, 기수·파트·지부·학교로 필터링한다.
+
+### 요청
+
+```
+GET /api/v1/member/search
+```
+
+**Query Parameters** (모두 optional)
+
+| 이름        | 타입                  | 설명                                  |
+| ----------- | --------------------- | ------------------------------------- |
+| `keyword`   | string                | 이름/닉네임/이메일/학교명 통합 키워드 |
+| `gisuId`    | long                  | 기수 ID 필터                          |
+| `part`      | enum `ChallengerPart` | 파트 필터                             |
+| `chapterId` | long                  | 지부 ID 필터                          |
+| `schoolId`  | long                  | 학교 ID 필터                          |
+| `page`      | int                   | 페이지 번호(0-base, 기본 0)           |
+| `size`      | int                   | 페이지 크기(기본 20)                  |
+| `sort`      | string                | 정렬, 예: `id,desc`                   |
+
+### 응답 (`result` 내부)
+
+[SearchMemberResponse.java](src/main/java/com/umc/product/member/adapter/in/web/dto/response/SearchMemberResponse.java)
+
+```json
+{
+  "totalCount": 153,
+  "page": {
+    "content": [
+      {
+        "memberId": 12,
+        "name": "홍길동",
+        "nickname": "gildong",
+        "email": null,
+        "schoolId": 1,
+        "schoolName": "가천대학교",
+        "profileImageLink": "https://.../profile.png",
+        "challengerId": 401,
+        "gisuId": 9,
+        "gisu": 9,
+        "part": "WEB",
+        "roleTypes": ["SCHOOL_PART_LEADER"]
+      }
+    ],
+    "page": 0,
+    "size": 20,
+    "totalElements": 153,
+    "totalPages": 8,
+    "hasNext": true,
+    "hasPrevious": false
+  }
+}
+```
+
+> `challengerId` / `gisuId` / `gisu` / `part` / `roleTypes` 는 해당 회원의 **현재(가장 최근) 챌린저 기록** 한 건 기준으로 채워진다. 전체 기록은 [A-2](#a-2-회원-정보-조회--member-101) 에서 조회한다.
+
+---
+
+## A-2. 회원 정보 조회 — `[MEMBER-101]`
+
+[MemberQueryController.java:32-42](src/main/java/com/umc/product/member/adapter/in/web/MemberQueryController.java#L32-L42)
+
+회원 프로필과 함께 **모든 챌린저 기록(기수별)** 을 한 번에 받아온다.
+
+### 요청
+
+```
+GET /api/v1/member/profile/{memberId}
+```
+
+**Path Parameters**
+
+| 이름       | 타입 | 설명         |
+| ---------- | ---- | ------------ |
+| `memberId` | long | 대상 회원 ID |
+
+권한: `@CheckAccess(MEMBER, READ)`
+
+### 응답 (`result` 내부)
+
+[MemberInfoResponse.java](src/main/java/com/umc/product/member/adapter/in/web/dto/response/MemberInfoResponse.java)
+
+```json
+{
+  "id": 12,
+  "name": "홍길동",
+  "nickname": "gildong",
+  "email": null,
+  "schoolId": 1,
+  "schoolName": "가천대학교",
+  "profileImageLink": "https://.../profile.png",
+  "status": null,
+  "roles": [
+    {
+      "id": 88,
+      "challengerId": 401,
+      "roleType": "SCHOOL_PART_LEADER",
+      "organizationType": "SCHOOL",
+      "organizationId": 1,
+      "responsiblePart": "WEB",
+      "gisuId": 9
+    }
+  ],
+  "challengerRecords": [
+    {
+      "challengerId": 401,
+      "memberId": 12,
+      "gisuId": 9,
+      "gisu": 9,
+      "chapterId": 3,
+      "chapterName": "수도권",
+      "part": "WEB",
+      "challengerStatus": "ACTIVE",
+      "points": [],
+      "challengerPoints": [],
+      "totalPoints": 0.0,
+      "roles": [],
+      "name": "홍길동",
+      "nickname": "gildong",
+      "email": null,
+      "schoolId": 1,
+      "schoolName": "가천대학교",
+      "profileImageLink": "https://.../profile.png",
+      "memberStatus": null,
+      "status": null
+    }
+  ],
+  "profile": null
+}
+```
+
+> **주의 — Public View:** 다른 회원 조회 시에는 보안상 `email`, `status`, `memberStatus` 가 모두 `null` 로 마스킹되며, 각 challengerRecord 의 `points` 도 빈 배열로 비워진다. 본인 조회 (`/me`) 와는 차이가 있음.
+
+> **본인 프로필 조회:** `GET /api/v1/member/me` — 동일 응답 구조이며 마스킹 없음 (이번 플로우에는 운영진이 타인을 보는 경우만 사용).
+
+> `challengerPoints` 는 deprecated 필드로 `points` 와 동일한 값. FE 에서는 `points` 를 사용할 것.
+
+---
+
+## A-3. 챌린저 기록 상세 조회 — `[CHALLENGER-101]`
+
+[ChallengerQueryController.java:44-48](src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerQueryController.java#L44-L48)
+
+특정 챌린저 기록 1건의 전체 상세 (상벌점 목록 + 역할 + 회원 정보 포함).
+
+### 요청
+
+```
+GET /api/v1/challenger/{challengerId}
+```
+
+**Path Parameters**
+
+| 이름           | 타입 | 설명           |
+| -------------- | ---- | -------------- |
+| `challengerId` | long | 챌린저 기록 ID |
+
+### 응답 (`result` 내부)
+
+[ChallengerInfoResponse.java](src/main/java/com/umc/product/challenger/adapter/in/web/dto/response/ChallengerInfoResponse.java)
+
+```json
+{
+  "challengerId": 401,
+  "memberId": 12,
+  "gisuId": 9,
+  "gisu": 9,
+  "chapterId": 3,
+  "chapterName": "수도권",
+  "part": "WEB",
+  "challengerStatus": "ACTIVE",
+  "points": [
+    {
+      "id": 9001,
+      "challengerId": 401,
+      "pointType": "STUDY_LATE",
+      "point": -2.0,
+      "description": "5/2 스터디 15분 지각",
+      "createdAt": "2026-05-02T13:05:00Z"
+    }
+  ],
+  "challengerPoints": [
+    /* 위와 동일, deprecated */
+  ],
+  "totalPoints": -2.0,
+  "roles": [
+    {
+      "challengerRoleId": 88,
+      "challengerId": 401,
+      "roleType": "SCHOOL_PART_LEADER",
+      "organizationType": "SCHOOL",
+      "organizationId": 1,
+      "responsiblePart": "WEB",
+      "gisuId": 9,
+      "gisu": 9
+    }
+  ],
+  "name": "홍길동",
+  "nickname": "gildong",
+  "email": null,
+  "schoolId": 1,
+  "schoolName": "가천대학교",
+  "profileImageLink": "https://.../profile.png",
+  "memberStatus": "ACTIVE",
+  "status": "ACTIVE"
+}
+```
+
+> `points[].point` 는 `pointType` 의 기본값 또는 부여 시 명시한 `pointValue` 가 반영된 **실제 적용된 값**.
+>
+> `totalPoints` 는 모든 `points[].point` 의 합산.
+
+**주요 에러:**
+
+- `CHALLENGER-0001` (404) — 챌린저 기록 없음
+
+---
+
+## A-4. 챌린저 상벌점 부여 — `[POINT-001]`
+
+[ChallengerPointCommandController.java:38-47](src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java#L38-L47)
+
+권한: `@CheckAccess(CHALLENGER_POINT, WRITE)` — 중앙운영사무국 소속 또는 해당 챌린저의 **학교 회장단** 만 부여 가능.
+
+### 요청
+
+```
+POST /api/v1/challenger/{challengerId}/points
+Content-Type: application/json
+```
+
+**Path Parameters**
+
+| 이름           | 타입 | 설명                     |
+| -------------- | ---- | ------------------------ |
+| `challengerId` | long | 부여 대상 챌린저 기록 ID |
+
+**Request Body** — [GrantChallengerPointRequest.java](src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/GrantChallengerPointRequest.java)
+
+| 필드          | 타입             | 필수        | 설명                                                                                             |
+| ------------- | ---------------- | ----------- | ------------------------------------------------------------------------------------------------ |
+| `pointType`   | `PointType` enum | ✅          | 상벌점 유형                                                                                      |
+| `pointValue`  | integer          | ⛔ optional | **null 이면 `pointType` 의 기본 점수 사용**. 명시 시 그 값으로 덮어씀 (`CUSTOM` 등 자체 제도용). |
+| `description` | string           | ✅          | 부여 사유                                                                                        |
+
+```json
+{
+  "pointType": "STUDY_LATE",
+  "pointValue": null,
+  "description": "5/2 스터디 15분 지각"
+}
+```
+
+또는 자체 제도용 커스텀 점수:
+
+```json
+{
+  "pointType": "CUSTOM",
+  "pointValue": -3,
+  "description": "가천대 자체 규정 위반"
+}
+```
+
+### 응답 (`result` 내부)
+
+부여 후의 [ChallengerInfoResponse](#a-3-챌린저-기록-상세-조회--challenger-101) — 새로 부여된 상벌점이 `points` 배열에 포함되어 반환된다.
+
+**주요 에러:**
+
+- `CHALLENGER-0001` (404) — 챌린저 기록 없음
+- `CHALLENGER-0004` (400) — 챌린저 상태 비유효 (이미 졸업/탈부 등)
+- 권한 부족 — 401/403
+
+---
+
+## A-5. 챌린저 상벌점 사유 수정 — `[POINT-002]`
+
+[ChallengerPointCommandController.java:55-62](src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java#L55-L62)
+
+권한: `@CheckAccess(CHALLENGER_POINT, EDIT)` — 중앙운영사무국 또는 해당 챌린저의 학교 회장단.
+
+### 요청
+
+```
+PATCH /api/v1/challenger/points/{challengerPointId}
+Content-Type: application/json
+```
+
+**Path Parameters**
+
+| 이름                | 타입 | 설명                                   |
+| ------------------- | ---- | -------------------------------------- |
+| `challengerPointId` | long | 수정할 상벌점 row ID (= `points[].id`) |
+
+**Request Body** — [EditChallengerPointRequest.java](src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/EditChallengerPointRequest.java)
+
+| 필드             | 타입   | 필수 | 설명        |
+| ---------------- | ------ | ---- | ----------- |
+| `newDescription` | string | ✅   | 변경할 사유 |
+
+```json
+{ "newDescription": "5/2 스터디 12분 지각으로 정정" }
+```
+
+### 응답
+
+`204 No Content` — `result: null`
+
+```json
+{
+  "success": true,
+  "code": "COMMON-200",
+  "message": "성공입니다.",
+  "result": null
+}
+```
+
+**주요 에러:**
+
+- `CHALLENGER-0007` (404) — 상벌점 row 없음
+
+---
+
+## A-6. 챌린저 상벌점 삭제 — `[POINT-003]`
+
+[ChallengerPointCommandController.java:70-76](src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerPointCommandController.java#L70-L76)
+
+권한: `@CheckAccess(CHALLENGER_POINT, DELETE)` — **중앙운영사무국 총괄단(`CENTRAL_PRESIDENT`, `CENTRAL_VICE_PRESIDENT`)** 만 가능.
+
+### 요청
+
+```
+DELETE /api/v1/challenger/points/{challengerPointId}
+```
+
+### 응답
+
+`204 No Content` — `result: null`
+
+---
+
+## A-보조: 챌린저 검색 (운영진용)
+
+회원이 아닌 **챌린저 기록(기수+파트별 활동)** 을 직접 검색할 때 사용. A-1 (회원 검색) 과 결과 단위가 다르다 — A-1 은 회원 단위, 이 API 는 (회원, 기수) 단위.
+
+### A-보조-1. Cursor 기반 — `[CHALLENGER-102]`
+
+[ChallengerSearchController.java:39-50](src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerSearchController.java#L39-L50)
+
+```
+GET /api/v1/challenger/search/cursor
+```
+
+**Query Parameters** ([SearchChallengerCursorRequest.java](src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/SearchChallengerCursorRequest.java))
+
+| 이름        | 타입             | 설명                                                         |
+| ----------- | ---------------- | ------------------------------------------------------------ |
+| `cursor`    | long             | 직전 페이지 마지막 challengerId, 첫 페이지 시 미전달         |
+| `size`      | int              | 기본 20, 최대 50                                             |
+| `keyword`   | string           | 이름 또는 닉네임 통합 검색 (있으면 `name` / `nickname` 무시) |
+| `name`      | string           | 이름 부분일치                                                |
+| `nickname`  | string           | 닉네임 부분일치                                              |
+| `schoolId`  | long             | 학교 ID                                                      |
+| `chapterId` | long             | 지부 ID                                                      |
+| `part`      | `ChallengerPart` | 파트                                                         |
+| `gisuId`    | long             | 기수 ID                                                      |
+
+> 모든 필터는 `AND` 조건. `keyword` 제공 시 `name`/`nickname` 은 무시되지만 다른 필터는 유효.
+>
+> 결과는 **`ACTIVE`** 상태의 챌린저로 한정됨.
+
+**응답 (`result`)** — [CursorSearchChallengerResponse.java](src/main/java/com/umc/product/challenger/adapter/in/web/dto/response/CursorSearchChallengerResponse.java)
+
+```json
+{
+  "cursor": {
+    "content": [
+      {
+        "challengerId": 401,
+        "memberId": 12,
+        "gisuId": 9,
+        "generation": 9,
+        "gisu": 9,
+        "part": "WEB",
+        "name": "홍길동",
+        "nickname": "gildong",
+        "schoolName": "가천대학교",
+        "pointSum": -2.0,
+        "profileImageLink": "https://.../profile.png",
+        "roleTypes": ["SCHOOL_PART_LEADER"]
+      }
+    ],
+    "nextCursor": 401,
+    "hasNext": true
+  },
+  "partCounts": [
+    { "part": "PLAN", "count": 12 },
+    { "part": "DESIGN", "count": 8 },
+    { "part": "WEB", "count": 30 },
+    { "part": "ANDROID", "count": 5 },
+    { "part": "IOS", "count": 4 },
+    { "part": "NODEJS", "count": 7 },
+    { "part": "SPRINGBOOT", "count": 11 }
+  ]
+}
+```
+
+> `generation` 은 deprecated, `gisu` 사용 권장.
+>
+> `partCounts` 는 **현재 필터 조건에 매칭되는 전체** 의 파트별 카운트 (페이지 기준이 아님).
+
+### A-보조-2. Offset 기반 — `[CHALLENGER-103]`
+
+[ChallengerSearchController.java:52-64](src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerSearchController.java#L52-L64)
+
+```
+GET /api/v1/challenger/search/offset?page=0&size=20&sort=id,desc
+```
+
+쿼리 필터는 cursor 와 동일(`cursor` 제외, `page`/`size`/`sort` 추가).
+
+**응답 (`result`)** — [SearchChallengerResponse.java](src/main/java/com/umc/product/challenger/adapter/in/web/dto/response/SearchChallengerResponse.java)
+
+```json
+{
+  "page": {
+    "content": [
+      /* SearchChallengerItemResponse[] (cursor 응답과 동일) */
+    ],
+    "page": 0,
+    "size": 20,
+    "totalElements": 77,
+    "totalPages": 4,
+    "hasNext": true,
+    "hasPrevious": false
+  },
+  "partCounts": [
+    /* 동일 */
+  ]
+}
+```
+
+---
+
+# 플로우 B — 챌린저 기록 부여 및 정보 조회
+
+챌린저 기록(`Challenger`)을 만드는 두 가지 방식과, 기록을 조회하는 API.
+
+```
+[방식 1] 현재 기수 챌린저 등록 (관리자가 회원 ID로 직접 생성)
+  [B-1] POST /api/v1/challenger
+  [B-2] POST /api/v1/challenger/batch  (다건)
+
+[방식 2] 과거 기수 코드 기반 등록 (관리자가 코드 발급 → 회원이 코드 입력)
+  [B-3] POST /api/v1/challenger-record           (관리자 — 코드 발급)
+  [B-4] POST /api/v1/challenger-record/bulk      (관리자 — 다건 코드 발급)
+  [B-5] POST /api/v1/challenger-record/member    (회원 — 코드 사용)
+
+[조회]
+  [B-6] GET  /api/v1/challenger-record/code/{code}
+  [B-7] GET  /api/v1/challenger-record/id/{id}
+```
+
+---
+
+## B-1. 챌린저 직접 생성 — `[CHALLENGER-001]`
+
+[ChallengerCommandController.java:40-46](src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java#L40-L46)
+
+권한: `@CheckAccess(CHALLENGER, WRITE)`
+
+### 요청
+
+```
+POST /api/v1/challenger
+Content-Type: application/json
+```
+
+**Request Body** — [CreateChallengerInfoRequest.java](src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/CreateChallengerInfoRequest.java)
+
+| 필드       | 타입             | 필수 | 설명         |
+| ---------- | ---------------- | ---- | ------------ |
+| `memberId` | long             | ✅   | 대상 회원 ID |
+| `part`     | `ChallengerPart` | ✅   | 파트         |
+| `gisuId`   | long             | ✅   | 기수 ID      |
+
+```json
+{ "memberId": 12, "part": "WEB", "gisuId": 10 }
+```
+
+### 응답 (`result`)
+
+생성된 챌린저의 [ChallengerInfoResponse](#a-3-챌린저-기록-상세-조회--challenger-101).
+
+---
+
+## B-2. 챌린저 다건 생성 — `[CHALLENGER-002]`
+
+[ChallengerCommandController.java:52-64](src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java#L52-L64)
+
+권한: `@CheckAccess(CHALLENGER, WRITE)`
+
+### 요청
+
+```
+POST /api/v1/challenger/batch
+Content-Type: application/json
+```
+
+**Request Body** — `CreateChallengerInfoRequest[]`
+
+```json
+[
+  { "memberId": 12, "part": "WEB", "gisuId": 10 },
+  { "memberId": 13, "part": "DESIGN", "gisuId": 10 }
+]
+```
+
+### 응답 (`result`)
+
+`ChallengerInfoResponse[]` — 각 항목은 [A-3 응답](#a-3-챌린저-기록-상세-조회--challenger-101) 과 동일.
+
+> 한 건이라도 실패하면 트랜잭션 자체는 항목별로 별도 호출되므로 부분 성공이 발생할 수 있음. FE 에서는 입력 길이와 응답 길이를 비교하여 실패 항목을 식별할 것 (정밀한 실패 보고가 필요하면 단건 API 반복 호출 권장).
+
+---
+
+## B-3. 챌린저 기록 코드 발급 (관리자) — `[CHALLENGER-RECORD-002]`
+
+[ChallengerRecordController.java:89-114](src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java#L89-L114)
+
+권한: `@CheckAccess(CHALLENGER_RECORD, WRITE)` — 중앙운영사무국 총괄단 전용. 9기 이전 기수의 활동 이력을 6자리 코드로 발급한다.
+
+### 요청
+
+```
+POST /api/v1/challenger-record
+Content-Type: application/json
+```
+
+**Request Body** — [CreateChallengerRecordRequest.java](src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/CreateChallengerRecordRequest.java)
+
+| 필드                 | 타입                 | 필수 | 설명                                        |
+| -------------------- | -------------------- | ---- | ------------------------------------------- |
+| `gisuId`             | long                 | ✅   | 기수 ID                                     |
+| `chapterId`          | long                 | ✅   | 지부 ID                                     |
+| `schoolId`           | long                 | ✅   | 학교 ID                                     |
+| `part`               | `ChallengerPart`     | ✅   | 파트                                        |
+| `memberName`         | string               | ✅   | 챌린저 본명 (코드 사용 시 일치 검증에 사용) |
+| `challengerRoleType` | `ChallengerRoleType` | ✅   | 해당 기수에서의 역할                        |
+
+```json
+{
+  "gisuId": 8,
+  "chapterId": 3,
+  "schoolId": 1,
+  "part": "WEB",
+  "memberName": "김챌린저",
+  "challengerRoleType": "SCHOOL_PRESIDENT"
+}
+```
+
+### 응답 (`result`)
+
+[ChallengerRecordResponse.java](src/main/java/com/umc/product/challenger/adapter/in/web/dto/response/ChallengerRecordResponse.java)
+
+```json
+{
+  "code": "AB12CD",
+  "part": "WEB",
+  "gisuId": 8,
+  "gisu": 8,
+  "schoolId": 1,
+  "schoolName": "가천대학교",
+  "chapterId": 3,
+  "chapterName": "수도권",
+  "memberName": "김챌린저",
+  "challengerRoleType": "SCHOOL_PRESIDENT",
+  "organizationId": 1
+}
+```
+
+> `code` 가 발급된 6자리 문자열. 회원에게 전달하여 [B-5](#b-5-회원-계정에-챌린저-기록-추가-코드-사용--challenger-record-001) 에서 사용하게 한다.
+
+---
+
+## B-4. 챌린저 기록 코드 다건 발급 — `[CHALLENGER-RECORD-003]`
+
+[ChallengerRecordController.java:123-147](src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java#L123-L147)
+
+권한: `@CheckAccess(CHALLENGER_RECORD, WRITE)`
+
+### 요청
+
+```
+POST /api/v1/challenger-record/bulk
+Content-Type: application/json
+```
+
+**Request Body** — `CreateChallengerRecordRequest[]` (B-3 의 객체 배열)
+
+### 응답 (`result`)
+
+성능 이슈로 ID 만 반환 — 실제 코드 / 정보는 [B-7](#b-7-id-로-챌린저-기록-조회--challenger-record-102) 로 개별 조회.
+
+```json
+[1001, 1002, 1003]
+```
+
+---
+
+## B-5. 회원 계정에 챌린저 기록 추가 (코드 사용) — `[CHALLENGER-RECORD-001]`
+
+[ChallengerRecordController.java:43-58](src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java#L43-L58)
+
+로그인한 회원이 6자리 코드를 입력하여 본인 계정에 챌린저 기록과 권한을 추가한다. 각 코드는 1회 사용 후 소진된다.
+
+### 요청
+
+```
+POST /api/v1/challenger-record/member
+Content-Type: application/json
+Authorization: Bearer {accessToken}
+```
+
+**Request Body** — [AddChallengerRecordToMemberRequest.java](src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/AddChallengerRecordToMemberRequest.java)
+
+| 필드   | 타입   | 필수 | 설명       |
+| ------ | ------ | ---- | ---------- |
+| `code` | string | ✅   | 6자리 코드 |
+
+```json
+{ "code": "AB12CD" }
+```
+
+### 응답
+
+`204 No Content` — `result: null`
+
+**주요 에러:**
+
+- `CHALLENGER-0012` (400) — 코드 없음 또는 이미 사용됨
+- `CHALLENGER-0013` (400) — 코드의 `memberName` 과 현재 회원 이름 불일치
+- `CHALLENGER-0014` (400) — 코드의 학교와 현재 회원 학교 불일치
+
+---
+
+## B-6. 코드로 챌린저 기록 조회 — `[CHALLENGER-RECORD-101]`
+
+[ChallengerRecordController.java:64-70](src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java#L64-L70)
+
+권한: `@CheckAccess(CHALLENGER_RECORD, READ)`
+
+### 요청
+
+```
+GET /api/v1/challenger-record/code/{code}
+```
+
+| 이름   | 타입   | 설명       |
+| ------ | ------ | ---------- |
+| `code` | string | 6자리 코드 |
+
+### 응답 (`result`)
+
+[ChallengerRecordResponse](#b-3-챌린저-기록-코드-발급-관리자--challenger-record-002) 와 동일.
+
+---
+
+## B-7. ID 로 챌린저 기록 조회 — `[CHALLENGER-RECORD-102]`
+
+[ChallengerRecordController.java:76-82](src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerRecordController.java#L76-L82)
+
+권한: `@CheckAccess(CHALLENGER_RECORD, READ)`
+
+### 요청
+
+```
+GET /api/v1/challenger-record/id/{id}
+```
+
+| 이름 | 타입 | 설명                                                                                                             |
+| ---- | ---- | ---------------------------------------------------------------------------------------------------------------- |
+| `id` | long | 챌린저 기록(코드) 의 DB ID — [B-4 bulk 응답](#b-4-챌린저-기록-코드-다건-발급--challenger-record-003) 으로 반환됨 |
+
+### 응답 (`result`)
+
+[ChallengerRecordResponse](#b-3-챌린저-기록-코드-발급-관리자--challenger-record-002) 와 동일.
+
+---
+
+## B-부록. 챌린저 기록 변경/삭제
+
+### B-부록-1. 챌린저 비활성화 (제명/탈부) — `[CHALLENGER-003]`
+
+[ChallengerCommandController.java:70-77](src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java#L70-L77) · 권한: `@CheckAccess(CHALLENGER, DELETE)`
+
+```
+POST /api/v1/challenger/{challengerId}/deactivate
+```
+
+**Body** — [DeactivateChallengerRequest.java](src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/DeactivateChallengerRequest.java)
+
+```json
+{
+  "deactivationType": "EXPEL",
+  "modifiedBy": 1,
+  "reason": "출석 4회 누락"
+}
+```
+
+- `deactivationType`: `WITHDRAW` (탈부) | `EXPEL` (제명)
+
+응답: `204 No Content`
+
+### B-부록-2. 챌린저 파트 변경 — `[CHALLENGER-004]`
+
+[ChallengerCommandController.java:84-93](src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java#L84-L93) · 권한: `@CheckAccess(CHALLENGER, EDIT)`
+
+```
+PATCH /api/v1/challenger/{challengerId}/part
+```
+
+**Body** — [EditChallengerPartRequest.java](src/main/java/com/umc/product/challenger/adapter/in/web/dto/request/EditChallengerPartRequest.java)
+
+```json
+{ "newPart": "DESIGN" }
+```
+
+응답: 변경 후 [ChallengerInfoResponse](#a-3-챌린저-기록-상세-조회--challenger-101).
+
+### B-부록-3. 챌린저 하드 삭제 — `[CHALLENGER-005]`
+
+[ChallengerCommandController.java:99-104](src/main/java/com/umc/product/challenger/adapter/in/web/ChallengerCommandController.java#L99-L104) · 권한: `@CheckAccess(CHALLENGER, DELETE)`
+
+```
+DELETE /api/v1/challenger/{challengerId}
+```
+
+응답: `204 No Content`. ⚠️ 복구 불가.
+
+---
+
+# 부록. 엔드포인트 요약 표
+
+## 플로우 A — 운영진 흐름
+
+| #        | 코드           | Method | Path                                            | 권한                      |
+| -------- | -------------- | ------ | ----------------------------------------------- | ------------------------- |
+| A-1      | MEMBER-103     | GET    | `/api/v1/member/search`                         | 인증                      |
+| A-2      | MEMBER-101     | GET    | `/api/v1/member/profile/{memberId}`             | `MEMBER:READ`             |
+| A-3      | CHALLENGER-101 | GET    | `/api/v1/challenger/{challengerId}`             | 인증                      |
+| A-4      | POINT-001      | POST   | `/api/v1/challenger/{challengerId}/points`      | `CHALLENGER_POINT:WRITE`  |
+| A-5      | POINT-002      | PATCH  | `/api/v1/challenger/points/{challengerPointId}` | `CHALLENGER_POINT:EDIT`   |
+| A-6      | POINT-003      | DELETE | `/api/v1/challenger/points/{challengerPointId}` | `CHALLENGER_POINT:DELETE` |
+| A-보조-1 | CHALLENGER-102 | GET    | `/api/v1/challenger/search/cursor`              | 인증                      |
+| A-보조-2 | CHALLENGER-103 | GET    | `/api/v1/challenger/search/offset`              | 인증                      |
+
+## 플로우 B — 챌린저 기록 부여 및 조회
+
+| #        | 코드                  | Method | Path                                           | 권한                      |
+| -------- | --------------------- | ------ | ---------------------------------------------- | ------------------------- |
+| B-1      | CHALLENGER-001        | POST   | `/api/v1/challenger`                           | `CHALLENGER:WRITE`        |
+| B-2      | CHALLENGER-002        | POST   | `/api/v1/challenger/batch`                     | `CHALLENGER:WRITE`        |
+| B-3      | CHALLENGER-RECORD-002 | POST   | `/api/v1/challenger-record`                    | `CHALLENGER_RECORD:WRITE` |
+| B-4      | CHALLENGER-RECORD-003 | POST   | `/api/v1/challenger-record/bulk`               | `CHALLENGER_RECORD:WRITE` |
+| B-5      | CHALLENGER-RECORD-001 | POST   | `/api/v1/challenger-record/member`             | 인증                      |
+| B-6      | CHALLENGER-RECORD-101 | GET    | `/api/v1/challenger-record/code/{code}`        | `CHALLENGER_RECORD:READ`  |
+| B-7      | CHALLENGER-RECORD-102 | GET    | `/api/v1/challenger-record/id/{id}`            | `CHALLENGER_RECORD:READ`  |
+| B-부록-1 | CHALLENGER-003        | POST   | `/api/v1/challenger/{challengerId}/deactivate` | `CHALLENGER:DELETE`       |
+| B-부록-2 | CHALLENGER-004        | PATCH  | `/api/v1/challenger/{challengerId}/part`       | `CHALLENGER:EDIT`         |
+| B-부록-3 | CHALLENGER-005        | DELETE | `/api/v1/challenger/{challengerId}`            | `CHALLENGER:DELETE`       |

--- a/src/features/auth/api/socialLogin.ts
+++ b/src/features/auth/api/socialLogin.ts
@@ -29,11 +29,12 @@ export async function loginWithKakao(
 }
 
 export async function loginWithApple(
-  payload: AppleLoginRequest,
+  payload: Omit<AppleLoginRequest, "clientType">,
 ): Promise<OAuthLoginResponse> {
+  const body: AppleLoginRequest = { ...payload, clientType: "WEB" }
   const { data } = await api.post<ApiResponse<OAuthLoginResponse>>(
     "/v1/auth/login/apple",
-    payload,
+    body,
   )
   return data.result
 }

--- a/src/features/auth/model/types.ts
+++ b/src/features/auth/model/types.ts
@@ -19,8 +19,11 @@ export interface KakaoLoginRequest {
   accessToken: string
 }
 
+export type ClientType = "ANDROID" | "IOS" | "WEB"
+
 export interface AppleLoginRequest {
   authorizationCode: string
+  clientType: ClientType
 }
 
 export interface SendEmailVerificationRequest {

--- a/src/features/challenger/api/challenger.ts
+++ b/src/features/challenger/api/challenger.ts
@@ -1,0 +1,13 @@
+import { api } from "@/shared/lib/axios"
+
+import type { ChallengerInfoResponse } from "@/features/challenger/model/types"
+import type { ApiResponse } from "@/shared/lib/apiResponse"
+
+export async function getChallengerInfo(
+  challengerId: string,
+): Promise<ChallengerInfoResponse> {
+  const { data } = await api.get<ApiResponse<ChallengerInfoResponse>>(
+    `/v1/challenger/${encodeURIComponent(challengerId)}`,
+  )
+  return data.result
+}

--- a/src/features/challenger/api/challengerPoint.ts
+++ b/src/features/challenger/api/challengerPoint.ts
@@ -1,0 +1,18 @@
+import { api } from "@/shared/lib/axios"
+
+import type {
+  ChallengerInfoResponse,
+  GrantChallengerPointRequest,
+} from "@/features/challenger/model/types"
+import type { ApiResponse } from "@/shared/lib/apiResponse"
+
+export async function grantChallengerPoints(
+  challengerId: string,
+  payload: GrantChallengerPointRequest,
+): Promise<ChallengerInfoResponse> {
+  const { data } = await api.post<ApiResponse<ChallengerInfoResponse>>(
+    `/v1/challenger/${encodeURIComponent(challengerId)}/points`,
+    payload,
+  )
+  return data.result
+}

--- a/src/features/challenger/api/challengerRecord.ts
+++ b/src/features/challenger/api/challengerRecord.ts
@@ -1,0 +1,26 @@
+import { api } from "@/shared/lib/axios"
+
+import type {
+  ChallengerRecordResponse,
+  CreateChallengerRecordRequest,
+} from "@/features/challenger/model/types"
+import type { ApiResponse } from "@/shared/lib/apiResponse"
+
+export async function createChallengerRecord(
+  payload: CreateChallengerRecordRequest,
+): Promise<ChallengerRecordResponse> {
+  const { data } = await api.post<ApiResponse<ChallengerRecordResponse>>(
+    "/v1/challenger-record",
+    payload,
+  )
+  return data.result
+}
+
+export async function getChallengerRecordByCode(
+  code: string,
+): Promise<ChallengerRecordResponse> {
+  const { data } = await api.get<ApiResponse<ChallengerRecordResponse>>(
+    `/v1/challenger-record/code/${encodeURIComponent(code)}`,
+  )
+  return data.result
+}

--- a/src/features/challenger/api/member.ts
+++ b/src/features/challenger/api/member.ts
@@ -1,0 +1,27 @@
+import { api } from "@/shared/lib/axios"
+
+import type {
+  MemberInfoResponse,
+  SearchMemberParams,
+  SearchMemberResponse,
+} from "@/features/challenger/model/types"
+import type { ApiResponse } from "@/shared/lib/apiResponse"
+
+export async function searchMembers(
+  params: SearchMemberParams,
+): Promise<SearchMemberResponse> {
+  const { data } = await api.get<ApiResponse<SearchMemberResponse>>(
+    "/v1/member/search",
+    { params },
+  )
+  return data.result
+}
+
+export async function getMemberProfile(
+  memberId: string,
+): Promise<MemberInfoResponse> {
+  const { data } = await api.get<ApiResponse<MemberInfoResponse>>(
+    `/v1/member/profile/${encodeURIComponent(memberId)}`,
+  )
+  return data.result
+}

--- a/src/features/challenger/api/organization.ts
+++ b/src/features/challenger/api/organization.ts
@@ -1,0 +1,107 @@
+import { api } from "@/shared/lib/axios"
+
+import type {
+  ChapterListResponse,
+  ChapterWithSchoolsResponse,
+  GisuNameListResponse,
+  SchoolNameListResponse,
+} from "@/features/challenger/model/types"
+import type { ApiResponse } from "@/shared/lib/apiResponse"
+
+/**
+ * 백엔드는 ID 류를 항상 numeric string 으로 반환하지만, OpenAPI 스키마와 다르게
+ * `id` / `name` 같은 축약 필드명을 쓰는 케이스가 있어 호출 측 타입으로 정규화한다.
+ *
+ * (근거: api-spec.json 의 GisuNameItem 설명에 "id+번호+isActive" 라고 적혀 있음.)
+ */
+
+function toStringId(value: unknown): string {
+  if (typeof value === "string") return value
+  if (typeof value === "number" && Number.isFinite(value)) return String(value)
+  return ""
+}
+
+interface RawGisuItem {
+  gisuId?: string | number
+  id?: string | number
+  generation?: string | number
+  gisu?: string | number
+  isActive?: boolean
+}
+
+export async function getAllGisu(): Promise<GisuNameListResponse> {
+  const { data } =
+    await api.get<ApiResponse<{ gisuList?: RawGisuItem[] } | RawGisuItem[]>>(
+      "/v1/gisu/all",
+    )
+  const raw = Array.isArray(data.result)
+    ? data.result
+    : (data.result?.gisuList ?? [])
+
+  return {
+    gisuList: raw
+      .map((item) => ({
+        gisuId: toStringId(item.gisuId ?? item.id),
+        generation: toStringId(item.generation ?? item.gisu),
+        gisu: toStringId(item.gisu ?? item.generation),
+        isActive: item.isActive ?? false,
+      }))
+      .filter((item) => item.gisuId !== ""),
+  }
+}
+
+export async function getAllChapters(): Promise<ChapterListResponse> {
+  const { data } =
+    await api.get<ApiResponse<ChapterListResponse>>("/v1/chapters")
+  return data.result
+}
+
+interface RawSchoolItem {
+  schoolId?: string | number
+  id?: string | number
+  schoolName?: string
+  name?: string
+}
+
+interface RawChapterWithSchools {
+  chapterId?: string | number
+  id?: string | number
+  chapterName?: string
+  name?: string
+  schools?: RawSchoolItem[]
+}
+
+export async function getChaptersWithSchools(
+  gisuId: string,
+): Promise<ChapterWithSchoolsResponse> {
+  const { data } = await api.get<
+    ApiResponse<
+      { chapters?: RawChapterWithSchools[] } | RawChapterWithSchools[]
+    >
+  >("/v1/chapters/with-schools", { params: { gisuId } })
+
+  const raw = Array.isArray(data.result)
+    ? data.result
+    : (data.result?.chapters ?? [])
+
+  return {
+    chapters: raw
+      .map((chapter) => ({
+        chapterId: toStringId(chapter.chapterId ?? chapter.id),
+        chapterName: chapter.chapterName ?? chapter.name ?? "",
+        schools: (chapter.schools ?? [])
+          .map((school) => ({
+            schoolId: toStringId(school.schoolId ?? school.id),
+            schoolName: school.schoolName ?? school.name ?? "",
+          }))
+          .filter((school) => school.schoolId !== ""),
+      }))
+      .filter((chapter) => chapter.chapterId !== ""),
+  }
+}
+
+export async function getAllSchools(): Promise<SchoolNameListResponse> {
+  const { data } =
+    await api.get<ApiResponse<SchoolNameListResponse>>("/v1/schools/all")
+  return data.result
+}

--- a/src/features/challenger/index.ts
+++ b/src/features/challenger/index.ts
@@ -1,0 +1,2 @@
+export { GrantPointsPage } from "./ui/grant-points/GrantPointsPage"
+export { RecordCodePage } from "./ui/record-code/RecordCodePage"

--- a/src/features/challenger/model/createRecordSchema.ts
+++ b/src/features/challenger/model/createRecordSchema.ts
@@ -1,0 +1,73 @@
+import { z } from "zod"
+
+const PART_VALUES = [
+  "PLAN",
+  "DESIGN",
+  "WEB",
+  "ANDROID",
+  "IOS",
+  "NODEJS",
+  "SPRINGBOOT",
+  "ADMIN",
+] as const
+
+const ROLE_TYPE_VALUES = [
+  "CHALLENGER",
+  "SUPER_ADMIN",
+  "CENTRAL_PRESIDENT",
+  "CENTRAL_VICE_PRESIDENT",
+  "CENTRAL_OPERATING_TEAM_MEMBER",
+  "CENTRAL_EDUCATION_TEAM_MEMBER",
+  "CHAPTER_PRESIDENT",
+  "SCHOOL_PRESIDENT",
+  "SCHOOL_VICE_PRESIDENT",
+  "SCHOOL_PART_LEADER",
+  "SCHOOL_ETC_ADMIN",
+] as const
+
+const PART_REQUIRING_ROLES: ReadonlyArray<(typeof ROLE_TYPE_VALUES)[number]> = [
+  "CHALLENGER",
+  "SCHOOL_PART_LEADER",
+]
+
+/**
+ * 백엔드는 ID 류를 numeric string 으로 직렬화하므로 폼도 string 으로 다룬다.
+ *
+ * `part` 는 `challengerRoleType` 가 CHALLENGER / SCHOOL_PART_LEADER 인 경우에만 사용자 입력이 필요하다.
+ * 그 외 역할은 폼 제출 시 ADMIN(운영진) 으로 자동 채워지므로 zod 단계에서는 optional 로 둔다.
+ */
+export const createRecordSchema = z
+  .object({
+    gisuId: z
+      .string({ message: "기수를 선택해주세요." })
+      .min(1, "기수를 선택해주세요."),
+    chapterId: z
+      .string({ message: "지부를 선택해주세요." })
+      .min(1, "지부를 선택해주세요."),
+    schoolId: z
+      .string({ message: "학교를 선택해주세요." })
+      .min(1, "학교를 선택해주세요."),
+    part: z.enum(PART_VALUES).optional(),
+    challengerRoleType: z.enum(ROLE_TYPE_VALUES, {
+      message: "역할을 선택해주세요.",
+    }),
+    memberName: z
+      .string()
+      .trim()
+      .min(1, "이름을 입력해주세요.")
+      .max(50, "이름은 50자 이하로 입력해주세요."),
+  })
+  .superRefine((data, ctx) => {
+    if (
+      PART_REQUIRING_ROLES.includes(data.challengerRoleType) &&
+      data.part === undefined
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "파트를 선택해주세요.",
+        path: ["part"],
+      })
+    }
+  })
+
+export type CreateRecordFormData = z.infer<typeof createRecordSchema>

--- a/src/features/challenger/model/enums.ts
+++ b/src/features/challenger/model/enums.ts
@@ -1,0 +1,165 @@
+import type {
+  Part,
+  PointType,
+  RoleType,
+} from "@/features/challenger/model/types"
+
+export const PART_OPTIONS: ReadonlyArray<{ value: Part; label: string }> = [
+  { value: "PLAN", label: "Plan" },
+  { value: "DESIGN", label: "Design" },
+  { value: "WEB", label: "Web" },
+  { value: "ANDROID", label: "Android" },
+  { value: "IOS", label: "iOS" },
+  { value: "NODEJS", label: "Node.js" },
+  { value: "SPRINGBOOT", label: "SpringBoot" },
+  { value: "ADMIN", label: "프로젝트 미참여 운영진" },
+] as const
+
+export const PART_LABEL: Record<Part, string> = PART_OPTIONS.reduce(
+  (acc, { value, label }) => ({ ...acc, [value]: label }),
+  {} as Record<Part, string>,
+)
+
+export const POINT_TYPE_OPTIONS: ReadonlyArray<{
+  value: PointType
+  label: string
+}> = [
+  { value: "BEST_WORKBOOK_V2", label: "베스트 워크북 선정" },
+  { value: "BLOG_CHALLENGE", label: "블로그 챌린지 작성" },
+  { value: "UMC_EVENT_REVIEW", label: "UMC 행사 후기 작성" },
+  { value: "PEER_REVIEW_SUBMISSION", label: "피어 리뷰 제출" },
+  { value: "NO_WORKBOOK_MISSION", label: "워크북 미션 미수행" },
+  { value: "STUDY_LATE", label: "스터디 지각" },
+  { value: "STUDY_ABSENT", label: "스터디 결석" },
+  { value: "EVENT_LATE", label: "행사 지각" },
+  { value: "EVENT_EARLY_LEAVE", label: "행사 조퇴" },
+  { value: "EVENT_LATE_CANCEL", label: "취소 기한 이후 행사 취소" },
+  { value: "EVENT_NO_SHOW", label: "행사 노쇼" },
+  { value: "PART_LEAD_FEEDBACK_LATE", label: "파트장 피드백 지연" },
+  { value: "SCHOOL_CORE_MEETING_ABSENT", label: "회장단 회의 미참여" },
+  {
+    value: "SCHOOL_CORE_TASK_NOT_COMPLETED",
+    label: "학교 운영진 업무 미완료",
+  },
+  { value: "CUSTOM", label: "기타 (직접 입력)" },
+] as const
+
+interface PointTypeMeta {
+  /** 백엔드 PointType 의 기본 점수 (가이드 0.4 표 참고). pointValue 미전달(null) 시 적용. */
+  defaultPoint: number
+  /** true 면 FE 에서 pointValue 명시 입력을 강제 (CUSTOM). */
+  requiresOverride?: boolean
+  /** legacy 라벨 fallback. POINT_TYPE_OPTIONS 가 큐레이션을 통해 가린 항목용. */
+  fallbackLabel?: string
+}
+
+/**
+ * 모든 PointType 값에 대한 메타 (기본점수 등). 과거 기록(legacy 포함) 표시용으로
+ * deprecated 인 BEST_WORKBOOK 도 포함한다.
+ */
+export const POINT_TYPE_META: Record<PointType, PointTypeMeta> = {
+  BLOG_CHALLENGE: { defaultPoint: 3 },
+  BEST_WORKBOOK_V2: { defaultPoint: 2 },
+  UMC_EVENT_REVIEW: { defaultPoint: 1 },
+  PEER_REVIEW_SUBMISSION: { defaultPoint: 1 },
+  OUT: { defaultPoint: 1, fallbackLabel: "탈부" },
+  WARNING: { defaultPoint: 0, fallbackLabel: "경고" },
+  CUSTOM: { defaultPoint: 0, requiresOverride: true },
+  BEST_WORKBOOK: {
+    defaultPoint: -0.5,
+    fallbackLabel: "(구) 베스트 워크북",
+  },
+  STUDY_LATE: { defaultPoint: -2 },
+  STUDY_ABSENT: { defaultPoint: -4 },
+  EVENT_LATE: { defaultPoint: -2 },
+  EVENT_EARLY_LEAVE: { defaultPoint: -2 },
+  EVENT_LATE_CANCEL: { defaultPoint: -4 },
+  EVENT_NO_SHOW: { defaultPoint: -10 },
+  NO_WORKBOOK_MISSION: { defaultPoint: -4 },
+  PART_LEAD_FEEDBACK_LATE: { defaultPoint: -4 },
+  SCHOOL_CORE_MEETING_ABSENT: { defaultPoint: -4 },
+  SCHOOL_CORE_TASK_NOT_COMPLETED: { defaultPoint: -4 },
+}
+
+/**
+ * 라벨 조회용. POINT_TYPE_OPTIONS 의 큐레이션 라벨을 우선 사용하고, 없으면 META 의 fallback.
+ * 모든 PointType (legacy 포함) 을 커버한다.
+ */
+export const POINT_TYPE_LABEL: Record<PointType, string> = (() => {
+  const fromOptions = POINT_TYPE_OPTIONS.reduce(
+    (acc, { value, label }) => ({ ...acc, [value]: label }),
+    {} as Record<string, string>,
+  )
+  return Object.fromEntries(
+    (Object.keys(POINT_TYPE_META) as PointType[]).map((value) => [
+      value,
+      fromOptions[value] ?? POINT_TYPE_META[value].fallbackLabel ?? value,
+    ]),
+  ) as Record<PointType, string>
+})()
+
+/** "+3" / "0" / "-2" / "-0.5" 형식으로 표기 */
+export function formatSignedPoint(value: number): string {
+  if (value > 0) return `+${value}`
+  return String(value)
+}
+
+/**
+ * 백엔드의 totalPoints / point 가 number · string · null 어느 형태로 와도
+ * 안전하게 number 로 정규화한다. 변환 실패 시 0.
+ */
+export function toNumberSafe(value: unknown, fallback = 0): number {
+  if (typeof value === "number" && !Number.isNaN(value)) return value
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value)
+    if (!Number.isNaN(parsed)) return parsed
+  }
+  return fallback
+}
+
+export const ROLE_TYPE_OPTIONS: ReadonlyArray<{
+  value: RoleType
+  label: string
+}> = [
+  { value: "CHALLENGER", label: "챌린저" },
+  { value: "SCHOOL_PART_LEADER", label: "학교 파트장" },
+  { value: "SCHOOL_PRESIDENT", label: "학교 회장" },
+  { value: "SCHOOL_VICE_PRESIDENT", label: "학교 부회장" },
+  { value: "SCHOOL_ETC_ADMIN", label: "학교 기타 운영진" },
+  { value: "CHAPTER_PRESIDENT", label: "지부장" },
+  { value: "CENTRAL_PRESIDENT", label: "중앙운영사무국 총괄" },
+  { value: "CENTRAL_VICE_PRESIDENT", label: "중앙운영사무국 부총괄" },
+  { value: "CENTRAL_OPERATING_TEAM_MEMBER", label: "중앙운영사무국 운영팀원" },
+  { value: "CENTRAL_EDUCATION_TEAM_MEMBER", label: "중앙운영사무국 교육팀원" },
+  { value: "SUPER_ADMIN", label: "최고 관리자" },
+] as const
+
+export const ROLE_TYPE_LABEL: Record<RoleType, string> =
+  ROLE_TYPE_OPTIONS.reduce(
+    (acc, { value, label }) => ({ ...acc, [value]: label }),
+    {} as Record<RoleType, string>,
+  )
+
+/**
+ * 챌린저 기록 코드 발급 시 파트 선택이 필요한 역할.
+ * - CHALLENGER: 본인 트랙(파트) 필요
+ * - SCHOOL_PART_LEADER: 담당 파트 필요
+ *
+ * 그 외 운영진 역할은 특정 파트에 묶이지 않으므로 폼에서 파트 입력을 숨기고
+ * 제출 시 `ADMIN` (운영진) 으로 자동 설정한다.
+ */
+export const PART_REQUIRING_ROLES: ReadonlySet<RoleType> = new Set([
+  "CHALLENGER",
+  "SCHOOL_PART_LEADER",
+])
+
+export function roleNeedsPart(roleType: RoleType | undefined): boolean {
+  return roleType !== undefined && PART_REQUIRING_ROLES.has(roleType)
+}
+
+export const CHALLENGER_STATUS_LABEL = {
+  ACTIVE: "활동중",
+  GRADUATED: "수료",
+  EXPELLED: "제명",
+  WITHDRAWN: "탈퇴",
+} as const

--- a/src/features/challenger/model/grantPointSchema.ts
+++ b/src/features/challenger/model/grantPointSchema.ts
@@ -1,0 +1,56 @@
+import { z } from "zod"
+
+const POINT_TYPE_VALUES = [
+  "BEST_WORKBOOK",
+  "WARNING",
+  "OUT",
+  "CUSTOM",
+  "BLOG_CHALLENGE",
+  "BEST_WORKBOOK_V2",
+  "UMC_EVENT_REVIEW",
+  "PEER_REVIEW_SUBMISSION",
+  "NO_WORKBOOK_MISSION",
+  "STUDY_LATE",
+  "STUDY_ABSENT",
+  "EVENT_LATE",
+  "EVENT_EARLY_LEAVE",
+  "EVENT_LATE_CANCEL",
+  "EVENT_NO_SHOW",
+  "PART_LEAD_FEEDBACK_LATE",
+  "SCHOOL_CORE_MEETING_ABSENT",
+  "SCHOOL_CORE_TASK_NOT_COMPLETED",
+] as const
+
+/**
+ * 가이드 문서 A-4 기준:
+ * - `pointType`: 필수
+ * - `pointValue`: optional. null/undefined 면 PointType 의 기본 점수 사용.
+ *   단, `CUSTOM` 은 기본 점수 0 이라 명시 입력을 강제한다.
+ * - `description`: 필수 (부여 사유)
+ */
+export const grantPointSchema = z
+  .object({
+    pointType: z.enum(POINT_TYPE_VALUES, {
+      message: "상벌점 유형을 선택해주세요.",
+    }),
+    pointValue: z
+      .number({ message: "점수를 숫자로 입력해주세요." })
+      .int("정수만 입력할 수 있습니다.")
+      .optional(),
+    description: z
+      .string({ message: "부여 사유를 입력해주세요." })
+      .trim()
+      .min(1, "부여 사유를 입력해주세요.")
+      .max(200, "사유는 200자 이하로 입력해주세요."),
+  })
+  .superRefine((data, ctx) => {
+    if (data.pointType === "CUSTOM" && data.pointValue === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "기타 유형은 점수를 직접 입력해야 합니다.",
+        path: ["pointValue"],
+      })
+    }
+  })
+
+export type GrantPointFormData = z.infer<typeof grantPointSchema>

--- a/src/features/challenger/model/types.ts
+++ b/src/features/challenger/model/types.ts
@@ -1,0 +1,250 @@
+export type Part =
+  | "PLAN"
+  | "DESIGN"
+  | "WEB"
+  | "ANDROID"
+  | "IOS"
+  | "NODEJS"
+  | "SPRINGBOOT"
+  | "ADMIN"
+
+export type ChallengerStatus = "ACTIVE" | "GRADUATED" | "EXPELLED" | "WITHDRAWN"
+
+export type MemberStatus = "ACTIVE" | "INACTIVE" | "WITHDRAWN"
+
+export type OrganizationType = "CENTRAL" | "CHAPTER" | "SCHOOL"
+
+export type RoleType =
+  | "CHALLENGER"
+  | "SUPER_ADMIN"
+  | "CENTRAL_PRESIDENT"
+  | "CENTRAL_VICE_PRESIDENT"
+  | "CENTRAL_OPERATING_TEAM_MEMBER"
+  | "CENTRAL_EDUCATION_TEAM_MEMBER"
+  | "CHAPTER_PRESIDENT"
+  | "SCHOOL_PRESIDENT"
+  | "SCHOOL_VICE_PRESIDENT"
+  | "SCHOOL_PART_LEADER"
+  | "SCHOOL_ETC_ADMIN"
+
+export type PointType =
+  | "BEST_WORKBOOK"
+  | "WARNING"
+  | "OUT"
+  | "CUSTOM"
+  | "BLOG_CHALLENGE"
+  | "BEST_WORKBOOK_V2"
+  | "UMC_EVENT_REVIEW"
+  | "PEER_REVIEW_SUBMISSION"
+  | "NO_WORKBOOK_MISSION"
+  | "STUDY_LATE"
+  | "STUDY_ABSENT"
+  | "EVENT_LATE"
+  | "EVENT_EARLY_LEAVE"
+  | "EVENT_LATE_CANCEL"
+  | "EVENT_NO_SHOW"
+  | "PART_LEAD_FEEDBACK_LATE"
+  | "SCHOOL_CORE_MEETING_ABSENT"
+  | "SCHOOL_CORE_TASK_NOT_COMPLETED"
+
+/**
+ * 백엔드는 모든 ID 류 (`*Id`) 를 Java Long 정밀도 보전을 위해 numeric string 으로 직렬화한다.
+ * FE 도 ID 는 string 으로 다룬다.
+ */
+
+export interface ChallengerPointInfo {
+  id: string
+  challengerId: string
+  pointType: PointType
+  /** 백엔드가 number/문자열로 줄 수 있음. 호출부에서 number 변환 필요 (toNumberSafe). */
+  point: number | string | null
+  description?: string | null
+  createdAt: string
+}
+
+export interface ChallengerRoleResponse {
+  challengerRoleId: string
+  challengerId: string
+  roleType: RoleType
+  organizationType: OrganizationType
+  organizationId: string
+  responsiblePart?: Part
+  gisuId: string
+  /** 표시용 기수 번호 (e.g. "9"). */
+  gisu: string
+}
+
+export interface ChallengerInfoResponse {
+  challengerId: string
+  memberId: string
+  gisuId: string
+  /** 표시용 기수 번호 */
+  gisu: string
+  chapterId: string
+  chapterName: string
+  part: Part
+  challengerStatus: ChallengerStatus
+  /** @deprecated `points` 사용 권장. 동일한 값. */
+  challengerPoints?: ChallengerPointInfo[]
+  points?: ChallengerPointInfo[]
+  /** 합계 점수. 호출부에서 number 변환 필요 (toNumberSafe). */
+  totalPoints?: number | string | null
+  roles?: ChallengerRoleResponse[]
+  name: string
+  nickname: string
+  /** Public View 에서는 null 로 마스킹됨 */
+  email: string | null
+  schoolId: string
+  schoolName: string
+  profileImageLink?: string | null
+  /** Public View 에서는 null 로 마스킹됨 */
+  memberStatus?: MemberStatus | null
+  /** Public View 에서는 null 로 마스킹됨 */
+  status?: MemberStatus | null
+}
+
+export interface SearchMemberItem {
+  memberId: string
+  name: string
+  nickname: string
+  email: string
+  schoolId: string
+  schoolName: string
+  profileImageLink?: string
+  challengerId?: string
+  gisuId?: string
+  gisu?: string
+  part?: Part
+  roleTypes?: RoleType[]
+}
+
+export interface SearchMemberPage {
+  content: SearchMemberItem[]
+  page: number
+  size: number
+  totalElements: number
+  totalPages: number
+  hasNext: boolean
+  hasPrevious: boolean
+}
+
+export interface SearchMemberResponse {
+  totalCount: number
+  page: SearchMemberPage
+}
+
+export interface SearchMemberParams {
+  page?: number
+  size?: number
+  keyword?: string
+  gisuId?: string
+  part?: Part
+  chapterId?: string
+  schoolId?: string
+}
+
+export interface MemberRoleInfo {
+  id: string
+  challengerId: string
+  roleType: RoleType
+  organizationType: OrganizationType
+  organizationId: string
+  responsiblePart?: Part
+  gisuId: string
+  gisu: string
+}
+
+export interface MemberProfileInfo {
+  id: string
+  linkedIn?: string
+  instagram?: string
+  github?: string
+  blog?: string
+  personal?: string
+}
+
+export interface MemberInfoResponse {
+  id: string
+  name: string
+  nickname: string
+  /** Public View 에서는 null 로 마스킹됨 */
+  email: string | null
+  schoolId: string
+  schoolName: string
+  profileImageLink?: string | null
+  /** Public View 에서는 null 로 마스킹됨 */
+  status: MemberStatus | null
+  roles?: MemberRoleInfo[]
+  challengerRecords?: ChallengerInfoResponse[]
+  profile?: MemberProfileInfo | null
+}
+
+export interface GrantChallengerPointRequest {
+  pointType: PointType
+  /** null 이면 pointType 의 기본 점수 사용. CUSTOM 등 자체 제도 운영 시 명시. */
+  pointValue?: number | null
+  /** 부여 사유 (필수) */
+  description: string
+}
+
+export interface CreateChallengerRecordRequest {
+  gisuId: string
+  chapterId: string
+  schoolId: string
+  part: Part
+  memberName: string
+  challengerRoleType: RoleType
+}
+
+export interface ChallengerRecordResponse {
+  code: string
+  part: Part
+  gisuId: string
+  gisu: string
+  schoolId: string
+  schoolName: string
+  chapterId: string
+  chapterName: string
+  memberName: string
+  challengerRoleType: RoleType
+  organizationId: string
+}
+
+export interface GisuNameItem {
+  gisuId: string
+  generation: string
+  gisu: string
+  isActive: boolean
+}
+
+export interface GisuNameListResponse {
+  gisuList: GisuNameItem[]
+}
+
+export interface ChapterItem {
+  id: string
+  name: string
+}
+
+export interface ChapterListResponse {
+  chapters: ChapterItem[]
+}
+
+export interface SchoolItem {
+  schoolId: string
+  schoolName: string
+}
+
+export interface ChapterWithSchools {
+  chapterId: string
+  chapterName: string
+  schools: SchoolItem[]
+}
+
+export interface ChapterWithSchoolsResponse {
+  chapters: ChapterWithSchools[]
+}
+
+export interface SchoolNameListResponse {
+  schools: SchoolItem[]
+}

--- a/src/features/challenger/ui/grant-points/ChallengerRecordDetail.tsx
+++ b/src/features/challenger/ui/grant-points/ChallengerRecordDetail.tsx
@@ -1,0 +1,149 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { getChallengerInfo } from "@/features/challenger/api/challenger"
+import {
+  CHALLENGER_STATUS_LABEL,
+  formatSignedPoint,
+  PART_LABEL,
+  POINT_TYPE_LABEL,
+  toNumberSafe,
+} from "@/features/challenger/model/enums"
+import { cn } from "@/shared/lib/utils"
+
+import type { ChallengerPointInfo } from "@/features/challenger/model/types"
+
+interface ChallengerRecordDetailProps {
+  challengerId: string
+}
+
+function formatDateTime(value: string) {
+  try {
+    const date = new Date(value)
+    if (Number.isNaN(date.getTime())) return value
+    return new Intl.DateTimeFormat("ko-KR", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(date)
+  } catch {
+    return value
+  }
+}
+
+export function ChallengerRecordDetail({
+  challengerId,
+}: ChallengerRecordDetailProps) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["challenger", "info", challengerId],
+    queryFn: () => getChallengerInfo(challengerId),
+  })
+
+  if (isLoading) {
+    return (
+      <p className="text-body-2-medium text-teal-gray-400">
+        챌린저 정보를 불러오는 중입니다...
+      </p>
+    )
+  }
+
+  if (isError || !data) {
+    return (
+      <p className="text-body-2-medium text-error-500">
+        챌린저 정보를 불러오지 못했습니다.
+      </p>
+    )
+  }
+
+  // 가이드 문서 A-2 / A-3: `challengerPoints` 는 deprecated, `points` 사용 권장
+  const points: ChallengerPointInfo[] =
+    data.points ?? data.challengerPoints ?? []
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="bg-teal-gray-50 grid grid-cols-2 gap-x-6 gap-y-3 rounded-[12px] px-5 py-4 sm:grid-cols-4">
+        <InfoItem label="이름" value={`${data.nickname}/${data.name}`} />
+        <InfoItem label="기수" value={`${data.gisu}기`} />
+        <InfoItem label="파트" value={PART_LABEL[data.part]} />
+        <InfoItem
+          label="상태"
+          value={CHALLENGER_STATUS_LABEL[data.challengerStatus]}
+        />
+        <InfoItem label="지부" value={data.chapterName} />
+        <InfoItem label="학교" value={data.schoolName} />
+        <InfoItem
+          label="이메일"
+          value={data.email ?? "—"}
+          className="col-span-2"
+        />
+        <InfoItem
+          label="누적 점수"
+          value={`${toNumberSafe(data.totalPoints).toFixed(1)}점`}
+        />
+      </div>
+
+      <div className="flex flex-col gap-2.5">
+        <h3 className="text-subtitle-4-semibold text-teal-gray-800">
+          상벌점 기록 ({points.length})
+        </h3>
+        {points.length === 0 ? (
+          <p className="text-body-2-medium text-teal-gray-400">
+            아직 부여된 상벌점이 없습니다.
+          </p>
+        ) : (
+          <ul className="border-teal-gray-100 divide-teal-gray-100 flex w-full flex-col divide-y rounded-[12px] border">
+            {points.map((point, index) => {
+              const pointValue = toNumberSafe(point.point)
+              return (
+                <li
+                  key={point.id ?? `${point.createdAt}-${index}`}
+                  className="flex items-start justify-between gap-4 px-5 py-3"
+                >
+                  <div className="flex flex-col gap-0.5">
+                    <span className="text-body-2-medium text-teal-gray-900">
+                      {POINT_TYPE_LABEL[point.pointType]}
+                    </span>
+                    {point.description && (
+                      <span className="text-caption-2-regular text-teal-gray-500">
+                        {point.description}
+                      </span>
+                    )}
+                    <span className="text-caption-3-regular text-teal-gray-400">
+                      {formatDateTime(point.createdAt)}
+                    </span>
+                  </div>
+                  <span
+                    className={cn(
+                      "text-subtitle-4-semibold whitespace-nowrap",
+                      pointValue >= 0 ? "text-teal-600" : "text-error-500",
+                    )}
+                  >
+                    {formatSignedPoint(pointValue)}
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface InfoItemProps {
+  label: string
+  value: string
+  className?: string
+}
+
+function InfoItem({ label, value, className }: InfoItemProps) {
+  return (
+    <div className={cn("flex flex-col gap-0.5", className)}>
+      <span className="text-caption-2-medium text-teal-gray-500">{label}</span>
+      <span className="text-body-2-medium text-teal-gray-900 truncate">
+        {value}
+      </span>
+    </div>
+  )
+}

--- a/src/features/challenger/ui/grant-points/GrantPointsForm.tsx
+++ b/src/features/challenger/ui/grant-points/GrantPointsForm.tsx
@@ -1,0 +1,260 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useEffect } from "react"
+import { Controller, useForm } from "react-hook-form"
+
+import { useToastStore } from "@/components/toast/useToastStore"
+import { grantChallengerPoints } from "@/features/challenger/api/challengerPoint"
+import {
+  formatSignedPoint,
+  POINT_TYPE_META,
+  POINT_TYPE_OPTIONS,
+} from "@/features/challenger/model/enums"
+import {
+  type GrantPointFormData,
+  grantPointSchema,
+} from "@/features/challenger/model/grantPointSchema"
+import { Dropdown } from "@/features/challenger/ui/shared/Dropdown"
+import { FieldRow } from "@/features/challenger/ui/shared/FieldRow"
+import { cn } from "@/shared/lib/utils"
+import { Button } from "@/shared/ui/Button"
+import { InputBox } from "@/shared/ui/input/InputBox"
+
+interface GrantPointsFormProps {
+  challengerId: string
+}
+
+export function GrantPointsForm({ challengerId }: GrantPointsFormProps) {
+  const addToast = useToastStore((state) => state.addToast)
+  const queryClient = useQueryClient()
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors },
+  } = useForm<GrantPointFormData>({
+    resolver: zodResolver(grantPointSchema),
+    mode: "onChange",
+    defaultValues: { description: "" },
+  })
+
+  useEffect(() => {
+    reset({ description: "" })
+  }, [challengerId, reset])
+
+  const pointType = watch("pointType")
+  const pointValue = watch("pointValue")
+  const description = watch("description") ?? ""
+
+  const meta = pointType ? POINT_TYPE_META[pointType] : null
+  const requiresOverride = meta?.requiresOverride ?? false
+  const effectivePoint = pointValue ?? meta?.defaultPoint
+
+  const mutation = useMutation({
+    mutationFn: (payload: GrantPointFormData) =>
+      grantChallengerPoints(challengerId, {
+        pointType: payload.pointType,
+        // 가이드 문서 A-4: pointValue 미입력 시 null 전송 → pointType 의 기본 점수 사용
+        pointValue: payload.pointValue ?? null,
+        description: payload.description,
+      }),
+    onSuccess: () => {
+      addToast({
+        message: "상벌점이 부여되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3,
+      })
+      reset({ description: "" })
+      void queryClient.invalidateQueries({
+        queryKey: ["challenger", "info", challengerId],
+      })
+      void queryClient.invalidateQueries({
+        queryKey: ["challenger", "member-profile"],
+      })
+    },
+    onError: () => {
+      addToast({
+        message: "상벌점 부여에 실패했습니다. 잠시 후 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3,
+      })
+    },
+  })
+
+  const onSubmit = (data: GrantPointFormData) => {
+    mutation.mutate(data)
+  }
+
+  return (
+    <form
+      noValidate
+      onSubmit={handleSubmit(onSubmit)}
+      className="flex w-full flex-col gap-5"
+    >
+      <div className="grid w-full grid-cols-1 gap-5 md:grid-cols-2">
+        <Controller
+          control={control}
+          name="pointType"
+          render={({ field }) => (
+            <FieldRow
+              label="상벌점 유형"
+              required
+              error={errors.pointType?.message}
+              htmlFor="pointType"
+              hint={
+                meta && !requiresOverride
+                  ? `기본 점수 ${formatSignedPoint(meta.defaultPoint)}점이 적용됩니다.`
+                  : meta && requiresOverride
+                    ? "기타 유형은 아래에서 점수를 직접 입력해야 합니다."
+                    : undefined
+              }
+            >
+              <Dropdown
+                id="pointType"
+                value={field.value}
+                onChange={field.onChange}
+                options={POINT_TYPE_OPTIONS}
+                placeholder="상벌점 유형을 선택해주세요."
+                error={Boolean(errors.pointType)}
+              />
+            </FieldRow>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="pointValue"
+          render={({ field }) => {
+            const stringValue =
+              field.value === undefined || Number.isNaN(field.value)
+                ? ""
+                : String(field.value)
+            return (
+              <FieldRow
+                label={requiresOverride ? "점수" : "점수 덮어쓰기 (선택)"}
+                htmlFor="pointValue"
+                required={requiresOverride}
+                error={errors.pointValue?.message}
+                hint={
+                  requiresOverride
+                    ? "음수는 벌점, 양수는 상점입니다."
+                    : "비워두면 위 유형의 기본 점수가 적용됩니다."
+                }
+              >
+                <InputBox
+                  id="pointValue"
+                  type="default"
+                  inputMode="numeric"
+                  value={stringValue}
+                  onChange={(event) => {
+                    const next = event.target.value
+                    if (next === "") {
+                      field.onChange(undefined)
+                      return
+                    }
+                    if (next === "-") {
+                      // 음수 입력 도중. 일단 보류 — 숫자가 오면 그때 number 로 커밋.
+                      field.onChange(next as unknown as number)
+                      return
+                    }
+                    const parsed = Number(next)
+                    field.onChange(
+                      Number.isNaN(parsed)
+                        ? (next as unknown as number)
+                        : parsed,
+                    )
+                  }}
+                  state={errors.pointValue ? "error" : "default"}
+                  placeholder={
+                    meta
+                      ? `예) ${formatSignedPoint(meta.defaultPoint)}`
+                      : "예) -2"
+                  }
+                  className="w-full max-w-none"
+                />
+              </FieldRow>
+            )
+          }}
+        />
+      </div>
+
+      {meta && (
+        <div
+          className={cn(
+            "flex items-center gap-3 rounded-[12px] border border-teal-100 bg-teal-50 px-5 py-3",
+            requiresOverride &&
+              effectivePoint === undefined &&
+              "border-teal-gray-100 bg-teal-gray-50",
+          )}
+        >
+          <span className="text-caption-2-medium text-teal-gray-500">
+            적용될 점수
+          </span>
+          <span
+            className={cn(
+              "text-subtitle-3-semibold tabular-nums",
+              effectivePoint === undefined
+                ? "text-teal-gray-400"
+                : effectivePoint > 0
+                  ? "text-teal-600"
+                  : effectivePoint < 0
+                    ? "text-error-500"
+                    : "text-teal-gray-700",
+            )}
+          >
+            {effectivePoint === undefined
+              ? "—"
+              : `${formatSignedPoint(effectivePoint)}점`}
+          </span>
+        </div>
+      )}
+
+      <Controller
+        control={control}
+        name="description"
+        render={({ field }) => (
+          <FieldRow
+            label="부여 사유"
+            htmlFor="description"
+            required
+            error={errors.description?.message}
+            hint={`${description.length}/200`}
+          >
+            <textarea
+              id="description"
+              rows={3}
+              maxLength={200}
+              value={field.value ?? ""}
+              onChange={(event) => field.onChange(event.target.value)}
+              onBlur={field.onBlur}
+              placeholder="상벌점 부여 사유를 입력해주세요."
+              className={cn(
+                "border-teal-gray-300 shadow-inner-neutral-2 text-body-1-regular text-teal-gray-900 placeholder:text-teal-gray-400 hover:bg-teal-gray-50 w-full resize-none rounded-[12px] border bg-white px-4 py-3 transition-colors outline-none focus-within:border-teal-400 focus-within:bg-teal-50",
+                errors.description &&
+                  "border-error-400 bg-error-50/60 text-error-500",
+              )}
+            />
+          </FieldRow>
+        )}
+      />
+
+      <div className="flex justify-end">
+        <Button
+          type="submit"
+          variant="fill"
+          color="primary"
+          size="m"
+          isLoading={mutation.isPending}
+        >
+          상벌점 부여
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/src/features/challenger/ui/grant-points/GrantPointsPage.tsx
+++ b/src/features/challenger/ui/grant-points/GrantPointsPage.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react"
+
+import { ChallengerRecordDetail } from "@/features/challenger/ui/grant-points/ChallengerRecordDetail"
+import { GrantPointsForm } from "@/features/challenger/ui/grant-points/GrantPointsForm"
+import { MemberRecordList } from "@/features/challenger/ui/grant-points/MemberRecordList"
+import { MemberSearchPanel } from "@/features/challenger/ui/grant-points/MemberSearchPanel"
+import { SectionCard } from "@/features/challenger/ui/shared/SectionCard"
+
+import type {
+  ChallengerInfoResponse,
+  SearchMemberItem,
+} from "@/features/challenger/model/types"
+
+export function GrantPointsPage() {
+  const [selectedMember, setSelectedMember] = useState<SearchMemberItem | null>(
+    null,
+  )
+  const [selectedChallengerId, setSelectedChallengerId] = useState<
+    string | null
+  >(null)
+
+  const handleSelectMember = (member: SearchMemberItem) => {
+    setSelectedMember(member)
+    setSelectedChallengerId(null)
+  }
+
+  const handleSelectRecord = (record: ChallengerInfoResponse) => {
+    setSelectedChallengerId(record.challengerId)
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-300 flex-col gap-6 px-8.5 py-10">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-heading-5-semibold text-teal-gray-900">
+          챌린저 상벌점 부여
+        </h1>
+        <p className="text-body-2-regular text-teal-gray-500">
+          회원을 검색하여 챌린저 기록을 선택하고, 상벌점을 부여할 수 있습니다.
+        </p>
+      </header>
+
+      <SectionCard
+        title="1. 회원 검색"
+        description="이름, 닉네임, 이메일로 회원을 찾아 선택하세요."
+      >
+        <MemberSearchPanel
+          selectedMember={selectedMember}
+          onSelectMember={handleSelectMember}
+        />
+      </SectionCard>
+
+      {selectedMember && (
+        <SectionCard
+          title="2. 챌린저 기록 선택"
+          description={`${selectedMember.nickname}/${selectedMember.name} 회원의 챌린저 기록입니다.`}
+        >
+          <MemberRecordList
+            memberId={selectedMember.memberId}
+            selectedChallengerId={selectedChallengerId}
+            onSelect={handleSelectRecord}
+          />
+        </SectionCard>
+      )}
+
+      {selectedChallengerId && (
+        <SectionCard
+          title="3. 챌린저 정보"
+          description="선택한 챌린저 기록의 상세 정보와 상벌점 내역입니다."
+        >
+          <ChallengerRecordDetail challengerId={selectedChallengerId} />
+        </SectionCard>
+      )}
+
+      {selectedChallengerId && (
+        <SectionCard
+          title="4. 상벌점 부여"
+          description="유형과 점수, 사유를 입력해 상벌점을 부여하세요."
+        >
+          <GrantPointsForm challengerId={selectedChallengerId} />
+        </SectionCard>
+      )}
+    </div>
+  )
+}

--- a/src/features/challenger/ui/grant-points/MemberRecordList.tsx
+++ b/src/features/challenger/ui/grant-points/MemberRecordList.tsx
@@ -1,0 +1,99 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { getMemberProfile } from "@/features/challenger/api/member"
+import {
+  CHALLENGER_STATUS_LABEL,
+  PART_LABEL,
+  toNumberSafe,
+} from "@/features/challenger/model/enums"
+import { cn } from "@/shared/lib/utils"
+
+import type { ChallengerInfoResponse } from "@/features/challenger/model/types"
+
+interface MemberRecordListProps {
+  memberId: string
+  selectedChallengerId: string | null
+  onSelect: (record: ChallengerInfoResponse) => void
+}
+
+export function MemberRecordList({
+  memberId,
+  selectedChallengerId,
+  onSelect,
+}: MemberRecordListProps) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["challenger", "member-profile", memberId],
+    queryFn: () => getMemberProfile(memberId),
+  })
+
+  if (isLoading) {
+    return (
+      <p className="text-body-2-medium text-teal-gray-400">
+        챌린저 기록을 불러오는 중입니다...
+      </p>
+    )
+  }
+
+  if (isError || !data) {
+    return (
+      <p className="text-body-2-medium text-error-500">
+        회원 정보를 불러오지 못했습니다.
+      </p>
+    )
+  }
+
+  const records = data.challengerRecords ?? []
+
+  if (records.length === 0) {
+    return (
+      <p className="text-body-2-medium text-teal-gray-400">
+        해당 회원의 챌린저 기록이 없습니다.
+      </p>
+    )
+  }
+
+  return (
+    <ul className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2">
+      {records.map((record, index) => {
+        const isSelected = selectedChallengerId === record.challengerId
+        const totalPoints = toNumberSafe(record.totalPoints)
+        return (
+          <li key={`${record.challengerId || "no-ch"}-${index}`}>
+            <button
+              type="button"
+              onClick={() => onSelect(record)}
+              className={cn(
+                "border-teal-gray-100 flex w-full flex-col gap-2 rounded-[12px] border bg-white px-5 py-4 text-left transition-colors hover:border-teal-300 hover:bg-teal-50/40",
+                isSelected && "border-teal-400 bg-teal-50",
+              )}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-subtitle-3-semibold text-teal-gray-900">
+                  {record.gisu}기 · {PART_LABEL[record.part]}
+                </span>
+                <span
+                  className={cn(
+                    "text-caption-2-medium rounded-full px-2 py-0.5",
+                    record.challengerStatus === "ACTIVE"
+                      ? "bg-teal-100 text-teal-600"
+                      : "bg-teal-gray-100 text-teal-gray-500",
+                  )}
+                >
+                  {CHALLENGER_STATUS_LABEL[record.challengerStatus]}
+                </span>
+              </div>
+              <div className="text-body-2-medium text-teal-gray-600 flex flex-col gap-0.5">
+                <span>
+                  {record.chapterName} · {record.schoolName}
+                </span>
+                <span className="text-caption-2-medium text-teal-gray-500">
+                  누적 점수 {totalPoints.toFixed(1)}점
+                </span>
+              </div>
+            </button>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/src/features/challenger/ui/grant-points/MemberSearchPanel.tsx
+++ b/src/features/challenger/ui/grant-points/MemberSearchPanel.tsx
@@ -1,0 +1,143 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query"
+import { useEffect, useRef, useState } from "react"
+
+import { searchMembers } from "@/features/challenger/api/member"
+import { PART_LABEL } from "@/features/challenger/model/enums"
+import SearchIcon from "@/shared/assets/icon/search/SearchIcon"
+import { cn } from "@/shared/lib/utils"
+import { InputBox } from "@/shared/ui/input/InputBox"
+
+import type { SearchMemberItem } from "@/features/challenger/model/types"
+
+interface MemberSearchPanelProps {
+  selectedMember: SearchMemberItem | null
+  onSelectMember: (member: SearchMemberItem) => void
+}
+
+function useDebounced<T>(value: T, delayMs = 300) {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const handle = window.setTimeout(() => setDebounced(value), delayMs)
+    return () => window.clearTimeout(handle)
+  }, [value, delayMs])
+  return debounced
+}
+
+export function MemberSearchPanel({
+  selectedMember,
+  onSelectMember,
+}: MemberSearchPanelProps) {
+  const [keyword, setKeyword] = useState("")
+  const [focused, setFocused] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const debouncedKeyword = useDebounced(keyword.trim(), 300)
+  const enabled = debouncedKeyword.length >= 1
+
+  const { data, isFetching, isError } = useQuery({
+    queryKey: ["challenger", "member-search", debouncedKeyword],
+    queryFn: () =>
+      searchMembers({ keyword: debouncedKeyword, page: 0, size: 10 }),
+    enabled,
+    placeholderData: keepPreviousData,
+  })
+
+  const items = data?.page.content ?? []
+  const showDropdown = focused && enabled
+
+  useEffect(() => {
+    const onMouseDown = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setFocused(false)
+      }
+    }
+    window.addEventListener("mousedown", onMouseDown)
+    return () => window.removeEventListener("mousedown", onMouseDown)
+  }, [])
+
+  return (
+    <div ref={containerRef} className="relative w-full max-w-115">
+      <InputBox
+        value={keyword}
+        onChange={(event) => setKeyword(event.target.value)}
+        onClear={() => setKeyword("")}
+        onFocus={() => setFocused(true)}
+        type="clear"
+        state={selectedMember ? "success" : "default"}
+        placeholder="이름, 닉네임, 이메일로 검색"
+        rightAdornment={
+          keyword.length === 0 ? (
+            <span className="text-teal-gray-400">
+              <SearchIcon width={20} height={20} />
+            </span>
+          ) : undefined
+        }
+        className="w-full max-w-none"
+      />
+
+      {showDropdown && (
+        <ul className="border-teal-gray-50 shadow-drop-neutral-1 scrollbar-hide absolute top-[calc(100%+0.5rem)] left-0 z-30 flex max-h-72 w-full flex-col overflow-y-auto rounded-[12px] border bg-white p-1">
+          {isFetching && items.length === 0 && (
+            <li className="text-body-2-medium text-teal-gray-400 px-4 py-3">
+              검색 중...
+            </li>
+          )}
+          {!isFetching && isError && (
+            <li className="text-body-2-medium text-error-500 px-4 py-3">
+              회원을 불러오지 못했습니다.
+            </li>
+          )}
+          {!isFetching && !isError && items.length === 0 && (
+            <li className="text-body-2-medium text-teal-gray-400 px-4 py-3">
+              일치하는 회원이 없습니다.
+            </li>
+          )}
+          {items.map((item, index) => {
+            const isSelected = selectedMember?.memberId === item.memberId
+            // 한 회원이 여러 챌린저 기록을 갖는 경우 memberId 가 중복될 수 있어
+            // challengerId · gisuId · index 를 조합한 키 사용 (가이드 A-1 응답 특성).
+            const itemKey = `${item.memberId}-${item.challengerId || "no-ch"}-${item.gisuId || "no-g"}-${index}`
+            return (
+              <li key={itemKey}>
+                <button
+                  type="button"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => {
+                    onSelectMember(item)
+                    setKeyword(`${item.nickname}/${item.name}`)
+                    setFocused(false)
+                  }}
+                  className={cn(
+                    "hover:bg-teal-gray-50 hover:shadow-inner-neutral-3 flex w-full flex-col items-start gap-0.5 rounded-[8px] px-4 py-2.5 text-left transition-colors",
+                    isSelected && "bg-teal-50",
+                  )}
+                >
+                  <div className="text-body-2-medium text-teal-gray-900 flex items-center gap-2">
+                    <span className="font-semibold">{item.nickname}</span>
+                    <span className="text-teal-gray-500">/</span>
+                    <span>{item.name}</span>
+                  </div>
+                  <div className="text-caption-2-medium text-teal-gray-500 flex flex-wrap items-center gap-1.5">
+                    <span>{item.schoolName}</span>
+                    {item.gisu && (
+                      <>
+                        <span aria-hidden>·</span>
+                        <span>{item.gisu}기</span>
+                      </>
+                    )}
+                    {item.part && (
+                      <>
+                        <span aria-hidden>·</span>
+                        <span>{PART_LABEL[item.part]}</span>
+                      </>
+                    )}
+                  </div>
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/features/challenger/ui/record-code/CreateRecordForm.tsx
+++ b/src/features/challenger/ui/record-code/CreateRecordForm.tsx
@@ -65,7 +65,7 @@ export function CreateRecordForm() {
     () =>
       (gisuQuery.data?.gisuList ?? []).map((item) => ({
         value: item.gisuId,
-        label: `${item.gisu}기${item.isActive ? " (활동중)" : ""}`,
+        label: `${item.gisu}기${item.isActive ? " (현재 기수)" : ""}`,
       })),
     [gisuQuery.data],
   )

--- a/src/features/challenger/ui/record-code/CreateRecordForm.tsx
+++ b/src/features/challenger/ui/record-code/CreateRecordForm.tsx
@@ -1,0 +1,357 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useEffect, useMemo } from "react"
+import { Controller, useForm } from "react-hook-form"
+
+import { useToastStore } from "@/components/toast/useToastStore"
+import { createChallengerRecord } from "@/features/challenger/api/challengerRecord"
+import {
+  getAllGisu,
+  getChaptersWithSchools,
+} from "@/features/challenger/api/organization"
+import {
+  type CreateRecordFormData,
+  createRecordSchema,
+} from "@/features/challenger/model/createRecordSchema"
+import {
+  PART_OPTIONS,
+  ROLE_TYPE_OPTIONS,
+  roleNeedsPart,
+} from "@/features/challenger/model/enums"
+import { Dropdown } from "@/features/challenger/ui/shared/Dropdown"
+import { FieldRow } from "@/features/challenger/ui/shared/FieldRow"
+import { Button } from "@/shared/ui/Button"
+import { InputBox } from "@/shared/ui/input/InputBox"
+
+import { GeneratedCodeCard } from "./GeneratedCodeCard"
+
+import type { DropdownOption } from "@/features/challenger/ui/shared/Dropdown"
+
+export function CreateRecordForm() {
+  const addToast = useToastStore((state) => state.addToast)
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    setValue,
+    watch,
+    formState: { errors },
+  } = useForm<CreateRecordFormData>({
+    resolver: zodResolver(createRecordSchema),
+    mode: "onChange",
+    defaultValues: { memberName: "" },
+  })
+
+  const watchedGisuId = watch("gisuId")
+  const watchedChapterId = watch("chapterId")
+  const watchedRoleType = watch("challengerRoleType")
+  const hasGisu = Boolean(watchedGisuId)
+  const hasChapter = Boolean(watchedChapterId)
+  const showPartField = roleNeedsPart(watchedRoleType)
+
+  const gisuQuery = useQuery({
+    queryKey: ["challenger", "gisu", "all"],
+    queryFn: getAllGisu,
+  })
+
+  const chaptersQuery = useQuery({
+    queryKey: ["challenger", "chapters", "with-schools", watchedGisuId],
+    queryFn: () => getChaptersWithSchools(watchedGisuId),
+    enabled: hasGisu,
+  })
+
+  const gisuOptions = useMemo<DropdownOption<string>[]>(
+    () =>
+      (gisuQuery.data?.gisuList ?? []).map((item) => ({
+        value: item.gisuId,
+        label: `${item.gisu}기${item.isActive ? " (활동중)" : ""}`,
+      })),
+    [gisuQuery.data],
+  )
+
+  const chapterOptions = useMemo<DropdownOption<string>[]>(
+    () =>
+      (chaptersQuery.data?.chapters ?? []).map((chapter) => ({
+        value: chapter.chapterId,
+        label: chapter.chapterName,
+      })),
+    [chaptersQuery.data],
+  )
+
+  const schoolOptions = useMemo<DropdownOption<string>[]>(() => {
+    if (!hasChapter) return []
+    const chapter = chaptersQuery.data?.chapters.find(
+      (item) => item.chapterId === watchedChapterId,
+    )
+    return (chapter?.schools ?? []).map((school) => ({
+      value: school.schoolId,
+      label: school.schoolName,
+    }))
+  }, [chaptersQuery.data, hasChapter, watchedChapterId])
+
+  useEffect(() => {
+    setValue("chapterId", "", { shouldDirty: false, shouldValidate: false })
+    setValue("schoolId", "", { shouldDirty: false, shouldValidate: false })
+  }, [watchedGisuId, setValue])
+
+  useEffect(() => {
+    setValue("schoolId", "", { shouldDirty: false, shouldValidate: false })
+  }, [watchedChapterId, setValue])
+
+  // 역할이 비파트류로 바뀌면 part 입력값을 정리한다 (제출 시 ADMIN 으로 자동 채워짐).
+  useEffect(() => {
+    if (!showPartField) {
+      setValue("part", undefined, {
+        shouldDirty: false,
+        shouldValidate: false,
+      })
+    }
+  }, [showPartField, setValue])
+
+  const mutation = useMutation({
+    mutationFn: (payload: CreateRecordFormData) =>
+      createChallengerRecord({
+        gisuId: payload.gisuId,
+        chapterId: payload.chapterId,
+        schoolId: payload.schoolId,
+        challengerRoleType: payload.challengerRoleType,
+        memberName: payload.memberName,
+        // 비파트 역할(회장·부회장·운영팀원 등) 은 운영진 파트(ADMIN) 로 채워 보낸다.
+        part: payload.part ?? "ADMIN",
+      }),
+    onSuccess: () => {
+      addToast({
+        message: "코드가 발급되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3,
+      })
+    },
+    onError: () => {
+      addToast({
+        message: "코드 발급에 실패했습니다. 잠시 후 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3,
+      })
+    },
+  })
+
+  const onSubmit = (data: CreateRecordFormData) => {
+    mutation.mutate(data)
+  }
+
+  const handleReset = () => {
+    reset({ memberName: "" })
+    mutation.reset()
+  }
+
+  return (
+    <form
+      noValidate
+      onSubmit={handleSubmit(onSubmit)}
+      className="flex w-full flex-col gap-5"
+    >
+      <div className="grid w-full grid-cols-1 gap-5 md:grid-cols-2">
+        <Controller
+          control={control}
+          name="gisuId"
+          render={({ field }) => (
+            <FieldRow
+              label="기수"
+              required
+              htmlFor="gisuId"
+              error={errors.gisuId?.message}
+            >
+              <Dropdown<string>
+                id="gisuId"
+                value={field.value || undefined}
+                onChange={field.onChange}
+                options={gisuOptions}
+                placeholder={
+                  gisuQuery.isLoading
+                    ? "기수를 불러오는 중..."
+                    : gisuOptions.length === 0
+                      ? "기수 정보가 없습니다."
+                      : "기수를 선택해주세요."
+                }
+                disabled={gisuQuery.isLoading}
+                error={Boolean(errors.gisuId)}
+              />
+            </FieldRow>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="chapterId"
+          render={({ field }) => (
+            <FieldRow
+              label="지부"
+              required
+              htmlFor="chapterId"
+              error={errors.chapterId?.message}
+            >
+              <Dropdown<string>
+                id="chapterId"
+                value={field.value || undefined}
+                onChange={field.onChange}
+                options={chapterOptions}
+                placeholder={
+                  !hasGisu
+                    ? "기수를 먼저 선택해주세요."
+                    : chaptersQuery.isLoading
+                      ? "지부를 불러오는 중..."
+                      : chapterOptions.length === 0
+                        ? "선택 가능한 지부가 없습니다."
+                        : "지부를 선택해주세요."
+                }
+                disabled={!hasGisu || chaptersQuery.isLoading}
+                error={Boolean(errors.chapterId)}
+              />
+            </FieldRow>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="schoolId"
+          render={({ field }) => (
+            <FieldRow
+              label="학교"
+              required
+              htmlFor="schoolId"
+              error={errors.schoolId?.message}
+            >
+              <Dropdown<string>
+                id="schoolId"
+                value={field.value || undefined}
+                onChange={field.onChange}
+                options={schoolOptions}
+                placeholder={
+                  !hasChapter
+                    ? "지부를 먼저 선택해주세요."
+                    : schoolOptions.length === 0
+                      ? "선택 가능한 학교가 없습니다."
+                      : "학교를 선택해주세요."
+                }
+                disabled={!hasChapter}
+                error={Boolean(errors.schoolId)}
+              />
+            </FieldRow>
+          )}
+        />
+
+        <Controller
+          control={control}
+          name="challengerRoleType"
+          render={({ field }) => (
+            <FieldRow
+              label="역할"
+              required
+              htmlFor="challengerRoleType"
+              error={errors.challengerRoleType?.message}
+            >
+              <Dropdown
+                id="challengerRoleType"
+                value={field.value}
+                onChange={field.onChange}
+                options={ROLE_TYPE_OPTIONS}
+                placeholder="역할을 선택해주세요."
+                error={Boolean(errors.challengerRoleType)}
+              />
+            </FieldRow>
+          )}
+        />
+
+        {showPartField ? (
+          <Controller
+            control={control}
+            name="part"
+            render={({ field }) => (
+              <FieldRow
+                label="파트"
+                required
+                htmlFor="part"
+                error={errors.part?.message}
+              >
+                <Dropdown
+                  id="part"
+                  value={field.value}
+                  onChange={field.onChange}
+                  options={PART_OPTIONS}
+                  placeholder="파트를 선택해주세요."
+                  error={Boolean(errors.part)}
+                />
+              </FieldRow>
+            )}
+          />
+        ) : (
+          <FieldRow
+            label="파트"
+            hint={
+              watchedRoleType
+                ? "선택한 역할은 특정 파트에 묶이지 않습니다. (운영진으로 자동 처리)"
+                : "역할을 먼저 선택해주세요."
+            }
+          >
+            <div className="border-teal-gray-200 bg-teal-gray-50 text-body-2-medium text-teal-gray-400 inline-flex h-11 w-full items-center rounded-[12px] border px-4">
+              파트 선택 불필요
+            </div>
+          </FieldRow>
+        )}
+
+        <Controller
+          control={control}
+          name="memberName"
+          render={({ field }) => (
+            <FieldRow
+              label="이름"
+              required
+              htmlFor="memberName"
+              error={errors.memberName?.message}
+            >
+              <InputBox
+                id="memberName"
+                value={field.value ?? ""}
+                onChange={(event) => field.onChange(event.target.value)}
+                onClear={() => field.onChange("")}
+                type="clear"
+                state={errors.memberName ? "error" : "default"}
+                placeholder="회원 이름을 입력해주세요."
+                className="w-full max-w-none"
+              />
+            </FieldRow>
+          )}
+        />
+      </div>
+
+      <div className="flex justify-end gap-3">
+        <Button
+          type="button"
+          variant="weak"
+          color="neutral"
+          size="m"
+          onClick={handleReset}
+          disabled={mutation.isPending}
+        >
+          초기화
+        </Button>
+        <Button
+          type="submit"
+          variant="fill"
+          color="primary"
+          size="m"
+          isLoading={mutation.isPending}
+        >
+          코드 발급
+        </Button>
+      </div>
+
+      {mutation.data && <GeneratedCodeCard record={mutation.data} />}
+    </form>
+  )
+}

--- a/src/features/challenger/ui/record-code/GeneratedCodeCard.tsx
+++ b/src/features/challenger/ui/record-code/GeneratedCodeCard.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react"
+
+import { useToastStore } from "@/components/toast/useToastStore"
+import { PART_LABEL, ROLE_TYPE_LABEL } from "@/features/challenger/model/enums"
+import { cn } from "@/shared/lib/utils"
+import { Button } from "@/shared/ui/Button"
+
+import type { ChallengerRecordResponse } from "@/features/challenger/model/types"
+
+interface GeneratedCodeCardProps {
+  record: ChallengerRecordResponse
+}
+
+export function GeneratedCodeCard({ record }: GeneratedCodeCardProps) {
+  const addToast = useToastStore((state) => state.addToast)
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(record.code)
+      setCopied(true)
+      addToast({
+        message: "코드를 복사했습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 2,
+      })
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      addToast({
+        message: "복사에 실패했습니다. 직접 복사해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3,
+      })
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex w-full flex-col gap-4 rounded-[12px] border border-teal-300 bg-teal-50 px-6 py-5",
+      )}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-subtitle-4-semibold text-teal-600">
+          발급된 코드
+        </span>
+        <Button
+          type="button"
+          variant="weak"
+          color="primary"
+          size="xs"
+          onClick={handleCopy}
+        >
+          {copied ? "복사됨" : "복사"}
+        </Button>
+      </div>
+      <div className="text-display-2-medium tracking-[0.4em] text-teal-700 tabular-nums">
+        {record.code}
+      </div>
+      <dl className="grid grid-cols-2 gap-x-6 gap-y-2 sm:grid-cols-3">
+        <Field label="기수" value={`${record.gisu}기`} />
+        <Field label="지부" value={record.chapterName} />
+        <Field label="학교" value={record.schoolName} />
+        <Field label="파트" value={PART_LABEL[record.part]} />
+        <Field
+          label="역할"
+          value={ROLE_TYPE_LABEL[record.challengerRoleType]}
+        />
+        <Field label="이름" value={record.memberName} />
+      </dl>
+    </div>
+  )
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <dt className="text-caption-2-medium text-teal-gray-500">{label}</dt>
+      <dd className="text-body-2-medium text-teal-gray-900 truncate">
+        {value}
+      </dd>
+    </div>
+  )
+}

--- a/src/features/challenger/ui/record-code/LookupRecordForm.tsx
+++ b/src/features/challenger/ui/record-code/LookupRecordForm.tsx
@@ -1,0 +1,124 @@
+import { useMutation } from "@tanstack/react-query"
+import { useState } from "react"
+
+import { useToastStore } from "@/components/toast/useToastStore"
+import { getChallengerRecordByCode } from "@/features/challenger/api/challengerRecord"
+import { PART_LABEL, ROLE_TYPE_LABEL } from "@/features/challenger/model/enums"
+import { Button } from "@/shared/ui/Button"
+import { InputBox } from "@/shared/ui/input/InputBox"
+
+import type { ChallengerRecordResponse } from "@/features/challenger/model/types"
+
+const CODE_LENGTH = 6
+
+export function LookupRecordForm() {
+  const addToast = useToastStore((state) => state.addToast)
+  const [code, setCode] = useState("")
+  const [result, setResult] = useState<ChallengerRecordResponse | null>(null)
+
+  const isCodeValid = code.length === CODE_LENGTH
+
+  const mutation = useMutation({
+    mutationFn: (value: string) => getChallengerRecordByCode(value),
+    onSuccess: (data) => {
+      setResult(data)
+    },
+    onError: () => {
+      setResult(null)
+      addToast({
+        message: "해당 코드의 기록을 찾을 수 없습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3,
+      })
+    },
+  })
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!isCodeValid) return
+    mutation.mutate(code.trim().toUpperCase())
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      noValidate
+      className="flex w-full flex-col gap-5"
+    >
+      <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-end">
+        <div className="flex flex-1 flex-col gap-1.5">
+          <label
+            htmlFor="lookup-code"
+            className="text-label-1-medium text-teal-gray-700"
+          >
+            챌린저 기록 코드
+            <span className="text-error-500 ml-1">*</span>
+          </label>
+          <InputBox
+            id="lookup-code"
+            value={code}
+            onChange={(event) => {
+              const next = event.target.value
+                .toUpperCase()
+                .replace(/[^A-Z0-9]/g, "")
+                .slice(0, CODE_LENGTH)
+              setCode(next)
+              if (result) setResult(null)
+            }}
+            onClear={() => {
+              setCode("")
+              setResult(null)
+            }}
+            type="clear"
+            state="default"
+            placeholder="6자리 코드를 입력해주세요."
+            inputClassName="tracking-[0.3em] uppercase"
+            className="w-full max-w-none"
+          />
+          <p className="text-caption-2-medium text-teal-gray-400">
+            대소문자 구분 없이 6자리 영숫자 코드입니다. ({code.length}/
+            {CODE_LENGTH})
+          </p>
+        </div>
+        <Button
+          type="submit"
+          variant="fill"
+          color="primary"
+          size="m"
+          disabled={!isCodeValid}
+          isLoading={mutation.isPending}
+          className="sm:self-start"
+        >
+          조회
+        </Button>
+      </div>
+
+      {result && (
+        <div className="border-teal-gray-100 bg-teal-gray-50 grid w-full grid-cols-2 gap-x-6 gap-y-3 rounded-[12px] border px-6 py-5 sm:grid-cols-3">
+          <Field label="기수" value={`${result.gisu}기`} />
+          <Field label="지부" value={result.chapterName} />
+          <Field label="학교" value={result.schoolName} />
+          <Field label="파트" value={PART_LABEL[result.part]} />
+          <Field
+            label="역할"
+            value={ROLE_TYPE_LABEL[result.challengerRoleType]}
+          />
+          <Field label="이름" value={result.memberName} />
+        </div>
+      )}
+    </form>
+  )
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-caption-2-medium text-teal-gray-500">{label}</span>
+      <span className="text-body-2-medium text-teal-gray-900 truncate">
+        {value}
+      </span>
+    </div>
+  )
+}

--- a/src/features/challenger/ui/record-code/RecordCodePage.tsx
+++ b/src/features/challenger/ui/record-code/RecordCodePage.tsx
@@ -1,0 +1,33 @@
+import { CreateRecordForm } from "@/features/challenger/ui/record-code/CreateRecordForm"
+import { LookupRecordForm } from "@/features/challenger/ui/record-code/LookupRecordForm"
+import { SectionCard } from "@/features/challenger/ui/shared/SectionCard"
+
+export function RecordCodePage() {
+  return (
+    <div className="mx-auto flex w-full max-w-300 flex-col gap-6 px-8.5 py-10">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-heading-5-semibold text-teal-gray-900">
+          챌린저 기록 코드
+        </h1>
+        <p className="text-body-2-regular text-teal-gray-500">
+          과거 챌린저 활동 기록을 위한 6자리 코드를 발급하거나, 코드를 입력해
+          내용을 확인할 수 있습니다.
+        </p>
+      </header>
+
+      <SectionCard
+        title="코드 생성"
+        description="기수, 지부, 학교, 파트, 역할, 이름을 선택해 코드를 발급받으세요."
+      >
+        <CreateRecordForm />
+      </SectionCard>
+
+      <SectionCard
+        title="코드 조회"
+        description="발급된 6자리 코드를 입력하면 관련 정보를 확인할 수 있습니다."
+      >
+        <LookupRecordForm />
+      </SectionCard>
+    </div>
+  )
+}

--- a/src/features/challenger/ui/shared/Dropdown.tsx
+++ b/src/features/challenger/ui/shared/Dropdown.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useRef, useState } from "react"
+
+import TypeCheckSizeSm from "@/shared/assets/icon/check/TypeCheckSizeSm"
+import DownChevronIcon from "@/shared/assets/icon/chevron/sidebar/DownChevronIcon"
+import { cn } from "@/shared/lib/utils"
+
+export interface DropdownOption<T extends string | number> {
+  value: T
+  label: string
+  disabled?: boolean
+}
+
+interface DropdownProps<T extends string | number> {
+  value: T | undefined
+  onChange: (value: T) => void
+  options: ReadonlyArray<DropdownOption<T>>
+  placeholder: string
+  disabled?: boolean
+  error?: boolean
+  className?: string
+  panelClassName?: string
+  id?: string
+}
+
+export function Dropdown<T extends string | number>({
+  value,
+  onChange,
+  options,
+  placeholder,
+  disabled,
+  error,
+  className,
+  panelClassName,
+  id,
+}: DropdownProps<T>) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+    window.addEventListener("mousedown", handler)
+    return () => window.removeEventListener("mousedown", handler)
+  }, [open])
+
+  const selected = options.find((option) => option.value === value)
+  const displayLabel = selected?.label ?? placeholder
+  const hasValue = selected !== undefined
+
+  const stateClass = (() => {
+    if (disabled) {
+      return "bg-teal-gray-50 border-teal-gray-200 text-teal-gray-300 cursor-not-allowed pointer-events-none"
+    }
+    if (error) {
+      return "bg-error-50/60 border-error-400 text-error-500"
+    }
+    if (open) {
+      return "bg-teal-50 border-teal-400 text-teal-600"
+    }
+    if (hasValue) {
+      return "bg-white border-teal-gray-300 text-teal-gray-900 hover:bg-teal-gray-50"
+    }
+    return "bg-white border-teal-gray-300 text-teal-gray-400 hover:bg-teal-gray-50"
+  })()
+
+  return (
+    <div ref={containerRef} className={cn("relative w-full", className)}>
+      <button
+        id={id}
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        disabled={disabled}
+        onClick={() => setOpen((prev) => !prev)}
+        className={cn(
+          "shadow-inner-neutral-2 text-label-1-medium inline-flex h-11 w-full items-center justify-between gap-1 rounded-[12px] border pr-2.5 pl-4 transition-colors",
+          stateClass,
+        )}
+      >
+        <span className="truncate">{displayLabel}</span>
+        <DownChevronIcon
+          className={cn(
+            "size-4 shrink-0 transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+
+      {open && (
+        <ul
+          role="listbox"
+          className={cn(
+            "border-teal-gray-50 shadow-drop-neutral-1 scrollbar-hide absolute top-[calc(100%+0.25rem)] left-0 z-30 flex max-h-60 w-full flex-col overflow-y-auto rounded-[12px] border bg-white p-0.5",
+            panelClassName,
+          )}
+        >
+          {options.length === 0 ? (
+            <li className="text-body-2-medium text-teal-gray-400 px-4 py-3">
+              항목이 없습니다.
+            </li>
+          ) : (
+            options.map((option) => {
+              const isSelected = option.value === value
+              return (
+                <li
+                  key={String(option.value)}
+                  role="option"
+                  aria-selected={isSelected}
+                >
+                  <button
+                    type="button"
+                    disabled={option.disabled}
+                    onClick={() => {
+                      onChange(option.value)
+                      setOpen(false)
+                    }}
+                    className={cn(
+                      "text-body-2-medium flex h-10 w-full items-center justify-between gap-2.5 rounded-[8px] py-0 pr-2.5 pl-4 text-left transition-[background-color,color,box-shadow]",
+                      option.disabled &&
+                        "text-teal-gray-300 cursor-not-allowed",
+                      !option.disabled &&
+                        !isSelected && [
+                          "text-teal-gray-700 hover:bg-teal-gray-50 hover:shadow-inner-neutral-3",
+                        ],
+                      !option.disabled &&
+                        isSelected &&
+                        "shadow-inner-neutral-4 text-subtitle-4-semibold bg-teal-50 text-teal-600",
+                    )}
+                  >
+                    <span className="truncate">{option.label}</span>
+                    {isSelected && (
+                      <TypeCheckSizeSm
+                        className="shrink-0 text-teal-500"
+                        aria-hidden
+                      />
+                    )}
+                  </button>
+                </li>
+              )
+            })
+          )}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/features/challenger/ui/shared/FieldRow.tsx
+++ b/src/features/challenger/ui/shared/FieldRow.tsx
@@ -1,0 +1,41 @@
+import { cn } from "@/shared/lib/utils"
+
+import type { ReactNode } from "react"
+
+interface FieldRowProps {
+  label: string
+  htmlFor?: string
+  required?: boolean
+  error?: string
+  hint?: string
+  children: ReactNode
+  className?: string
+}
+
+export function FieldRow({
+  label,
+  htmlFor,
+  required,
+  error,
+  hint,
+  children,
+  className,
+}: FieldRowProps) {
+  return (
+    <div className={cn("flex w-full flex-col gap-1.5", className)}>
+      <label
+        htmlFor={htmlFor}
+        className="text-label-1-medium text-teal-gray-700"
+      >
+        {label}
+        {required && <span className="text-error-500 ml-1">*</span>}
+      </label>
+      {children}
+      {error ? (
+        <p className="text-caption-2-medium text-error-500">{error}</p>
+      ) : hint ? (
+        <p className="text-caption-2-medium text-teal-gray-400">{hint}</p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/features/challenger/ui/shared/SectionCard.tsx
+++ b/src/features/challenger/ui/shared/SectionCard.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/shared/lib/utils"
+
+import type { ReactNode } from "react"
+
+interface SectionCardProps {
+  title: string
+  description?: string
+  trailing?: ReactNode
+  children: ReactNode
+  className?: string
+}
+
+export function SectionCard({
+  title,
+  description,
+  trailing,
+  children,
+  className,
+}: SectionCardProps) {
+  return (
+    <section
+      className={cn(
+        "border-teal-gray-100 flex w-full flex-col gap-5 rounded-[12px] border bg-white px-7 py-6",
+        className,
+      )}
+    >
+      <header className="flex items-start justify-between gap-4">
+        <div className="flex flex-col gap-1">
+          <h2 className="text-heading-7-semibold text-teal-gray-900">
+            {title}
+          </h2>
+          {description && (
+            <p className="text-body-2-regular text-teal-gray-500">
+              {description}
+            </p>
+          )}
+        </div>
+        {trailing}
+      </header>
+      <div className="flex w-full flex-col gap-4">{children}</div>
+    </section>
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -37,11 +37,11 @@ import { Route as MatchingRoundsRouteImport } from './routes/matching/rounds'
 import { Route as MatchingNoticePublishRouteImport } from './routes/matching/notice-publish'
 import { Route as MatchingApplicationsRouteImport } from './routes/matching/applications'
 import { Route as LoginDefaultRouteImport } from './routes/login/default'
-import { Route as AdminChallengerRecordsRouteImport } from './routes/admin/challenger-records'
-import { Route as AdminChallengerPointsRouteImport } from './routes/admin/challenger-points'
 import { Route as MatchingProjectsIndexRouteImport } from './routes/matching/projects/index'
 import { Route as MatchingProjectsNewRouteImport } from './routes/matching/projects/new'
 import { Route as MatchingNoticePublishNoticeIdRouteImport } from './routes/matching/notice-publish.$noticeId'
+import { Route as AdminChallengerRecordsRouteImport } from './routes/admin/challenger/records'
+import { Route as AdminChallengerPointsRouteImport } from './routes/admin/challenger/points'
 import { Route as MatchingProjectsAnnounceRouteRouteImport } from './routes/matching/projects/announce/route'
 import { Route as MatchingProjectsAnnounceIndexRouteImport } from './routes/matching/projects/announce/index'
 import { Route as MatchingProjectsAnnounceNoticePublishRouteImport } from './routes/matching/projects/announce/notice-publish'
@@ -188,16 +188,6 @@ const LoginDefaultRoute = LoginDefaultRouteImport.update({
   path: '/login/default',
   getParentRoute: () => rootRouteImport,
 } as any)
-const AdminChallengerRecordsRoute = AdminChallengerRecordsRouteImport.update({
-  id: '/challenger-records',
-  path: '/challenger-records',
-  getParentRoute: () => AdminRouteRoute,
-} as any)
-const AdminChallengerPointsRoute = AdminChallengerPointsRouteImport.update({
-  id: '/challenger-points',
-  path: '/challenger-points',
-  getParentRoute: () => AdminRouteRoute,
-} as any)
 const MatchingProjectsIndexRoute = MatchingProjectsIndexRouteImport.update({
   id: '/projects/',
   path: '/projects/',
@@ -214,6 +204,16 @@ const MatchingNoticePublishNoticeIdRoute =
     path: '/$noticeId',
     getParentRoute: () => MatchingNoticePublishRoute,
   } as any)
+const AdminChallengerRecordsRoute = AdminChallengerRecordsRouteImport.update({
+  id: '/challenger/records',
+  path: '/challenger/records',
+  getParentRoute: () => AdminRouteRoute,
+} as any)
+const AdminChallengerPointsRoute = AdminChallengerPointsRouteImport.update({
+  id: '/challenger/points',
+  path: '/challenger/points',
+  getParentRoute: () => AdminRouteRoute,
+} as any)
 const MatchingProjectsAnnounceRouteRoute =
   MatchingProjectsAnnounceRouteRouteImport.update({
     id: '/projects/announce',
@@ -244,8 +244,6 @@ export interface FileRoutesByFullPath {
   '/admin': typeof AdminRouteRouteWithChildren
   '/matching': typeof MatchingRouteRouteWithChildren
   '/auth-test': typeof AuthTestRoute
-  '/admin/challenger-points': typeof AdminChallengerPointsRoute
-  '/admin/challenger-records': typeof AdminChallengerRecordsRoute
   '/login/default': typeof LoginDefaultRoute
   '/matching/applications': typeof MatchingApplicationsRoute
   '/matching/notice-publish': typeof MatchingNoticePublishRouteWithChildren
@@ -271,6 +269,8 @@ export interface FileRoutesByFullPath {
   '/login/': typeof LoginIndexRoute
   '/matching/': typeof MatchingIndexRoute
   '/matching/projects/announce': typeof MatchingProjectsAnnounceRouteRouteWithChildren
+  '/admin/challenger/points': typeof AdminChallengerPointsRoute
+  '/admin/challenger/records': typeof AdminChallengerRecordsRoute
   '/matching/notice-publish/$noticeId': typeof MatchingNoticePublishNoticeIdRoute
   '/matching/projects/new': typeof MatchingProjectsNewRoute
   '/matching/projects/': typeof MatchingProjectsIndexRoute
@@ -281,8 +281,6 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/auth-test': typeof AuthTestRoute
-  '/admin/challenger-points': typeof AdminChallengerPointsRoute
-  '/admin/challenger-records': typeof AdminChallengerRecordsRoute
   '/login/default': typeof LoginDefaultRoute
   '/matching/applications': typeof MatchingApplicationsRoute
   '/matching/notice-publish': typeof MatchingNoticePublishRouteWithChildren
@@ -307,6 +305,8 @@ export interface FileRoutesByTo {
   '/admin': typeof AdminIndexRoute
   '/login': typeof LoginIndexRoute
   '/matching': typeof MatchingIndexRoute
+  '/admin/challenger/points': typeof AdminChallengerPointsRoute
+  '/admin/challenger/records': typeof AdminChallengerRecordsRoute
   '/matching/notice-publish/$noticeId': typeof MatchingNoticePublishNoticeIdRoute
   '/matching/projects/new': typeof MatchingProjectsNewRoute
   '/matching/projects': typeof MatchingProjectsIndexRoute
@@ -320,8 +320,6 @@ export interface FileRoutesById {
   '/admin': typeof AdminRouteRouteWithChildren
   '/matching': typeof MatchingRouteRouteWithChildren
   '/auth-test': typeof AuthTestRoute
-  '/admin/challenger-points': typeof AdminChallengerPointsRoute
-  '/admin/challenger-records': typeof AdminChallengerRecordsRoute
   '/login/default': typeof LoginDefaultRoute
   '/matching/applications': typeof MatchingApplicationsRoute
   '/matching/notice-publish': typeof MatchingNoticePublishRouteWithChildren
@@ -347,6 +345,8 @@ export interface FileRoutesById {
   '/login/': typeof LoginIndexRoute
   '/matching/': typeof MatchingIndexRoute
   '/matching/projects/announce': typeof MatchingProjectsAnnounceRouteRouteWithChildren
+  '/admin/challenger/points': typeof AdminChallengerPointsRoute
+  '/admin/challenger/records': typeof AdminChallengerRecordsRoute
   '/matching/notice-publish/$noticeId': typeof MatchingNoticePublishNoticeIdRoute
   '/matching/projects/new': typeof MatchingProjectsNewRoute
   '/matching/projects/': typeof MatchingProjectsIndexRoute
@@ -361,8 +361,6 @@ export interface FileRouteTypes {
     | '/admin'
     | '/matching'
     | '/auth-test'
-    | '/admin/challenger-points'
-    | '/admin/challenger-records'
     | '/login/default'
     | '/matching/applications'
     | '/matching/notice-publish'
@@ -388,6 +386,8 @@ export interface FileRouteTypes {
     | '/login/'
     | '/matching/'
     | '/matching/projects/announce'
+    | '/admin/challenger/points'
+    | '/admin/challenger/records'
     | '/matching/notice-publish/$noticeId'
     | '/matching/projects/new'
     | '/matching/projects/'
@@ -398,8 +398,6 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/auth-test'
-    | '/admin/challenger-points'
-    | '/admin/challenger-records'
     | '/login/default'
     | '/matching/applications'
     | '/matching/notice-publish'
@@ -424,6 +422,8 @@ export interface FileRouteTypes {
     | '/admin'
     | '/login'
     | '/matching'
+    | '/admin/challenger/points'
+    | '/admin/challenger/records'
     | '/matching/notice-publish/$noticeId'
     | '/matching/projects/new'
     | '/matching/projects'
@@ -436,8 +436,6 @@ export interface FileRouteTypes {
     | '/admin'
     | '/matching'
     | '/auth-test'
-    | '/admin/challenger-points'
-    | '/admin/challenger-records'
     | '/login/default'
     | '/matching/applications'
     | '/matching/notice-publish'
@@ -463,6 +461,8 @@ export interface FileRouteTypes {
     | '/login/'
     | '/matching/'
     | '/matching/projects/announce'
+    | '/admin/challenger/points'
+    | '/admin/challenger/records'
     | '/matching/notice-publish/$noticeId'
     | '/matching/projects/new'
     | '/matching/projects/'
@@ -695,20 +695,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LoginDefaultRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/admin/challenger-records': {
-      id: '/admin/challenger-records'
-      path: '/challenger-records'
-      fullPath: '/admin/challenger-records'
-      preLoaderRoute: typeof AdminChallengerRecordsRouteImport
-      parentRoute: typeof AdminRouteRoute
-    }
-    '/admin/challenger-points': {
-      id: '/admin/challenger-points'
-      path: '/challenger-points'
-      fullPath: '/admin/challenger-points'
-      preLoaderRoute: typeof AdminChallengerPointsRouteImport
-      parentRoute: typeof AdminRouteRoute
-    }
     '/matching/projects/': {
       id: '/matching/projects/'
       path: '/projects'
@@ -729,6 +715,20 @@ declare module '@tanstack/react-router' {
       fullPath: '/matching/notice-publish/$noticeId'
       preLoaderRoute: typeof MatchingNoticePublishNoticeIdRouteImport
       parentRoute: typeof MatchingNoticePublishRoute
+    }
+    '/admin/challenger/records': {
+      id: '/admin/challenger/records'
+      path: '/challenger/records'
+      fullPath: '/admin/challenger/records'
+      preLoaderRoute: typeof AdminChallengerRecordsRouteImport
+      parentRoute: typeof AdminRouteRoute
+    }
+    '/admin/challenger/points': {
+      id: '/admin/challenger/points'
+      path: '/challenger/points'
+      fullPath: '/admin/challenger/points'
+      preLoaderRoute: typeof AdminChallengerPointsRouteImport
+      parentRoute: typeof AdminRouteRoute
     }
     '/matching/projects/announce': {
       id: '/matching/projects/announce'
@@ -762,15 +762,15 @@ declare module '@tanstack/react-router' {
 }
 
 interface AdminRouteRouteChildren {
+  AdminIndexRoute: typeof AdminIndexRoute
   AdminChallengerPointsRoute: typeof AdminChallengerPointsRoute
   AdminChallengerRecordsRoute: typeof AdminChallengerRecordsRoute
-  AdminIndexRoute: typeof AdminIndexRoute
 }
 
 const AdminRouteRouteChildren: AdminRouteRouteChildren = {
+  AdminIndexRoute: AdminIndexRoute,
   AdminChallengerPointsRoute: AdminChallengerPointsRoute,
   AdminChallengerRecordsRoute: AdminChallengerRecordsRoute,
-  AdminIndexRoute: AdminIndexRoute,
 }
 
 const AdminRouteRouteWithChildren = AdminRouteRoute._addFileChildren(

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as AdminRouteRouteImport } from './routes/admin/route'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as MatchingIndexRouteImport } from './routes/matching/index'
 import { Route as LoginIndexRouteImport } from './routes/login/index'
+import { Route as AdminIndexRouteImport } from './routes/admin/index'
 import { Route as TestTooltipRouteImport } from './routes/test/tooltip'
 import { Route as TestToggleInputsRouteImport } from './routes/test/toggle-inputs'
 import { Route as TestToggleRouteImport } from './routes/test/toggle'
@@ -36,6 +37,8 @@ import { Route as MatchingRoundsRouteImport } from './routes/matching/rounds'
 import { Route as MatchingNoticePublishRouteImport } from './routes/matching/notice-publish'
 import { Route as MatchingApplicationsRouteImport } from './routes/matching/applications'
 import { Route as LoginDefaultRouteImport } from './routes/login/default'
+import { Route as AdminChallengerRecordsRouteImport } from './routes/admin/challenger-records'
+import { Route as AdminChallengerPointsRouteImport } from './routes/admin/challenger-points'
 import { Route as MatchingProjectsIndexRouteImport } from './routes/matching/projects/index'
 import { Route as MatchingProjectsNewRouteImport } from './routes/matching/projects/new'
 import { Route as MatchingNoticePublishNoticeIdRouteImport } from './routes/matching/notice-publish.$noticeId'
@@ -73,6 +76,11 @@ const LoginIndexRoute = LoginIndexRouteImport.update({
   id: '/login/',
   path: '/login/',
   getParentRoute: () => rootRouteImport,
+} as any)
+const AdminIndexRoute = AdminIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => AdminRouteRoute,
 } as any)
 const TestTooltipRoute = TestTooltipRouteImport.update({
   id: '/test/tooltip',
@@ -180,6 +188,16 @@ const LoginDefaultRoute = LoginDefaultRouteImport.update({
   path: '/login/default',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AdminChallengerRecordsRoute = AdminChallengerRecordsRouteImport.update({
+  id: '/challenger-records',
+  path: '/challenger-records',
+  getParentRoute: () => AdminRouteRoute,
+} as any)
+const AdminChallengerPointsRoute = AdminChallengerPointsRouteImport.update({
+  id: '/challenger-points',
+  path: '/challenger-points',
+  getParentRoute: () => AdminRouteRoute,
+} as any)
 const MatchingProjectsIndexRoute = MatchingProjectsIndexRouteImport.update({
   id: '/projects/',
   path: '/projects/',
@@ -223,9 +241,11 @@ const MatchingProjectsAnnounceNoticePublishNoticeIdRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
-  '/admin': typeof AdminRouteRoute
+  '/admin': typeof AdminRouteRouteWithChildren
   '/matching': typeof MatchingRouteRouteWithChildren
   '/auth-test': typeof AuthTestRoute
+  '/admin/challenger-points': typeof AdminChallengerPointsRoute
+  '/admin/challenger-records': typeof AdminChallengerRecordsRoute
   '/login/default': typeof LoginDefaultRoute
   '/matching/applications': typeof MatchingApplicationsRoute
   '/matching/notice-publish': typeof MatchingNoticePublishRouteWithChildren
@@ -247,6 +267,7 @@ export interface FileRoutesByFullPath {
   '/test/toggle': typeof TestToggleRoute
   '/test/toggle-inputs': typeof TestToggleInputsRoute
   '/test/tooltip': typeof TestTooltipRoute
+  '/admin/': typeof AdminIndexRoute
   '/login/': typeof LoginIndexRoute
   '/matching/': typeof MatchingIndexRoute
   '/matching/projects/announce': typeof MatchingProjectsAnnounceRouteRouteWithChildren
@@ -259,8 +280,9 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
-  '/admin': typeof AdminRouteRoute
   '/auth-test': typeof AuthTestRoute
+  '/admin/challenger-points': typeof AdminChallengerPointsRoute
+  '/admin/challenger-records': typeof AdminChallengerRecordsRoute
   '/login/default': typeof LoginDefaultRoute
   '/matching/applications': typeof MatchingApplicationsRoute
   '/matching/notice-publish': typeof MatchingNoticePublishRouteWithChildren
@@ -282,6 +304,7 @@ export interface FileRoutesByTo {
   '/test/toggle': typeof TestToggleRoute
   '/test/toggle-inputs': typeof TestToggleInputsRoute
   '/test/tooltip': typeof TestTooltipRoute
+  '/admin': typeof AdminIndexRoute
   '/login': typeof LoginIndexRoute
   '/matching': typeof MatchingIndexRoute
   '/matching/notice-publish/$noticeId': typeof MatchingNoticePublishNoticeIdRoute
@@ -294,9 +317,11 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
-  '/admin': typeof AdminRouteRoute
+  '/admin': typeof AdminRouteRouteWithChildren
   '/matching': typeof MatchingRouteRouteWithChildren
   '/auth-test': typeof AuthTestRoute
+  '/admin/challenger-points': typeof AdminChallengerPointsRoute
+  '/admin/challenger-records': typeof AdminChallengerRecordsRoute
   '/login/default': typeof LoginDefaultRoute
   '/matching/applications': typeof MatchingApplicationsRoute
   '/matching/notice-publish': typeof MatchingNoticePublishRouteWithChildren
@@ -318,6 +343,7 @@ export interface FileRoutesById {
   '/test/toggle': typeof TestToggleRoute
   '/test/toggle-inputs': typeof TestToggleInputsRoute
   '/test/tooltip': typeof TestTooltipRoute
+  '/admin/': typeof AdminIndexRoute
   '/login/': typeof LoginIndexRoute
   '/matching/': typeof MatchingIndexRoute
   '/matching/projects/announce': typeof MatchingProjectsAnnounceRouteRouteWithChildren
@@ -335,6 +361,8 @@ export interface FileRouteTypes {
     | '/admin'
     | '/matching'
     | '/auth-test'
+    | '/admin/challenger-points'
+    | '/admin/challenger-records'
     | '/login/default'
     | '/matching/applications'
     | '/matching/notice-publish'
@@ -356,6 +384,7 @@ export interface FileRouteTypes {
     | '/test/toggle'
     | '/test/toggle-inputs'
     | '/test/tooltip'
+    | '/admin/'
     | '/login/'
     | '/matching/'
     | '/matching/projects/announce'
@@ -368,8 +397,9 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
-    | '/admin'
     | '/auth-test'
+    | '/admin/challenger-points'
+    | '/admin/challenger-records'
     | '/login/default'
     | '/matching/applications'
     | '/matching/notice-publish'
@@ -391,6 +421,7 @@ export interface FileRouteTypes {
     | '/test/toggle'
     | '/test/toggle-inputs'
     | '/test/tooltip'
+    | '/admin'
     | '/login'
     | '/matching'
     | '/matching/notice-publish/$noticeId'
@@ -405,6 +436,8 @@ export interface FileRouteTypes {
     | '/admin'
     | '/matching'
     | '/auth-test'
+    | '/admin/challenger-points'
+    | '/admin/challenger-records'
     | '/login/default'
     | '/matching/applications'
     | '/matching/notice-publish'
@@ -426,6 +459,7 @@ export interface FileRouteTypes {
     | '/test/toggle'
     | '/test/toggle-inputs'
     | '/test/tooltip'
+    | '/admin/'
     | '/login/'
     | '/matching/'
     | '/matching/projects/announce'
@@ -439,7 +473,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
-  AdminRouteRoute: typeof AdminRouteRoute
+  AdminRouteRoute: typeof AdminRouteRouteWithChildren
   MatchingRouteRoute: typeof MatchingRouteRouteWithChildren
   AuthTestRoute: typeof AuthTestRoute
   LoginDefaultRoute: typeof LoginDefaultRoute
@@ -506,6 +540,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/login/'
       preLoaderRoute: typeof LoginIndexRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/admin/': {
+      id: '/admin/'
+      path: '/'
+      fullPath: '/admin/'
+      preLoaderRoute: typeof AdminIndexRouteImport
+      parentRoute: typeof AdminRouteRoute
     }
     '/test/tooltip': {
       id: '/test/tooltip'
@@ -654,6 +695,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LoginDefaultRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/admin/challenger-records': {
+      id: '/admin/challenger-records'
+      path: '/challenger-records'
+      fullPath: '/admin/challenger-records'
+      preLoaderRoute: typeof AdminChallengerRecordsRouteImport
+      parentRoute: typeof AdminRouteRoute
+    }
+    '/admin/challenger-points': {
+      id: '/admin/challenger-points'
+      path: '/challenger-points'
+      fullPath: '/admin/challenger-points'
+      preLoaderRoute: typeof AdminChallengerPointsRouteImport
+      parentRoute: typeof AdminRouteRoute
+    }
     '/matching/projects/': {
       id: '/matching/projects/'
       path: '/projects'
@@ -705,6 +760,22 @@ declare module '@tanstack/react-router' {
     }
   }
 }
+
+interface AdminRouteRouteChildren {
+  AdminChallengerPointsRoute: typeof AdminChallengerPointsRoute
+  AdminChallengerRecordsRoute: typeof AdminChallengerRecordsRoute
+  AdminIndexRoute: typeof AdminIndexRoute
+}
+
+const AdminRouteRouteChildren: AdminRouteRouteChildren = {
+  AdminChallengerPointsRoute: AdminChallengerPointsRoute,
+  AdminChallengerRecordsRoute: AdminChallengerRecordsRoute,
+  AdminIndexRoute: AdminIndexRoute,
+}
+
+const AdminRouteRouteWithChildren = AdminRouteRoute._addFileChildren(
+  AdminRouteRouteChildren,
+)
 
 interface MatchingNoticePublishRouteChildren {
   MatchingNoticePublishNoticeIdRoute: typeof MatchingNoticePublishNoticeIdRoute
@@ -778,7 +849,7 @@ const MatchingRouteRouteWithChildren = MatchingRouteRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
-  AdminRouteRoute: AdminRouteRoute,
+  AdminRouteRoute: AdminRouteRouteWithChildren,
   MatchingRouteRoute: MatchingRouteRouteWithChildren,
   AuthTestRoute: AuthTestRoute,
   LoginDefaultRoute: LoginDefaultRoute,

--- a/src/routes/admin/challenger-points.tsx
+++ b/src/routes/admin/challenger-points.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { GrantPointsPage } from "@/features/challenger"
+
+export const Route = createFileRoute("/admin/challenger-points")({
+  component: GrantPointsPage,
+})

--- a/src/routes/admin/challenger-records.tsx
+++ b/src/routes/admin/challenger-records.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { RecordCodePage } from "@/features/challenger"
+
+export const Route = createFileRoute("/admin/challenger-records")({
+  component: RecordCodePage,
+})

--- a/src/routes/admin/challenger/points.tsx
+++ b/src/routes/admin/challenger/points.tsx
@@ -2,6 +2,6 @@ import { createFileRoute } from "@tanstack/react-router"
 
 import { GrantPointsPage } from "@/features/challenger"
 
-export const Route = createFileRoute("/admin/challenger-points")({
+export const Route = createFileRoute("/admin/challenger/points")({
   component: GrantPointsPage,
 })

--- a/src/routes/admin/challenger/records.tsx
+++ b/src/routes/admin/challenger/records.tsx
@@ -2,6 +2,6 @@ import { createFileRoute } from "@tanstack/react-router"
 
 import { RecordCodePage } from "@/features/challenger"
 
-export const Route = createFileRoute("/admin/challenger-records")({
+export const Route = createFileRoute("/admin/challenger/records")({
   component: RecordCodePage,
 })

--- a/src/routes/admin/index.tsx
+++ b/src/routes/admin/index.tsx
@@ -1,0 +1,9 @@
+import { createFileRoute, Navigate } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/admin/")({
+  component: AdminIndex,
+})
+
+function AdminIndex() {
+  return <Navigate to="/admin/challenger-points" replace />
+}

--- a/src/routes/admin/index.tsx
+++ b/src/routes/admin/index.tsx
@@ -5,5 +5,5 @@ export const Route = createFileRoute("/admin/")({
 })
 
 function AdminIndex() {
-  return <Navigate to="/admin/challenger-points" replace />
+  return <Navigate to="/admin/challenger/points" replace />
 }

--- a/src/routes/admin/route.tsx
+++ b/src/routes/admin/route.tsx
@@ -18,8 +18,8 @@ interface AdminNavItem {
 }
 
 const ADMIN_NAV: AdminNavItem[] = [
-  { label: "챌린저 상벌점", to: "/admin/challenger-points" },
-  { label: "챌린저 기록 코드", to: "/admin/challenger-records" },
+  { label: "챌린저 상벌점", to: "/admin/challenger/points" },
+  { label: "챌린저 기록 코드", to: "/admin/challenger/records" },
 ]
 
 function AdminLayout() {

--- a/src/routes/admin/route.tsx
+++ b/src/routes/admin/route.tsx
@@ -1,17 +1,55 @@
-import { createFileRoute } from "@tanstack/react-router"
+import {
+  createFileRoute,
+  Link,
+  Outlet,
+  useLocation,
+} from "@tanstack/react-router"
 
 import Header from "@/components/header/Header"
+import { cn } from "@/shared/lib/utils"
 
 export const Route = createFileRoute("/admin")({
-  component: AdminPage,
+  component: AdminLayout,
 })
 
-function AdminPage() {
+interface AdminNavItem {
+  label: string
+  to: string
+}
+
+const ADMIN_NAV: AdminNavItem[] = [
+  { label: "챌린저 상벌점", to: "/admin/challenger-points" },
+  { label: "챌린저 기록 코드", to: "/admin/challenger-records" },
+]
+
+function AdminLayout() {
+  const location = useLocation()
+
   return (
     <main className="h-full min-h-screen w-full">
       <Header />
-      <div className="flex min-h-[calc(100vh-4.5rem)] items-center justify-center">
-        <p className="text-heading-5-semibold text-teal-gray-400">준비중</p>
+      <nav className="border-teal-gray-100 border-b bg-white">
+        <ul className="mx-auto flex w-full max-w-300 items-center gap-2 px-8.5">
+          {ADMIN_NAV.map((item) => {
+            const active = location.pathname.startsWith(item.to)
+            return (
+              <li key={item.to}>
+                <Link
+                  to={item.to}
+                  className={cn(
+                    "text-body-2-medium text-teal-gray-500 inline-flex h-12 items-center border-b-2 border-transparent px-3 transition-colors hover:text-teal-600",
+                    active && "border-teal-500 text-teal-600",
+                  )}
+                >
+                  {item.label}
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+      </nav>
+      <div className="flex w-full">
+        <Outlet />
       </div>
     </main>
   )


### PR DESCRIPTION
## 📸 작업 내용

> 작업한 내용을 두괄식으로 작성해주세요

운영진용 **챌린저 관리** 페이지 2종을 신규 도메인 `features/challenger/` 로 추가했습니다.

- **챌린저 상벌점 부여** (`/admin/challenger/points`) — 회원 검색 → 챌린저 기록 선택 → 상세/상벌점 내역 조회 → 상벌점 부여
- **챌린저 기록 코드 발급·조회** (`/admin/challenger/records`) — 9기 이전 활동 이력의 6자리 코드 발급 + 코드 조회
- 기존 `준비중` 상태였던 `/admin` 라우트를 sub-nav 가 있는 segment 레이아웃으로 전환
- 백엔드 응답 가이드를 정리한 문서와 작업 보고서를 `docs/` 에 추가

호출하는 API 는 [챌린저\_관리\_FE\_API\_가이드.md](./docs/챌린저_관리_FE_API_가이드.md) 에 정리된 플로우 A (운영진 흐름) / 플로우 B (코드 기반 흐름) 입니다.

## 🎞️ 주요 코드 설명

> 설명이 필요한 코드 위주로 작성해주세요

### 1. ID 류는 모두 numeric string

백엔드가 Java `Long` 정밀도 보전을 위해 모든 `*Id` 필드를 numeric string 으로 직렬화합니다. FE 도 동일하게 string 으로 다뤄 dropdown 의 `===` 비교가 깨지지 않도록 했습니다.

```ts
// src/features/challenger/model/types.ts
export interface ChallengerInfoResponse {
  challengerId: string
  memberId: string
  gisuId: string
  chapterId: string
  // ...
}

// src/features/challenger/api/organization.ts — 응답 정규화
function toStringId(value: unknown): string {
  if (typeof value === "string") return value
  if (typeof value === "number" && Number.isFinite(value)) return String(value)
  return ""
}
```

- field alias (`id` ↔ `chapterId` / `gisuId` / `schoolId`) fallback 도 함께 흡수해서 OpenAPI 와 실제 응답이 다른 경우도 방어합니다.

### 2. 상벌점 부여 — `pointType` 기본 점수 자동 적용

가이드 A-4 에 따르면 `pointValue` 는 optional 이고 미전달(null) 시 `pointType` 의 기본 점수가 자동 적용됩니다. `CUSTOM` 만 직접 입력 필수.

```ts
// src/features/challenger/model/grantPointSchema.ts
export const grantPointSchema = z
  .object({
    pointType: z.enum(POINT_TYPE_VALUES, { ... }),
    pointValue: z.number().int().optional(),
    description: z.string().trim().min(1).max(200),
  })
  .superRefine((data, ctx) => {
    if (data.pointType === "CUSTOM" && data.pointValue === undefined) {
      ctx.addIssue({
        code: "custom",
        message: "기타 유형은 점수를 직접 입력해야 합니다.",
        path: ["pointValue"],
      })
    }
  })
```

- 폼 라벨이 동적으로 전환됩니다: 일반 유형은 "점수 덮어쓰기 (선택)", `CUSTOM` 은 "점수" + 필수 표시
- 유형 선택 시 hint 로 `"기본 점수 -2점이 적용됩니다."` 안내
- "적용될 점수" 미리보기 카드(부호별 색상) 추가로 운영자가 어떤 점수가 부여될지 즉시 확인 가능

### 3. 코드 발급 폼 — 역할에 따른 파트 필드 조건부 노출

`CHALLENGER` / `SCHOOL_PART_LEADER` 만 특정 파트와 묶이고 나머지 운영진 역할은 파트가 무의미합니다. 이를 역할별로 분기:

```ts
// src/features/challenger/model/enums.ts
export const PART_REQUIRING_ROLES: ReadonlySet<RoleType> = new Set([
  "CHALLENGER",
  "SCHOOL_PART_LEADER",
])

export function roleNeedsPart(roleType: RoleType | undefined): boolean {
  return roleType !== undefined && PART_REQUIRING_ROLES.has(roleType)
}
```

```tsx
// src/features/challenger/ui/record-code/CreateRecordForm.tsx
{showPartField ? (
  <Controller name="part" ... />
) : (
  <FieldRow label="파트" hint="선택한 역할은 특정 파트에 묶이지 않습니다. (운영진으로 자동 처리)">
    <div className="...">파트 선택 불필요</div>
  </FieldRow>
)}

// 제출 직전: 비파트 역할은 ADMIN 으로 자동 채워서 전송
mutationFn: (payload) => createChallengerRecord({
  ...payload,
  part: payload.part ?? "ADMIN",
})
```

- zod 도 `.optional()` + `superRefine` 으로 위 두 역할일 때만 필수 검증

### 4. /admin 을 segment 레이아웃으로 전환

기존 `routes/admin/route.tsx` 가 단일 `준비중` 페이지였는데, 두 챌린저 페이지를 호스팅하기 위해 `<Outlet />` + sub-nav 구조로 변경했습니다. `/admin` 으로 들어오면 `/admin/challenger-points` 로 자동 redirect.

## 🖥️ 구현화면

> localhost 캡쳐 사진을 첨부해 주세요.

|       챌린저 상벌점 부여        |        챌린저 기록 코드         |
| :-----------------------------: | :-----------------------------: |
| `/admin/challenger-points`      | `/admin/challenger-records`     |
|   <img src = "" width ="250">   |   <img src = "" width ="250">   |

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #이슈번호

## 📚 참고자료

- [docs/챌린저\_관리\_FE\_API\_가이드.md](./docs/챌린저_관리_FE_API_가이드.md) — 플로우 A·B 의 request/response 스펙 정리
- [docs/2026-05-06\_챌린저\_관리\_FE\_업무보고서.md](./docs/2026-05-06_챌린저_관리_FE_업무보고서.md) — 1차 구현 → 2차 가이드 정합화 변경사항
- [ARCHITECTURE.md](./ARCHITECTURE.md) — feature 도메인 구조 / api · model · ui 레이어 규칙

## 💬 기타 더 이야기해볼 점

- 본 PR 의 범위 외로 남겨둔 후속 작업
  - **A-5 / A-6**: 부여된 상벌점의 사유 수정 / 삭제 (각 row 옆 액션 버튼 + CtaModal 패턴으로 추가 가능)
  - **A-1 페이지네이션**: 회원 검색이 `page=0&size=10` 만 호출 — 무한스크롤 또는 "더 보기" 버튼 필요 여부 검토
  - **B-1 / B-2**: 현재 기수 챌린저 직접 등록 (현 PR 은 9기 이전 코드 발급만 다룸)
  - **권한 부족 시 사용자 친화 메시지**: 현재는 axios 인터셉터가 401 만 다루고 403 은 일반 reject — 권한 부족 메시지 노출 패턴 합의 필요
- `RoleType` 에 `CHALLENGER` 를 추가했지만 OpenAPI 스펙의 `challengerRoleType` enum 에는 명시되어 있지 않습니다. 백엔드가 실제로 `CHALLENGER` 값을 받아주는지 확인 필요
- `/v1/gisu/all` 과 `/v1/chapters` (`with-schools` 아님) 가 deprecated 표기 — 추후 페이징 API 로 교체 검토
