### PR TITLE
fix: 공용 컴포넌트 수정 및 프로젝트 관리 페이지 수정 사항 반영

### DIFF
--- a/src/features/project/list/ui/FilterDropDown.tsx
+++ b/src/features/project/list/ui/FilterDropDown.tsx
@@ -88,7 +88,7 @@ export function FilterDropdown(props: FilterDropdownProps) {
         aria-haspopup="listbox"
         onClick={onClick}
         className={cn(
-          "shadow-inner-neutral-2 inline-flex h-11 min-w-[6.375rem] shrink-0 items-center gap-1 rounded-xl border py-0 pr-2.5 pl-4 text-left transition-colors",
+          "shadow-inner-neutral-2 inline-flex h-11 min-w-20 shrink-0 items-center gap-1 rounded-xl border py-0 pr-2.5 pl-4 text-left transition-colors",
           highlighted
             ? "border-teal-300 bg-teal-50 text-teal-600"
             : [

--- a/src/features/project/list/ui/MatchingProjectsListPage.tsx
+++ b/src/features/project/list/ui/MatchingProjectsListPage.tsx
@@ -23,6 +23,7 @@ export function MatchingProjectsListPage() {
     filterKey,
   } = useMatchingProjectListFilters()
 
+  const [searchQuery, setSearchQuery] = useState("")
   const [page, setPage] = useState(1)
   const [selectedProject, setSelectedProject] =
     useState<MatchingProject | null>(null)
@@ -64,7 +65,7 @@ export function MatchingProjectsListPage() {
         </div>
 
         <div className="relative z-30 mb-3 flex items-start justify-between self-stretch">
-          <ProjectSearchField />
+          <ProjectSearchField value={searchQuery} onChange={setSearchQuery} />
           <div className="flex items-center gap-2">
             {filterDescriptors.map((filter) => (
               <FilterDropdown

--- a/src/features/project/list/ui/ProjectSearchField.tsx
+++ b/src/features/project/list/ui/ProjectSearchField.tsx
@@ -1,15 +1,21 @@
+import { useState } from "react"
+
 import SearchIcon from "@/shared/assets/icon/search/SearchIcon"
 
 export function ProjectSearchField() {
+  const [value, setValue] = useState("")
+
   return (
     <div className="bg-teal-gray-100 flex h-11 w-[28.5rem] items-center justify-between rounded-xl px-4">
       <input
         type="text"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
         placeholder="프로젝트 명으로 검색하세요."
         aria-label="프로젝트 검색"
         className="text-body-2-medium text-teal-gray-900 placeholder:text-teal-gray-400 w-full bg-transparent outline-none"
       />
-      <SearchIcon className="color-teal-gray-400 shrink-0" aria-hidden />
+      <SearchIcon className="text-teal-gray-400 shrink-0" aria-hidden />
     </div>
   )
 }

--- a/src/features/project/list/ui/ProjectSearchField.tsx
+++ b/src/features/project/list/ui/ProjectSearchField.tsx
@@ -1,16 +1,20 @@
-import { useState } from "react"
-
 import SearchIcon from "@/shared/assets/icon/search/SearchIcon"
 
-export function ProjectSearchField() {
-  const [value, setValue] = useState("")
+interface ProjectSearchFieldProps {
+  value: string
+  onChange: (value: string) => void
+}
 
+export function ProjectSearchField({
+  value,
+  onChange,
+}: ProjectSearchFieldProps) {
   return (
     <div className="bg-teal-gray-100 flex h-11 w-[28.5rem] items-center justify-between rounded-xl px-4">
       <input
         type="text"
         value={value}
-        onChange={(e) => setValue(e.target.value)}
+        onChange={(e) => onChange(e.target.value)}
         placeholder="프로젝트 명으로 검색하세요."
         aria-label="프로젝트 검색"
         className="text-body-2-medium text-teal-gray-900 placeholder:text-teal-gray-400 w-full bg-transparent outline-none"

--- a/src/features/project/management/ui/ProjectManagementCard.tsx
+++ b/src/features/project/management/ui/ProjectManagementCard.tsx
@@ -36,7 +36,7 @@ export function ProjectManagementCard({
           if (e.key === "Enter" || e.key === " ") setOpen(true)
         }}
       >
-        <div className="bg-teal-gray-200 text-teal-gray-400 flex h-[10.5625rem] w-80 shrink-0 items-center justify-center overflow-hidden rounded-l-[0.625rem] text-center text-sm">
+        <div className="bg-teal-gray-200 text-teal-gray-400 flex h-[10.5625rem] w-80 shrink-0 items-center justify-center overflow-hidden rounded-[0.625rem] text-center text-sm">
           {cover?.src ? (
             <img
               src={cover.src}

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -38,10 +38,10 @@ export function ProjectManagementMoreMenu({
   }
 
   const MENU_ITEMS = [
-    { label: "지원현황 확인하기", onClick: handleApplicationClick },
+    { label: "지원 현황 확인하기", onClick: handleApplicationClick },
     { label: "기획 보기", onClick: () => {} },
     { label: "프로젝트 수정하기", onClick: () => {} },
-    { label: "팀원 구성보기", onClick: () => {} },
+    { label: "팀원 구성 보기", onClick: () => {} },
   ]
 
   return (

--- a/src/shared/ui/dropdown/DropdownItem.tsx
+++ b/src/shared/ui/dropdown/DropdownItem.tsx
@@ -6,6 +6,24 @@ interface DropdownItemProps {
   onClick: () => void
   isSelected?: boolean
   className?: string
+  size?: "xs" | "md"
+}
+
+type Size = "xs" | "md"
+
+const baseClass: Record<Size, string> = {
+  xs: "text-body-3-regular text-teal-gray-600 h-[1.625rem] py-1",
+  md: "text-body-2-regular text-teal-gray-700 h-10 py-0",
+}
+
+const paddingClass: Record<Size, { default: string; selected: string }> = {
+  xs: { default: "px-3", selected: "pl-3 pr-2" },
+  md: { default: "px-4", selected: "pl-4 pr-2.5" },
+}
+
+const labelSelectedClass: Record<Size, string> = {
+  xs: "text-body-3-medium text-teal-600",
+  md: "text-body-2-medium text-teal-600",
 }
 
 export function DropdownItem({
@@ -13,23 +31,26 @@ export function DropdownItem({
   onClick,
   isSelected = false,
   className,
+  size = "md",
 }: DropdownItemProps) {
   return (
     <button
       type="button"
       onClick={onClick}
       className={cn(
-        "text-body-2-medium text-teal-gray-700 flex h-10 w-full shrink-0 items-center gap-2.5 rounded-lg bg-white py-0 pr-2.5 pl-4 text-left transition-[background-color,color,box-shadow]",
-        !isSelected && "hover:bg-teal-gray-50 hover:shadow-inner-neutral-3",
-        isSelected &&
-          "shadow-inner-neutral-4 hover:shadow-inner-neutral-4 bg-teal-50 text-teal-600 hover:bg-teal-50",
+        "flex w-full shrink-0 rounded-lg bg-white text-left transition-[background-color,color,box-shadow]",
+        baseClass[size],
+        isSelected ? paddingClass[size].selected : paddingClass[size].default,
+        isSelected
+          ? "shadow-inner-neutral-1 bg-teal-50"
+          : "hover:bg-teal-gray-50 hover:shadow-inner-neutral-2",
         className,
       )}
     >
       <span
         className={cn(
           "flex w-full min-w-0 items-center justify-between gap-2.5",
-          isSelected && "text-subtitle-4-semibold text-teal-600",
+          isSelected && labelSelectedClass[size],
         )}
       >
         {label}

--- a/src/shared/ui/dropdown/DropdownSearchField.tsx
+++ b/src/shared/ui/dropdown/DropdownSearchField.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react"
+
+import CloseCircleIcon from "@/shared/assets/icon/close/CloseCircleIcon"
+import SearchIcon from "@/shared/assets/icon/search/SearchIcon"
+import { cn } from "@/shared/lib/utils"
+
+export function DropdownSearchField() {
+  const [value, setValue] = useState("")
+
+  return (
+    <div
+      className={cn(
+        "flex h-11 w-[8.75rem] items-center gap-2 rounded-lg pr-3.5 pl-3 transition-colors",
+        value
+          ? "bg-teal-gray-50 border-teal-gray-400 border-[1.5px]"
+          : "bg-teal-gray-50 hover:bg-teal-gray-400",
+      )}
+    >
+      <SearchIcon className="text-teal-gray-400 size-5 shrink-0" aria-hidden />
+      <div className="flex min-w-0 flex-1 items-center gap-0.5">
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          placeholder="검색"
+          className="text-body-3-regular text-teal-gray-900 placeholder:text-teal-gray-400 min-w-0 flex-1 bg-transparent outline-none"
+        />
+        {value && (
+          <button
+            type="button"
+            onClick={() => setValue("")}
+            aria-label="검색어 지우기"
+          >
+            <CloseCircleIcon className="text-teal-gray-300 size-[1.125rem] shrink-0" />
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 📸 작업 내용

> 공용 컴포넌트 수정 및 프로젝트 관리 페이지 수정 사항 반영

- 프로젝트 관리 카드 좌우 radius 10px 통일
- filterdropdown 최소 크기 80px로 고정 반영
- dropdownItem size xs 추가
- ProjectManagementMoreMenu label 띄어쓰기 반영
- 작은 검색창 필드(DropdownSearchField) 임시 구현


## 🎞️ 주요 코드 설명

### DropdownItem 스타일 구조 개선

```TypeScript
const baseClass: Record<Size, string> = {
  xs: "text-body-3-regular text-teal-gray-600 h-[1.625rem] py-1",
  md: "text-body-2-regular text-teal-gray-700 h-10 py-0",
}

const paddingClass: Record<Size, { default: string; selected: string }> = {
  xs: { default: "px-3", selected: "pl-3 pr-2" },
  md: { default: "px-4", selected: "pl-4 pr-2.5" },
}

const labelSelectedClass: Record<Size, string> = {
  xs: "text-body-3-medium text-teal-600",
  md: "text-body-2-medium text-teal-600",
}
```

- size(xs, md)에 따라 스타일을 분리하여 관리하도록 개선
- selected 상태에 따른 padding / 텍스트 스타일 명확히 분리


## 🖥️ 구현화면

<img width="677" height="144" alt="image" src="https://github.com/user-attachments/assets/bf7cbb98-8f42-40b6-a902-b2b402c2c0d5" />
<img width="321" height="232" alt="image" src="https://github.com/user-attachments/assets/162feeff-e349-4d99-a805-6c1e48aa3920" />
<img width="128" height="185" alt="image" src="https://github.com/user-attachments/assets/de10c72a-a88c-4cd3-8079-009e3f38e0fd" />


## 🔗 연결된 이슈

- Connected: #73 