### PR TITLE
feat: 사이드바 ViewMode 드롭다운을 사용자 권한 기반으로 연동

### DIFF
--- a/src/components/sidebar/SideBar.tsx
+++ b/src/components/sidebar/SideBar.tsx
@@ -78,7 +78,7 @@ export default function SideBar({ className }: SideBarProps) {
       {availableOptions.length >= 2 && (
         <SideBarDropDown
           options={availableOptions}
-          selectedIdx={selectedDropdownIdx === -1 ? 0 : selectedDropdownIdx}
+          selectedIdx={selectedDropdownIdx}
           onSelect={(idx) => {
             const selected = availableOptions[idx]
             if (selected) setMode(selected.mode)

--- a/src/components/sidebar/SideBar.tsx
+++ b/src/components/sidebar/SideBar.tsx
@@ -33,7 +33,7 @@ export default function SideBar({ className }: SideBarProps) {
   const mode = useViewModeStore((s) => s.mode)
   const setMode = useViewModeStore((s) => s.setMode)
 
-  const { data: me } = useMe()
+  const { data: me, isLoading: isMeLoading } = useMe()
 
   const availableModes = useMemo(() => rolesToViewModes(me?.roles), [me?.roles])
 
@@ -85,25 +85,33 @@ export default function SideBar({ className }: SideBarProps) {
           }}
         />
       )}
-      <div className="flex flex-col py-4">
-        <span className="text-body-3-regular text-teal-gray-400 mb-2 pl-0.5">
-          {DEMO_DAY_EDITION}th Demoday
-        </span>
-        {visibleSections.map(({ id, title, icon, menus }) => (
-          <SideBarMenu
-            key={id}
-            id={id}
-            title={title}
-            icon={icon}
-            isOpen={openSectionId === id}
-            onToggle={() => setOpenSectionId((prev) => (prev === id ? "" : id))}
-          >
-            {menus.map((menu) => (
-              <SideBarMenuItem key={menu.id} title={menu.title} to={menu.to} />
-            ))}
-          </SideBarMenu>
-        ))}
-      </div>
+      {!isMeLoading && (
+        <div className="flex flex-col py-4">
+          <span className="text-body-3-regular text-teal-gray-400 mb-2 pl-0.5">
+            {DEMO_DAY_EDITION}th Demoday
+          </span>
+          {visibleSections.map(({ id, title, icon, menus }) => (
+            <SideBarMenu
+              key={id}
+              id={id}
+              title={title}
+              icon={icon}
+              isOpen={openSectionId === id}
+              onToggle={() =>
+                setOpenSectionId((prev) => (prev === id ? "" : id))
+              }
+            >
+              {menus.map((menu) => (
+                <SideBarMenuItem
+                  key={menu.id}
+                  title={menu.title}
+                  to={menu.to}
+                />
+              ))}
+            </SideBarMenu>
+          ))}
+        </div>
+      )}
     </nav>
   )
 }

--- a/src/components/sidebar/SideBar.tsx
+++ b/src/components/sidebar/SideBar.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useMemo, useState } from "react"
 
+import { useMe } from "@/features/auth/hooks/useMe"
+import { rolesToViewModes } from "@/features/auth/model/mappers"
 import { SIDEBAR_ITEMS } from "@/shared/config/navigation"
 import { cn } from "@/shared/lib/utils"
-import { indexFromMode, useViewModeStore } from "@/shared/view-mode"
+import {
+  useViewModeStore,
+  VIEW_MODE_OPTIONS,
+  type ViewMode,
+} from "@/shared/view-mode"
 
 import { SideBarDropDown } from "./dropdown/SideBarDropDown"
 import { SideBarMenu } from "./menu/SideBarMenu"
@@ -15,13 +21,36 @@ interface SideBarProps {
 
 const DEMO_DAY_EDITION = 10
 
+function resolveActiveMode(
+  mode: ViewMode,
+  availableModes: ViewMode[],
+): ViewMode {
+  if (availableModes.length === 0) return mode
+  return availableModes.includes(mode) ? mode : availableModes[0]!
+}
+
 export default function SideBar({ className }: SideBarProps) {
   const mode = useViewModeStore((s) => s.mode)
-  const setModeByIndex = useViewModeStore((s) => s.setModeByIndex)
+  const setMode = useViewModeStore((s) => s.setMode)
+
+  const { data: me } = useMe()
+
+  const availableModes = useMemo(() => rolesToViewModes(me?.roles), [me?.roles])
+
+  const availableOptions = useMemo(
+    () => VIEW_MODE_OPTIONS.filter((opt) => availableModes.includes(opt.mode)),
+    [availableModes],
+  )
+
+  const activeMode = resolveActiveMode(mode, availableModes)
+
+  useEffect(() => {
+    if (activeMode !== mode) setMode(activeMode)
+  }, [activeMode, mode, setMode])
 
   const visibleSections = useMemo(
-    () => getVisibleSectionsByViewMode(SIDEBAR_ITEMS, mode),
-    [mode],
+    () => getVisibleSectionsByViewMode(SIDEBAR_ITEMS, activeMode),
+    [activeMode],
   )
   const [openSectionId, setOpenSectionId] = useState<string>(
     visibleSections[0]?.id ?? SIDEBAR_ITEMS[0]?.id ?? "",
@@ -29,10 +58,14 @@ export default function SideBar({ className }: SideBarProps) {
 
   useEffect(() => {
     const ids = new Set(visibleSections.map((section) => section.id))
-    if (!ids.has(openSectionId)) {
-      setOpenSectionId(visibleSections[0]?.id ?? "")
-    }
-  }, [openSectionId, visibleSections])
+    setOpenSectionId((prev) =>
+      ids.has(prev) ? prev : (visibleSections[0]?.id ?? ""),
+    )
+  }, [visibleSections])
+
+  const selectedDropdownIdx = availableOptions.findIndex(
+    (opt) => opt.mode === activeMode,
+  )
 
   return (
     <nav
@@ -42,10 +75,16 @@ export default function SideBar({ className }: SideBarProps) {
         className,
       )}
     >
-      <SideBarDropDown
-        selectedIdx={indexFromMode(mode)}
-        onSelect={setModeByIndex}
-      />
+      {availableOptions.length >= 2 && (
+        <SideBarDropDown
+          options={availableOptions}
+          selectedIdx={selectedDropdownIdx === -1 ? 0 : selectedDropdownIdx}
+          onSelect={(idx) => {
+            const selected = availableOptions[idx]
+            if (selected) setMode(selected.mode)
+          }}
+        />
+      )}
       <div className="flex flex-col py-4">
         <span className="text-body-3-regular text-teal-gray-400 mb-2 pl-0.5">
           {DEMO_DAY_EDITION}th Demoday

--- a/src/components/sidebar/dropdown/SideBarDropDown.tsx
+++ b/src/components/sidebar/dropdown/SideBarDropDown.tsx
@@ -41,7 +41,7 @@ export function SideBarDropDown({
       <button
         onClick={() => setIsOpen(!isOpen)}
         aria-expanded={isOpen}
-        aria-haspopup="listbox"
+        aria-haspopup="menu"
         className={cn(
           "flex h-6.5 w-43 justify-between rounded-[8px] py-1 pr-2 pl-3",
           isOpen ? "bg-teal-gray-200" : "bg-teal-gray-150",

--- a/src/components/sidebar/dropdown/SideBarDropDown.tsx
+++ b/src/components/sidebar/dropdown/SideBarDropDown.tsx
@@ -3,22 +3,25 @@ import { useEffect, useRef, useState } from "react"
 
 import DownChevronIcon from "@/shared/assets/icon/chevron/sidebar/DownChevronIcon"
 import { cn } from "@/shared/lib/utils"
-import { VIEW_MODE_OPTIONS } from "@/shared/view-mode"
 
 import { SideBarDropDownMenu } from "./SideBarDropDownMenu"
 
+import type { ViewMode } from "@/shared/view-mode"
+
 interface SideBarDropDownProps {
+  options: ReadonlyArray<{ mode: ViewMode; label: string }>
   selectedIdx: number
   onSelect: (idx: number) => void
 }
 
 export function SideBarDropDown({
+  options,
   selectedIdx,
   onSelect,
 }: SideBarDropDownProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false)
   const containerRef = useRef<HTMLDivElement>(null)
-  const selectedLabel = VIEW_MODE_OPTIONS[selectedIdx]?.label ?? "Admin View"
+  const selectedLabel = options[selectedIdx]?.label ?? options[0]?.label ?? ""
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -37,6 +40,8 @@ export function SideBarDropDown({
     <div ref={containerRef}>
       <button
         onClick={() => setIsOpen(!isOpen)}
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
         className={cn(
           "flex h-6.5 w-43 justify-between rounded-[8px] py-1 pr-2 pl-3",
           isOpen ? "bg-teal-gray-200" : "bg-teal-gray-150",
@@ -45,7 +50,12 @@ export function SideBarDropDown({
         <span className="text-teal-gray-600 text-body-3-regular">
           {selectedLabel}
         </span>
-        <DownChevronIcon className="text-teal-gray-400 h-4 w-4" />
+        <DownChevronIcon
+          className={cn(
+            "text-teal-gray-400 h-4 w-4 transition-transform duration-200",
+            isOpen && "rotate-180",
+          )}
+        />
       </button>
       <AnimatePresence>
         {isOpen && (
@@ -57,7 +67,7 @@ export function SideBarDropDown({
             className="overflow-hidden"
           >
             <SideBarDropDownMenu
-              items={VIEW_MODE_OPTIONS.map((item) => item.label)}
+              items={options.map((item) => item.label)}
               selectedIdx={selectedIdx}
               onSelect={(idx) => {
                 onSelect(idx)

--- a/src/components/sidebar/dropdown/SideBarDropDownMenu.tsx
+++ b/src/components/sidebar/dropdown/SideBarDropDownMenu.tsx
@@ -15,7 +15,7 @@ export function SideBarDropDownMenu({
     <div className="flex flex-col justify-center gap-1 rounded-[8px] bg-white p-0.5">
       {items.map((item, idx) => (
         <SideBarDropDownMenuItem
-          key={idx}
+          key={item}
           label={item}
           isSelected={selectedIdx === idx}
           onClick={() => onSelect(idx)}

--- a/src/features/auth/model/mappers.ts
+++ b/src/features/auth/model/mappers.ts
@@ -1,7 +1,10 @@
-import type { RoleType } from "@/features/challenger"
+import type {
+  ChallengerRoleResponse,
+  RoleType,
+} from "@/features/challenger/model/types"
 import type { Role } from "@/shared/ui/chip/RoleTagChip"
+import type { ViewMode } from "@/shared/view-mode"
 
-// 서버 roleType -> 프로필 드롭다운 Role Tag
 const ROLE_MAP: Record<RoleType, Role> = {
   CHALLENGER: "challenger",
   SUPER_ADMIN: "central",
@@ -18,4 +21,22 @@ const ROLE_MAP: Record<RoleType, Role> = {
 
 export function toRoleTag(roleType: RoleType): Role {
   return ROLE_MAP[roleType]
+}
+
+export function roleToViewMode(role: ChallengerRoleResponse): ViewMode {
+  const { roleType, responsiblePart } = role
+  if (roleType !== "CHALLENGER") return "admin"
+  if (responsiblePart === "PLAN") return "pm"
+  if (responsiblePart === "ADMIN") return "admin"
+  return "others"
+}
+
+export function rolesToViewModes(
+  roles: ChallengerRoleResponse[] | undefined,
+): ViewMode[] {
+  if (!roles?.length) return []
+  const set = new Set<ViewMode>()
+  for (const r of roles) set.add(roleToViewMode(r))
+  const order: ViewMode[] = ["admin", "pm", "others"]
+  return order.filter((m) => set.has(m))
 }

--- a/src/shared/view-mode/index.ts
+++ b/src/shared/view-mode/index.ts
@@ -12,6 +12,7 @@ interface ViewModeState {
   mode: ViewMode
   previewMode: ViewMode
   viewerBranch: string
+  setMode: (mode: ViewMode) => void
   setModeByIndex: (index: number) => void
   setPreviewModeByIndex: (index: number) => void
 }
@@ -25,11 +26,11 @@ export function indexFromMode(mode: ViewMode): number {
   return idx === -1 ? 0 : idx
 }
 
-/** 임시 상태: 권한에 따른 뷰 변화를 보고 싶으시면 아래에서 임시 설정 가능합니다. */
 export const useViewModeStore = create<ViewModeState>((set) => ({
   mode: "admin",
   previewMode: "admin",
   viewerBranch: "Selenium",
+  setMode: (mode) => set({ mode }),
   setModeByIndex: (index) => set({ mode: modeFromIndex(index) }),
   setPreviewModeByIndex: (index) => set({ previewMode: modeFromIndex(index) }),
 }))


### PR DESCRIPTION
## 개요

사이드바 상단 ViewMode 드롭다운이 `\"admin\"`으로 하드코딩된 임시 상태였던 것을 `GET /v1/member/me`의 `roles` 응답과 실제로 연동합니다.

## 변경 사항

### 권한 매핑 로직 (`src/features/auth/model/mappers.ts`)
- `roleToViewMode(role)` — `ChallengerRoleResponse` 한 건을 `ViewMode`로 변환
- `rolesToViewModes(roles)` — 전체 `roles` 배열을 중복 제거 후 `ViewMode[]` 반환

**매핑 규칙**
| 조건 | ViewMode |
|---|---|
| `CHALLENGER` + `responsiblePart=PLAN` | `pm` |
| `CHALLENGER` + `responsiblePart=ADMIN` | `admin` |
| `CHALLENGER` + 나머지 part | `others` |
| `SUPER_ADMIN`, `CENTRAL_*`, `CHAPTER_*`, `SCHOOL_*` | `admin` |

### 사이드바 동작 (`src/components/sidebar/SideBar.tsx`)
- `useMe()`로 `roles` 조회 후 `availableModes` 계산
- 권한 **1개**: 드롭다운 미표시, 해당 `ViewMode`로 메뉴 자동 분기
- 권한 **2개 이상**: 보유 권한 옵션만 드롭다운에 노출, 선택 시 전환
- `resolveActiveMode`로 store 보정 로직 단일화

### 기타
- `useViewModeStore`에 `setMode(mode: ViewMode)` 액션 추가
- `SideBarDropDown`: `options` prop 도입, `aria-expanded`/`aria-haspopup` 추가, 아이콘 열림 방향 회전 애니메이션 적용
- `SideBarDropDownMenu`: `key={idx}` → `key={item}` 수정

## 영향 범위

`useViewModeStore`를 이미 구독 중인 컴포넌트들(`ProjectManagementPage`, `applications.tsx`, `matching/index.tsx` 등)은 별도 수정 없이 권한 기반 분기가 자동 적용됩니다.

## 미포함 범위

- `viewerBranch`(지부 식별자) 실제 사용자 데이터 연동은 별도 작업 예정