### PR TITLE
feat: 공지사항 CRUD API 연결 및 권한/지부별 뷰 분기 처리

### DIFF
--- a/src/features/notice/api/noticeApi.ts
+++ b/src/features/notice/api/noticeApi.ts
@@ -49,9 +49,5 @@ export async function postNotice(body: PostNoticeRequest) {
 
 // 공지사항 수정
 export async function patchNotice(noticeId: number, body: PatchNoticeRequest) {
-  const { data } = await api.patch<ApiResponse<void>>(
-    `/v1/notices/${noticeId}`,
-    body,
-  )
-  return data
+  await api.patch<ApiResponse<void>>(`/v1/notices/${noticeId}`, body)
 }

--- a/src/features/notice/api/noticeApi.ts
+++ b/src/features/notice/api/noticeApi.ts
@@ -7,6 +7,7 @@ import type {
   NoticeSummaryResponse,
   NoticeTabEnum,
   PartEnum,
+  PatchNoticeRequest,
   PostNoticeRequest,
   PostNoticeResponse,
 } from "../model/apiTypes"
@@ -44,4 +45,13 @@ export async function postNotice(body: PostNoticeRequest) {
     body,
   )
   return data.result
+}
+
+// 공지사항 수정
+export async function patchNotice(noticeId: number, body: PatchNoticeRequest) {
+  const { data } = await api.patch<ApiResponse<void>>(
+    `/v1/notices/${noticeId}`,
+    body,
+  )
+  return data
 }

--- a/src/features/notice/api/noticeApi.ts
+++ b/src/features/notice/api/noticeApi.ts
@@ -52,7 +52,7 @@ export async function patchNotice(noticeId: number, body: PatchNoticeRequest) {
   await api.patch<ApiResponse<void>>(`/v1/notices/${noticeId}`, body)
 }
 
-// 공지사항 수정
+// 공지사항 삭제
 export async function deleteNotice(noticeId: number) {
   await api.delete<ApiResponse<void>>(`/v1/notices/${noticeId}`)
 }

--- a/src/features/notice/api/noticeApi.ts
+++ b/src/features/notice/api/noticeApi.ts
@@ -7,6 +7,8 @@ import type {
   NoticeSummaryResponse,
   NoticeTabEnum,
   PartEnum,
+  PostNoticeRequest,
+  PostNoticeResponse,
 } from "../model/apiTypes"
 
 // 공지사항 전체 조회
@@ -31,6 +33,15 @@ export async function getNotices(params: {
 export async function getNoticeDetail(noticeId: number) {
   const { data } = await api.get<ApiResponse<NoticeDetailResponse>>(
     `/v1/notices/${noticeId}`,
+  )
+  return data.result
+}
+
+// 공지사항 생성
+export async function postNotice(body: PostNoticeRequest) {
+  const { data } = await api.post<ApiResponse<PostNoticeResponse>>(
+    `/v1/notices`,
+    body,
   )
   return data.result
 }

--- a/src/features/notice/api/noticeApi.ts
+++ b/src/features/notice/api/noticeApi.ts
@@ -1,0 +1,27 @@
+import { api } from "@/shared/lib/axios"
+
+import type { ApiResponse } from "@/shared/lib/apiResponse"
+
+import type {
+  NoticeSummaryResponse,
+  NoticeTabEnum,
+  PartEnum,
+} from "../model/apiTypes"
+
+// 공지사항 전체 조회
+export async function getNotices(params: {
+  gisuId: number
+  chapterId?: number
+  schoolId?: number
+  part?: PartEnum
+  noticeTab: NoticeTabEnum
+  page?: number
+  size?: number
+  sort?: string // property,(asc|desc) 형식으로 작성 (ex: createdAt,DESC)
+}) {
+  const { data } = await api.get<ApiResponse<NoticeSummaryResponse>>(
+    `/v1/notices`,
+    { params },
+  )
+  return data.result
+}

--- a/src/features/notice/api/noticeApi.ts
+++ b/src/features/notice/api/noticeApi.ts
@@ -3,6 +3,7 @@ import { api } from "@/shared/lib/axios"
 import type { ApiResponse } from "@/shared/lib/apiResponse"
 
 import type {
+  NoticeDetailResponse,
   NoticeSummaryResponse,
   NoticeTabEnum,
   PartEnum,
@@ -22,6 +23,14 @@ export async function getNotices(params: {
   const { data } = await api.get<ApiResponse<NoticeSummaryResponse>>(
     `/v1/notices`,
     { params },
+  )
+  return data.result
+}
+
+// 공지사항 상세 조회
+export async function getNoticeDetail(noticeId: number) {
+  const { data } = await api.get<ApiResponse<NoticeDetailResponse>>(
+    `/v1/notices/${noticeId}`,
   )
   return data.result
 }

--- a/src/features/notice/api/noticeApi.ts
+++ b/src/features/notice/api/noticeApi.ts
@@ -51,3 +51,8 @@ export async function postNotice(body: PostNoticeRequest) {
 export async function patchNotice(noticeId: number, body: PatchNoticeRequest) {
   await api.patch<ApiResponse<void>>(`/v1/notices/${noticeId}`, body)
 }
+
+// 공지사항 수정
+export async function deleteNotice(noticeId: number) {
+  await api.delete<ApiResponse<void>>(`/v1/notices/${noticeId}`)
+}

--- a/src/features/notice/index.ts
+++ b/src/features/notice/index.ts
@@ -1,6 +1,7 @@
 export { Border } from "./ui/Border"
 export { NoticeCard } from "./ui/NoticeCard"
 export { NoticeCardList, type NoticeItem } from "./ui/NoticeCardList"
+export { NoticeDetailContent } from "./ui/NoticeDetailContent"
 export { NoticePublishForm } from "./ui/NoticePublishForm"
 export { NoticeSubmitButton } from "./ui/NoticeSubmitButton"
 export {

--- a/src/features/notice/model/apiTypes.ts
+++ b/src/features/notice/model/apiTypes.ts
@@ -94,3 +94,17 @@ export interface NoticeDetailResponse {
   viewCount: number
   createdAt: string // "2026-05-14T11:10:02.955Z"
 }
+
+// POST /api/v1/notices Request Body
+export interface PostNoticeRequest {
+  title: string
+  content: string
+  shouldNotify: boolean
+  mustRead: boolean
+  targetInfo: TargetInfo
+}
+
+// POST /api/v1/notices 응답 항목
+export interface PostNoticeResponse {
+  noticeId: number
+}

--- a/src/features/notice/model/apiTypes.ts
+++ b/src/features/notice/model/apiTypes.ts
@@ -108,3 +108,10 @@ export interface PostNoticeRequest {
 export interface PostNoticeResponse {
   noticeId: number
 }
+
+// PATCH /api/v1/notices/{noticeId} Request Body
+export interface PatchNoticeRequest {
+  title: string
+  content: string
+  mustRead: boolean
+}

--- a/src/features/notice/model/apiTypes.ts
+++ b/src/features/notice/model/apiTypes.ts
@@ -65,31 +65,25 @@ export interface NoticeDetailResponse {
     startsAt: string // "2026-05-14T11:10:02.955Z"
     endsAtExclusive: string
     totalParticipants: number
-    options: [
-      {
-        optionId: number
-        content: string
-        voteCount: number
-        voteRate: number
-        selectedMemberIds: number[]
-      },
-    ]
+    options: {
+      optionId: number
+      content: string
+      voteCount: number
+      voteRate: number
+      selectedMemberIds: number[]
+    }[]
     mySelectedOptionIds: number[]
   }
-  images: [
-    {
-      id: number
-      url: string
-      displayOrder: number
-    },
-  ]
-  links: [
-    {
-      id: number
-      url: string
-      displayOrder: number
-    },
-  ]
+  images: {
+    id: number
+    url: string
+    displayOrder: number
+  }[]
+  links: {
+    id: number
+    url: string
+    displayOrder: number
+  }[]
   targetInfo: TargetInfo
   viewCount: number
   createdAt: string // "2026-05-14T11:10:02.955Z"

--- a/src/features/notice/model/apiTypes.ts
+++ b/src/features/notice/model/apiTypes.ts
@@ -14,6 +14,7 @@ export type NoticeTabEnum =
   | "SCHOOL_CORE"
   | "SCHOOL_PART_LEADER"
 
+// GET /api/v1/notices 응답 항목
 export interface NoticeSummaryResponse {
   content: NoticeSummaryResponseContent[]
   page: number
@@ -31,16 +32,65 @@ export interface NoticeSummaryResponseContent {
   shouldSendNotification: boolean
   mustRead: boolean
   viewCount: number
-  createdAt: string
-  targetInfo: {
-    targetGisuId: number
-    targetChapterId: number
-    targetSchoolId: number
-    targetParts: PartEnum[]
-    targetNoticeTab: NoticeTabEnum
-  }
+  createdAt: string // "2026-05-14T11:10:02.955Z"
+  targetInfo: TargetInfo
   authorChallengerId: number
   authorMemberId: number
   authorNickname: string
   authorName: string
+}
+
+export interface TargetInfo {
+  targetGisuId: number
+  targetChapterId: number
+  targetSchoolId: number
+  targetParts: PartEnum[]
+  targetNoticeTab: NoticeTabEnum
+}
+
+// GET /api/v1/notices/{noticeId} 응답 항목
+export interface NoticeDetailResponse {
+  id: number
+  title: string
+  content: string
+  authorChallengerId: number
+  authorMemberId: number
+  mustRead: boolean
+  vote: {
+    voteId: number
+    title: string
+    isAnonymous: boolean
+    allowMultipleChoice: boolean
+    status: string
+    startsAt: string // "2026-05-14T11:10:02.955Z"
+    endsAtExclusive: string
+    totalParticipants: number
+    options: [
+      {
+        optionId: number
+        content: string
+        voteCount: number
+        voteRate: number
+        selectedMemberIds: number[]
+      },
+    ]
+    mySelectedOptionIds: number[]
+  }
+  images: [
+    {
+      id: number
+      url: string
+      displayOrder: number
+    },
+  ]
+  links: [
+    {
+      id: number
+      url: string
+      displayOrder: number
+    },
+  ]
+  targetInfo: TargetInfo
+  viewCount: number
+  createdAt: string // "2026-05-14T11:10:02.955Z"
 }

--- a/src/features/notice/model/apiTypes.ts
+++ b/src/features/notice/model/apiTypes.ts
@@ -1,0 +1,46 @@
+export type PartEnum =
+  | "PLAN"
+  | "DESIGN"
+  | "WEB"
+  | "ANDROID"
+  | "IOS"
+  | "NODEJS"
+  | "SPRINGBOOT"
+  | "ADMIN"
+
+export type NoticeTabEnum =
+  | "CHALLENGER"
+  | "CENTRAL_MEMBER"
+  | "SCHOOL_CORE"
+  | "SCHOOL_PART_LEADER"
+
+export interface NoticeSummaryResponse {
+  content: NoticeSummaryResponseContent[]
+  page: number
+  size: number
+  totalElements: number
+  totalPages: number
+  hasNext: boolean
+  hasPrevious: boolean
+}
+
+export interface NoticeSummaryResponseContent {
+  id: number
+  title: string
+  content: string
+  shouldSendNotification: boolean
+  mustRead: boolean
+  viewCount: number
+  createdAt: string
+  targetInfo: {
+    targetGisuId: number
+    targetChapterId: number
+    targetSchoolId: number
+    targetParts: PartEnum[]
+    targetNoticeTab: NoticeTabEnum
+  }
+  authorChallengerId: number
+  authorMemberId: number
+  authorNickname: string
+  authorName: string
+}

--- a/src/features/notice/ui/NoticeCardList.tsx
+++ b/src/features/notice/ui/NoticeCardList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { type ReactNode, useEffect, useState } from "react"
 
 import { Border } from "./Border"
 import { NoticeCard } from "./NoticeCard"
@@ -19,6 +19,7 @@ interface NoticeCardListProps {
   focusedNoticeId?: string | null
   onDeleteNotice?: (noticeId: string) => void
   onEditNotice?: (noticeId: string) => void
+  renderContent?: (noticeId: string) => ReactNode
 }
 
 export function NoticeCardList({
@@ -28,6 +29,7 @@ export function NoticeCardList({
   focusedNoticeId,
   onDeleteNotice,
   onEditNotice,
+  renderContent,
 }: NoticeCardListProps) {
   const [expandedIndex, setExpandedIndex] = useState<number | null>(null)
 
@@ -90,7 +92,7 @@ export function NoticeCardList({
                 onDeleteNotice?.(notice.id)
               }}
             >
-              임시 내용
+              {renderContent ? renderContent(notice.id) : "임시 내용"}
             </NoticeCard>
 
             {!isExpanded && index < notices.length - 1 ? <Border /> : null}

--- a/src/features/notice/ui/NoticeDetailContent.tsx
+++ b/src/features/notice/ui/NoticeDetailContent.tsx
@@ -41,7 +41,7 @@ export function NoticeDetailContent({ noticeId }: NoticeDetailContentProps) {
 
       {data.images && data.images.length > 0 && (
         <div className="flex flex-wrap gap-2 pt-4">
-          {data.images
+          {[...data.images]
             .sort((a, b) => a.displayOrder - b.displayOrder)
             .map((image) => (
               <img
@@ -56,7 +56,7 @@ export function NoticeDetailContent({ noticeId }: NoticeDetailContentProps) {
 
       {data.links && data.links.length > 0 && (
         <div className="flex flex-col gap-2 pt-4">
-          {data.links
+          {[...data.links]
             .sort((a, b) => a.displayOrder - b.displayOrder)
             .map((link) => (
               <a

--- a/src/features/notice/ui/NoticeDetailContent.tsx
+++ b/src/features/notice/ui/NoticeDetailContent.tsx
@@ -1,0 +1,76 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { getNoticeDetail } from "../api/noticeApi"
+
+interface NoticeDetailContentProps {
+  noticeId: string
+}
+
+export function NoticeDetailContent({ noticeId }: NoticeDetailContentProps) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["notice", "detail", noticeId],
+    queryFn: () => getNoticeDetail(Number(noticeId)),
+    enabled: !!noticeId,
+  })
+
+  if (isLoading) {
+    return (
+      <div className="flex w-full items-center justify-center py-10">
+        <span className="text-body-2-medium text-teal-gray-500 italic">
+          로딩 중...
+        </span>
+      </div>
+    )
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="flex w-full items-center justify-center py-10">
+        <span className="text-body-2-medium text-red-500">
+          공지 내용을 불러오는 중 오류가 발생했습니다.
+        </span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="text-body-1-regular text-teal-gray-900 whitespace-pre-wrap">
+        {data.content}
+      </div>
+
+      {data.images && data.images.length > 0 && (
+        <div className="flex flex-wrap gap-2 pt-4">
+          {data.images
+            .sort((a, b) => a.displayOrder - b.displayOrder)
+            .map((image) => (
+              <img
+                key={image.id}
+                src={image.url}
+                alt="notice attachment"
+                className="max-h-60 rounded-lg object-contain shadow-sm"
+              />
+            ))}
+        </div>
+      )}
+
+      {data.links && data.links.length > 0 && (
+        <div className="flex flex-col gap-2 pt-4">
+          {data.links
+            .sort((a, b) => a.displayOrder - b.displayOrder)
+            .map((link) => (
+              <a
+                key={link.id}
+                href={link.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-body-2-medium text-teal-600 underline underline-offset-4 transition-colors hover:text-teal-700"
+              >
+                {link.url}
+              </a>
+            ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/features/notice/ui/NoticePublishForm.tsx
+++ b/src/features/notice/ui/NoticePublishForm.tsx
@@ -1,6 +1,6 @@
-import { useMutation, useQuery } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useBlocker } from "@tanstack/react-router"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import { useAuthStore } from "@/features/auth/store/authStore"
 import { getMemberProfile } from "@/features/challenger/api/member"
@@ -16,8 +16,12 @@ import { Modal } from "@/shared/ui/Modal"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
 import { TextQuestionField } from "@/shared/ui/question-field/TextQuestionField"
 
-import { postNotice } from "../api/noticeApi"
-import { type NoticeTabEnum, type PartEnum } from "../model/apiTypes"
+import { getNoticeDetail, patchNotice, postNotice } from "../api/noticeApi"
+import {
+  type NoticeTabEnum,
+  type PartEnum,
+  type PatchNoticeRequest,
+} from "../model/apiTypes"
 
 const MAX_CHARS = 2000
 const NOTICE_COMPLETION_STORAGE_KEY = "notice:completion-target"
@@ -37,6 +41,7 @@ export function NoticePublishForm({
   targetParts = [],
   chapter,
 }: NoticePublishFormProps) {
+  const queryClient = useQueryClient()
   const [noticeContent, setNoticeContent] = useState("")
   const [noticeTitle, setNoticeTitle] = useState("")
   const [isRequired, setIsRequired] = useState(false)
@@ -64,6 +69,22 @@ export function NoticePublishForm({
     queryFn: () => getMemberProfile(String(memberId)),
     enabled: !!memberId,
   })
+
+  // 공지 상세 조회 (수정 모드일 때)
+  const { data: noticeDetail } = useQuery({
+    queryKey: ["notice", "detail", noticeId],
+    queryFn: () => getNoticeDetail(Number(noticeId)),
+    enabled: variant === "edit" && !!noticeId,
+  })
+
+  // 수정 모드일 때 기존 데이터로 폼 채우기
+  useEffect(() => {
+    if (variant === "edit" && noticeDetail) {
+      setNoticeTitle(noticeDetail.title)
+      setNoticeContent(noticeDetail.content)
+      setIsRequired(noticeDetail.mustRead)
+    }
+  }, [variant, noticeDetail])
 
   const activeGisuId = useMemo(() => {
     if (!gisuData) return null
@@ -99,6 +120,7 @@ export function NoticePublishForm({
   const publishMutation = useMutation({
     mutationFn: postNotice,
     onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["notices"] })
       setIsLoading(false)
       setIsDone(true)
 
@@ -119,6 +141,35 @@ export function NoticePublishForm({
     onError: () => {
       setIsLoading(false)
       // TODO: 에러 처리 (토스트 등)
+    },
+  })
+
+  const editMutation = useMutation({
+    mutationFn: ({ id, body }: { id: number; body: PatchNoticeRequest }) =>
+      patchNotice(id, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["notices"] })
+      queryClient.invalidateQueries({
+        queryKey: ["notice", "detail", noticeId],
+      })
+      setIsLoading(false)
+      setIsDone(true)
+
+      sessionStorage.setItem(
+        NOTICE_COMPLETION_STORAGE_KEY,
+        JSON.stringify({
+          id: noticeId,
+          title: noticeTitle,
+          chip: isRequired ? "필독" : undefined,
+          mode: variant,
+        }),
+      )
+
+      setIsCompletionModalOpen(true)
+    },
+    onError: () => {
+      setIsLoading(false)
+      // TODO: 에러 처리
     },
   })
 
@@ -179,19 +230,15 @@ export function NoticePublishForm({
         shouldNotify: false, // UI에 알림 여부 토글이 없으므로 기본값 false
         targetInfo,
       })
-    } else {
-      // TODO: edit API 연결
-      console.log("Updating notice:", {
-        noticeId,
-        title: noticeTitle,
-        content: noticeContent,
-        isRequired,
+    } else if (variant === "edit" && noticeId) {
+      editMutation.mutate({
+        id: Number(noticeId),
+        body: {
+          title: noticeTitle,
+          content: noticeContent,
+          mustRead: isRequired,
+        },
       })
-      setTimeout(() => {
-        setIsLoading(false)
-        setIsDone(true)
-        setIsCompletionModalOpen(true)
-      }, 1000)
     }
   }
 

--- a/src/features/notice/ui/NoticePublishForm.tsx
+++ b/src/features/notice/ui/NoticePublishForm.tsx
@@ -1,6 +1,13 @@
+import { useMutation, useQuery } from "@tanstack/react-query"
 import { useBlocker } from "@tanstack/react-router"
-import { useState } from "react"
+import { useMemo, useState } from "react"
 
+import { useAuthStore } from "@/features/auth/store/authStore"
+import { getMemberProfile } from "@/features/challenger/api/member"
+import {
+  getAllChapters,
+  getAllGisu,
+} from "@/features/challenger/api/organization"
 import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
 import LeftChevronIcon from "@/shared/assets/icon/chevron/LeftChevronIcon"
 import { Button } from "@/shared/ui/Button"
@@ -9,17 +16,26 @@ import { Modal } from "@/shared/ui/Modal"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
 import { TextQuestionField } from "@/shared/ui/question-field/TextQuestionField"
 
+import { postNotice } from "../api/noticeApi"
+import { type NoticeTabEnum, type PartEnum } from "../model/apiTypes"
+
 const MAX_CHARS = 2000
 const NOTICE_COMPLETION_STORAGE_KEY = "notice:completion-target"
 
 interface NoticePublishFormProps {
   variant: "publish" | "edit"
   noticeId?: string
+  noticeTab: NoticeTabEnum
+  targetParts?: PartEnum[]
+  chapter?: string
 }
 
 export function NoticePublishForm({
   variant,
   noticeId,
+  noticeTab,
+  targetParts = [],
+  chapter,
 }: NoticePublishFormProps) {
   const [noticeContent, setNoticeContent] = useState("")
   const [noticeTitle, setNoticeTitle] = useState("")
@@ -27,6 +43,84 @@ export function NoticePublishForm({
   const [isLoading, setIsLoading] = useState(false)
   const [isDone, setIsDone] = useState(false)
   const [isCompletionModalOpen, setIsCompletionModalOpen] = useState(false)
+
+  const memberId = useAuthStore((s) => s.memberId)
+
+  // 기수 정보 조회
+  const { data: gisuData } = useQuery({
+    queryKey: ["gisu", "all"],
+    queryFn: getAllGisu,
+  })
+
+  // 지부 정보 조회
+  const { data: chaptersData } = useQuery({
+    queryKey: ["chapters", "all"],
+    queryFn: getAllChapters,
+  })
+
+  // 내 정보 조회
+  const { data: profile } = useQuery({
+    queryKey: ["member", "profile", memberId],
+    queryFn: () => getMemberProfile(String(memberId)),
+    enabled: !!memberId,
+  })
+
+  const activeGisuId = useMemo(() => {
+    if (!gisuData) return null
+    const active = gisuData.gisuList.find((g) => g.isActive)
+    return active ? active.gisuId : gisuData.gisuList[0]?.gisuId || null
+  }, [gisuData])
+
+  const targetInfo = useMemo(() => {
+    if (!profile) return null
+
+    const activeRecord =
+      profile.challengerRecords?.find((r) => r.challengerStatus === "ACTIVE") ||
+      profile.challengerRecords?.[0]
+
+    if (!activeRecord) return null
+
+    // 만약 파라미터로 chapter가 넘어왔다면 해당 지부의 ID를 찾아서 사용
+    let chapterId = Number(activeRecord.chapterId)
+    if (chapter && chaptersData) {
+      const found = chaptersData.chapters.find((c) => c.name === chapter)
+      if (found) chapterId = Number(found.id)
+    }
+
+    return {
+      targetGisuId: Number(activeGisuId || activeRecord.gisuId),
+      targetChapterId: chapterId,
+      targetSchoolId: Number(activeRecord.schoolId),
+      targetParts: targetParts,
+      targetNoticeTab: noticeTab,
+    }
+  }, [profile, activeGisuId, noticeTab, targetParts, chapter, chaptersData])
+
+  const publishMutation = useMutation({
+    mutationFn: postNotice,
+    onSuccess: (data) => {
+      setIsLoading(false)
+      setIsDone(true)
+
+      const completionNoticeId = String(data.noticeId)
+
+      sessionStorage.setItem(
+        NOTICE_COMPLETION_STORAGE_KEY,
+        JSON.stringify({
+          id: completionNoticeId,
+          title: noticeTitle,
+          chip: isRequired ? "필독" : undefined,
+          mode: variant,
+        }),
+      )
+
+      setIsCompletionModalOpen(true)
+    },
+    onError: () => {
+      setIsLoading(false)
+      // TODO: 에러 처리 (토스트 등)
+    },
+  })
 
   const hasPendingChanges =
     !isDone &&
@@ -72,39 +166,33 @@ export function NoticePublishForm({
     setIsRequired((prev) => !prev)
   }
 
-  // TODO: API 연결 후 수정
   const handlePublishNotice = () => {
-    if (isLoading || isDone) return
+    if (isLoading || isDone || !targetInfo) return
 
     setIsLoading(true)
 
-    // 1초 후 loading -> done 상태로 변경 (API 호출 시뮬레이션)
-    setTimeout(() => {
-      setIsLoading(false)
-      setIsDone(true)
-      const completionNoticeId = noticeId ?? crypto.randomUUID()
-
-      sessionStorage.setItem(
-        NOTICE_COMPLETION_STORAGE_KEY,
-        JSON.stringify({
-          id: completionNoticeId,
-          title: noticeTitle,
-          chip: isRequired ? "필독" : undefined,
-          mode: variant,
-        }),
-      )
-
-      setIsCompletionModalOpen(true)
-      console.log(
-        variant === "edit" ? "Updating notice:" : "Publishing notice:",
-        {
-          noticeId,
-          title: noticeTitle,
-          content: noticeContent,
-          isRequired,
-        },
-      )
-    }, 1000)
+    if (variant === "publish") {
+      publishMutation.mutate({
+        title: noticeTitle,
+        content: noticeContent,
+        mustRead: isRequired,
+        shouldNotify: false, // UI에 알림 여부 토글이 없으므로 기본값 false
+        targetInfo,
+      })
+    } else {
+      // TODO: edit API 연결
+      console.log("Updating notice:", {
+        noticeId,
+        title: noticeTitle,
+        content: noticeContent,
+        isRequired,
+      })
+      setTimeout(() => {
+        setIsLoading(false)
+        setIsDone(true)
+        setIsCompletionModalOpen(true)
+      }, 1000)
+    }
   }
 
   const isSubmittable = noticeTitle.trim() !== "" && noticeContent.trim() !== ""
@@ -166,7 +254,7 @@ export function NoticePublishForm({
                 variant={submitButtonVariant}
                 color="primary"
                 size="m"
-                disabled={!isSubmittable || isDone}
+                disabled={!isSubmittable || isDone || !targetInfo}
                 isLoading={isLoading}
                 onClick={handlePublishNotice}
               >

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -20,6 +20,7 @@ import { deleteNotice, getNotices } from "@/features/notice/api/noticeApi"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import { Button } from "@/shared/ui/Button"
 import { Pagination } from "@/shared/ui/Pagination"
+import { useViewModeStore } from "@/shared/view-mode"
 
 interface AnnounceSearch {
   chapter: Chapter
@@ -159,6 +160,8 @@ function TeamMatchingAnnouncePage() {
   const focusedNoticeId = pendingNotice?.id ?? null
 
   const queryClient = useQueryClient()
+  const mode = useViewModeStore((s) => s.mode)
+  const canManage = mode === "admin"
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => deleteNotice(Number(id)),
@@ -176,9 +179,6 @@ function TeamMatchingAnnouncePage() {
       // TODO: 삭제 실패 시 동작 추가
     },
   })
-
-  // TODO: 사용자 권한 API 연동 후 실제 권한 값으로 교체
-  const canManage = true
 
   const handleChapterChange = (nextChapter: Chapter) => {
     navigate({

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -1,14 +1,22 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
-import { useEffect, useState } from "react"
+import dayjs from "dayjs"
+import { useEffect, useMemo, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
+import {
+  getAllChapters,
+  getAllGisu,
+} from "@/features/challenger/api/organization"
 import {
   type Chapter,
   CHAPTERS,
   ChapterSelector,
   NoticeCardList,
+  NoticeDetailContent,
   type NoticeItem,
 } from "@/features/notice"
+import { getNotices } from "@/features/notice/api/noticeApi"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import { Button } from "@/shared/ui/Button"
 import { Pagination } from "@/shared/ui/Pagination"
@@ -66,67 +74,7 @@ function readPendingNotice() {
   }
 }
 
-// TODO: 공지 API 응답 형식에 맞추어 수정
-const INITIAL_NOTICES: NoticeItem[] = [
-  {
-    id: "1",
-    title: "임시 공지",
-    date: "0000.00.00",
-    chip: "필독",
-  },
-  {
-    id: "2",
-    title: "임시 공지",
-    date: "0000.00.00",
-    chip: "필독",
-  },
-  {
-    id: "3",
-    title: "임시 공지",
-    date: "0000.00.00",
-    chip: "필독",
-  },
-  {
-    id: "4",
-    title: "임시 공지",
-    date: "0000.00.00",
-    chip: "필독",
-  },
-  {
-    id: "5",
-    title: "임시 공지",
-    date: "0000.00.00",
-    chip: "필독",
-  },
-  {
-    id: "6",
-    title: "임시 공지",
-    date: "0000.00.00",
-    chip: "필독",
-  },
-  {
-    id: "7",
-    title: "임시 공지",
-    date: "0000.00.00",
-  },
-  {
-    id: "8",
-    title: "임시 공지",
-    date: "0000.00.00",
-  },
-  {
-    id: "9",
-    title: "임시 공지",
-    date: "0000.00.00",
-  },
-  {
-    id: "10",
-    title: "임시 공지",
-    date: "0000.00.00",
-  },
-]
-
-/** 팀 매칭 · 공지 — 레이아웃 하위 인덱스 (/matching) */
+/** 팀 매칭 공지 페이지 (/matching) */
 export const Route = createFileRoute("/matching/")({
   validateSearch: (search: Record<string, unknown>): AnnounceSearch => {
     return {
@@ -142,34 +90,74 @@ function TeamMatchingAnnouncePage() {
   const navigate = useNavigate({ from: Route.fullPath })
   const addToast = useToastStore((state) => state.addToast)
   const [pendingNotice] = useState(readPendingNotice)
-  const [notices, setNotices] = useState(() => {
-    if (!pendingNotice) return INITIAL_NOTICES
 
-    if (pendingNotice.mode === "edit") {
-      return INITIAL_NOTICES.map((notice) =>
-        notice.id === pendingNotice.id
-          ? { ...notice, title: pendingNotice.title, chip: pendingNotice.chip }
-          : notice,
-      )
-    }
-
-    return [
-      {
-        id: pendingNotice.id,
-        title: pendingNotice.title,
-        date: "0000.00.00",
-        chip: pendingNotice.chip,
-      },
-      ...INITIAL_NOTICES,
-    ]
+  // 기수 정보 조회
+  const { data: gisuData } = useQuery({
+    queryKey: ["gisu", "all"],
+    queryFn: getAllGisu,
   })
-  const totalPages = Math.max(1, Math.ceil(notices.length / NOTICE_PAGE_SIZE))
+
+  // 지부 정보 조회
+  const { data: chaptersData } = useQuery({
+    queryKey: ["chapters", "all"],
+    queryFn: getAllChapters,
+  })
+
+  const activeGisuId = useMemo(() => {
+    if (!gisuData) return null
+    const active = gisuData.gisuList.find((g) => g.isActive)
+    return active ? active.gisuId : gisuData.gisuList[0]?.gisuId || null
+  }, [gisuData])
+
+  const selectedChapterId = useMemo(() => {
+    if (!chaptersData) return null
+    return chaptersData.chapters.find((c) => c.name === chapter)?.id || null
+  }, [chaptersData, chapter])
+
+  // 공지사항 조회 (전체 챌린저 대상: CHALLENGER)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { data: noticesData, isLoading } = useQuery({
+    queryKey: [
+      "notices",
+      "team-matching",
+      activeGisuId,
+      selectedChapterId,
+      page,
+    ],
+    queryFn: () =>
+      getNotices({
+        gisuId: Number(activeGisuId),
+        chapterId: selectedChapterId ? Number(selectedChapterId) : undefined,
+        noticeTab: "CHALLENGER",
+        page: page - 1,
+        size: NOTICE_PAGE_SIZE,
+        sort: "createdAt,DESC",
+      }),
+    enabled: !!activeGisuId,
+  })
+
+  const notices = useMemo(() => {
+    if (!noticesData) return []
+
+    const mappedNotices: NoticeItem[] = noticesData.content.map((item) => ({
+      id: String(item.id),
+      title: item.title,
+      date: dayjs(item.createdAt).format("YYYY.MM.DD"),
+      chip: item.mustRead ? "필독" : undefined,
+    }))
+
+    // 필독 공지 상단 정렬
+    return [...mappedNotices].sort((a, b) => {
+      if (a.chip === "필독" && b.chip !== "필독") return -1
+      if (a.chip !== "필독" && b.chip === "필독") return 1
+      return 0
+    })
+  }, [noticesData])
+
+  const totalPages = noticesData?.totalPages || 1
   const safePage = Math.min(Math.max(1, page), totalPages)
   const focusedNoticeId = pendingNotice?.id ?? null
-  const paginatedNotices = notices.slice(
-    (safePage - 1) * NOTICE_PAGE_SIZE,
-    safePage * NOTICE_PAGE_SIZE,
-  )
+
   // TODO: 사용자 권한 API 연동 후 실제 권한 값으로 교체
   const canManage = true
 
@@ -192,8 +180,8 @@ function TeamMatchingAnnouncePage() {
   }
 
   // TODO: API 연동 후 실제 삭제 API 호출로 교체
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleNoticeDeleteClick = (noticeId: string) => {
-    setNotices((prev) => prev.filter((notice) => notice.id !== noticeId))
     addToast({
       message: "공지가 삭제되었습니다.",
       color: "primary",
@@ -266,12 +254,15 @@ function TeamMatchingAnnouncePage() {
             </div>
 
             <NoticeCardList
-              notices={paginatedNotices}
+              notices={notices}
               page={safePage}
               canManage={canManage}
               focusedNoticeId={focusedNoticeId}
               onDeleteNotice={handleNoticeDeleteClick}
               onEditNotice={handleNoticeEditClick}
+              renderContent={(noticeId) => (
+                <NoticeDetailContent noticeId={noticeId} />
+              )}
             />
           </div>
         </div>

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -27,7 +27,6 @@ interface AnnounceSearch {
   page: number
 }
 
-const DEFAULT_CHAPTER: Chapter = "Chromium"
 const DEFAULT_PAGE = 1
 const NOTICE_PAGE_SIZE = 10
 const NOTICE_COMPLETION_STORAGE_KEY = "notice:completion-target"
@@ -78,8 +77,10 @@ function readPendingNotice() {
 /** 팀 매칭 공지 페이지 (/matching) */
 export const Route = createFileRoute("/matching/")({
   validateSearch: (search: Record<string, unknown>): AnnounceSearch => {
+    // TODO: 사용자 지부 불러오기. 아래는 임시 상태.
+    const userChapter = useViewModeStore.getState().viewerBranch as Chapter
     return {
-      chapter: isChapter(search.chapter) ? search.chapter : DEFAULT_CHAPTER,
+      chapter: isChapter(search.chapter) ? search.chapter : userChapter,
       page: parsePage(search.page),
     }
   },
@@ -160,7 +161,9 @@ function TeamMatchingAnnouncePage() {
   const focusedNoticeId = pendingNotice?.id ?? null
 
   const queryClient = useQueryClient()
+  // TODO: 사용자 권한 및 지부 불러오기. 아래는 임시 상태.
   const mode = useViewModeStore((s) => s.mode)
+  const userChapter = useViewModeStore((s) => s.viewerBranch) as Chapter
   const canManage = mode === "admin"
 
   const deleteMutation = useMutation({
@@ -181,6 +184,17 @@ function TeamMatchingAnnouncePage() {
   })
 
   const handleChapterChange = (nextChapter: Chapter) => {
+    if (mode !== "admin" && nextChapter !== userChapter) {
+      addToast({
+        message: "소속된 지부의 공지만 확인할 수 있습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3,
+      })
+      return
+    }
+
     navigate({
       search: (prev) => ({ ...prev, chapter: nextChapter }),
       replace: true,

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -117,8 +117,8 @@ function TeamMatchingAnnouncePage() {
   }, [chaptersData, chapter])
 
   // 공지사항 조회 (전체 챌린저 대상: CHALLENGER)
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { data: noticesData, isLoading } = useQuery({
+  // TODO: 공지사항 조회 실패 / 로딩 중 처리 로직 추가
+  const { data: noticesData } = useQuery({
     queryKey: [
       "notices",
       "team-matching",

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -169,7 +169,10 @@ function TeamMatchingAnnouncePage() {
   }
 
   const handleNoticePublishClick = () => {
-    navigate({ to: "/matching/notice-publish" })
+    navigate({
+      to: "/matching/notice-publish",
+      search: { chapter },
+    })
   }
 
   const handleNoticeEditClick = (noticeId: string) => {

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import dayjs from "dayjs"
 import { useEffect, useMemo, useState } from "react"
@@ -16,7 +16,7 @@ import {
   NoticeDetailContent,
   type NoticeItem,
 } from "@/features/notice"
-import { getNotices } from "@/features/notice/api/noticeApi"
+import { deleteNotice, getNotices } from "@/features/notice/api/noticeApi"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import { Button } from "@/shared/ui/Button"
 import { Pagination } from "@/shared/ui/Pagination"
@@ -158,6 +158,25 @@ function TeamMatchingAnnouncePage() {
   const safePage = Math.min(Math.max(1, page), totalPages)
   const focusedNoticeId = pendingNotice?.id ?? null
 
+  const queryClient = useQueryClient()
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteNotice(Number(id)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["notices"] })
+      addToast({
+        message: "공지가 삭제되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3,
+      })
+    },
+    onError: () => {
+      // TODO: 삭제 실패 시 동작 추가
+    },
+  })
+
   // TODO: 사용자 권한 API 연동 후 실제 권한 값으로 교체
   const canManage = true
 
@@ -182,16 +201,8 @@ function TeamMatchingAnnouncePage() {
     })
   }
 
-  // TODO: API 연동 후 실제 삭제 API 호출로 교체
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleNoticeDeleteClick = (noticeId: string) => {
-    addToast({
-      message: "공지가 삭제되었습니다.",
-      color: "primary",
-      variant: "deep",
-      type: "default",
-      duration: 3,
-    })
+    deleteMutation.mutate(noticeId)
   }
 
   const handlePageChange = (nextPage: number) => {

--- a/src/routes/matching/notice-publish.$noticeId.tsx
+++ b/src/routes/matching/notice-publish.$noticeId.tsx
@@ -9,5 +9,11 @@ export const Route = createFileRoute("/matching/notice-publish/$noticeId")({
 function TeamMatchingNoticePublishEditPage() {
   const { noticeId } = Route.useParams()
 
-  return <NoticePublishForm variant="edit" noticeId={noticeId} />
+  return (
+    <NoticePublishForm
+      variant="edit"
+      noticeId={noticeId}
+      noticeTab="CHALLENGER"
+    />
+  )
 }

--- a/src/routes/matching/notice-publish.tsx
+++ b/src/routes/matching/notice-publish.tsx
@@ -2,11 +2,21 @@ import { createFileRoute, Outlet, useMatchRoute } from "@tanstack/react-router"
 
 import { NoticePublishForm } from "@/features/notice"
 
+interface NoticePublishSearch {
+  chapter?: string
+}
+
 export const Route = createFileRoute("/matching/notice-publish")({
+  validateSearch: (search: Record<string, unknown>): NoticePublishSearch => {
+    return {
+      chapter: typeof search.chapter === "string" ? search.chapter : undefined,
+    }
+  },
   component: TeamMatchingNoticePublishPage,
 })
 
 function TeamMatchingNoticePublishPage() {
+  const { chapter } = Route.useSearch()
   const matchRoute = useMatchRoute()
   const isEditPage = Boolean(
     matchRoute({ to: "/matching/notice-publish/$noticeId" }),
@@ -16,5 +26,11 @@ function TeamMatchingNoticePublishPage() {
     return <Outlet />
   }
 
-  return <NoticePublishForm variant="publish" />
+  return (
+    <NoticePublishForm
+      variant="publish"
+      noticeTab="CHALLENGER"
+      chapter={chapter}
+    />
+  )
 }

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import dayjs from "dayjs"
 import { useEffect, useMemo, useState } from "react"
@@ -16,7 +16,7 @@ import {
   NoticeDetailContent,
   type NoticeItem,
 } from "@/features/notice"
-import { getNotices } from "@/features/notice/api/noticeApi"
+import { deleteNotice, getNotices } from "@/features/notice/api/noticeApi"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import { Button } from "@/shared/ui/Button"
 import { Pagination } from "@/shared/ui/Pagination"
@@ -114,7 +114,7 @@ function ProjectSettingsAnnouncePage() {
     return chaptersData.chapters.find((c) => c.name === chapter)?.id || null
   }, [chaptersData, chapter])
 
-  // 공지사항 조회 (PM 대상: SCHOOL_CORE)
+  // 공지사항 조회 (PM 대상)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { data: noticesData, isLoading } = useQuery({
     queryKey: [
@@ -128,7 +128,8 @@ function ProjectSettingsAnnouncePage() {
       getNotices({
         gisuId: Number(activeGisuId),
         chapterId: selectedChapterId ? Number(selectedChapterId) : undefined,
-        noticeTab: "SCHOOL_CORE",
+        noticeTab: "CHALLENGER",
+        part: "PLAN",
         page: page - 1,
         size: NOTICE_PAGE_SIZE,
         sort: "createdAt,DESC",
@@ -158,6 +159,25 @@ function ProjectSettingsAnnouncePage() {
   const safePage = Math.min(Math.max(1, page), totalPages)
   const focusedNoticeId = pendingNotice?.id ?? null
 
+  const queryClient = useQueryClient()
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deleteNotice(Number(id)),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["notices"] })
+      addToast({
+        message: "공지가 삭제되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3,
+      })
+    },
+    onError: () => {
+      // TODO: 삭제 실패 시 동작 추가
+    },
+  })
+
   // TODO: 사용자 권한 API 연동 후 실제 권한 값으로 교체
   const canManage = true
 
@@ -182,16 +202,8 @@ function ProjectSettingsAnnouncePage() {
     })
   }
 
-  // TODO: API 연동 후 실제 삭제 API 호출로 교체
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleNoticeDeleteClick = (noticeId: string) => {
-    addToast({
-      message: "공지가 삭제되었습니다.",
-      color: "primary",
-      variant: "deep",
-      type: "default",
-      duration: 3,
-    })
+    deleteMutation.mutate(noticeId)
   }
 
   const handlePageChange = (nextPage: number) => {

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -117,8 +117,8 @@ function ProjectSettingsAnnouncePage() {
   }, [chaptersData, chapter])
 
   // 공지사항 조회: PM(PLAN CHALLENGER) 대상
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { data: noticesData, isLoading } = useQuery({
+  // TODO: 공지사항 조회 실패 / 로딩 중 처리 로직 추가
+  const { data: noticesData } = useQuery({
     queryKey: [
       "notices",
       "project-settings",

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -20,6 +20,7 @@ import { deleteNotice, getNotices } from "@/features/notice/api/noticeApi"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import { Button } from "@/shared/ui/Button"
 import { Pagination } from "@/shared/ui/Pagination"
+import { useViewModeStore } from "@/shared/view-mode"
 
 interface AnnounceSearch {
   chapter: Chapter
@@ -114,7 +115,7 @@ function ProjectSettingsAnnouncePage() {
     return chaptersData.chapters.find((c) => c.name === chapter)?.id || null
   }, [chaptersData, chapter])
 
-  // 공지사항 조회 (PM 대상)
+  // 공지사항 조회: PM(PLAN CHALLENGER) 대상
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { data: noticesData, isLoading } = useQuery({
     queryKey: [
@@ -160,6 +161,8 @@ function ProjectSettingsAnnouncePage() {
   const focusedNoticeId = pendingNotice?.id ?? null
 
   const queryClient = useQueryClient()
+  const mode = useViewModeStore((s) => s.mode)
+  const canManage = mode === "admin"
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => deleteNotice(Number(id)),
@@ -177,9 +180,6 @@ function ProjectSettingsAnnouncePage() {
       // TODO: 삭제 실패 시 동작 추가
     },
   })
-
-  // TODO: 사용자 권한 API 연동 후 실제 권한 값으로 교체
-  const canManage = true
 
   const handleChapterChange = (nextChapter: Chapter) => {
     navigate({

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -116,7 +116,7 @@ function ProjectSettingsAnnouncePage() {
     return chaptersData.chapters.find((c) => c.name === chapter)?.id || null
   }, [chaptersData, chapter])
 
-  // 공지사항 조회 (PM 대상: SCHOOL_CORE)
+  // 공지사항 조회: PM(PLAN CHALLENGER) 대상
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { data: noticesData, isLoading } = useQuery({
     queryKey: [
@@ -130,7 +130,8 @@ function ProjectSettingsAnnouncePage() {
       getNotices({
         gisuId: Number(activeGisuId),
         chapterId: selectedChapterId ? Number(selectedChapterId) : undefined,
-        noticeTab: "SCHOOL_CORE",
+        noticeTab: "CHALLENGER",
+        part: "PLAN",
         page: page - 1,
         size: NOTICE_PAGE_SIZE,
         sort: "createdAt,DESC",

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -1,14 +1,22 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
-import { useEffect, useState } from "react"
+import dayjs from "dayjs"
+import { useEffect, useMemo, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
+import {
+  getAllChapters,
+  getAllGisu,
+} from "@/features/challenger/api/organization"
 import {
   type Chapter,
   CHAPTERS,
   ChapterSelector,
   NoticeCardList,
+  NoticeDetailContent,
   type NoticeItem,
 } from "@/features/notice"
+import { getNotices } from "@/features/notice/api/noticeApi"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import { Button } from "@/shared/ui/Button"
 import { Pagination } from "@/shared/ui/Pagination"
@@ -66,27 +74,7 @@ function readPendingNotice() {
   }
 }
 
-// TODO: 공지 API 응답 형식에 맞추어 수정
-const INITIAL_NOTICES: NoticeItem[] = [
-  {
-    id: "1",
-    title: "임시 공지",
-    date: "0000.00.00",
-    chip: "필독",
-  },
-  {
-    id: "2",
-    title: "임시 공지",
-    date: "0000.00.00",
-    chip: "필독",
-  },
-  {
-    id: "3",
-    title: "임시 공지",
-    date: "0000.00.00",
-  },
-]
-
+/** 프로젝트 설정 공지 페이지 (/matching/projects/announce) */
 export const Route = createFileRoute("/matching/projects/announce/")({
   validateSearch: (search: Record<string, unknown>): AnnounceSearch => {
     return {
@@ -102,34 +90,75 @@ function ProjectSettingsAnnouncePage() {
   const navigate = useNavigate({ from: Route.fullPath })
   const addToast = useToastStore((state) => state.addToast)
   const [pendingNotice] = useState(readPendingNotice)
-  const [notices, setNotices] = useState(() => {
-    if (!pendingNotice) return INITIAL_NOTICES
 
-    if (pendingNotice.mode === "edit") {
-      return INITIAL_NOTICES.map((notice) =>
-        notice.id === pendingNotice.id
-          ? { ...notice, title: pendingNotice.title, chip: pendingNotice.chip }
-          : notice,
-      )
-    }
-
-    return [
-      {
-        id: pendingNotice.id,
-        title: pendingNotice.title,
-        date: "0000.00.00",
-        chip: pendingNotice.chip,
-      },
-      ...INITIAL_NOTICES,
-    ]
+  // 기수 정보 조회
+  const { data: gisuData } = useQuery({
+    queryKey: ["gisu", "all"],
+    queryFn: getAllGisu,
   })
-  const totalPages = Math.max(1, Math.ceil(notices.length / NOTICE_PAGE_SIZE))
+
+  // 지부 정보 조회
+  const { data: chaptersData } = useQuery({
+    queryKey: ["chapters", "all"],
+    queryFn: getAllChapters,
+  })
+
+  const activeGisuId = useMemo(() => {
+    if (!gisuData) return null
+    const active = gisuData.gisuList.find((g) => g.isActive)
+    return active ? active.gisuId : gisuData.gisuList[0]?.gisuId || null
+  }, [gisuData])
+
+  const selectedChapterId = useMemo(() => {
+    if (!chaptersData) return null
+    return chaptersData.chapters.find((c) => c.name === chapter)?.id || null
+  }, [chaptersData, chapter])
+
+  // 공지사항 조회 (PM 대상)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { data: noticesData, isLoading } = useQuery({
+    queryKey: [
+      "notices",
+      "project-settings",
+      activeGisuId,
+      selectedChapterId,
+      page,
+    ],
+    queryFn: () =>
+      getNotices({
+        gisuId: Number(activeGisuId),
+        chapterId: selectedChapterId ? Number(selectedChapterId) : undefined,
+        noticeTab: "CHALLENGER",
+        part: "PLAN",
+        page: page - 1,
+        size: NOTICE_PAGE_SIZE,
+        sort: "createdAt,DESC",
+      }),
+    enabled: !!activeGisuId,
+  })
+
+  const notices = useMemo(() => {
+    if (!noticesData) return []
+
+    const mappedNotices: NoticeItem[] = noticesData.content.map((item) => ({
+      id: String(item.id),
+      title: item.title,
+      date: dayjs(item.createdAt).format("YYYY.MM.DD"),
+      chip: item.mustRead ? "필독" : undefined,
+    }))
+
+    // 필독 공지 상단 정렬
+    return [...mappedNotices].sort((a, b) => {
+      if (a.chip === "필독" && b.chip !== "필독") return -1
+      if (a.chip !== "필독" && b.chip === "필독") return 1
+      return 0
+    })
+  }, [noticesData])
+
+  const totalPages = noticesData?.totalPages || 1
   const safePage = Math.min(Math.max(1, page), totalPages)
   const focusedNoticeId = pendingNotice?.id ?? null
-  const paginatedNotices = notices.slice(
-    (safePage - 1) * NOTICE_PAGE_SIZE,
-    safePage * NOTICE_PAGE_SIZE,
-  )
+
   // TODO: 사용자 권한 API 연동 후 실제 권한 값으로 교체
   const canManage = true
 
@@ -154,8 +183,8 @@ function ProjectSettingsAnnouncePage() {
   }
 
   // TODO: API 연동 후 실제 삭제 API 호출로 교체
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleNoticeDeleteClick = (noticeId: string) => {
-    setNotices((prev) => prev.filter((notice) => notice.id !== noticeId))
     addToast({
       message: "공지가 삭제되었습니다.",
       color: "primary",
@@ -228,12 +257,15 @@ function ProjectSettingsAnnouncePage() {
             </div>
 
             <NoticeCardList
-              notices={paginatedNotices}
+              notices={notices}
               page={safePage}
               canManage={canManage}
               focusedNoticeId={focusedNoticeId}
               onDeleteNotice={handleNoticeDeleteClick}
               onEditNotice={handleNoticeEditClick}
+              renderContent={(noticeId) => (
+                <NoticeDetailContent noticeId={noticeId} />
+              )}
             />
           </div>
         </div>

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -27,7 +27,6 @@ interface AnnounceSearch {
   page: number
 }
 
-const DEFAULT_CHAPTER: Chapter = "Chromium"
 const DEFAULT_PAGE = 1
 const NOTICE_PAGE_SIZE = 10
 const NOTICE_COMPLETION_STORAGE_KEY = "notice:completion-target"
@@ -78,8 +77,10 @@ function readPendingNotice() {
 /** 프로젝트 설정 공지 페이지 (/matching/projects/announce) */
 export const Route = createFileRoute("/matching/projects/announce/")({
   validateSearch: (search: Record<string, unknown>): AnnounceSearch => {
+    // TODO: 사용자 지부 불러오기. 아래는 임시 상태.
+    const userChapter = useViewModeStore.getState().viewerBranch as Chapter
     return {
-      chapter: isChapter(search.chapter) ? search.chapter : DEFAULT_CHAPTER,
+      chapter: isChapter(search.chapter) ? search.chapter : userChapter,
       page: parsePage(search.page),
     }
   },
@@ -115,7 +116,7 @@ function ProjectSettingsAnnouncePage() {
     return chaptersData.chapters.find((c) => c.name === chapter)?.id || null
   }, [chaptersData, chapter])
 
-  // 공지사항 조회: PM(PLAN CHALLENGER) 대상
+  // 공지사항 조회 (PM 대상: SCHOOL_CORE)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { data: noticesData, isLoading } = useQuery({
     queryKey: [
@@ -129,8 +130,7 @@ function ProjectSettingsAnnouncePage() {
       getNotices({
         gisuId: Number(activeGisuId),
         chapterId: selectedChapterId ? Number(selectedChapterId) : undefined,
-        noticeTab: "CHALLENGER",
-        part: "PLAN",
+        noticeTab: "SCHOOL_CORE",
         page: page - 1,
         size: NOTICE_PAGE_SIZE,
         sort: "createdAt,DESC",
@@ -161,7 +161,9 @@ function ProjectSettingsAnnouncePage() {
   const focusedNoticeId = pendingNotice?.id ?? null
 
   const queryClient = useQueryClient()
+  // TODO: 사용자 권한 및 지부 불러오기. 아래는 임시 상태.
   const mode = useViewModeStore((s) => s.mode)
+  const userChapter = useViewModeStore((s) => s.viewerBranch) as Chapter
   const canManage = mode === "admin"
 
   const deleteMutation = useMutation({
@@ -182,6 +184,17 @@ function ProjectSettingsAnnouncePage() {
   })
 
   const handleChapterChange = (nextChapter: Chapter) => {
+    if (mode !== "admin" && nextChapter !== userChapter) {
+      addToast({
+        message: "소속된 지부의 공지만 확인할 수 있습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3,
+      })
+      return
+    }
+
     navigate({
       search: (prev) => ({ ...prev, chapter: nextChapter }),
       replace: true,

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -114,7 +114,7 @@ function ProjectSettingsAnnouncePage() {
     return chaptersData.chapters.find((c) => c.name === chapter)?.id || null
   }, [chaptersData, chapter])
 
-  // 공지사항 조회 (PM 대상)
+  // 공지사항 조회 (PM 대상: SCHOOL_CORE)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { data: noticesData, isLoading } = useQuery({
     queryKey: [
@@ -128,8 +128,7 @@ function ProjectSettingsAnnouncePage() {
       getNotices({
         gisuId: Number(activeGisuId),
         chapterId: selectedChapterId ? Number(selectedChapterId) : undefined,
-        noticeTab: "CHALLENGER",
-        part: "PLAN",
+        noticeTab: "SCHOOL_CORE",
         page: page - 1,
         size: NOTICE_PAGE_SIZE,
         sort: "createdAt,DESC",
@@ -172,6 +171,7 @@ function ProjectSettingsAnnouncePage() {
   const handleNoticePublishClick = () => {
     navigate({
       to: "/matching/projects/announce/notice-publish",
+      search: { chapter },
     })
   }
 

--- a/src/routes/matching/projects/announce/notice-publish.$noticeId.tsx
+++ b/src/routes/matching/projects/announce/notice-publish.$noticeId.tsx
@@ -11,5 +11,11 @@ export const Route = createFileRoute(
 function ProjectSettingsNoticePublishEditPage() {
   const { noticeId } = Route.useParams()
 
-  return <NoticePublishForm variant="edit" noticeId={noticeId} />
+  return (
+    <NoticePublishForm
+      variant="edit"
+      noticeId={noticeId}
+      noticeTab="CHALLENGER"
+    />
+  )
 }

--- a/src/routes/matching/projects/announce/notice-publish.$noticeId.tsx
+++ b/src/routes/matching/projects/announce/notice-publish.$noticeId.tsx
@@ -16,6 +16,7 @@ function ProjectSettingsNoticePublishEditPage() {
       variant="edit"
       noticeId={noticeId}
       noticeTab="CHALLENGER"
+      targetParts={["PLAN"]}
     />
   )
 }

--- a/src/routes/matching/projects/announce/notice-publish.tsx
+++ b/src/routes/matching/projects/announce/notice-publish.tsx
@@ -2,13 +2,23 @@ import { createFileRoute, Outlet, useMatchRoute } from "@tanstack/react-router"
 
 import { NoticePublishForm } from "@/features/notice"
 
+interface NoticePublishSearch {
+  chapter?: string
+}
+
 export const Route = createFileRoute(
   "/matching/projects/announce/notice-publish",
 )({
+  validateSearch: (search: Record<string, unknown>): NoticePublishSearch => {
+    return {
+      chapter: typeof search.chapter === "string" ? search.chapter : undefined,
+    }
+  },
   component: ProjectSettingsNoticePublishPage,
 })
 
 function ProjectSettingsNoticePublishPage() {
+  const { chapter } = Route.useSearch()
   const matchRoute = useMatchRoute()
   const isEditPage = Boolean(
     matchRoute({ to: "/matching/projects/announce/notice-publish/$noticeId" }),
@@ -18,5 +28,11 @@ function ProjectSettingsNoticePublishPage() {
     return <Outlet />
   }
 
-  return <NoticePublishForm variant="publish" />
+  return (
+    <NoticePublishForm
+      variant="publish"
+      noticeTab="SCHOOL_CORE"
+      chapter={chapter}
+    />
+  )
 }


### PR DESCRIPTION
## 📸 작업 내용

- 공지사항 CRUD API 연결
- 어드민 뷰에서만 공지 작성/수정/삭제 버튼이 나타나도록 분기
- 소속된 지부의 공지만 확인할 수 있도록 분기 (어드민은 모든 지부 공지 확인 가능)

## 🎞️ 주요 코드 설명

## 🖥️ 구현화면

<img width="100%" alt="image" src="https://github.com/user-attachments/assets/e80298a9-bace-4949-a940-63526f5799f0" />

## 🔗 연결된 이슈

- Connected: #82 

## 💬 기타 더 이야기해볼 점

- 디폴트 공지는 QA 이후 공지 내용이 확정되면 추가될 예정입니다.
- 스켈레톤 UI가 추가됐는데 디폴트 공지와 함께 추후 구현하겠습니다.
