### PR TITLE
feat: 프로필 드롭다운 UI 수정 및 API 연결

### DIFF
--- a/src/features/auth/api/me.ts
+++ b/src/features/auth/api/me.ts
@@ -1,5 +1,6 @@
 import { api } from "@/shared/lib/axios"
 
+import type { ChallengerInfoResponse } from "@/features/challenger/model/types"
 import type { ApiResponse } from "@/shared/lib/apiResponse"
 
 export interface MemberInfoResponse {
@@ -11,6 +12,7 @@ export interface MemberInfoResponse {
   schoolName: string
   profileImageLink: string
   status: "ACTIVE" | "INACTIVE" | "WITHDRAWN"
+  challengerRecords?: ChallengerInfoResponse[]
 }
 
 export async function getMyInfo(): Promise<MemberInfoResponse> {

--- a/src/features/auth/api/me.ts
+++ b/src/features/auth/api/me.ts
@@ -1,6 +1,9 @@
 import { api } from "@/shared/lib/axios"
 
-import type { ChallengerInfoResponse } from "@/features/challenger/model/types"
+import type {
+  ChallengerInfoResponse,
+  ChallengerRoleResponse,
+} from "@/features/challenger/model/types"
 import type { ApiResponse } from "@/shared/lib/apiResponse"
 
 export interface MemberInfoResponse {
@@ -12,6 +15,7 @@ export interface MemberInfoResponse {
   schoolName: string
   profileImageLink: string
   status: "ACTIVE" | "INACTIVE" | "WITHDRAWN"
+  roles: ChallengerRoleResponse[]
   challengerRecords?: ChallengerInfoResponse[]
 }
 

--- a/src/features/auth/hooks/useMe.ts
+++ b/src/features/auth/hooks/useMe.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { getMyInfo } from "../api/me"
+
+export function useMe() {
+  return useQuery({
+    queryKey: ["auth", "me"],
+    queryFn: getMyInfo,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+  })
+}

--- a/src/features/auth/model/mappers.ts
+++ b/src/features/auth/model/mappers.ts
@@ -1,0 +1,21 @@
+import type { RoleType } from "@/features/challenger"
+import type { Role } from "@/shared/ui/chip/RoleTagChip"
+
+// 서버 roleType -> 프로필 드롭다운 Role Tag
+const ROLE_MAP: Record<RoleType, Role> = {
+  CHALLENGER: "challenger",
+  SUPER_ADMIN: "central",
+  CENTRAL_PRESIDENT: "central",
+  CENTRAL_VICE_PRESIDENT: "central",
+  CENTRAL_OPERATING_TEAM_MEMBER: "central",
+  CENTRAL_EDUCATION_TEAM_MEMBER: "central",
+  CHAPTER_PRESIDENT: "central",
+  SCHOOL_PRESIDENT: "campus",
+  SCHOOL_VICE_PRESIDENT: "campus",
+  SCHOOL_PART_LEADER: "campus",
+  SCHOOL_ETC_ADMIN: "challenger",
+}
+
+export function toRoleTag(roleType: RoleType): Role {
+  return ROLE_MAP[roleType]
+}

--- a/src/features/challenger/index.ts
+++ b/src/features/challenger/index.ts
@@ -1,2 +1,3 @@
+export { type RoleType } from "./model/types"
 export { GrantPointsPage } from "./ui/grant-points/GrantPointsPage"
 export { RecordCodePage } from "./ui/record-code/RecordCodePage"

--- a/src/shared/ui/ProfileDropdown.tsx
+++ b/src/shared/ui/ProfileDropdown.tsx
@@ -110,27 +110,21 @@ export function ProfileDropdown({
 
               <div className="border-teal-gray-100 flex w-full flex-col gap-0.5 rounded-[10px] border px-0.5 py-0.5">
                 {/* TODO: 기수 선택 시 글로벌 상태 변경 */}
-                <GenerationListItem
-                  generation={10}
-                  year={2026}
-                  active={true}
-                  className="w-full"
-                />
-                <GenerationListItem
-                  generation={9}
-                  year={2025}
-                  className="w-full"
-                />
-                <GenerationListItem
-                  generation={8}
-                  year={2025}
-                  className="w-full"
-                />
-                <GenerationListItem
-                  generation={7}
-                  year={2024}
-                  className="w-full"
-                />
+                {me?.challengerRecords && me.challengerRecords.length > 0 ? (
+                  me.challengerRecords.map((record, index) => (
+                    <GenerationListItem
+                      key={record.challengerId}
+                      generation={Number(record.gisu)}
+                      year={2026} // API에서 연도 정보를 제공하지 않으므로 임시값 사용
+                      active={index === 0} // 현재는 첫 번째 항목을 활성 상태로 표시
+                      className="w-full"
+                    />
+                  ))
+                ) : (
+                  <div className="text-caption-3-medium text-teal-gray-400 py-2 text-center">
+                    참여 기록이 없습니다.
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/src/shared/ui/ProfileDropdown.tsx
+++ b/src/shared/ui/ProfileDropdown.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react"
 
 import GenerationListItem from "@/components/header/GenerationListItem"
+import { logout } from "@/features/auth/lib/logout"
 import { cn } from "@/shared/lib/utils"
 
 import ProfileIcon from "../assets/icon/people/ProfileIcon"
@@ -141,7 +142,7 @@ export function ProfileDropdown({
                 계정 삭제
               </span>
             </button>
-            <button type="button" className="h-6 w-15">
+            <button type="button" onClick={logout} className="h-6 w-15">
               <span className="text-body-2-medium text-teal-gray-700">
                 로그아웃
               </span>

--- a/src/shared/ui/ProfileDropdown.tsx
+++ b/src/shared/ui/ProfileDropdown.tsx
@@ -31,8 +31,7 @@ export function ProfileDropdown({
   const containerRef = useRef<HTMLDivElement>(null)
 
   const mode = useViewModeStore((s) => s.mode)
-  const hasToken = !!localStorage.getItem("access_token")
-  const { data: me } = useMe({ enabled: hasToken })
+  const { data: me } = useMe()
 
   useEffect(() => {
     if (!isOpen) return

--- a/src/shared/ui/ProfileDropdown.tsx
+++ b/src/shared/ui/ProfileDropdown.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react"
 
 import GenerationListItem from "@/components/header/GenerationListItem"
+import { useMe } from "@/features/auth/hooks/useMe"
 import { logout } from "@/features/auth/lib/logout"
 import { cn } from "@/shared/lib/utils"
 
@@ -26,6 +27,8 @@ export function ProfileDropdown({
 }: ProfileDropdownProps) {
   const [isOpen, setIsOpen] = useState(open)
   const containerRef = useRef<HTMLDivElement>(null)
+
+  const { data: me } = useMe()
 
   useEffect(() => {
     if (!isOpen) return
@@ -65,23 +68,30 @@ export function ProfileDropdown({
             dropdownClassName,
           )}
         >
-          {/* TODO: 사용자 정보 API 연동 */}
           <div className="flex flex-col gap-2.5 px-2.5">
             <div className="h-11.5 w-11.5 shrink-0 overflow-hidden rounded-full">
-              <ProfileIcon className="size-full" />
+              {me?.profileImageLink ? (
+                <img
+                  src={me.profileImageLink}
+                  alt={me.name}
+                  className="size-full object-cover"
+                />
+              ) : (
+                <ProfileIcon className="size-full" />
+              )}
             </div>
 
             <div className="flex flex-col gap-0.5">
               <div className="flex items-center justify-between">
                 <span className="text-teal-gray-900 text-subtitle-3-semibold">
-                  이방토/이예원
+                  {me ? `${me.nickname}/${me.name}` : ""}
                 </span>
 
                 <RoleTagChip role="challenger" />
               </div>
 
               <span className="text-caption-2-medium text-teal-gray-500">
-                한양대 ERICA
+                {me?.schoolName ?? ""}
               </span>
             </div>
           </div>

--- a/src/shared/ui/ProfileDropdown.tsx
+++ b/src/shared/ui/ProfileDropdown.tsx
@@ -5,6 +5,7 @@ import { useMe } from "@/features/auth/hooks/useMe"
 import { logout } from "@/features/auth/lib/logout"
 import { toRoleTag } from "@/features/auth/model/mappers"
 import { cn } from "@/shared/lib/utils"
+import { useViewModeStore } from "@/shared/view-mode"
 
 import ProfileIcon from "../assets/icon/people/ProfileIcon"
 import { RoleTagChip } from "./chip/RoleTagChip"
@@ -29,7 +30,9 @@ export function ProfileDropdown({
   const [isOpen, setIsOpen] = useState(open)
   const containerRef = useRef<HTMLDivElement>(null)
 
-  const { data: me } = useMe()
+  const mode = useViewModeStore((s) => s.mode)
+  const hasToken = !!localStorage.getItem("access_token")
+  const { data: me } = useMe({ enabled: hasToken })
 
   useEffect(() => {
     if (!isOpen) return
@@ -139,11 +142,13 @@ export function ProfileDropdown({
 
           {/* TODO: 기수 관리 페이지로 연결/계정 설정 페이지로 연결/로그아웃 API 연동 */}
           <div className="flex flex-col gap-1 px-2.5">
-            <button type="button" className="h-6 w-15">
-              <span className="text-body-2-medium text-teal-gray-700">
-                기수 관리
-              </span>
-            </button>
+            {mode === "admin" && (
+              <button type="button" className="h-6 w-15">
+                <span className="text-body-2-medium text-teal-gray-700">
+                  기수 관리
+                </span>
+              </button>
+            )}
             <button type="button" className="h-6 w-15">
               <span className="text-body-2-medium text-teal-gray-700">
                 계정 설정

--- a/src/shared/ui/ProfileDropdown.tsx
+++ b/src/shared/ui/ProfileDropdown.tsx
@@ -130,16 +130,16 @@ export function ProfileDropdown({
             className="bg-teal-gray-100 h-px w-full rounded-[0.5px]"
           />
 
-          {/* TODO: 계정 연동/계정 삭제/로그아웃 기능 추가 */}
+          {/* TODO: 기수 관리 페이지로 연결/계정 설정 페이지로 연결 */}
           <div className="flex flex-col gap-0.5 px-2.5">
             <button type="button" className="h-6 w-15">
               <span className="text-body-2-medium text-teal-gray-700">
-                계정 연동
+                기수 관리
               </span>
             </button>
             <button type="button" className="h-6 w-15">
               <span className="text-body-2-medium text-teal-gray-700">
-                계정 삭제
+                계정 설정
               </span>
             </button>
             <button type="button" onClick={logout} className="h-6 w-15">

--- a/src/shared/ui/ProfileDropdown.tsx
+++ b/src/shared/ui/ProfileDropdown.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react"
 import GenerationListItem from "@/components/header/GenerationListItem"
 import { useMe } from "@/features/auth/hooks/useMe"
 import { logout } from "@/features/auth/lib/logout"
+import { toRoleTag } from "@/features/auth/model/mappers"
 import { cn } from "@/shared/lib/utils"
 
 import ProfileIcon from "../assets/icon/people/ProfileIcon"
@@ -47,6 +48,8 @@ export function ProfileDropdown({
     onOpenChange?.(newOpen)
   }
 
+  const role = me?.roles?.[0] ? toRoleTag(me.roles[0].roleType) : "challenger"
+
   return (
     <div ref={containerRef} className="relative">
       <button
@@ -87,7 +90,7 @@ export function ProfileDropdown({
                   {me ? `${me.nickname}/${me.name}` : ""}
                 </span>
 
-                <RoleTagChip role="challenger" />
+                <RoleTagChip role={role} />
               </div>
 
               <span className="text-caption-2-medium text-teal-gray-500">

--- a/src/shared/ui/ProfileDropdown.tsx
+++ b/src/shared/ui/ProfileDropdown.tsx
@@ -82,7 +82,7 @@ export function ProfileDropdown({
             </div>
 
             <div className="flex flex-col gap-0.5">
-              <div className="flex items-center justify-between">
+              <div className="flex items-center justify-between gap-4">
                 <span className="text-teal-gray-900 text-subtitle-3-semibold">
                   {me ? `${me.nickname}/${me.name}` : ""}
                 </span>
@@ -140,8 +140,8 @@ export function ProfileDropdown({
             className="bg-teal-gray-100 h-px w-full rounded-[0.5px]"
           />
 
-          {/* TODO: 기수 관리 페이지로 연결/계정 설정 페이지로 연결 */}
-          <div className="flex flex-col gap-0.5 px-2.5">
+          {/* TODO: 기수 관리 페이지로 연결/계정 설정 페이지로 연결/로그아웃 API 연동 */}
+          <div className="flex flex-col gap-1 px-2.5">
             <button type="button" className="h-6 w-15">
               <span className="text-body-2-medium text-teal-gray-700">
                 기수 관리
@@ -153,7 +153,7 @@ export function ProfileDropdown({
               </span>
             </button>
             <button type="button" onClick={logout} className="h-6 w-15">
-              <span className="text-body-2-medium text-teal-gray-700">
+              <span className="text-body-2-medium text-error-500">
                 로그아웃
               </span>
             </button>

--- a/src/shared/ui/chip/RoleTagChip.tsx
+++ b/src/shared/ui/chip/RoleTagChip.tsx
@@ -17,7 +17,7 @@ const roleTagChipVariants = cva(
 
 const ROLE_LABEL = {
   central: "중앙 운영진",
-  campus: "캠퍼스 운영진",
+  campus: "교내 운영진",
   challenger: "챌린저",
 } as const
 

--- a/src/shared/ui/chip/RoleTagChip.tsx
+++ b/src/shared/ui/chip/RoleTagChip.tsx
@@ -21,7 +21,7 @@ const ROLE_LABEL = {
   challenger: "챌린저",
 } as const
 
-type Role = keyof typeof ROLE_LABEL
+export type Role = keyof typeof ROLE_LABEL
 
 interface RoleTagChipProps {
   role: Role


### PR DESCRIPTION
## 📸 작업 내용

- 프로필 드롭다운과 내 프로필 조회 API 연동
    - 로그아웃은 아직 임시 동작
- RoleTagChip과 내 프로필 조회 api의 roleType 매핑
- 프로필 드롭다운의 권한별 뷰 분기처리 (기수 관리 버튼)

## 🎞️ 주요 코드 설명

```
// src\features\auth\hooks\useMe.ts
import { useQuery } from "@tanstack/react-query"

import { getMyInfo } from "../api/me"

export function useMe() {
  return useQuery({
    queryKey: ["auth", "me"],
    queryFn: getMyInfo,
    staleTime: 1000 * 60 * 5, // 5 minutes
  })
}
```

- 내 프로필 조회 api로 불러온 정보를 tanstack query로 관리합니다.

## 🖥️ 구현화면

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/3777f7de-5888-4550-9307-59179f843a75" />

## 🔗 연결된 이슈

- Connected: #97 

## 💬 기타 더 이야기해볼 점

- 프로필 드롭다운의 기수 선택 버튼에는 해당 기수의 연도도 같이 표기되는데, 기수의 연도 정보가 내 프로필 조회 api에는 포함되어 있지 않아 아직 미구현 상태입니다.
