### PR TITLE
feat: 서비스 준비중 페이지 추가 및 prod 배포

### DIFF
--- a/src/features/error/ui/ServiceUnavailablePage.tsx
+++ b/src/features/error/ui/ServiceUnavailablePage.tsx
@@ -1,0 +1,28 @@
+import errorCone from "@/shared/assets/icon/error/error-cone.svg"
+
+export function ServiceUnavailablePage() {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{
+        backgroundImage:
+          "linear-gradient(-63.18deg, rgba(34, 144, 132, 0.06) 10.77%, rgba(255, 255, 255, 0.2) 29.55%), linear-gradient(121.23deg, rgba(34, 144, 132, 0.1) 5.09%, rgba(255, 255, 255, 0.2) 42.81%), linear-gradient(90deg, rgba(143, 255, 243, 0.08) 0%, rgba(143, 255, 243, 0.08) 100%), linear-gradient(90deg, #fff 0%, #fff 100%)",
+      }}
+    >
+      <div className="flex flex-col items-center gap-11.5">
+        <img src={errorCone} alt="" width={192} height={180} />
+
+        <div className="flex flex-col items-center gap-4.5 text-center">
+          <h1 className="text-display-2-medium font-bold text-teal-500">
+            서비스 준비 중입니다.
+          </h1>
+          <p className="text-subtitle-1-medium text-teal-gray-600">
+            더 나은 매칭 경험을 제공하기 위해 준비 중입니다.
+            <br />
+            매칭 기간에 새로운 모습으로 찾아뵙겠습니다!
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,11 @@ import { createRouter, RouterProvider } from "@tanstack/react-router"
 import { StrictMode } from "react"
 import ReactDOM from "react-dom/client"
 
+import { ServiceUnavailablePage } from "@/features/error/ui/ServiceUnavailablePage"
+
 import { routeTree } from "./routeTree.gen"
+
+const isMaintenance = import.meta.env.VITE_MAINTENANCE === "true"
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -34,9 +38,13 @@ if (!rootElement.innerHTML) {
   const root = ReactDOM.createRoot(rootElement)
   root.render(
     <StrictMode>
-      <QueryClientProvider client={queryClient}>
-        <RouterProvider router={router} />
-      </QueryClientProvider>
+      {isMaintenance ? (
+        <ServiceUnavailablePage />
+      ) : (
+        <QueryClientProvider client={queryClient}>
+          <RouterProvider router={router} />
+        </QueryClientProvider>
+      )}
     </StrictMode>,
   )
 }


### PR DESCRIPTION
## 📸 작업 내용
- Figma 디자인 기반 501 서비스 준비 중 페이지 UI 구현
- `VITE_MAINTENANCE` 환경변수 플래그로 점검 모드 분기 처리
- 점검 모드 활성 시 라우터를 바이패스하여 모든 경로에서 준비 중 페이지만 노출

## 🎞️ 주요 코드 설명
### `main.tsx`

```TypeScript
const isMaintenance = import.meta.env.VITE_MAINTENANCE === "true"

root.render(
    <StrictMode>
      {isMaintenance ? (
        <ServiceUnavailablePage />
      ) : (
        <QueryClientProvider client={queryClient}>
          <RouterProvider router={router} />
        </QueryClientProvider>
      )}
    </StrictMode>,
  )
```
- TanStack Router는 파일 기반 라우팅이라 라우터 자체를 환경변수로 분기하는 방식으로 구현.
- VITE_MAINTENANCE=true일 때 TanStack Router 자체를 마운트하지 않아, 와일드카드 라우팅 없이도 모든 경로에서 준비중 페이지만 렌더링 됨. 
- Amplify 환경변수 설정만으로 on/off가능하며 develop 브랜치(dev.umc.it.kr)에는 영향 없음. 

## 🖥️ 구현화면
|           준비중 페이지            | 
| :-------------------------: | 
| <img width="1438" height="693" alt="image" src="https://github.com/user-attachments/assets/78301f96-0f2f-4d28-8775-d2b773cdbb54" /> |

## 🔗 연결된 이슈

- Closed: #153 

## 💬 기타 더 이야기해볼 점
- umc.it.kr 배포 시 Amplify 환경변수에 VITE_MAINTENANCE=true 추가 필요합니다!! 
<img width="300" alt="image" src="https://github.com/user-attachments/assets/ba2052e6-0e7b-459c-a7a9-98cde1ae4376" />