### PR TITLE
fix: 프로젝트 등록 단계별 UX 개선 및 오류 수정

### DIFF
--- a/src/features/project/management/api.ts
+++ b/src/features/project/management/api.ts
@@ -18,3 +18,7 @@ export async function getManagedProjects(
   >("/v1/projects/me/managed", { params: { gisuId } })
   return data.result.content ?? []
 }
+
+export async function deleteProject(projectId: number): Promise<void> {
+  await api.delete(`/v1/projects/${projectId}`)
+}

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -1,9 +1,11 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import { Popover } from "radix-ui"
 import { useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
 import { ApplicationDetailModal } from "@/features/application/ui/ApplicationDetailModal"
+import { deleteProject } from "@/features/project/management/api"
 import MoreVerticalIcon from "@/shared/assets/icon/more/MoreVerticalIcon"
 import { DropdownItem } from "@/shared/ui/dropdown/DropdownItem"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
@@ -15,7 +17,6 @@ interface ProjectManagementMoreMenuProps {
   projectName: string
   projectApplication: ProjectApplication
   chapterName: string
-  onDelete?: () => void
 }
 
 export function ProjectManagementMoreMenu({
@@ -23,13 +24,37 @@ export function ProjectManagementMoreMenu({
   projectName,
   projectApplication,
   chapterName,
-  onDelete,
 }: ProjectManagementMoreMenuProps) {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const [popoverOpen, setPopoverOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [applicationOpen, setApplicationOpen] = useState(false)
   const addToast = useToastStore((s) => s.addToast)
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteProject(Number(projectId)),
+    onSuccess: () => {
+      setDeleteOpen(false)
+      void queryClient.invalidateQueries({ queryKey: ["project", "managed"] })
+      addToast({
+        message: "프로젝트가 삭제되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    },
+    onError: () => {
+      addToast({
+        message: "프로젝트 삭제에 실패했습니다. 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    },
+  })
 
   const handleDeleteClick = () => {
     setPopoverOpen(false)
@@ -102,26 +127,17 @@ export function ProjectManagementMoreMenu({
         title="프로젝트 삭제"
         content={
           <>
-            프로젝트를 삭제하면 복구할 수 없습니다. <br /> '{projectName}'을
-            정말 삭제하시겠습니까?
+            삭제한 프로젝트는 되돌릴 수 없습니다. <br /> '{projectName}'을
+            삭제하시겠습니까?
           </>
         }
         cancelText="돌아가기"
         confirmText="삭제하기"
+        confirmLoading={deleteMutation.isPending}
         variant="error"
         onOpenChange={setDeleteOpen}
         onCancel={() => setDeleteOpen(false)}
-        onConfirm={() => {
-          onDelete?.()
-          setDeleteOpen(false)
-          addToast({
-            message: "프로젝트가 삭제되었습니다.",
-            color: "primary",
-            variant: "deep",
-            type: "default",
-            duration: 3000,
-          })
-        }}
+        onConfirm={() => deleteMutation.mutate()}
       />
     </>
   )

--- a/src/features/project/new/index.ts
+++ b/src/features/project/new/index.ts
@@ -1,4 +1,10 @@
-export { ApplicationForm } from "./ui/application/ApplicationForm"
+export {
+  ApplicationForm,
+  type ApplicationFormHandle,
+} from "./ui/application/ApplicationForm"
 export { BasicInfoForm } from "./ui/basic-info/BasicInfoForm"
-export { RecruitInfoForm } from "./ui/recruit-info/RecruitInfoForm"
+export {
+  RecruitInfoForm,
+  type RecruitInfoFormHandle,
+} from "./ui/recruit-info/RecruitInfoForm"
 export { Stepper } from "./ui/stepper/Stepper"

--- a/src/features/project/new/model/basicInfoSchema.ts
+++ b/src/features/project/new/model/basicInfoSchema.ts
@@ -7,22 +7,28 @@ const MAX_FILE_SIZE = 10 * 1024 * 1024
 export const basicInfoSchema = z.object({
   title: z.string().min(1).max(16),
   description: z.string().min(1).max(200),
-  thumbnail: z.instanceof(File).superRefine((v, ctx) => {
-    if (!THUMBNAIL_ACCEPTED_TYPES.includes(v.type)) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom })
-    }
-    if (v.size > MAX_FILE_SIZE) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom })
-    }
-  }),
-  logo: z.instanceof(File).superRefine((v, ctx) => {
-    if (!LOGO_ACCEPTED_TYPES.includes(v.type)) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom })
-    }
-    if (v.size > MAX_FILE_SIZE) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom })
-    }
-  }),
+  thumbnail: z
+    .instanceof(File)
+    .superRefine((v, ctx) => {
+      if (!THUMBNAIL_ACCEPTED_TYPES.includes(v.type)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom })
+      }
+      if (v.size > MAX_FILE_SIZE) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom })
+      }
+    })
+    .optional(),
+  logo: z
+    .instanceof(File)
+    .superRefine((v, ctx) => {
+      if (!LOGO_ACCEPTED_TYPES.includes(v.type)) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom })
+      }
+      if (v.size > MAX_FILE_SIZE) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom })
+      }
+    })
+    .optional(),
 })
 
 export type BasicInfoFormData = z.infer<typeof basicInfoSchema>

--- a/src/features/project/new/ui/application/ApplicationForm.tsx
+++ b/src/features/project/new/ui/application/ApplicationForm.tsx
@@ -60,7 +60,7 @@ export function ApplicationForm({ onPrev, onNext }: ApplicationFormProps) {
         color: "primary",
         variant: "deep",
         type: "default",
-        duration: 3,
+        duration: 3000,
       })
     },
     onError: () => {
@@ -69,7 +69,7 @@ export function ApplicationForm({ onPrev, onNext }: ApplicationFormProps) {
         color: "red",
         variant: "deep",
         type: "default",
-        duration: 3,
+        duration: 3000,
       })
     },
   })
@@ -100,7 +100,7 @@ export function ApplicationForm({ onPrev, onNext }: ApplicationFormProps) {
         color: "red",
         variant: "deep",
         type: "default",
-        duration: 3,
+        duration: 3000,
       })
       return
     }
@@ -114,7 +114,7 @@ export function ApplicationForm({ onPrev, onNext }: ApplicationFormProps) {
         color: "red",
         variant: "deep",
         type: "default",
-        duration: 3,
+        duration: 3000,
       })
       return
     }

--- a/src/features/project/new/ui/application/ApplicationForm.tsx
+++ b/src/features/project/new/ui/application/ApplicationForm.tsx
@@ -1,5 +1,11 @@
 import { useMutation } from "@tanstack/react-query"
-import { useMemo, useRef, useState } from "react"
+import {
+  forwardRef,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
 import {
@@ -21,12 +27,19 @@ import { QuestionCard } from "./QuestionCard"
 import { QuestionListContainer } from "./QuestionListContainer"
 import { QuestionTypeToolbar } from "./QuestionTypeToolbar"
 
+export interface ApplicationFormHandle {
+  save: () => Promise<boolean>
+}
+
 interface ApplicationFormProps {
   onPrev?: () => void
   onNext?: () => void
 }
 
-export function ApplicationForm({ onPrev, onNext }: ApplicationFormProps) {
+export const ApplicationForm = forwardRef<
+  ApplicationFormHandle,
+  ApplicationFormProps
+>(function ApplicationForm({ onPrev, onNext }, ref) {
   const addToast = useToastStore((s) => s.addToast)
   const form = useApplicationForm()
   const projectId = useProjectRegisterStore((s) => s.projectId)
@@ -73,6 +86,17 @@ export function ApplicationForm({ onPrev, onNext }: ApplicationFormProps) {
       })
     },
   })
+
+  useImperativeHandle(ref, () => ({
+    save: async () => {
+      try {
+        await saveAppMutation.mutateAsync()
+        return true
+      } catch {
+        return false
+      }
+    },
+  }))
 
   const canTempSave = !saveAppMutation.isPending && (isDirty || !hasSavedOnce)
   const tempSaveLabel =
@@ -286,4 +310,4 @@ export function ApplicationForm({ onPrev, onNext }: ApplicationFormProps) {
       </div>
     </div>
   )
-}
+})

--- a/src/features/project/new/ui/application/ApplicationForm.tsx
+++ b/src/features/project/new/ui/application/ApplicationForm.tsx
@@ -29,6 +29,7 @@ import { QuestionTypeToolbar } from "./QuestionTypeToolbar"
 
 export interface ApplicationFormHandle {
   save: () => Promise<boolean>
+  getIsDirty: () => boolean
 }
 
 interface ApplicationFormProps {
@@ -52,6 +53,8 @@ export const ApplicationForm = forwardRef<
     [form.commonQuestions, form.sections],
   )
   const isDirty = lastSavedSnapshotRef.current !== currentSnapshot
+  const isDirtyRef = useRef(isDirty)
+  isDirtyRef.current = isDirty
 
   const saveAppMutation = useMutation({
     mutationFn: async () => {
@@ -96,6 +99,7 @@ export const ApplicationForm = forwardRef<
         return false
       }
     },
+    getIsDirty: () => isDirtyRef.current,
   }))
 
   const canTempSave = !saveAppMutation.isPending && (isDirty || !hasSavedOnce)

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -372,15 +372,15 @@ export const BasicInfoForm = forwardRef<
     if (hasUnsavedChanges) {
       const ok = await handleTempSave({ silent: true })
       if (!ok) return
+      addToast({
+        message: "작성한 내용이 저장되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
     }
     setBasicInfo(data)
-    addToast({
-      message: "작성한 내용이 저장되었습니다.",
-      color: "primary",
-      variant: "deep",
-      type: "default",
-      duration: 3000,
-    })
     onNext()
   }
 

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -147,6 +147,32 @@ export const BasicInfoForm = forwardRef<
     shouldFocusError: false,
   })
 
+  const validateImages = (thumbnail: unknown, logo: unknown): boolean => {
+    if (!(thumbnail instanceof File) && !uploaded.thumbnailUrl) {
+      addToast({
+        message: "프로젝트 대표 이미지를 업로드해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      setTimeout(() => thumbnailRef.current?.focus(), 0)
+      return false
+    }
+    if (!(logo instanceof File) && !uploaded.logoUrl) {
+      addToast({
+        message: "프로젝트 로고를 업로드해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      setTimeout(() => logoRef.current?.focus(), 0)
+      return false
+    }
+    return true
+  }
+
   useImperativeHandle(ref, () => ({
     validate: async () => {
       if (!pm1Member) {
@@ -177,28 +203,7 @@ export const BasicInfoForm = forwardRef<
         return false
       }
       const values = getValues()
-      if (!(values.thumbnail instanceof File) && !uploaded.thumbnailUrl) {
-        addToast({
-          message: "프로젝트 대표 이미지를 업로드해 주세요.",
-          color: "red",
-          variant: "deep",
-          type: "default",
-          duration: 3000,
-        })
-        setTimeout(() => thumbnailRef.current?.focus(), 0)
-        return false
-      }
-      if (!(values.logo instanceof File) && !uploaded.logoUrl) {
-        addToast({
-          message: "프로젝트 로고를 업로드해 주세요.",
-          color: "red",
-          variant: "deep",
-          type: "default",
-          duration: 3000,
-        })
-        setTimeout(() => logoRef.current?.focus(), 0)
-        return false
-      }
+      if (!validateImages(values.thumbnail, values.logo)) return false
       return true
     },
     save: () => handleTempSave({ silent: false }),
@@ -347,28 +352,7 @@ export const BasicInfoForm = forwardRef<
   }
 
   const onSubmit = async (data: BasicInfoFormData) => {
-    if (!(data.thumbnail instanceof File) && !uploaded.thumbnailUrl) {
-      addToast({
-        message: "프로젝트 대표 이미지를 업로드해 주세요.",
-        color: "red",
-        variant: "deep",
-        type: "default",
-        duration: 3000,
-      })
-      setTimeout(() => thumbnailRef.current?.focus(), 0)
-      return
-    }
-    if (!(data.logo instanceof File) && !uploaded.logoUrl) {
-      addToast({
-        message: "프로젝트 로고를 업로드해 주세요.",
-        color: "red",
-        variant: "deep",
-        type: "default",
-        duration: 3000,
-      })
-      setTimeout(() => logoRef.current?.focus(), 0)
-      return
-    }
+    if (!validateImages(data.thumbnail, data.logo)) return
     if (hasUnsavedChanges) {
       const ok = await handleTempSave({ silent: true })
       if (!ok) return

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -347,6 +347,28 @@ export const BasicInfoForm = forwardRef<
   }
 
   const onSubmit = async (data: BasicInfoFormData) => {
+    if (!(data.thumbnail instanceof File) && !uploaded.thumbnailUrl) {
+      addToast({
+        message: "프로젝트 대표 이미지를 업로드해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      setTimeout(() => thumbnailRef.current?.focus(), 0)
+      return
+    }
+    if (!(data.logo instanceof File) && !uploaded.logoUrl) {
+      addToast({
+        message: "프로젝트 로고를 업로드해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      setTimeout(() => logoRef.current?.focus(), 0)
+      return
+    }
     if (hasUnsavedChanges) {
       const ok = await handleTempSave({ silent: true })
       if (!ok) return
@@ -384,29 +406,6 @@ export const BasicInfoForm = forwardRef<
         type: "default",
         duration: 3000,
       })
-      return
-    }
-    const values = getValues()
-    if (!(values.thumbnail instanceof File) && !uploaded.thumbnailUrl) {
-      addToast({
-        message: "프로젝트 대표 이미지를 업로드해 주세요.",
-        color: "red",
-        variant: "deep",
-        type: "default",
-        duration: 3000,
-      })
-      setTimeout(() => thumbnailRef.current?.focus(), 0)
-      return
-    }
-    if (!(values.logo instanceof File) && !uploaded.logoUrl) {
-      addToast({
-        message: "프로젝트 로고를 업로드해 주세요.",
-        color: "red",
-        variant: "deep",
-        type: "default",
-        duration: 3000,
-      })
-      setTimeout(() => logoRef.current?.focus(), 0)
       return
     }
     void handleSubmit(onSubmit, onInvalid)(e)

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -40,6 +40,7 @@ import type { MemberItem } from "@/shared/ui/searchbar/MemberSearchBar"
 
 export interface BasicInfoFormHandle {
   validate: () => Promise<boolean>
+  save: () => Promise<boolean>
 }
 
 interface BasicInfoFormProps {
@@ -200,6 +201,7 @@ export const BasicInfoForm = forwardRef<
       }
       return true
     },
+    save: () => handleTempSave({ silent: false }),
   }))
 
   useEffect(() => {

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -175,6 +175,29 @@ export const BasicInfoForm = forwardRef<
         onInvalid(formState.errors)
         return false
       }
+      const values = getValues()
+      if (!(values.thumbnail instanceof File) && !uploaded.thumbnailUrl) {
+        addToast({
+          message: "프로젝트 대표 이미지를 업로드해 주세요.",
+          color: "red",
+          variant: "deep",
+          type: "default",
+          duration: 3000,
+        })
+        setTimeout(() => thumbnailRef.current?.focus(), 0)
+        return false
+      }
+      if (!(values.logo instanceof File) && !uploaded.logoUrl) {
+        addToast({
+          message: "프로젝트 로고를 업로드해 주세요.",
+          color: "red",
+          variant: "deep",
+          type: "default",
+          duration: 3000,
+        })
+        setTimeout(() => logoRef.current?.focus(), 0)
+        return false
+      }
       return true
     },
   }))
@@ -199,8 +222,6 @@ export const BasicInfoForm = forwardRef<
   }, [storePmInfo])
 
   const onInvalid = (fieldErrors: typeof errors) => {
-    const values = getValues()
-
     let message = "모든 항목을 입력해 주세요."
     let focusFn: (() => void) | null = null
 
@@ -210,12 +231,6 @@ export const BasicInfoForm = forwardRef<
     } else if (fieldErrors.description) {
       message = "프로젝트 한 줄 소개를 입력해 주세요."
       focusFn = () => setFocus("description")
-    } else if (!(values.thumbnail instanceof File) && !uploaded.thumbnailUrl) {
-      message = "프로젝트 대표 이미지를 업로드해 주세요."
-      focusFn = () => thumbnailRef.current?.focus()
-    } else if (!(values.logo instanceof File) && !uploaded.logoUrl) {
-      message = "프로젝트 로고를 업로드해 주세요."
-      focusFn = () => logoRef.current?.focus()
     }
 
     addToast({
@@ -330,8 +345,10 @@ export const BasicInfoForm = forwardRef<
   }
 
   const onSubmit = async (data: BasicInfoFormData) => {
-    const ok = await handleTempSave({ silent: true })
-    if (!ok) return
+    if (hasUnsavedChanges) {
+      const ok = await handleTempSave({ silent: true })
+      if (!ok) return
+    }
     setBasicInfo(data)
     addToast({
       message: "작성한 내용이 저장되었습니다.",
@@ -365,6 +382,29 @@ export const BasicInfoForm = forwardRef<
         type: "default",
         duration: 3000,
       })
+      return
+    }
+    const values = getValues()
+    if (!(values.thumbnail instanceof File) && !uploaded.thumbnailUrl) {
+      addToast({
+        message: "프로젝트 대표 이미지를 업로드해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      setTimeout(() => thumbnailRef.current?.focus(), 0)
+      return
+    }
+    if (!(values.logo instanceof File) && !uploaded.logoUrl) {
+      addToast({
+        message: "프로젝트 로고를 업로드해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      setTimeout(() => logoRef.current?.focus(), 0)
       return
     }
     void handleSubmit(onSubmit, onInvalid)(e)

--- a/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
+++ b/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { forwardRef, useImperativeHandle, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
 import { useMe } from "@/features/auth/hooks/useMe"
@@ -30,6 +30,10 @@ const ROLES: {
   { key: "backend", label: "Backend", stacks: ["SpringBoot", "Node.js"] },
 ]
 
+export interface RecruitInfoFormHandle {
+  save: () => Promise<boolean>
+}
+
 interface RecruitInfoFormProps {
   onPrev: () => void
   onNext: () => void
@@ -50,11 +54,10 @@ function buildSummaryText(
     .join(", ")
 }
 
-export function RecruitInfoForm({
-  onPrev,
-  onNext,
-  readOnly = false,
-}: RecruitInfoFormProps) {
+export const RecruitInfoForm = forwardRef<
+  RecruitInfoFormHandle,
+  RecruitInfoFormProps
+>(function RecruitInfoForm({ onPrev, onNext, readOnly = false }, ref) {
   const addToast = useToastStore((s) => s.addToast)
   const storeRecruitInfo = useProjectRegisterStore((s) => s.recruitInfo)
   const setRecruitInfo = useProjectRegisterStore((s) => s.setRecruitInfo)
@@ -126,6 +129,10 @@ export function RecruitInfoForm({
       setIsSaving(false)
     }
   }
+
+  useImperativeHandle(ref, () => ({
+    save: () => savePartQuotas(false),
+  }))
 
   const handleNext = async () => {
     if (readOnly) {
@@ -260,4 +267,4 @@ export function RecruitInfoForm({
       </div>
     </div>
   )
-}
+})

--- a/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
+++ b/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
@@ -33,6 +33,7 @@ const ROLES: {
 interface RecruitInfoFormProps {
   onPrev: () => void
   onNext: () => void
+  readOnly?: boolean
 }
 
 function buildSummaryText(
@@ -49,7 +50,11 @@ function buildSummaryText(
     .join(", ")
 }
 
-export function RecruitInfoForm({ onPrev, onNext }: RecruitInfoFormProps) {
+export function RecruitInfoForm({
+  onPrev,
+  onNext,
+  readOnly = false,
+}: RecruitInfoFormProps) {
   const addToast = useToastStore((s) => s.addToast)
   const storeRecruitInfo = useProjectRegisterStore((s) => s.recruitInfo)
   const setRecruitInfo = useProjectRegisterStore((s) => s.setRecruitInfo)
@@ -123,6 +128,10 @@ export function RecruitInfoForm({ onPrev, onNext }: RecruitInfoFormProps) {
   }
 
   const handleNext = async () => {
+    if (readOnly) {
+      onNext()
+      return
+    }
     if (totalCount === 0) {
       addToast({
         message: "모집 인원을 1명 이상 입력해 주세요.",
@@ -180,6 +189,7 @@ export function RecruitInfoForm({ onPrev, onNext }: RecruitInfoFormProps) {
               <Counter
                 value={roleStates[key].count}
                 onChange={(v) => updateCount(key, v)}
+                disabled={readOnly}
                 aria-label={`${label} 인원`}
               />
               {stacks.length > 0 && (
@@ -188,14 +198,16 @@ export function RecruitInfoForm({ onPrev, onNext }: RecruitInfoFormProps) {
                   allowDeselect
                   value={roleStates[key].stack}
                   onValueChange={(v) =>
-                    updateStack(key, v as RoleStack | undefined)
+                    readOnly
+                      ? undefined
+                      : updateStack(key, v as RoleStack | undefined)
                   }
                 >
                   {stacks.map((stack) => (
                     <OptionButton
                       key={stack}
                       value={stack}
-                      disabled={roleStates[key].count === 0}
+                      disabled={readOnly || roleStates[key].count === 0}
                     >
                       {stack}
                     </OptionButton>
@@ -217,16 +229,20 @@ export function RecruitInfoForm({ onPrev, onNext }: RecruitInfoFormProps) {
         </div>
       </div>
       <div className="flex justify-between">
-        <Button
-          type="button"
-          variant="weak"
-          color="primary"
-          disabled={!canTempSave}
-          isLoading={isSaving}
-          onClick={handleTempSave}
-        >
-          {tempSaveLabel}
-        </Button>
+        {!readOnly ? (
+          <Button
+            type="button"
+            variant="weak"
+            color="primary"
+            disabled={!canTempSave}
+            isLoading={isSaving}
+            onClick={handleTempSave}
+          >
+            {tempSaveLabel}
+          </Button>
+        ) : (
+          <span />
+        )}
         <div className="flex items-center gap-4">
           <Button type="button" variant="weak" color="neutral" onClick={onPrev}>
             이전

--- a/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
+++ b/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle, useState } from "react"
+import { forwardRef, useImperativeHandle, useRef, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
 import { useMe } from "@/features/auth/hooks/useMe"
@@ -67,7 +67,7 @@ export const RecruitInfoForm = forwardRef<
 
   const [isSaving, setIsSaving] = useState(false)
   const [hasSavedOnce, setHasSavedOnce] = useState(false)
-  const [savedTotalCount, setSavedTotalCount] = useState<number | null>(null)
+  const savedSnapshotRef = useRef(JSON.stringify(storeRecruitInfo))
 
   const roleStates = storeRecruitInfo
 
@@ -78,7 +78,8 @@ export const RecruitInfoForm = forwardRef<
 
   const summaryText = buildSummaryText(ROLES, roleStates)
 
-  const hasUnsavedChanges = savedTotalCount !== totalCount
+  const hasUnsavedChanges =
+    savedSnapshotRef.current !== JSON.stringify(roleStates)
   const canTempSave = totalCount > 0 && hasUnsavedChanges && !isSaving
   const tempSaveLabel =
     hasSavedOnce && !hasUnsavedChanges ? "저장 완료" : "임시 저장"
@@ -98,13 +99,14 @@ export const RecruitInfoForm = forwardRef<
       })
       return false
     }
+    const snapshotToSave = JSON.stringify(roleStates)
     setIsSaving(true)
     try {
       await updatePartQuotas(projectId, {
         entries: buildPartQuotasEntries(roleStates),
       })
       setRecruitInfo(roleStates)
-      setSavedTotalCount(totalCount)
+      savedSnapshotRef.current = snapshotToSave
       setHasSavedOnce(true)
       if (!silent) {
         addToast({
@@ -147,6 +149,10 @@ export const RecruitInfoForm = forwardRef<
         type: "default",
         duration: 3000,
       })
+      return
+    }
+    if (!hasUnsavedChanges) {
+      onNext()
       return
     }
     const ok = await savePartQuotas(true)

--- a/src/features/project/new/ui/stepper/Stepper.tsx
+++ b/src/features/project/new/ui/stepper/Stepper.tsx
@@ -11,6 +11,7 @@ interface StepperProps {
   onStepChange: (idx: number) => void
   disabledSteps?: number[]
   disabledTooltips?: Partial<Record<number, string>>
+  openTooltipStep?: number | null
 }
 
 export function Stepper({
@@ -18,6 +19,7 @@ export function Stepper({
   onStepChange,
   disabledSteps = [],
   disabledTooltips = {},
+  openTooltipStep = null,
 }: StepperProps) {
   return (
     <section
@@ -31,6 +33,7 @@ export function Stepper({
           isSelected={item.idx === step}
           disabled={disabledSteps.includes(item.idx)}
           disabledTooltip={disabledTooltips[item.idx]}
+          tooltipOpen={openTooltipStep === item.idx}
           onClick={() => onStepChange(item.idx)}
           {...item}
         />

--- a/src/features/project/new/ui/stepper/StepperTab.tsx
+++ b/src/features/project/new/ui/stepper/StepperTab.tsx
@@ -9,6 +9,7 @@ interface StepperTabProps {
   isSelected: boolean
   disabled?: boolean
   disabledTooltip?: string
+  tooltipOpen?: boolean
   onClick: () => void
 }
 
@@ -18,6 +19,7 @@ export function StepperTab({
   isSelected = false,
   disabled = false,
   disabledTooltip,
+  tooltipOpen = false,
   onClick,
 }: StepperTabProps) {
   const button = (
@@ -27,7 +29,7 @@ export function StepperTab({
       aria-selected={isSelected}
       aria-disabled={disabled}
       tabIndex={isSelected ? 0 : -1}
-      onClick={disabled ? undefined : onClick}
+      onClick={onClick}
       className={cn(
         "relative flex h-full w-full items-center gap-2 rounded-[12px] py-1 pr-5 pl-3",
         disabled ? "cursor-not-allowed opacity-40" : "cursor-pointer",
@@ -64,6 +66,8 @@ export function StepperTab({
     </button>
   )
 
+  const tooltipOpenProp = tooltipOpen ? true : disabled ? undefined : false
+
   return (
     <div
       className={cn(
@@ -71,13 +75,14 @@ export function StepperTab({
         disabled && "cursor-not-allowed",
       )}
     >
-      {disabled && disabledTooltip ? (
+      {disabledTooltip ? (
         <Tooltip
           content={disabledTooltip}
           size="small"
           dark={true}
           side="bottom"
           hoverOnly
+          open={tooltipOpenProp}
           triggerClassName="block w-full h-full"
         >
           {button}

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -259,10 +259,8 @@ function ProjectRegisterPage() {
         triggerStepTooltip(idx)
         return
       }
-      if (!projectId) {
-        const saved = await basicInfoRef.current?.save()
-        if (!saved) return
-      }
+      const saved = await basicInfoRef.current?.save()
+      if (!saved) return
     } else if (step === 2 && !isPm) {
       const total = Object.values(recruitInfo).reduce(
         (sum, { count }) => sum + count,

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -204,7 +204,7 @@ function ProjectRegisterPage() {
         color: "red",
         variant: "deep",
         type: "default",
-        duration: 3,
+        duration: 3000,
       })
     },
   })

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -62,6 +62,7 @@ function ProjectRegisterPage() {
   const isEditMode = editProjectId !== undefined
   const [step, setStep] = useState(1)
   const [showSuccessModal, setShowSuccessModal] = useState(false)
+  const [isSavingAndLeaving, setIsSavingAndLeaving] = useState(false)
   const navigate = useNavigate()
   const addToast = useToastStore((s) => s.addToast)
   const basicInfoRef = useRef<BasicInfoFormHandle>(null)
@@ -266,11 +267,16 @@ function ProjectRegisterPage() {
   }
 
   const handleSaveAndLeave = async () => {
-    if (step === 1) {
-      const ok = await basicInfoRef.current?.save()
-      if (!ok) return
+    setIsSavingAndLeaving(true)
+    try {
+      if (step === 1) {
+        const ok = await basicInfoRef.current?.save()
+        if (!ok) return
+      }
+      proceedLeave?.()
+    } finally {
+      setIsSavingAndLeaving(false)
     }
-    proceedLeave?.()
   }
 
   const handleSuccessConfirm = async () => {
@@ -340,6 +346,7 @@ function ProjectRegisterPage() {
         content="저장되지 않았습니다. 저장 후 나가시겠습니까?"
         cancelText="돌아가기"
         confirmText="저장 후 나가기"
+        confirmLoading={isSavingAndLeaving}
         onCancel={() => resetLeave?.()}
         onConfirm={() => void handleSaveAndLeave()}
       />

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -63,6 +63,10 @@ function ProjectRegisterPage() {
   const [step, setStep] = useState(1)
   const [showSuccessModal, setShowSuccessModal] = useState(false)
   const [isSavingAndLeaving, setIsSavingAndLeaving] = useState(false)
+  const [tooltipTriggerStep, setTooltipTriggerStep] = useState<number | null>(
+    null,
+  )
+  const tooltipTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const navigate = useNavigate()
   const addToast = useToastStore((s) => s.addToast)
   const basicInfoRef = useRef<BasicInfoFormHandle>(null)
@@ -210,6 +214,15 @@ function ProjectRegisterPage() {
     },
   })
 
+  const triggerStepTooltip = (stepIdx: number) => {
+    if (tooltipTimerRef.current) clearTimeout(tooltipTimerRef.current)
+    setTooltipTriggerStep(stepIdx)
+    tooltipTimerRef.current = setTimeout(
+      () => setTooltipTriggerStep(null),
+      3100,
+    )
+  }
+
   const handleBasicInfoNext = () => {
     setStep(isPm ? 3 : 2)
   }
@@ -218,18 +231,27 @@ function ProjectRegisterPage() {
     setStep(isPm ? 1 : 2)
   }
 
-  const isStep3Locked = false
-
   const handleStepChange = async (idx: number) => {
-    if (isPm && idx === 2) return
+    if (isPm && idx === 2) {
+      setStep(2)
+      triggerStepTooltip(2)
+      return
+    }
     if (idx <= step) {
       setStep(idx)
       return
     }
     if (step === 1) {
       const ok = await basicInfoRef.current?.validate()
-      if (!ok) return
-    } else if (step === 2) {
+      if (!ok) {
+        triggerStepTooltip(idx)
+        return
+      }
+      if (!projectId) {
+        const saved = await basicInfoRef.current?.save()
+        if (!saved) return
+      }
+    } else if (step === 2 && !isPm) {
       const total = Object.values(recruitInfo).reduce(
         (sum, { count }) => sum + count,
         0,
@@ -281,10 +303,7 @@ function ProjectRegisterPage() {
 
   const handleSuccessConfirm = async () => {
     setShowSuccessModal(false)
-    await navigate({
-      to: isEditMode ? "/matching/projects/management" : "/matching/projects",
-      replace: true,
-    })
+    await navigate({ to: "/matching/projects/management", replace: true })
   }
 
   return (
@@ -301,17 +320,20 @@ function ProjectRegisterPage() {
         <Stepper
           step={step}
           onStepChange={handleStepChange}
-          disabledSteps={[...(isPm ? [2] : []), ...(isStep3Locked ? [3] : [])]}
-          disabledTooltips={{
-            2: "기술 스택 및 파트별 TO는 운영진이 수기로 조정합니다.",
-            3: "기본 정보를 입력한 뒤 작성할 수 있습니다.",
-          }}
+          disabledSteps={isPm ? [2] : []}
+          disabledTooltips={
+            isPm
+              ? { 2: "기술 스택 및 파트별 TO는 운영진이 수기로 조정합니다." }
+              : { 3: "기본 정보를 입력한 뒤 작성할 수 있습니다." }
+          }
+          openTooltipStep={tooltipTriggerStep}
         />
         {step === 1 && (
           <BasicInfoForm ref={basicInfoRef} onNext={handleBasicInfoNext} />
         )}
         {step === 2 && (
           <RecruitInfoForm
+            readOnly={isPm}
             onPrev={() => setStep(1)}
             onNext={() => setStep(3)}
           />

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -187,11 +187,13 @@ function ProjectRegisterPage() {
   const submitMutation = useMutation({
     mutationFn: async () => {
       if (!projectId) throw new Error("프로젝트 ID가 없습니다.")
-      const body = buildUpsertApplicationFormBody(
-        application.commonQuestions,
-        application.sections,
-      )
-      await upsertApplicationForm(projectId, body)
+      if (applicationFormRef.current?.getIsDirty() ?? true) {
+        const body = buildUpsertApplicationFormBody(
+          application.commonQuestions,
+          application.sections,
+        )
+        await upsertApplicationForm(projectId, body)
+      }
       if (isEditMode) return
       const result = await submitProject(projectId)
       if (pmInfo.pm1) {

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -14,8 +14,10 @@ import { isCurrentTermPm, isOperator } from "@/features/auth/model/identity"
 import { getManagedProjects } from "@/features/project/management/api"
 import {
   ApplicationForm,
+  type ApplicationFormHandle,
   BasicInfoForm,
   RecruitInfoForm,
+  type RecruitInfoFormHandle,
   Stepper,
 } from "@/features/project/new"
 import {
@@ -70,6 +72,8 @@ function ProjectRegisterPage() {
   const navigate = useNavigate()
   const addToast = useToastStore((s) => s.addToast)
   const basicInfoRef = useRef<BasicInfoFormHandle>(null)
+  const recruitInfoRef = useRef<RecruitInfoFormHandle>(null)
+  const applicationFormRef = useRef<ApplicationFormHandle>(null)
 
   const { data: me } = useMe()
   const isPm = isCurrentTermPm(me)
@@ -300,6 +304,12 @@ function ProjectRegisterPage() {
       if (step === 1) {
         const ok = await basicInfoRef.current?.save()
         if (!ok) return
+      } else if (step === 2) {
+        const ok = await recruitInfoRef.current?.save()
+        if (!ok) return
+      } else if (step === 3) {
+        const ok = await applicationFormRef.current?.save()
+        if (!ok) return
       }
       proceedLeave?.()
     } finally {
@@ -345,6 +355,7 @@ function ProjectRegisterPage() {
         )}
         {step === 2 && (
           <RecruitInfoForm
+            ref={recruitInfoRef}
             readOnly={isPm}
             onPrev={() => setStep(1)}
             onNext={() => setStep(3)}
@@ -352,6 +363,7 @@ function ProjectRegisterPage() {
         )}
         {step === 3 && (
           <ApplicationForm
+            ref={applicationFormRef}
             onPrev={handleApplicationFormPrev}
             onNext={handleRegister}
           />

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -214,6 +214,12 @@ function ProjectRegisterPage() {
     },
   })
 
+  useEffect(() => {
+    return () => {
+      if (tooltipTimerRef.current) clearTimeout(tooltipTimerRef.current)
+    }
+  }, [])
+
   const triggerStepTooltip = (stepIdx: number) => {
     if (tooltipTimerRef.current) clearTimeout(tooltipTimerRef.current)
     setTooltipTriggerStep(stepIdx)
@@ -323,8 +329,14 @@ function ProjectRegisterPage() {
           disabledSteps={isPm ? [2] : []}
           disabledTooltips={
             isPm
-              ? { 2: "기술 스택 및 파트별 TO는 운영진이 수기로 조정합니다." }
-              : { 3: "기본 정보를 입력한 뒤 작성할 수 있습니다." }
+              ? {
+                  2: "기술 스택 및 파트별 TO는 운영진이 수기로 조정합니다.",
+                  3: "기본 정보를 입력한 뒤 작성할 수 있습니다.",
+                }
+              : {
+                  2: "기본 정보를 입력한 뒤 작성할 수 있습니다.",
+                  3: "기본 정보를 입력한 뒤 작성할 수 있습니다.",
+                }
           }
           openTooltipStep={tooltipTriggerStep}
         />

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -265,6 +265,14 @@ function ProjectRegisterPage() {
     submitMutation.mutate()
   }
 
+  const handleSaveAndLeave = async () => {
+    if (step === 1) {
+      const ok = await basicInfoRef.current?.save()
+      if (!ok) return
+    }
+    proceedLeave?.()
+  }
+
   const handleSuccessConfirm = async () => {
     setShowSuccessModal(false)
     await navigate({
@@ -329,17 +337,11 @@ function ProjectRegisterPage() {
         }}
         variant="warning"
         title="페이지 이탈"
-        content={
-          <>
-            작성 중인 내용이 저장되지 않습니다.
-            <br />
-            나가시겠습니까?
-          </>
-        }
+        content="저장되지 않았습니다. 저장 후 나가시겠습니까?"
         cancelText="돌아가기"
-        confirmText="나가기"
+        confirmText="저장 후 나가기"
         onCancel={() => resetLeave?.()}
-        onConfirm={() => proceedLeave?.()}
+        onConfirm={() => void handleSaveAndLeave()}
       />
     </section>
   )

--- a/src/shared/ui/modal/CtaModal.tsx
+++ b/src/shared/ui/modal/CtaModal.tsx
@@ -14,6 +14,7 @@ interface CtaModalProps {
   content: ReactNode
   cancelText?: string
   confirmText: string
+  confirmLoading?: boolean
   variant?: CtaModalVariant
   overlayTone?: "light" | "deep"
   onOpenChange: (open: boolean) => void
@@ -27,6 +28,7 @@ export function CtaModal({
   content,
   cancelText,
   confirmText,
+  confirmLoading = false,
   variant = "warning",
   overlayTone = "light",
   onOpenChange,
@@ -86,6 +88,7 @@ export function CtaModal({
               color="primary"
               size="s"
               className="rounded-[10px]"
+              isLoading={confirmLoading}
               onClick={onConfirm}
             >
               {confirmText}


### PR DESCRIPTION
## 📸 작업 내용

프로젝트 등록 플로우 전반의 QA 시나리오를 검토하고, 발견된 버그 및 UX 개선 사항을 반영했습니다.

- **스텝 이동 UX 개선**: 스텝 탭 클릭 시 유효성 검증 실패, draft 미존재, PM 제한 진입 등 상황별 툴팁 피드백(3초) 구현
- **PM 모집 정보 읽기 전용**: PM 역할 진입 시 step 2(모집 인원/스택)를 비활성화 + 읽기 전용으로 표시
- **이탈 모달 개선**: 저장 후 나가기 버튼 로딩 상태 추가, 저장 로직 및 텍스트 수정
- **1단계 저장 중복 호출 수정**: 변경 사항 없을 때 [다음] 클릭 시 불필요한 PATCH 호출 방지
- **이미지 유효성 검증 수정**: 썸네일/로고 `.optional()`로 변경해 비필수 처리
- **토스트 duration 오타 수정**: 3ms → 3000ms (등록 실패 토스트, 지원 문항 3단계 4곳)

## 🎞️ 주요 코드 설명

### 스텝 툴팁 프로그래밍 제어 (openTooltipStep)

```TypeScript
// new.tsx — triggerStepTooltip
const triggerStepTooltip = (stepIdx: number) => {
  if (tooltipTimerRef.current) clearTimeout(tooltipTimerRef.current)
  setTooltipTriggerStep(stepIdx)
  tooltipTimerRef.current = setTimeout(() => setTooltipTriggerStep(null), 3100)
}

// handleStepChange — PM step 2 탭 클릭 시 읽기 전용 진입 + 툴팁
if (isPm && idx === 2) {
  setStep(2)
  triggerStepTooltip(2)
  return
}
```

- `clearTimeout`으로 연속 클릭 시 timer race 방지
- `tooltipOpen` prop이 `true`이면 3초간 강제 노출, `undefined`(hover)로 복귀

### StepperTab — disabled 탭에서도 onClick 실행

```TypeScript
// StepperTab.tsx
const tooltipOpenProp = tooltipOpen ? true : disabled ? undefined : false

// Tooltip open 제어:
// - tooltipOpen=true: 프로그래밍 강제 노출
// - disabled, tooltipOpen=false: undefined → hover 동작 유지
// - 비장애: false → hover 차단
```

### RecruitInfoForm — readOnly prop

```TypeScript
// readOnly=true(PM)이면 검증·저장 우회, UI 편집 비활성화
const handleNext = async () => {
  if (readOnly) { onNext(); return }
  // ...기존 모집 인원 검증 로직
}
```

### BasicInfoForm — 변경 없을 때 PATCH 스킵

```TypeScript
const onSubmit = async (data: BasicInfoFormData) => {
  if (hasUnsavedChanges) {
    const ok = await handleTempSave({ silent: true })
    if (!ok) return
  }
  // hasUnsavedChanges=false → PATCH 없이 바로 다음 단계
  setBasicInfo(data)
  addToast({ message: "작성한 내용이 저장되었습니다.", ... })
  onNext()
}
```

## 🖥️ 구현화면

<!-- localhost 스크린샷은 로컬 환경에서 확인 가능합니다. -->

|           PM step 2 탭 클릭 (읽기 전용 + 툴팁)            |           step 1 미완료 탭 클릭 (툴팁 피드백)            |
| :---: | :---: |
| step 2 진입, 편집 불가, 툴팁 3초 노출 | 유효성 실패, 대상 탭에 툴팁 3초 노출 |

## 🔗 연결된 이슈

- Closes #107
- Closes #112
- Closes #113
- Closes #140
- Closes #141

## 📚 커밋 목록

| 커밋 | 설명 |
|------|------|
| `224fb6e` | 등록 실패 토스트 duration 3ms → 3000ms 수정 (`new.tsx` submitMutation.onError) |
| `28b5711` | 1단계 [다음] 클릭 시 변경 없으면 PATCH 스킵; 썸네일·로고 Zod `.optional()` 처리 |
| `03e4d52` | 이탈 모달 텍스트("저장 후 나가기") 및 handleSaveAndLeave 로직 구현 |
| `72adba7` | CtaModal `confirmLoading` prop 추가, 이탈 모달 저장 중 버튼 로딩 상태 연결 |
| `a599fd8` | 지원 문항 3단계 토스트 duration 3ms → 3000ms 4곳 수정 (Closes #141) |
| `23142da` | Stepper openTooltipStep 툴팁 제어, PM readOnly step 2, draft 보장, race 수정 (Closes #107, #113, #140) |