### PR TITLE
✨ feat: 공지 설명 문구 UI 분기

### DIFF
--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -253,7 +253,11 @@ function TeamMatchingAnnouncePage() {
               공지
             </span>
             <p className="text-body-2-regular text-teal-gray-600">
-              팀 매칭에 대한 지부별 공지를 모든 챌린저에게 안내합니다.
+              {mode === "admin"
+                ? "팀 매칭에 대한 지부별 공지를 모든 챌린저에게 안내합니다."
+                : mode === "pm"
+                  ? "팀 매칭에 대한 우리 지부의 모든 공지를 한눈에 조회합니다."
+                  : "팀 매칭에 대한 우리 지부의 공지를 한눈에 조회합니다."}
             </p>
           </div>
 

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -254,7 +254,9 @@ function ProjectSettingsAnnouncePage() {
               공지
             </span>
             <p className="text-body-2-regular text-teal-gray-600">
-              프로젝트 설정에 대한 지부별 공지를 PM 챌린저에게 안내합니다.
+              {mode === "admin"
+                ? "프로젝트 설정에 대한 지부별 공지를 PM 챌린저에게 안내합니다."
+                : "프로젝트 설정에 대한 우리 지부의 PM 챌린저 공지를 한눈에 조회합니다."}
             </p>
           </div>
 


### PR DESCRIPTION
## 📸 작업 내용

공지사항 페이지 설명 문구를 아래와 같이 분기

1. Admin
- 프로젝트 설정 공지: "프로젝트 설정에 대한 지부별 공지를 PM 챌린저에게 안내합니다."
- 팀 매칭 공지: "팀 매칭에 대한 지부별 공지를 모든 챌린저에게 안내합니다."
2. Plan Challanger
- 프로젝트 설정 공지: "프로젝트 설정에 대한 우리 지부의 PM 챌린저 공지를 한눈에 조회합니다."
- 팀 매칭 공지: "팀 매칭에 대한 우리 지부의 모든 공지를 한눈에 조회합니다."
3. Design/FE/BE Challenger:
- 팀 매칭 공지: "팀 매칭에 대한 우리 지부의 공지를 한눈에 조회합니다."

## 🎞️ 주요 코드 설명

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #103 

