### PR TITLE
fix: viewMode 폐기로 인한 공지사항 권한 로직 수정

### DIFF
--- a/src/features/auth/hooks/useResourcePermission.ts
+++ b/src/features/auth/hooks/useResourcePermission.ts
@@ -21,7 +21,7 @@ export function useResourcePermission(
       resourceId,
     ],
     queryFn: () => getResourcePermission({ resourceType, resourceId }),
-    enabled: isAuthed && (options?.enabled ?? true),
+    enabled: isAuthed && resourceId !== undefined && (options?.enabled ?? true),
     staleTime: 0,
   })
 

--- a/src/features/auth/hooks/useResourcePermission.ts
+++ b/src/features/auth/hooks/useResourcePermission.ts
@@ -10,6 +10,7 @@ import { useAuthStore } from "@/features/auth/store/authStore"
 export function useResourcePermission(
   resourceType: ResourceType,
   resourceId?: number,
+  options?: { enabled?: boolean },
 ) {
   const isAuthed = useAuthStore((s) => s.isAuthed)
   const query = useQuery({
@@ -20,7 +21,7 @@ export function useResourcePermission(
       resourceId,
     ],
     queryFn: () => getResourcePermission({ resourceType, resourceId }),
-    enabled: isAuthed,
+    enabled: isAuthed && (options?.enabled ?? true),
     staleTime: 0,
   })
 

--- a/src/features/notice/ui/NoticeCard.tsx
+++ b/src/features/notice/ui/NoticeCard.tsx
@@ -62,7 +62,8 @@ interface NoticeCardProps
   date: string
   chip?: string
   children?: ReactNode
-  canManage?: boolean
+  canEdit?: boolean
+  canDelete?: boolean
   expanded?: boolean
   onExpandedChange?: (expanded: boolean) => void
   onDelete?: () => void
@@ -75,7 +76,8 @@ export function NoticeCard({
   chip,
   variant,
   children,
-  canManage = false,
+  canEdit = false,
+  canDelete = false,
   expanded,
   onExpandedChange,
   onDelete,
@@ -161,26 +163,30 @@ export function NoticeCard({
                 {/* TODO: 공지 API 응답 형식에 맞추어 수정 */}
                 {children}
 
-                {canManage ? (
+                {canEdit || canDelete ? (
                   <div className="flex items-center justify-end gap-2 pt-8">
-                    <Button
-                      type="button"
-                      variant="weak"
-                      color="neutral"
-                      size="m"
-                      onClick={handleDeleteClick}
-                    >
-                      삭제
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="weak"
-                      color="primary"
-                      size="m"
-                      onClick={onEdit}
-                    >
-                      수정
-                    </Button>
+                    {canDelete ? (
+                      <Button
+                        type="button"
+                        variant="weak"
+                        color="neutral"
+                        size="m"
+                        onClick={handleDeleteClick}
+                      >
+                        삭제
+                      </Button>
+                    ) : null}
+                    {canEdit ? (
+                      <Button
+                        type="button"
+                        variant="weak"
+                        color="primary"
+                        size="m"
+                        onClick={onEdit}
+                      >
+                        수정
+                      </Button>
+                    ) : null}
                   </div>
                 ) : null}
               </div>

--- a/src/features/notice/ui/NoticeCardList.tsx
+++ b/src/features/notice/ui/NoticeCardList.tsx
@@ -17,7 +17,8 @@ interface NoticeCardListProps {
   notices: NoticeItem[]
   page: number
   isLoading?: boolean
-  canManage?: boolean
+  canEdit?: boolean
+  canDelete?: boolean
   focusedNoticeId?: string | null
   onDeleteNotice?: (noticeId: string) => void
   onEditNotice?: (noticeId: string) => void
@@ -30,7 +31,8 @@ export function NoticeCardList({
   notices,
   page,
   isLoading = false,
-  canManage = false,
+  canEdit = false,
+  canDelete = false,
   focusedNoticeId,
   onDeleteNotice,
   onEditNotice,
@@ -97,7 +99,8 @@ export function NoticeCardList({
               date={notice.date}
               chip={notice.chip}
               variant={cardVariant}
-              canManage={canManage}
+              canEdit={canEdit}
+              canDelete={canDelete}
               expanded={isExpanded}
               data-notice-id={notice.id}
               onExpandedChange={(nextExpanded) => {

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -168,7 +168,6 @@ function TeamMatchingAnnouncePage() {
   const { hasPermission } = useResourcePermission(
     "NOTICE",
     firstNoticeId ? Number(firstNoticeId) : undefined,
-    { enabled: !!firstNoticeId },
   )
 
   const canWrite =

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -9,6 +9,7 @@ import { useResourcePermission } from "@/features/auth/hooks/useResourcePermissi
 import { ensureMe } from "@/features/auth/lib/ensureMe"
 import {
   getViewerBranch,
+  isCentralStaff,
   isCurrentTermPm,
   isOperator,
 } from "@/features/auth/model/identity"
@@ -112,7 +113,7 @@ function TeamMatchingAnnouncePage() {
   const { data: me } = useMe()
   const { hasPermission } = useResourcePermission("NOTICE")
 
-  const isOp = isOperator(me)
+  const isCentral = isCentralStaff(me)
   const isPm = isCurrentTermPm(me)
   const userChapter = getViewerBranch(me) as Chapter | undefined
 
@@ -204,7 +205,7 @@ function TeamMatchingAnnouncePage() {
   })
 
   const handleChapterChange = (nextChapter: Chapter) => {
-    if (!isOp && userChapter && nextChapter !== userChapter) {
+    if (!isCentral && userChapter && nextChapter !== userChapter) {
       addToast({
         message: "소속된 지부의 공지만 확인할 수 있습니다.",
         color: "red",

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
 import { useMe } from "@/features/auth/hooks/useMe"
+import { useResourcePermission } from "@/features/auth/hooks/useResourcePermission"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
 import {
   getViewerBranch,
@@ -109,9 +110,15 @@ function TeamMatchingAnnouncePage() {
   const [pendingNotice] = useState(readPendingNotice)
 
   const { data: me } = useMe()
-  const canManage = isOperator(me)
+  const { hasPermission } = useResourcePermission("NOTICE")
+
+  const isOp = isOperator(me)
   const isPm = isCurrentTermPm(me)
   const userChapter = getViewerBranch(me) as Chapter | undefined
+
+  const canWrite = hasPermission("WRITE")
+  const canEdit = hasPermission("EDIT")
+  const canDelete = hasPermission("DELETE")
 
   // 기수 정보 조회
   const { data: gisuData } = useQuery({
@@ -197,7 +204,7 @@ function TeamMatchingAnnouncePage() {
   })
 
   const handleChapterChange = (nextChapter: Chapter) => {
-    if (!canManage && userChapter && nextChapter !== userChapter) {
+    if (!isOp && userChapter && nextChapter !== userChapter) {
       addToast({
         message: "소속된 지부의 공지만 확인할 수 있습니다.",
         color: "red",
@@ -266,7 +273,7 @@ function TeamMatchingAnnouncePage() {
               공지
             </span>
             <p className="text-body-2-regular text-teal-gray-600">
-              {canManage
+              {isOp
                 ? "팀 매칭에 대한 지부별 공지를 모든 챌린저에게 안내합니다."
                 : isPm
                   ? "팀 매칭에 대한 우리 지부의 모든 공지를 한눈에 조회합니다."
@@ -281,7 +288,7 @@ function TeamMatchingAnnouncePage() {
                 onChapterChange={handleChapterChange}
               />
 
-              {canManage ? (
+              {canWrite ? (
                 <Button
                   type="button"
                   variant="fill"
@@ -302,7 +309,8 @@ function TeamMatchingAnnouncePage() {
               notices={notices}
               page={safePage}
               isLoading={isNoticesLoading}
-              canManage={canManage}
+              canEdit={canEdit}
+              canDelete={canDelete}
               focusedNoticeId={focusedNoticeId}
               onDeleteNotice={handleNoticeDeleteClick}
               onEditNotice={handleNoticeEditClick}

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -273,7 +273,7 @@ function TeamMatchingAnnouncePage() {
               공지
             </span>
             <p className="text-body-2-regular text-teal-gray-600">
-              {isOp
+              {canWrite
                 ? "팀 매칭에 대한 지부별 공지를 모든 챌린저에게 안내합니다."
                 : isPm
                   ? "팀 매칭에 대한 우리 지부의 모든 공지를 한눈에 조회합니다."

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -10,7 +10,9 @@ import { ensureMe } from "@/features/auth/lib/ensureMe"
 import {
   getViewerBranch,
   isCentralStaff,
+  isChapterPresident,
   isCurrentTermPm,
+  isSuperAdmin,
 } from "@/features/auth/model/identity"
 import {
   getAllChapters,
@@ -91,7 +93,9 @@ export const Route = createFileRoute("/matching/")({
   },
   beforeLoad: async ({ search, context }) => {
     const me = await ensureMe(context.queryClient)
-    if (isCentralStaff(me)) return
+    const isFullAccess = isSuperAdmin(me) || isCentralStaff(me)
+    if (isFullAccess) return
+
     const userChapter = getViewerBranch(me)
     if (isChapter(userChapter) && search.chapter !== userChapter) {
       throw redirect({
@@ -110,15 +114,12 @@ function TeamMatchingAnnouncePage() {
   const [pendingNotice] = useState(readPendingNotice)
 
   const { data: me } = useMe()
-  const { hasPermission } = useResourcePermission("NOTICE")
 
+  const isSuper = isSuperAdmin(me)
   const isCentral = isCentralStaff(me)
+  const isChapterPres = isChapterPresident(me)
   const isPm = isCurrentTermPm(me)
   const userChapter = getViewerBranch(me) as Chapter | undefined
-
-  const canWrite = hasPermission("WRITE")
-  const canEdit = hasPermission("EDIT")
-  const canDelete = hasPermission("DELETE")
 
   // 기수 정보 조회
   const { data: gisuData } = useQuery({
@@ -163,6 +164,18 @@ function TeamMatchingAnnouncePage() {
     enabled: !!activeGisuId,
   })
 
+  const firstNoticeId = noticesData?.content[0]?.id
+  const { hasPermission } = useResourcePermission(
+    "NOTICE",
+    firstNoticeId ? Number(firstNoticeId) : undefined,
+    { enabled: !!firstNoticeId },
+  )
+
+  const canWrite =
+    !isSuper && (isCentral || (isChapterPres && chapter === userChapter))
+  const canEdit = hasPermission("EDIT")
+  const canDelete = hasPermission("DELETE")
+
   const notices = useMemo(() => {
     if (!noticesData) return []
 
@@ -204,7 +217,7 @@ function TeamMatchingAnnouncePage() {
   })
 
   const handleChapterChange = (nextChapter: Chapter) => {
-    if (!isCentral && userChapter && nextChapter !== userChapter) {
+    if (!(isSuper || isCentral) && userChapter && nextChapter !== userChapter) {
       addToast({
         message: "소속된 지부의 공지만 확인할 수 있습니다.",
         color: "red",

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -11,7 +11,6 @@ import {
   getViewerBranch,
   isCentralStaff,
   isCurrentTermPm,
-  isOperator,
 } from "@/features/auth/model/identity"
 import {
   getAllChapters,
@@ -92,7 +91,7 @@ export const Route = createFileRoute("/matching/")({
   },
   beforeLoad: async ({ search, context }) => {
     const me = await ensureMe(context.queryClient)
-    if (isOperator(me)) return
+    if (isCentralStaff(me)) return
     const userChapter = getViewerBranch(me)
     if (isChapter(userChapter) && search.chapter !== userChapter) {
       throw redirect({

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -167,7 +167,6 @@ function ProjectSettingsAnnouncePage() {
   const { hasPermission } = useResourcePermission(
     "NOTICE",
     firstNoticeId ? Number(firstNoticeId) : undefined,
-    { enabled: !!firstNoticeId },
   )
 
   const canWrite =

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
 import { useMe } from "@/features/auth/hooks/useMe"
+import { useResourcePermission } from "@/features/auth/hooks/useResourcePermission"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
 import { getViewerBranch, isOperator } from "@/features/auth/model/identity"
 import {
@@ -105,8 +106,14 @@ function ProjectSettingsAnnouncePage() {
   const [pendingNotice] = useState(readPendingNotice)
 
   const { data: me } = useMe()
-  const canManage = isOperator(me)
+  const { hasPermission } = useResourcePermission("NOTICE")
+
+  const isOp = isOperator(me)
   const userChapter = getViewerBranch(me) as Chapter | undefined
+
+  const canWrite = hasPermission("WRITE")
+  const canEdit = hasPermission("EDIT")
+  const canDelete = hasPermission("DELETE")
 
   // 기수 정보 조회
   const { data: gisuData } = useQuery({
@@ -193,7 +200,7 @@ function ProjectSettingsAnnouncePage() {
   })
 
   const handleChapterChange = (nextChapter: Chapter) => {
-    if (!canManage && userChapter && nextChapter !== userChapter) {
+    if (!isOp && userChapter && nextChapter !== userChapter) {
       addToast({
         message: "소속된 지부의 공지만 확인할 수 있습니다.",
         color: "red",
@@ -262,7 +269,7 @@ function ProjectSettingsAnnouncePage() {
               공지
             </span>
             <p className="text-body-2-regular text-teal-gray-600">
-              {canManage
+              {isOp
                 ? "프로젝트 설정에 대한 지부별 공지를 PM 챌린저에게 안내합니다."
                 : "프로젝트 설정에 대한 우리 지부의 PM 챌린저 공지를 한눈에 조회합니다."}
             </p>
@@ -275,7 +282,7 @@ function ProjectSettingsAnnouncePage() {
                 onChapterChange={handleChapterChange}
               />
 
-              {canManage ? (
+              {canWrite ? (
                 <Button
                   type="button"
                   variant="fill"
@@ -296,7 +303,8 @@ function ProjectSettingsAnnouncePage() {
               notices={notices}
               page={safePage}
               isLoading={isNoticesLoading}
-              canManage={canManage}
+              canEdit={canEdit}
+              canDelete={canDelete}
               focusedNoticeId={focusedNoticeId}
               onDeleteNotice={handleNoticeDeleteClick}
               onEditNotice={handleNoticeEditClick}

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -269,7 +269,7 @@ function ProjectSettingsAnnouncePage() {
               공지
             </span>
             <p className="text-body-2-regular text-teal-gray-600">
-              {isOp
+              {canWrite
                 ? "프로젝트 설정에 대한 지부별 공지를 PM 챌린저에게 안내합니다."
                 : "프로젝트 설정에 대한 우리 지부의 PM 챌린저 공지를 한눈에 조회합니다."}
             </p>

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -7,7 +7,11 @@ import { useToastStore } from "@/components/toast/useToastStore"
 import { useMe } from "@/features/auth/hooks/useMe"
 import { useResourcePermission } from "@/features/auth/hooks/useResourcePermission"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
-import { getViewerBranch, isOperator } from "@/features/auth/model/identity"
+import {
+  getViewerBranch,
+  isCentralStaff,
+  isOperator,
+} from "@/features/auth/model/identity"
 import {
   getAllChapters,
   getAllGisu,
@@ -108,7 +112,7 @@ function ProjectSettingsAnnouncePage() {
   const { data: me } = useMe()
   const { hasPermission } = useResourcePermission("NOTICE")
 
-  const isOp = isOperator(me)
+  const isCentral = isCentralStaff(me)
   const userChapter = getViewerBranch(me) as Chapter | undefined
 
   const canWrite = hasPermission("WRITE")
@@ -200,7 +204,7 @@ function ProjectSettingsAnnouncePage() {
   })
 
   const handleChapterChange = (nextChapter: Chapter) => {
-    if (!isOp && userChapter && nextChapter !== userChapter) {
+    if (!isCentral && userChapter && nextChapter !== userChapter) {
       addToast({
         message: "소속된 지부의 공지만 확인할 수 있습니다.",
         color: "red",

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -7,11 +7,7 @@ import { useToastStore } from "@/components/toast/useToastStore"
 import { useMe } from "@/features/auth/hooks/useMe"
 import { useResourcePermission } from "@/features/auth/hooks/useResourcePermission"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
-import {
-  getViewerBranch,
-  isCentralStaff,
-  isOperator,
-} from "@/features/auth/model/identity"
+import { getViewerBranch, isCentralStaff } from "@/features/auth/model/identity"
 import {
   getAllChapters,
   getAllGisu,
@@ -91,7 +87,7 @@ export const Route = createFileRoute("/matching/projects/announce/")({
   },
   beforeLoad: async ({ search, context }) => {
     const me = await ensureMe(context.queryClient)
-    if (isOperator(me)) return
+    if (isCentralStaff(me)) return
     const userChapter = getViewerBranch(me)
     if (isChapter(userChapter) && search.chapter !== userChapter) {
       throw redirect({

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -7,7 +7,12 @@ import { useToastStore } from "@/components/toast/useToastStore"
 import { useMe } from "@/features/auth/hooks/useMe"
 import { useResourcePermission } from "@/features/auth/hooks/useResourcePermission"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
-import { getViewerBranch, isCentralStaff } from "@/features/auth/model/identity"
+import {
+  getViewerBranch,
+  isCentralStaff,
+  isChapterPresident,
+  isSuperAdmin,
+} from "@/features/auth/model/identity"
 import {
   getAllChapters,
   getAllGisu,
@@ -87,7 +92,9 @@ export const Route = createFileRoute("/matching/projects/announce/")({
   },
   beforeLoad: async ({ search, context }) => {
     const me = await ensureMe(context.queryClient)
-    if (isCentralStaff(me)) return
+    const isFullAccess = isSuperAdmin(me) || isCentralStaff(me)
+    if (isFullAccess) return
+
     const userChapter = getViewerBranch(me)
     if (isChapter(userChapter) && search.chapter !== userChapter) {
       throw redirect({
@@ -106,14 +113,11 @@ function ProjectSettingsAnnouncePage() {
   const [pendingNotice] = useState(readPendingNotice)
 
   const { data: me } = useMe()
-  const { hasPermission } = useResourcePermission("NOTICE")
 
+  const isSuper = isSuperAdmin(me)
   const isCentral = isCentralStaff(me)
+  const isChapterPres = isChapterPresident(me)
   const userChapter = getViewerBranch(me) as Chapter | undefined
-
-  const canWrite = hasPermission("WRITE")
-  const canEdit = hasPermission("EDIT")
-  const canDelete = hasPermission("DELETE")
 
   // 기수 정보 조회
   const { data: gisuData } = useQuery({
@@ -159,6 +163,18 @@ function ProjectSettingsAnnouncePage() {
     enabled: !!activeGisuId,
   })
 
+  const firstNoticeId = noticesData?.content[0]?.id
+  const { hasPermission } = useResourcePermission(
+    "NOTICE",
+    firstNoticeId ? Number(firstNoticeId) : undefined,
+    { enabled: !!firstNoticeId },
+  )
+
+  const canWrite =
+    !isSuper && (isCentral || (isChapterPres && chapter === userChapter))
+  const canEdit = hasPermission("EDIT")
+  const canDelete = hasPermission("DELETE")
+
   const notices = useMemo(() => {
     if (!noticesData) return []
 
@@ -200,7 +216,7 @@ function ProjectSettingsAnnouncePage() {
   })
 
   const handleChapterChange = (nextChapter: Chapter) => {
-    if (!isCentral && userChapter && nextChapter !== userChapter) {
+    if (!(isSuper || isCentral) && userChapter && nextChapter !== userChapter) {
       addToast({
         message: "소속된 지부의 공지만 확인할 수 있습니다.",
         color: "red",


### PR DESCRIPTION
## 📸 작업 내용

- `viewMode` 폐기 및 `useResourcePermission` 기반의 리소스 권한 제어 도입
- `useResourcePermission` 훅에 `enabled` 옵션 추가 및 리소스 ID 필수 대응 (목록 내 첫 번째 리소스 활용)
- RoleType별 정밀 권한 분기 처리 (`SUPER_ADMIN`, `CENTRAL_STAFF`, `CHAPTER_PRESIDENT` 등)
- 타 지부 공지 조회 제한 및 본인 소속 지부 강제 리다이렉트 로직 구현

## 🎞️ 주요 코드 설명

### 1. 대표 리소스를 활용한 권한 검사
`useResourcePermission` 훅은 특정 `resourceId`가 없을 경우 에러를 반환하므로, 조회된 공지사항 중 첫 번째 ID를 대표로 뽑아 권한을 확인합니다. 공지가 없는 경우를 대비해 `enabled` 옵션으로 쿼리를 제어합니다.

```TypeScript
const firstNoticeId = noticesData?.content[0]?.id
const { hasPermission } = useResourcePermission(
  "NOTICE",
  firstNoticeId ? Number(firstNoticeId) : undefined,
  { enabled: !!firstNoticeId },
)

const canEdit = hasPermission("EDIT")
const canDelete = hasPermission("DELETE")
```

### 2. RoleType 기반 정체성 분기
`useMe()` 응답에서 도출한 역할을 바탕으로 서비스 접근 및 작성 권한을 제어합니다.

```TypeScript
const isSuper = isSuperAdmin(me)
const isCentral = isCentralStaff(me)
const isChapterPres = isChapterPresident(me)

// SUPER_ADMIN은 읽기 전용, 운영진 및 지부장은 조건부 작성 권한 부여
const canWrite = !isSuper && (isCentral || (isChapterPres && chapter === userChapter))
```

- **SUPER_ADMIN**: 모든 지부 조회 가능, 작성 불가
- **CENTRAL_***: 모든 지부 조회 및 작성 가능
- **CHAPTER_PRESIDENT**: 본인 지부만 조회 및 작성 가능 (타 지부 접근 시 리다이렉트)
- **일반 PM/챌린저**: 본인 지부만 조회 가능

### 3. 라우트 진입 전 접근 제어 (beforeLoad)
중앙 권한이 없는 사용자가 URL 파라미터 조작 등으로 타 지부 공지에 접근하는 것을 방지합니다.

```TypeScript
beforeLoad: async ({ search, context }) => {
  const me = await ensureMe(context.queryClient)
  const isFullAccess = isSuperAdmin(me) || isCentralStaff(me)
  if (isFullAccess) return

  const userChapter = getViewerBranch(me)
  if (isChapter(userChapter) && search.chapter !== userChapter) {
    throw redirect({
      to: "/matching",
      search: { ...search, chapter: userChapter },
    })
  }
}
```

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #132

