### PR TITLE
feat: 챌린저 지원 플로우 구현

### DIFF
--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -107,7 +107,7 @@ export function ToastProvider() {
 
   return (
     <div
-      className="pointer-events-none fixed bottom-24 left-1/2 z-50 -translate-x-1/2"
+      className="pointer-events-none fixed bottom-24 left-1/2 z-9999 -translate-x-1/2"
       aria-live="polite"
       aria-label="알림 목록"
     >

--- a/src/features/project/list/api/matchingProject.ts
+++ b/src/features/project/list/api/matchingProject.ts
@@ -179,10 +179,10 @@ export type ApplicationAnswerItem = {
 }
 
 export type ActiveMatchingRound = {
-  id: number
+  id: number | string
   type: string
   phase: string
-  chapterId: number
+  chapterId: number | string
   startsAt: string
   endsAt: string
 }
@@ -224,6 +224,96 @@ export async function submitApplication(
 ): Promise<ApplicationStatusResponse> {
   const { data } = await api.post<ApiResponse<ApplicationStatusResponse>>(
     `/v1/projects/${projectId}/applications/me/submit`,
+  )
+  return data.result
+}
+
+export type AnswerView = {
+  answerId: number
+  answeredAsType:
+    | "SHORT_TEXT"
+    | "LONG_TEXT"
+    | "RADIO"
+    | "CHECKBOX"
+    | "DROPDOWN"
+    | "SCHEDULE"
+    | "FILE"
+    | "PORTFOLIO"
+  textValue?: string
+  selectedOptions?: { questionOptionId: number; answeredAsContent: string }[]
+  files?: { fileId: string; originalFileName: string; url: string }[]
+  times?: string[]
+}
+
+export type QuestionView = {
+  questionId: number
+  type: AnswerView["answeredAsType"]
+  title: string
+  description?: string
+  isRequired: boolean
+  orderNo: number
+  options: {
+    optionId: number
+    content: string
+    orderNo: number
+    isOther?: boolean
+  }[]
+  answer?: AnswerView
+}
+
+export type ApplicationDetailSectionView = {
+  sectionId: number
+  type: "COMMON" | "PART"
+  allowedParts: ProjectPart[]
+  title: string
+  description?: string
+  orderNo: number
+  questions: QuestionView[]
+}
+
+export type FormResponseView = {
+  formResponseId: number
+  formId: number
+  status: "DRAFT" | "SUBMITTED"
+  submittedAt?: string
+  lastSavedAt?: string
+  sections: ApplicationDetailSectionView[]
+}
+
+export type ApplicationDetail = {
+  applicationId: number
+  applicant: {
+    memberId: number
+    nickname: string
+    name: string
+    schoolName: string
+    part: ProjectPart
+  }
+  matchingRound: { id: number; type: string; phase: string }
+  status: MyApplicationStatus
+  submittedAt?: string
+  statusChangedAt?: string
+  formResponse: FormResponseView
+}
+
+export async function getApplicationDetail(
+  projectId: number,
+  applicationId: number,
+): Promise<ApplicationDetail> {
+  const { data } = await api.get<ApiResponse<ApplicationDetail>>(
+    `/v1/projects/${projectId}/applications/${applicationId}`,
+  )
+  return data.result
+}
+
+export async function cancelApplication(
+  projectId: number,
+  applicationId: number,
+  reason?: string,
+): Promise<ApplicationStatusResponse> {
+  const { data } = await api.delete<ApiResponse<ApplicationStatusResponse>>(
+    `/v1/projects/${projectId}/applications/${applicationId}`,
+    { params: reason ? { reason } : undefined },
   )
   return data.result
 }

--- a/src/features/project/list/api/matchingProject.ts
+++ b/src/features/project/list/api/matchingProject.ts
@@ -29,16 +29,15 @@ type ProjectMember = {
 }
 
 export type ProjectItem = {
-  id: number
+  id: number | string
   name: string
   description: string
   thumbnailImageUrl: string | null
-  chapterId: number
   productOwner: ProjectMember
   partQuotas: {
     part: ProjectPart
-    currentCount: number
-    quota: number
+    currentCount: number | string
+    quota: number | string
     status: PartQuotaStatus
   }[]
   partQuotaStatus: PartQuotaStatus
@@ -140,10 +139,10 @@ export type MyApplicationStatus =
   | "CANCELLED"
 
 export type MyProjectApplicationResponse = {
-  applicationId: number
-  projectId: number
+  applicationId: number | string
+  projectId: number | string
   matchingRound: {
-    id: number | null
+    id: number | string | null
     type: string
     phase: string
   }
@@ -156,6 +155,75 @@ export async function getMyApplications(
   const { data } = await api.get<ApiResponse<MyProjectApplicationResponse[]>>(
     "/v1/projects/me/applications",
     { params: { gisuId } },
+  )
+  return data.result
+}
+
+export type ApplicationStatus =
+  | "DRAFT"
+  | "SUBMITTED"
+  | "APPROVED"
+  | "REJECTED"
+  | "CANCELLED"
+
+export type ApplicationStatusResponse = {
+  applicationId: number
+  status: ApplicationStatus
+}
+
+export type ApplicationAnswerItem = {
+  questionId: number
+  textValue?: string
+  selectedOptionIds?: number[]
+  fileIds?: string[]
+}
+
+export type ActiveMatchingRound = {
+  id: number
+  type: string
+  phase: string
+  chapterId: number
+  startsAt: string
+  endsAt: string
+}
+
+export async function getActiveMatchingRound(
+  chapterId: number,
+): Promise<ActiveMatchingRound | null> {
+  const { data } = await api.get<ApiResponse<ActiveMatchingRound[]>>(
+    "/v1/project/matching-rounds",
+    { params: { chapterId, time: new Date().toISOString() } },
+  )
+  return data.result?.[0] ?? null
+}
+
+export async function createApplicationDraft(
+  projectId: number,
+  matchingRoundId: number,
+): Promise<ApplicationStatusResponse> {
+  const { data } = await api.post<ApiResponse<ApplicationStatusResponse>>(
+    `/v1/projects/${projectId}/applications`,
+    { matchingRoundId },
+  )
+  return data.result
+}
+
+export async function saveApplicationDraft(
+  projectId: number,
+  answers: ApplicationAnswerItem[],
+): Promise<ApplicationStatusResponse> {
+  const { data } = await api.put<ApiResponse<ApplicationStatusResponse>>(
+    `/v1/projects/${projectId}/applications/me`,
+    { answers },
+  )
+  return data.result
+}
+
+export async function submitApplication(
+  projectId: number,
+): Promise<ApplicationStatusResponse> {
+  const { data } = await api.post<ApiResponse<ApplicationStatusResponse>>(
+    `/v1/projects/${projectId}/applications/me/submit`,
   )
   return data.result
 }

--- a/src/features/project/list/model/applyValidation.ts
+++ b/src/features/project/list/model/applyValidation.ts
@@ -6,7 +6,17 @@ import type {
 } from "@/features/project/new/model/applicationQuestion"
 
 const TEXT_MAX = 500
-const MAX_FILE_BYTES = 150 * 1024 * 1024
+
+export type UploadedFileValue = { fileId: string; fileName: string }
+
+export type ApplyPortfolioValue =
+  | { kind: "link"; url: string }
+  | { kind: "file"; fileId: string; fileName: string }
+
+const uploadedFileSchema = z.object({
+  fileId: z.string().min(1),
+  fileName: z.string().min(1),
+})
 
 const portfolioSchema = z.discriminatedUnion("kind", [
   z.object({
@@ -17,13 +27,8 @@ const portfolioSchema = z.discriminatedUnion("kind", [
   }),
   z.object({
     kind: z.literal("file"),
-    name: z.string().min(1),
-    file: z
-      .instanceof(File)
-      .refine(
-        (f) => f.size <= MAX_FILE_BYTES,
-        "150MB 이하의 PDF 파일만 업로드 가능합니다.",
-      ),
+    fileId: z.string().min(1),
+    fileName: z.string().min(1),
   }),
 ])
 
@@ -43,9 +48,18 @@ function fieldSchema(q: Question, enabled: boolean): z.ZodTypeAny {
         ? z.array(z.string()).min(1, "한 개 이상 선택해 주세요.")
         : z.array(z.string())
     case "file":
-      return required
-        ? z.string().min(1, "파일을 첨부해 주세요.")
-        : z.string().nullable().optional()
+      if (required) {
+        return z.unknown().superRefine((val, ctx) => {
+          const parsed = uploadedFileSchema.safeParse(val)
+          if (!parsed.success) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: "파일을 첨부해 주세요.",
+            })
+          }
+        })
+      }
+      return uploadedFileSchema.nullable().optional()
     case "portfolio":
       if (required) {
         return z.unknown().superRefine((val, ctx) => {

--- a/src/features/project/list/model/projectDetailCta.ts
+++ b/src/features/project/list/model/projectDetailCta.ts
@@ -2,16 +2,32 @@ export type ProjectDetailCtaMode =
   | "recruit-questions"
   | "my-application"
   | "apply"
+  | "apply-blocked-other"
+  | "apply-blocked-approved"
   | "plan-only"
 
-export function resolveProjectDetailCtaMode(
-  isOperator: boolean,
-  isPm: boolean,
-  isSameBranch: boolean,
-  isApplied: boolean,
-): ProjectDetailCtaMode {
+interface ResolveCtaParams {
+  isOperator: boolean
+  isPm: boolean
+  isSameBranch: boolean
+  isApplied: boolean
+  hasOtherActiveApplication: boolean
+  isAlreadyApproved: boolean
+}
+
+export function resolveProjectDetailCtaMode({
+  isOperator,
+  isPm,
+  isSameBranch,
+  isApplied,
+  hasOtherActiveApplication,
+  isAlreadyApproved,
+}: ResolveCtaParams): ProjectDetailCtaMode {
   if (isOperator) return "recruit-questions"
   if (!isSameBranch) return "plan-only"
   if (isPm) return "recruit-questions"
-  return isApplied ? "my-application" : "apply"
+  if (isApplied) return "my-application"
+  if (isAlreadyApproved) return "apply-blocked-approved"
+  if (hasOtherActiveApplication) return "apply-blocked-other"
+  return "apply"
 }

--- a/src/features/project/list/ui/MatchingProjectsListPage.tsx
+++ b/src/features/project/list/ui/MatchingProjectsListPage.tsx
@@ -57,11 +57,8 @@ export function MatchingProjectsListPage() {
     filterDescriptors,
   } = useMatchingProjectListFilters()
 
-  const [selectedProjectId, setSelectedProjectId] = useState<number | null>(
-    null,
-  )
-  const [selectedProjectChapterId, setSelectedProjectChapterId] = useState<
-    number | null
+  const [selectedProjectId, setSelectedProjectId] = useState<
+    number | string | null
   >(null)
 
   return (
@@ -132,7 +129,6 @@ export function MatchingProjectsListPage() {
                   className="w-full text-left"
                   onClick={() => {
                     setSelectedProjectId(item.id)
-                    setSelectedProjectChapterId(item.chapterId)
                   }}
                 >
                   <MatchingProjectCard variant="default" data={project} />
@@ -157,7 +153,6 @@ export function MatchingProjectsListPage() {
         onOpenChange={(open) => {
           if (!open) {
             setSelectedProjectId(null)
-            setSelectedProjectChapterId(null)
           }
         }}
       >
@@ -166,10 +161,7 @@ export function MatchingProjectsListPage() {
           <Modal.Content className="shadow-drop-neutral-3 rounded-2xl">
             <Modal.Title className="sr-only">프로젝트 상세</Modal.Title>
             {selectedProjectId !== null && (
-              <ProjectDetailCard
-                projectId={selectedProjectId}
-                projectChapterId={selectedProjectChapterId ?? undefined}
-              />
+              <ProjectDetailCard projectId={selectedProjectId} />
             )}
           </Modal.Content>
         </Modal.Portal>

--- a/src/features/project/list/ui/MatchingProjectsListPage.tsx
+++ b/src/features/project/list/ui/MatchingProjectsListPage.tsx
@@ -37,8 +37,8 @@ function toMatchingProject(project: ProjectItem): MatchingProject {
       : null,
     recruitRows: project.partQuotas.map((q) => ({
       part: q.part,
-      current: q.currentCount,
-      total: q.quota,
+      current: Number(q.currentCount),
+      total: Number(q.quota),
     })),
     partQuotaStatus: project.partQuotaStatus,
   }

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -210,7 +210,7 @@ export function ProjectDetailCard({
       color: "red",
       variant: "deep",
       type: "default",
-      duration: 3,
+      duration: 3000,
     })
     setIsApplyModalOpen(false)
     setIsRecruitQuestionsModalOpen(false)
@@ -531,11 +531,11 @@ export function ProjectDetailCard({
                   등록된 지원 양식이 없습니다.
                 </span>
               </div>
-            ) : (
+            ) : activeMatchingRound == null ? null : (
               <ProjectApplyModal
                 data={data}
                 projectId={projectId}
-                matchingRoundId={Number(activeMatchingRound!.id)}
+                matchingRoundId={Number(activeMatchingRound.id)}
                 sections={sections}
                 canToggleSection={userIsOperator || userIsPm}
                 onBack={() => setIsApplyModalOpen(false)}

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -28,11 +28,13 @@ import {
 import { isRecruitDone } from "../model/matchingProject"
 import { DEFAULT_MATCHING_PROJECT_MOCK } from "../model/matchingProject.mock"
 import { resolveProjectDetailCtaMode } from "../model/projectDetailCta"
+import { ApplyFormSkeleton } from "./apply-modal/ApplyFormSkeleton"
+import { MyApplicationModal } from "./apply-modal/MyApplicationModal"
 import { ProjectApplyModal } from "./apply-modal/ProjectApplyModal"
 import { RecruitQuestionsViewModal } from "./apply-modal/RecruitQuestionsViewModal"
 import { TeamMemberModal } from "./team-member-modal/TeamMemberModal"
 
-import type { ProjectDetail } from "../api/matchingProject"
+import type { ActiveMatchingRound, ProjectDetail } from "../api/matchingProject"
 import type {
   MatchingProject,
   ProjectCoverImage,
@@ -124,6 +126,8 @@ export function ProjectDetailCard({
   const addToast = useToastStore((s) => s.addToast)
   const [isTeamModalOpen, setIsTeamModalOpen] = useState(false)
   const [isApplyModalOpen, setIsApplyModalOpen] = useState(false)
+  const [isMyApplicationModalOpen, setIsMyApplicationModalOpen] =
+    useState(false)
   const [isRecruitQuestionsModalOpen, setIsRecruitQuestionsModalOpen] =
     useState(false)
   const { data: detail, isLoading: isDetailLoading } = useQuery({
@@ -158,8 +162,13 @@ export function ProjectDetailCard({
     return id != null ? Number(id) : null
   }, [me])
 
-  const isApplied =
-    myApplications?.some((a) => Number(a.projectId) === projectId) ?? false
+  const myApplicationForProject = myApplications?.find(
+    (a) => Number(a.projectId) === projectId && a.status !== "CANCELLED",
+  )
+  const isApplied = myApplicationForProject != null
+
+  const isAlreadyApproved =
+    myApplications?.some((a) => a.status === "APPROVED") ?? false
 
   const data = detail
     ? toMatchingProject(detail)
@@ -176,6 +185,18 @@ export function ProjectDetailCard({
     enabled: isShowingFormModal,
     staleTime: 5 * 60 * 1000,
   })
+
+  const [minSkeletonElapsed, setMinSkeletonElapsed] = useState(false)
+  useEffect(() => {
+    if (!isShowingFormModal) {
+      setMinSkeletonElapsed(false)
+      return
+    }
+    const timer = setTimeout(() => setMinSkeletonElapsed(true), 1000)
+    return () => clearTimeout(timer)
+  }, [isShowingFormModal])
+
+  const showFormSkeleton = isFormLoading || !minSkeletonElapsed
   const sections = useMemo(
     () =>
       applicationForm ? mapApplicationFormToSections(applicationForm) : [],
@@ -195,19 +216,69 @@ export function ProjectDetailCard({
     setIsRecruitQuestionsModalOpen(false)
   }, [formError, addToast])
 
+  useEffect(() => {
+    if (
+      !isShowingFormModal ||
+      isFormLoading ||
+      applicationForm ||
+      !minSkeletonElapsed
+    )
+      return
+    addToast({
+      message: "등록된 지원 양식이 없습니다.",
+      color: "red",
+      variant: "deep",
+      type: "default",
+      duration: 3000,
+    })
+    setIsApplyModalOpen(false)
+    setIsRecruitQuestionsModalOpen(false)
+  }, [
+    isShowingFormModal,
+    isFormLoading,
+    applicationForm,
+    minSkeletonElapsed,
+    addToast,
+  ])
+
   const isSameBranch = !userIsOperator
-  const ctaMode = resolveProjectDetailCtaMode(
-    userIsOperator,
-    userIsPm,
-    isSameBranch,
-    isApplied,
-  )
+  const isChallengerView = !userIsOperator && !userIsPm
+
+  const devMatchingRoundId =
+    Number(import.meta.env.VITE_DEV_MATCHING_ROUND_ID) || null
 
   const { data: activeMatchingRound } = useQuery({
     queryKey: ["activeMatchingRound", myChapterId],
-    queryFn: () => getActiveMatchingRound(myChapterId!),
-    enabled: myChapterId != null && ctaMode === "apply",
+    queryFn: (): Promise<ActiveMatchingRound | null> => {
+      if (devMatchingRoundId)
+        return Promise.resolve({
+          id: devMatchingRoundId,
+        } as ActiveMatchingRound)
+      return getActiveMatchingRound(myChapterId!)
+    },
+    enabled:
+      isChallengerView && (myChapterId != null || devMatchingRoundId != null),
     staleTime: 60 * 1000,
+  })
+
+  const hasOtherActiveApplication = useMemo(() => {
+    if (!myApplications || !activeMatchingRound) return false
+    return myApplications.some(
+      (a) =>
+        Number(a.matchingRound?.id) === Number(activeMatchingRound.id) &&
+        Number(a.projectId) !== projectId &&
+        a.status !== "CANCELLED" &&
+        a.status !== "REJECTED",
+    )
+  }, [myApplications, activeMatchingRound, projectId])
+
+  const ctaMode = resolveProjectDetailCtaMode({
+    isOperator: userIsOperator,
+    isPm: userIsPm,
+    isSameBranch,
+    isApplied,
+    hasOtherActiveApplication,
+    isAlreadyApproved,
   })
 
   const cover: ProjectCoverImage | null = detail?.thumbnailImageUrl
@@ -338,12 +409,30 @@ export function ProjectDetailCard({
                   </Button>
                 )}
                 {ctaMode === "my-application" && (
-                  <Button className="flex-1">내 지원서 확인하기</Button>
+                  <Button
+                    className="flex-1"
+                    disabled={myApplicationForProject == null}
+                    onClick={() => setIsMyApplicationModalOpen(true)}
+                  >
+                    내 지원서 확인하기
+                  </Button>
                 )}
                 {ctaMode === "apply" && (
                   <Button
                     className="flex-1"
+                    isLoading={isDetailLoading}
+                    disabled={!isDetailLoading && !detail?.applicationFormId}
                     onClick={() => {
+                      if (!detail?.applicationFormId) {
+                        addToast({
+                          message: "지원 양식이 등록되지 않은 프로젝트입니다.",
+                          color: "red",
+                          variant: "deep",
+                          type: "default",
+                          duration: 3000,
+                        })
+                        return
+                      }
                       if (!activeMatchingRound) {
                         addToast({
                           message: "매칭 기간이 아닙니다!",
@@ -360,9 +449,37 @@ export function ProjectDetailCard({
                     지원하기
                   </Button>
                 )}
+                {(ctaMode === "apply-blocked-other" ||
+                  ctaMode === "apply-blocked-approved") && (
+                  <>
+                    <Button
+                      variant="weak"
+                      color="primary"
+                      className="flex-1"
+                      isLoading={isDetailLoading}
+                      disabled={!isDetailLoading && !detail?.applicationFormId}
+                      onClick={() => setIsRecruitQuestionsModalOpen(true)}
+                    >
+                      모집 문항 보기
+                    </Button>
+                    <Button className="flex-1" disabled>
+                      지원하기
+                    </Button>
+                  </>
+                )}
               </>
             )}
           </div>
+          {ctaMode === "apply-blocked-other" && (
+            <p className="text-caption-2-regular text-error-600 mt-2 w-full text-center">
+              이번 차수에 이미 다른 프로젝트에 지원하여 지원할 수 없습니다.
+            </p>
+          )}
+          {ctaMode === "apply-blocked-approved" && (
+            <p className="text-caption-2-regular text-error-600 mt-2 w-full text-center">
+              이미 합격한 챌린저는 추가로 지원할 수 없습니다.
+            </p>
+          )}
         </div>
       </div>
 
@@ -386,15 +503,11 @@ export function ProjectDetailCard({
       >
         <Modal.Portal>
           <Modal.Overlay tone="deep" />
-          <Modal.Content className="shadow-drop-neutral-3 rounded-2xl">
-            {isFormLoading ? (
-              <div className="flex h-40 w-232 items-center justify-center rounded-b-2xl bg-white">
-                <span className="text-body-2-regular text-teal-gray-500">
-                  불러오는 중...
-                </span>
-              </div>
+          <Modal.Content>
+            {showFormSkeleton ? (
+              <ApplyFormSkeleton />
             ) : applicationForm == null ? (
-              <div className="flex h-40 w-232 items-center justify-center rounded-b-2xl bg-white">
+              <div className="shadow-drop-neutral-3 flex h-40 w-232 items-center justify-center rounded-2xl bg-white">
                 <span className="text-body-2-regular text-teal-gray-500">
                   등록된 모집 문항이 없습니다.
                 </span>
@@ -409,15 +522,11 @@ export function ProjectDetailCard({
       <Modal.Root open={isApplyModalOpen} onOpenChange={setIsApplyModalOpen}>
         <Modal.Portal>
           <Modal.Overlay tone="deep" />
-          <Modal.Content className="shadow-drop-neutral-3 rounded-2xl">
-            {isFormLoading ? (
-              <div className="flex h-40 w-232 items-center justify-center rounded-b-2xl bg-white">
-                <span className="text-body-2-regular text-teal-gray-500">
-                  불러오는 중...
-                </span>
-              </div>
+          <Modal.Content>
+            {showFormSkeleton ? (
+              <ApplyFormSkeleton />
             ) : applicationForm == null ? (
-              <div className="flex h-40 w-232 items-center justify-center rounded-b-2xl bg-white">
+              <div className="shadow-drop-neutral-3 flex h-40 w-232 items-center justify-center rounded-2xl bg-white">
                 <span className="text-body-2-regular text-teal-gray-500">
                   등록된 지원 양식이 없습니다.
                 </span>
@@ -426,7 +535,7 @@ export function ProjectDetailCard({
               <ProjectApplyModal
                 data={data}
                 projectId={projectId}
-                matchingRoundId={activeMatchingRound!.id}
+                matchingRoundId={Number(activeMatchingRound!.id)}
                 sections={sections}
                 canToggleSection={userIsOperator || userIsPm}
                 onBack={() => setIsApplyModalOpen(false)}
@@ -437,6 +546,42 @@ export function ProjectDetailCard({
                   })
                 }}
               />
+            )}
+          </Modal.Content>
+        </Modal.Portal>
+      </Modal.Root>
+
+      <Modal.Root
+        open={isMyApplicationModalOpen}
+        onOpenChange={setIsMyApplicationModalOpen}
+      >
+        <Modal.Portal>
+          <Modal.Overlay tone="deep" />
+          <Modal.Content>
+            {myApplicationForProject ? (
+              <MyApplicationModal
+                data={data}
+                projectId={projectId}
+                applicationId={Number(myApplicationForProject.applicationId)}
+                isRoundOpen={
+                  activeMatchingRound != null &&
+                  Number(myApplicationForProject.matchingRound?.id) ===
+                    Number(activeMatchingRound.id)
+                }
+                onClose={() => setIsMyApplicationModalOpen(false)}
+                onCancelled={() => {
+                  setIsMyApplicationModalOpen(false)
+                  void queryClient.invalidateQueries({
+                    queryKey: ["myApplications", activeGisuId],
+                  })
+                }}
+              />
+            ) : (
+              <div className="shadow-drop-neutral-3 flex h-40 w-232 items-center justify-center rounded-2xl bg-white">
+                <span className="text-body-2-regular text-teal-gray-500">
+                  지원 내역을 찾을 수 없습니다.
+                </span>
+              </div>
             )}
           </Modal.Content>
         </Modal.Portal>

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -1,5 +1,5 @@
 /** 피그마 기준 Project Card Lg입니다. */
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import { useEffect, useMemo, useState } from "react"
 
@@ -20,7 +20,11 @@ import { RecruitStatusChip } from "@/shared/ui/chip/RecruitStatusChip"
 import MemberCount from "@/shared/ui/MemberCount"
 import { Modal } from "@/shared/ui/Modal"
 
-import { getMyApplications, getProjectDetail } from "../api/matchingProject"
+import {
+  getActiveMatchingRound,
+  getMyApplications,
+  getProjectDetail,
+} from "../api/matchingProject"
 import { isRecruitDone } from "../model/matchingProject"
 import { DEFAULT_MATCHING_PROJECT_MOCK } from "../model/matchingProject.mock"
 import { resolveProjectDetailCtaMode } from "../model/projectDetailCta"
@@ -29,15 +33,53 @@ import { RecruitQuestionsViewModal } from "./apply-modal/RecruitQuestionsViewMod
 import { TeamMemberModal } from "./team-member-modal/TeamMemberModal"
 
 import type { ProjectDetail } from "../api/matchingProject"
-import type { MatchingProject } from "../model/matchingProject"
+import type {
+  MatchingProject,
+  ProjectCoverImage,
+} from "../model/matchingProject"
 
 type ProjectDetailCardLogo = "on" | "off"
 
 interface ProjectDetailCardProps {
-  projectId: number
-  projectChapterId?: number
+  projectId: number | string
   logo?: ProjectDetailCardLogo
   showEditCta?: boolean
+}
+
+function ProjectDetailCardSkeleton() {
+  return (
+    <div className="flex w-[33.75rem] flex-col items-start overflow-hidden rounded-2xl bg-white">
+      <div className="bg-teal-gray-200 h-[17.875rem] w-[33.75rem] animate-pulse" />
+      <div className="flex w-full flex-col items-start p-5">
+        <div className="flex w-full flex-col items-start gap-6">
+          <div className="flex w-full flex-col items-start gap-2.5">
+            <div className="flex w-full items-center justify-between gap-4">
+              <div className="bg-teal-gray-150 h-6 w-52 animate-pulse rounded-md" />
+              <div className="bg-teal-gray-150 h-4 w-32 animate-pulse rounded-md" />
+            </div>
+            <div className="flex w-full flex-col gap-1.5">
+              <div className="bg-teal-gray-150 h-4 w-full animate-pulse rounded-md" />
+              <div className="bg-teal-gray-150 h-4 w-4/5 animate-pulse rounded-md" />
+              <div className="bg-teal-gray-150 h-4 w-2/3 animate-pulse rounded-md" />
+            </div>
+          </div>
+          <div className="flex w-full flex-col items-start gap-1.5">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="flex w-full items-center justify-between">
+                <div className="bg-teal-gray-150 h-4 w-28 animate-pulse rounded-md" />
+                <div className="bg-teal-gray-150 h-6 w-14 animate-pulse rounded-full" />
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="mt-8.5 flex w-full items-start gap-2.5">
+          <div className="bg-teal-gray-150 h-11 w-11 animate-pulse rounded-xl" />
+          <div className="bg-teal-gray-150 h-11 flex-1 animate-pulse rounded-xl" />
+          <div className="bg-teal-gray-150 h-11 flex-1 animate-pulse rounded-xl" />
+        </div>
+      </div>
+    </div>
+  )
 }
 
 function toMatchingProject(detail: ProjectDetail): MatchingProject {
@@ -71,20 +113,20 @@ function toMatchingProject(detail: ProjectDetail): MatchingProject {
 }
 
 export function ProjectDetailCard({
-  projectId,
-  projectChapterId,
+  projectId: projectIdProp,
   logo = "on",
   showEditCta = false,
 }: ProjectDetailCardProps) {
+  const projectId = Number(projectIdProp)
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const { data: me } = useMe()
   const addToast = useToastStore((s) => s.addToast)
   const [isTeamModalOpen, setIsTeamModalOpen] = useState(false)
   const [isApplyModalOpen, setIsApplyModalOpen] = useState(false)
   const [isRecruitQuestionsModalOpen, setIsRecruitQuestionsModalOpen] =
     useState(false)
-
-  const { data: detail } = useQuery({
+  const { data: detail, isLoading: isDetailLoading } = useQuery({
     queryKey: ["projectDetail", projectId],
     queryFn: () => getProjectDetail(projectId),
     staleTime: 5 * 60 * 1000,
@@ -117,7 +159,7 @@ export function ProjectDetailCard({
   }, [me])
 
   const isApplied =
-    myApplications?.some((a) => a.projectId === projectId) ?? false
+    myApplications?.some((a) => Number(a.projectId) === projectId) ?? false
 
   const data = detail
     ? toMatchingProject(detail)
@@ -153,19 +195,29 @@ export function ProjectDetailCard({
     setIsRecruitQuestionsModalOpen(false)
   }, [formError, addToast])
 
-  const isSameBranch =
-    userIsOperator ||
-    (projectChapterId !== undefined &&
-      myChapterId !== null &&
-      myChapterId === projectChapterId)
+  const isSameBranch = !userIsOperator
   const ctaMode = resolveProjectDetailCtaMode(
     userIsOperator,
     userIsPm,
     isSameBranch,
     isApplied,
   )
-  const cover = data.coverImage
+
+  const { data: activeMatchingRound } = useQuery({
+    queryKey: ["activeMatchingRound", myChapterId],
+    queryFn: () => getActiveMatchingRound(myChapterId!),
+    enabled: myChapterId != null && ctaMode === "apply",
+    staleTime: 60 * 1000,
+  })
+
+  const cover: ProjectCoverImage | null = detail?.thumbnailImageUrl
+    ? { src: detail.thumbnailImageUrl }
+    : null
   const showLogo = logo === "on"
+
+  if (isDetailLoading) {
+    return <ProjectDetailCardSkeleton />
+  }
 
   return (
     <>
@@ -278,6 +330,8 @@ export function ProjectDetailCard({
                 {ctaMode === "recruit-questions" && (
                   <Button
                     className="flex-1"
+                    isLoading={isDetailLoading}
+                    disabled={!isDetailLoading && !detail?.applicationFormId}
                     onClick={() => setIsRecruitQuestionsModalOpen(true)}
                   >
                     모집 문항 보기
@@ -289,7 +343,19 @@ export function ProjectDetailCard({
                 {ctaMode === "apply" && (
                   <Button
                     className="flex-1"
-                    onClick={() => setIsApplyModalOpen(true)}
+                    onClick={() => {
+                      if (!activeMatchingRound) {
+                        addToast({
+                          message: "매칭 기간이 아닙니다!",
+                          color: "red",
+                          variant: "deep",
+                          type: "default",
+                          duration: 3000,
+                        })
+                        return
+                      }
+                      setIsApplyModalOpen(true)
+                    }}
                   >
                     지원하기
                   </Button>
@@ -359,12 +425,16 @@ export function ProjectDetailCard({
             ) : (
               <ProjectApplyModal
                 data={data}
+                projectId={projectId}
+                matchingRoundId={activeMatchingRound!.id}
                 sections={sections}
                 canToggleSection={userIsOperator || userIsPm}
                 onBack={() => setIsApplyModalOpen(false)}
-                onSubmit={(_answers) => {
-                  // TODO: 지원서 제출 API 연동
+                onSubmitSuccess={() => {
                   setIsApplyModalOpen(false)
+                  void queryClient.invalidateQueries({
+                    queryKey: ["myApplications", activeGisuId],
+                  })
                 }}
               />
             )}

--- a/src/features/project/list/ui/apply-modal/ApplyFormSkeleton.tsx
+++ b/src/features/project/list/ui/apply-modal/ApplyFormSkeleton.tsx
@@ -1,0 +1,59 @@
+export function ApplyFormSkeleton() {
+  return (
+    <div className="flex w-232 flex-col">
+      <div className="flex w-full items-end">
+        <div className="clip-trapezoid-sm flex h-15 w-69.5 items-center gap-3.5 bg-teal-100 py-2.5 pr-14 pl-4">
+          <div className="bg-teal-gray-200 size-8 shrink-0 animate-pulse rounded-lg" />
+          <div className="flex flex-col gap-1.5">
+            <div className="bg-teal-gray-200 h-3 w-40 animate-pulse rounded" />
+            <div className="bg-teal-gray-200 h-2.5 w-28 animate-pulse rounded" />
+          </div>
+        </div>
+        <div className="-ml-1.5 h-1.75 flex-1 rounded-tr-xl bg-teal-100" />
+      </div>
+
+      <div className="shadow-drop-neutral-3 flex w-full flex-col rounded-2xl bg-white">
+        <div className="scrollbar-none max-h-[75vh] overflow-y-auto px-11.5 py-9">
+          <div className="flex items-start gap-6 self-stretch px-1 py-5">
+            <div className="flex flex-1 flex-col gap-2">
+              <div className="bg-teal-gray-150 h-4 w-full animate-pulse rounded-md" />
+              <div className="bg-teal-gray-150 h-4 w-5/6 animate-pulse rounded-md" />
+              <div className="bg-teal-gray-150 h-4 w-2/3 animate-pulse rounded-md" />
+            </div>
+            <div className="flex w-74.5 shrink-0 flex-col gap-2.5">
+              {[0, 1, 2].map((i) => (
+                <div
+                  key={i}
+                  className="flex w-full items-center justify-between"
+                >
+                  <div className="bg-teal-gray-150 h-4 w-30.5 animate-pulse rounded-md" />
+                  <div className="bg-teal-gray-150 h-6 w-14 animate-pulse rounded-full" />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex w-full flex-col gap-5 pb-6">
+            <div className="flex w-full items-end">
+              <div className="bg-teal-gray-150 h-9 w-32 rounded-t-[12px]" />
+              <div className="bg-teal-gray-150 h-1.5 flex-1 rounded-tr-xl" />
+            </div>
+            <div className="flex flex-col gap-10 self-stretch rounded-b-[12px] border border-teal-200 bg-white pt-8.5 pr-5 pb-9.5 pl-5">
+              {[0, 1].map((i) => (
+                <div key={i} className="flex w-full flex-col gap-3">
+                  <div className="bg-teal-gray-150 h-5 w-2/3 animate-pulse rounded-md" />
+                  <div className="bg-teal-gray-150 h-15 w-full animate-pulse rounded-[12px]" />
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="border-teal-gray-100 flex justify-center gap-3 border-t px-6 py-4">
+          <div className="bg-teal-gray-150 h-14 w-24 animate-pulse rounded-xl" />
+          <div className="bg-teal-gray-150 h-14 w-24 animate-pulse rounded-xl" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/project/list/ui/apply-modal/ApplyProjectTitleCard.tsx
+++ b/src/features/project/list/ui/apply-modal/ApplyProjectTitleCard.tsx
@@ -1,0 +1,68 @@
+import { cn } from "@/shared/lib/utils"
+
+interface ApplyProjectTitleCardProps {
+  projectName: string
+  challengerName?: string
+  challengerUniversity?: string
+  subtitle?: string
+  className?: string
+}
+
+const TRAPEZOID_CLIP_PATH = [
+  "polygon(",
+  "12px 0,",
+  "calc(100% - 63px) 0,",
+  "calc(100% - 61px) 0.2px,",
+  "calc(100% - 59px) 0.6px,",
+  "calc(100% - 57.5px) 1.4px,",
+  "calc(100% - 56px) 2.4px,",
+  "calc(100% - 54.5px) 3.7px,",
+  "100% 100%,",
+  "0 100%,",
+  "0 12px,",
+  "0.5px 9px,",
+  "1.5px 6px,",
+  "3.5px 3.5px,",
+  "6px 1.5px,",
+  "9px 0.5px",
+  ")",
+].join(" ")
+
+export function ApplyProjectTitleCard({
+  projectName,
+  challengerName,
+  challengerUniversity,
+  subtitle,
+  className,
+}: ApplyProjectTitleCardProps) {
+  const subtitleText =
+    subtitle ??
+    (challengerName && challengerUniversity
+      ? `${challengerName} · ${challengerUniversity}`
+      : (challengerName ?? challengerUniversity ?? null))
+
+  return (
+    <div
+      className={cn("flex w-full items-end", className)}
+      style={{ transform: "translateY(14px)" }}
+    >
+      <div
+        className="flex h-15 w-fit max-w-[calc(100%-1rem)] min-w-69.5 shrink-0 items-center gap-3.5 bg-teal-100 bg-linear-to-r py-2.5 pr-14 pl-4"
+        style={{ clipPath: TRAPEZOID_CLIP_PATH }}
+      >
+        <div className="bg-teal-gray-200 size-8 shrink-0 rounded-lg" />
+        <div className="flex min-w-0 flex-col">
+          <span className="text-subtitle-4-semibold text-teal-gray-800 truncate">
+            {projectName}
+          </span>
+          {subtitleText && (
+            <span className="text-caption-2-medium text-teal-gray-600 truncate">
+              {subtitleText}
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="-ml-14 h-3.5 flex-1 rounded-tr-xl bg-teal-100" />
+    </div>
+  )
+}

--- a/src/features/project/list/ui/apply-modal/MyApplicationModal.tsx
+++ b/src/features/project/list/ui/apply-modal/MyApplicationModal.tsx
@@ -50,7 +50,11 @@ export function MyApplicationModal({
   const addToast = useToastStore((s) => s.addToast)
   const [isCancelConfirmOpen, setIsCancelConfirmOpen] = useState(false)
 
-  const { data: detail, isLoading } = useQuery({
+  const {
+    data: detail,
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: ["myApplicationDetail", projectId, applicationId],
     queryFn: () => getApplicationDetail(projectId, applicationId),
     staleTime: 60 * 1000,
@@ -123,66 +127,69 @@ export function MyApplicationModal({
             </div>
           </div>
 
-          {detail && (
-            <div className="text-body-2-regular text-teal-gray-700 px-1 pb-4">
-              지원 상태:{" "}
-              <span className="font-semibold text-teal-600">
-                {STATUS_LABEL[detail.status]}
-              </span>
-              {detail.submittedAt && (
-                <span className="text-teal-gray-500 ml-3">
-                  제출 일시: {formatDateTime(detail.submittedAt)}
-                </span>
-              )}
+          {isError ? (
+            <div className="text-body-2-regular py-20 text-center text-red-400">
+              지원 정보를 불러오지 못했습니다.
             </div>
-          )}
-
-          {isLoading || !detail ? (
+          ) : isLoading || !detail ? (
             <div className="text-body-2-regular text-teal-gray-500 py-20 text-center">
               불러오는 중...
             </div>
           ) : (
-            <div className="flex w-full flex-col gap-5 pb-6">
-              {detail.formResponse.sections.map((section) => {
-                const indexMap = new Map<number, number>()
-                section.questions.forEach((q, i) =>
-                  indexMap.set(q.questionId, i + 1),
-                )
+            <>
+              <div className="text-body-2-regular text-teal-gray-700 px-1 pb-4">
+                지원 상태:{" "}
+                <span className="font-semibold text-teal-600">
+                  {STATUS_LABEL[detail.status]}
+                </span>
+                {detail.submittedAt && (
+                  <span className="text-teal-gray-500 ml-3">
+                    제출 일시: {formatDateTime(detail.submittedAt)}
+                  </span>
+                )}
+              </div>
+              <div className="flex w-full flex-col gap-5 pb-6">
+                {detail.formResponse.sections.map((section) => {
+                  const indexMap = new Map<number, number>()
+                  section.questions.forEach((q, i) =>
+                    indexMap.set(q.questionId, i + 1),
+                  )
 
-                return (
-                  <div key={section.sectionId}>
-                    {section.type === "COMMON" ? (
-                      <FormHeader variant="common" />
-                    ) : (
-                      <FormHeader
-                        variant="part"
-                        partName={section.allowedParts.join(", ")}
-                        toggleChecked
-                        showToggle={false}
-                        onToggleChange={() => {}}
-                      />
-                    )}
-                    {section.questions.length > 0 && (
-                      <div className="flex flex-col items-start gap-10 self-stretch rounded-b-[12px] border border-teal-200 bg-white pt-8.5 pr-5 pb-9.5 pl-5">
-                        {section.questions.map((q) => (
-                          <div
-                            key={q.questionId}
-                            className="flex w-full flex-col gap-3"
-                          >
-                            <QuestionItemTitle
-                              index={`Q${indexMap.get(q.questionId) ?? ""}`}
-                              title={q.title}
-                              required={q.isRequired}
-                            />
-                            <AnswerDisplay question={q} answer={q.answer} />
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                )
-              })}
-            </div>
+                  return (
+                    <div key={section.sectionId}>
+                      {section.type === "COMMON" ? (
+                        <FormHeader variant="common" />
+                      ) : (
+                        <FormHeader
+                          variant="part"
+                          partName={section.allowedParts.join(", ")}
+                          toggleChecked
+                          showToggle={false}
+                          onToggleChange={() => {}}
+                        />
+                      )}
+                      {section.questions.length > 0 && (
+                        <div className="flex flex-col items-start gap-10 self-stretch rounded-b-[12px] border border-teal-200 bg-white pt-8.5 pr-5 pb-9.5 pl-5">
+                          {section.questions.map((q) => (
+                            <div
+                              key={q.questionId}
+                              className="flex w-full flex-col gap-3"
+                            >
+                              <QuestionItemTitle
+                                index={`Q${indexMap.get(q.questionId) ?? ""}`}
+                                title={q.title}
+                                required={q.isRequired}
+                              />
+                              <AnswerDisplay question={q} answer={q.answer} />
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+            </>
           )}
         </div>
 

--- a/src/features/project/list/ui/apply-modal/MyApplicationModal.tsx
+++ b/src/features/project/list/ui/apply-modal/MyApplicationModal.tsx
@@ -1,0 +1,358 @@
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { useState } from "react"
+
+import { useToastStore } from "@/components/toast/useToastStore"
+import WarningTriangleIcon from "@/shared/assets/icon/infomation/WarningTriangleIcon"
+import { Button } from "@/shared/ui/Button"
+import { RecruitStatusChip } from "@/shared/ui/chip/RecruitStatusChip"
+import { FormHeader } from "@/shared/ui/FormHeader"
+import MemberCount from "@/shared/ui/MemberCount"
+import { Modal } from "@/shared/ui/Modal"
+import { QuestionItemTitle } from "@/shared/ui/question-field/QuestionItemTitle"
+
+import {
+  type AnswerView,
+  cancelApplication,
+  getApplicationDetail,
+  type QuestionView,
+} from "../../api/matchingProject"
+import { isRecruitDone } from "../../model/matchingProject"
+import { ApplyProjectTitleCard } from "./ApplyProjectTitleCard"
+
+import type { MyApplicationStatus } from "../../api/matchingProject"
+import type { MatchingProject } from "../../model/matchingProject"
+
+interface MyApplicationModalProps {
+  data: MatchingProject
+  projectId: number
+  applicationId: number
+  isRoundOpen: boolean
+  onClose: () => void
+  onCancelled: () => void
+}
+
+const STATUS_LABEL: Record<MyApplicationStatus, string> = {
+  DRAFT: "임시 저장",
+  SUBMITTED: "제출 완료",
+  APPROVED: "합격",
+  REJECTED: "불합격",
+  CANCELLED: "취소됨",
+}
+
+export function MyApplicationModal({
+  data,
+  projectId,
+  applicationId,
+  isRoundOpen,
+  onClose,
+  onCancelled,
+}: MyApplicationModalProps) {
+  const addToast = useToastStore((s) => s.addToast)
+  const [isCancelConfirmOpen, setIsCancelConfirmOpen] = useState(false)
+
+  const { data: detail, isLoading } = useQuery({
+    queryKey: ["myApplicationDetail", projectId, applicationId],
+    queryFn: () => getApplicationDetail(projectId, applicationId),
+    staleTime: 60 * 1000,
+  })
+
+  const cancelMutation = useMutation({
+    mutationFn: () => cancelApplication(projectId, applicationId),
+    onSuccess: () => {
+      setIsCancelConfirmOpen(false)
+      addToast({
+        message: "지원이 취소되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      onCancelled()
+    },
+    onError: () => {
+      addToast({
+        message: "지원 취소에 실패했습니다. 다시 시도해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    },
+  })
+
+  const isCancellableStatus =
+    detail?.status === "DRAFT" || detail?.status === "SUBMITTED"
+  const canCancel = isRoundOpen && isCancellableStatus
+
+  return (
+    <div className="flex w-232 flex-col">
+      <div className="flex w-full">
+        <ApplyProjectTitleCard
+          projectName={data.title}
+          subtitle={data.authorSchoolLine}
+        />
+      </div>
+      <div className="shadow-drop-neutral-3 flex w-full flex-col rounded-2xl bg-white">
+        <div className="scrollbar-none max-h-[75vh] overflow-y-auto px-11.5 py-9">
+          <div className="flex items-start gap-6 self-stretch px-1 py-5">
+            <p className="text-body-1-regular text-teal-gray-600 flex-1">
+              {data.description}
+            </p>
+            <div className="flex w-74.5 shrink-0 flex-col gap-1.25">
+              {data.recruitRows.map((row) => {
+                const done = isRecruitDone(row)
+                return (
+                  <div
+                    key={row.part}
+                    className="flex w-full items-center justify-between pr-1"
+                  >
+                    <div className="flex w-30.5 items-center justify-between">
+                      <span className="text-body-2-medium text-teal-gray-700">
+                        {row.part}
+                      </span>
+                      <MemberCount
+                        size="sm"
+                        current={row.current}
+                        total={row.total}
+                      />
+                    </div>
+                    <RecruitStatusChip done={done} />
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+
+          {detail && (
+            <div className="text-body-2-regular text-teal-gray-700 px-1 pb-4">
+              지원 상태:{" "}
+              <span className="font-semibold text-teal-600">
+                {STATUS_LABEL[detail.status]}
+              </span>
+              {detail.submittedAt && (
+                <span className="text-teal-gray-500 ml-3">
+                  제출 일시: {formatDateTime(detail.submittedAt)}
+                </span>
+              )}
+            </div>
+          )}
+
+          {isLoading || !detail ? (
+            <div className="text-body-2-regular text-teal-gray-500 py-20 text-center">
+              불러오는 중...
+            </div>
+          ) : (
+            <div className="flex w-full flex-col gap-5 pb-6">
+              {detail.formResponse.sections.map((section) => {
+                const indexMap = new Map<number, number>()
+                section.questions.forEach((q, i) =>
+                  indexMap.set(q.questionId, i + 1),
+                )
+
+                return (
+                  <div key={section.sectionId}>
+                    {section.type === "COMMON" ? (
+                      <FormHeader variant="common" />
+                    ) : (
+                      <FormHeader
+                        variant="part"
+                        partName={section.allowedParts.join(", ")}
+                        toggleChecked
+                        showToggle={false}
+                        onToggleChange={() => {}}
+                      />
+                    )}
+                    {section.questions.length > 0 && (
+                      <div className="flex flex-col items-start gap-10 self-stretch rounded-b-[12px] border border-teal-200 bg-white pt-8.5 pr-5 pb-9.5 pl-5">
+                        {section.questions.map((q) => (
+                          <div
+                            key={q.questionId}
+                            className="flex w-full flex-col gap-3"
+                          >
+                            <QuestionItemTitle
+                              index={`Q${indexMap.get(q.questionId) ?? ""}`}
+                              title={q.title}
+                              required={q.isRequired}
+                            />
+                            <AnswerDisplay question={q} answer={q.answer} />
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="border-teal-gray-100 flex flex-col items-center gap-2 border-t px-6 py-4">
+          <div className="flex justify-center gap-3">
+            <Button variant="weak" color="neutral" size="xl" onClick={onClose}>
+              닫기
+            </Button>
+            {isCancellableStatus && (
+              <Button
+                color="primary"
+                size="xl"
+                onClick={() => setIsCancelConfirmOpen(true)}
+                disabled={!canCancel || cancelMutation.isPending}
+              >
+                지원 취소
+              </Button>
+            )}
+          </div>
+          {isCancellableStatus && !isRoundOpen && (
+            <p className="text-caption-2-medium text-teal-gray-400">
+              매칭 차수가 종료되어 취소할 수 없습니다.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <Modal.Root
+        open={isCancelConfirmOpen}
+        onOpenChange={setIsCancelConfirmOpen}
+      >
+        <Modal.Portal>
+          <Modal.Overlay tone="light" />
+          <Modal.Content className="shadow-drop-neutral-1 flex w-115 max-w-[calc(100vw-32px)] flex-col gap-8 rounded-[9.2px] border border-neutral-200 bg-white px-6 py-6 focus:outline-none">
+            <div className="flex flex-col items-start gap-4">
+              <div className="flex items-center gap-2">
+                <WarningTriangleIcon className="h-6 w-6 text-teal-500" />
+                <Modal.Title className="text-subtitle-1-semibold text-teal-500">
+                  지원 취소
+                </Modal.Title>
+              </div>
+              <Modal.Description className="text-subtitle-3-semibold text-teal-gray-800">
+                지원을 취소하면 작성한 답변이 모두 사라집니다.
+                <br />
+                같은 매칭 차수가 진행 중이라면 다시 지원할 수 있습니다.
+                <br />
+                정말 취소하시겠어요?
+              </Modal.Description>
+            </div>
+            <div className="flex justify-end gap-3">
+              <Button
+                variant="weak"
+                color="neutral"
+                size="s"
+                onClick={() => setIsCancelConfirmOpen(false)}
+                disabled={cancelMutation.isPending}
+              >
+                돌아가기
+              </Button>
+              <Button
+                size="s"
+                onClick={() => cancelMutation.mutate()}
+                disabled={cancelMutation.isPending}
+              >
+                지원 취소하기
+              </Button>
+            </div>
+          </Modal.Content>
+        </Modal.Portal>
+      </Modal.Root>
+    </div>
+  )
+}
+
+function AnswerDisplay({
+  question,
+  answer,
+}: {
+  question: QuestionView
+  answer?: AnswerView
+}) {
+  const wrapperClass =
+    "text-body-1-regular text-teal-gray-800 border-teal-gray-150 w-full rounded-[12px] border bg-[color-mix(in_srgb,var(--color-teal-50)_40%,white)] px-4 py-3 whitespace-pre-wrap break-words"
+  const emptyClass =
+    "text-body-1-regular text-teal-gray-400 border-teal-gray-150 w-full rounded-[12px] border bg-[color-mix(in_srgb,var(--color-teal-50)_40%,white)] px-4 py-3"
+
+  if (!answer) {
+    return <div className={emptyClass}>답변이 없습니다.</div>
+  }
+
+  switch (question.type) {
+    case "SHORT_TEXT":
+    case "LONG_TEXT":
+      return (
+        <div className={answer.textValue ? wrapperClass : emptyClass}>
+          {answer.textValue || "답변이 없습니다."}
+        </div>
+      )
+    case "RADIO":
+    case "DROPDOWN":
+    case "CHECKBOX": {
+      const contents =
+        answer.selectedOptions?.map((o) => o.answeredAsContent) ?? []
+      if (contents.length === 0) {
+        return <div className={emptyClass}>선택한 항목이 없습니다.</div>
+      }
+      return (
+        <ul className={wrapperClass}>
+          {contents.map((content, idx) => (
+            <li key={`${content}-${idx}`}>• {content}</li>
+          ))}
+        </ul>
+      )
+    }
+    case "FILE":
+    case "PORTFOLIO": {
+      const files = answer.files ?? []
+      const linkText = answer.textValue
+      if (files.length === 0 && !linkText) {
+        return <div className={emptyClass}>첨부된 파일이 없습니다.</div>
+      }
+      return (
+        <div className="flex w-full flex-col gap-1">
+          {files.map((f) => (
+            <a
+              key={f.fileId}
+              href={f.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`${wrapperClass} block text-teal-600 underline`}
+            >
+              {f.originalFileName}
+            </a>
+          ))}
+          {linkText && (
+            <a
+              href={linkText}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`${wrapperClass} block text-teal-600 underline`}
+            >
+              {linkText}
+            </a>
+          )}
+        </div>
+      )
+    }
+    case "SCHEDULE": {
+      const times = answer.times ?? []
+      if (times.length === 0) {
+        return <div className={emptyClass}>선택한 일정이 없습니다.</div>
+      }
+      return (
+        <ul className={wrapperClass}>
+          {times.map((t) => (
+            <li key={t}>• {formatDateTime(t)}</li>
+          ))}
+        </ul>
+      )
+    }
+  }
+}
+
+function formatDateTime(iso: string): string {
+  const date = new Date(iso)
+  if (Number.isNaN(date.getTime())) return iso
+  const yyyy = date.getFullYear()
+  const mm = String(date.getMonth() + 1).padStart(2, "0")
+  const dd = String(date.getDate()).padStart(2, "0")
+  const hh = String(date.getHours()).padStart(2, "0")
+  const min = String(date.getMinutes()).padStart(2, "0")
+  return `${yyyy}-${mm}-${dd} ${hh}:${min}`
+}

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -237,6 +237,7 @@ export function ProjectApplyModal({
     () => Object.fromEntries(sections.map((s) => [s.id, s.isEnabled])),
   )
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isPortfolioUploading, setIsPortfolioUploading] = useState(false)
   const [isLeaveModalOpen, setIsLeaveModalOpen] = useState(false)
   const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false)
   const [isSubmitConfirmModalOpen, setIsSubmitConfirmModalOpen] =
@@ -493,6 +494,7 @@ export function ProjectApplyModal({
                 return
               }
               if (val.file) {
+                setIsPortfolioUploading(true)
                 void uploadPortfolioFile(val.file)
                   .then((uploaded) =>
                     onChange({
@@ -514,6 +516,7 @@ export function ProjectApplyModal({
                       duration: 3000,
                     }),
                   )
+                  .finally(() => setIsPortfolioUploading(false))
               }
             }}
             error={error}
@@ -636,7 +639,7 @@ export function ProjectApplyModal({
             </Button>
             <Button
               size="xl"
-              disabled={isSubmitting}
+              disabled={isSubmitting || isPortfolioUploading}
               onClick={() => {
                 void handleSubmit(onValid, onInvalid)()
               }}

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -104,7 +104,8 @@ function buildAnswerPayload(
     if (question.fieldType === "radio") {
       if (typeof value !== "string" || !value) return [base]
       const idx = question.options.indexOf(value)
-      const optionId = idx !== -1 ? (question.optionIds?.[idx] ?? 0) : 0
+      const optionId = idx !== -1 ? question.optionIds?.[idx] : undefined
+      if (optionId == null) return [base]
       return [{ ...base, selectedOptionIds: [optionId] }]
     }
 
@@ -112,8 +113,10 @@ function buildAnswerPayload(
       if (!Array.isArray(value) || value.length === 0) return [base]
       const selectedIds = value.flatMap((content) => {
         const idx = question.options.indexOf(content)
-        return idx !== -1 ? [question.optionIds?.[idx] ?? 0] : []
+        const optionId = idx !== -1 ? question.optionIds?.[idx] : undefined
+        return optionId != null ? [optionId] : []
       })
+      if (selectedIds.length === 0) return [base]
       return [{ ...base, selectedOptionIds: selectedIds }]
     }
 

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import { Controller, useForm } from "react-hook-form"
 
 import { useToastStore } from "@/components/toast/useToastStore"
+import { uploadFileFlow } from "@/features/project/new/api/storage"
 import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
 import WarningTriangleIcon from "@/shared/assets/icon/infomation/WarningTriangleIcon"
 import { Button } from "@/shared/ui/Button"
@@ -13,7 +14,6 @@ import { CheckboxList } from "@/shared/ui/input/checkbox/CheckboxList"
 import { RadioList } from "@/shared/ui/input/radio/RadioList"
 import MemberCount from "@/shared/ui/MemberCount"
 import { Modal } from "@/shared/ui/Modal"
-import { ProjectTitleCard } from "@/shared/ui/ProjectTitleCard"
 import { FileUploadField } from "@/shared/ui/question-field/FileUploadField"
 import {
   PortfolioField,
@@ -29,10 +29,13 @@ import {
   submitApplication,
 } from "../../api/matchingProject"
 import {
+  type ApplyPortfolioValue,
   buildApplyAnswersSchema,
   defaultByFieldType,
+  type UploadedFileValue,
 } from "../../model/applyValidation"
 import { isRecruitDone } from "../../model/matchingProject"
+import { ApplyProjectTitleCard } from "./ApplyProjectTitleCard"
 
 import type { FieldErrors, Resolver } from "react-hook-form"
 
@@ -43,14 +46,42 @@ import type {
 
 import type { MatchingProject } from "../../model/matchingProject"
 
-type ApplyAnswerValue = string | string[] | PortfolioValue | null
+const FILE_UPLOAD_CATEGORY = "POST_ATTACHMENT" as const
+const PORTFOLIO_UPLOAD_CATEGORY = "PORTFOLIO" as const
+
+const FILE_ACCEPT = ".pdf,.docx,.zip"
+const FILE_ALLOWED_LABEL = "PDF, DOCX, ZIP"
+const PORTFOLIO_ALLOWED_LABEL = "PDF"
+
+type ApplyAnswerValue =
+  | string
+  | string[]
+  | UploadedFileValue
+  | ApplyPortfolioValue
+  | null
 
 const OPTION_LIST_CLASS =
   "border-teal-gray-150 flex flex-col gap-0.5 rounded-[12px] border bg-[color-mix(in_srgb,var(--color-teal-50)_40%,white)] p-1"
 const COMMON_SECTION_ID = "common"
 
-function isPortfolioValue(v: ApplyAnswerValue): v is PortfolioValue {
-  return v !== null && typeof v === "object" && !Array.isArray(v)
+function isUploadedFileValue(v: ApplyAnswerValue): v is UploadedFileValue {
+  return (
+    v !== null &&
+    typeof v === "object" &&
+    !Array.isArray(v) &&
+    "fileId" in v &&
+    !("kind" in v)
+  )
+}
+
+function isApplyPortfolioValue(v: ApplyAnswerValue): v is ApplyPortfolioValue {
+  return (
+    v !== null &&
+    typeof v === "object" &&
+    !Array.isArray(v) &&
+    "kind" in v &&
+    (v.kind === "link" || v.kind === "file")
+  )
 }
 
 function buildAnswerPayload(
@@ -86,45 +117,100 @@ function buildAnswerPayload(
       return [{ ...base, selectedOptionIds: selectedIds }]
     }
 
+    if (question.fieldType === "file") {
+      if (!isUploadedFileValue(value)) return [base]
+      return [{ ...base, fileIds: [value.fileId] }]
+    }
+
     if (question.fieldType === "portfolio") {
-      if (!isPortfolioValue(value)) return [base]
+      if (!isApplyPortfolioValue(value)) return [base]
       if (value.kind === "link") return [{ ...base, textValue: value.url }]
-      return [base]
+      return [{ ...base, fileIds: [value.fileId] }]
     }
 
     return [base]
   })
 }
 
+function extractUploadErrorMessage(
+  err: unknown,
+  fallback: string,
+  allowedLabel: string,
+): string {
+  if (err instanceof AxiosError) {
+    const data = err.response?.data as
+      | { code?: string; message?: string }
+      | undefined
+    if (data?.code === "STORAGE-0004") {
+      const base = data.message ?? "허용되지 않는 파일 확장자입니다."
+      return `${base} (허용 확장자: ${allowedLabel})`
+    }
+    if (data?.message) return data.message
+  }
+  return fallback
+}
+
 function FileAnswerField({
   value,
   onChange,
+  onUploadError,
   error,
 }: {
-  value: string | null
-  onChange: (name: string | null) => void
+  value: UploadedFileValue | null
+  onChange: (v: UploadedFileValue | null) => void
+  onUploadError: (message: string) => void
   error?: string
 }) {
   const inputRef = useRef<HTMLInputElement>(null)
+  const [isUploading, setIsUploading] = useState(false)
+
+  async function handleSelect(file: File) {
+    setIsUploading(true)
+    try {
+      const { fileId } = await uploadFileFlow(file, FILE_UPLOAD_CATEGORY)
+      onChange({ fileId, fileName: file.name })
+    } catch (err) {
+      onUploadError(
+        extractUploadErrorMessage(
+          err,
+          "파일 업로드에 실패했습니다. 다시 시도해 주세요.",
+          FILE_ALLOWED_LABEL,
+        ),
+      )
+    } finally {
+      setIsUploading(false)
+    }
+  }
+
   return (
     <>
       <input
         type="file"
         ref={inputRef}
         className="hidden"
+        accept={FILE_ACCEPT}
         onChange={(e) => {
           const file = e.target.files?.[0]
-          onChange(file?.name ?? null)
+          if (!file) return
+          void handleSelect(file)
+          e.target.value = ""
         }}
       />
       <FileUploadField
-        fileName={value}
+        fileName={isUploading ? "업로드 중..." : (value?.fileName ?? null)}
         onUpload={() => inputRef.current?.click()}
         onDelete={() => onChange(null)}
         error={error}
       />
     </>
   )
+}
+
+async function uploadPortfolioFile(
+  file: File,
+): Promise<{ fileId: string; fileName: string }> {
+  const { fileId } = await uploadFileFlow(file, PORTFOLIO_UPLOAD_CATEGORY)
+  return { fileId, fileName: file.name }
 }
 
 interface ProjectApplyModalProps {
@@ -153,12 +239,18 @@ export function ProjectApplyModal({
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isLeaveModalOpen, setIsLeaveModalOpen] = useState(false)
   const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false)
+  const [isSubmitConfirmModalOpen, setIsSubmitConfirmModalOpen] =
+    useState(false)
+  const pendingFormValuesRef = useRef<Record<string, ApplyAnswerValue> | null>(
+    null,
+  )
   const draftInitializedRef = useRef(false)
 
   useEffect(() => {
     if (draftInitializedRef.current) return
     draftInitializedRef.current = true
     async function initDraft() {
+      if (import.meta.env.VITE_DEV_MATCHING_ROUND_ID) return
       try {
         await createApplicationDraft(projectId, matchingRoundId)
       } catch (err) {
@@ -197,7 +289,6 @@ export function ProjectApplyModal({
   const {
     control,
     handleSubmit,
-    getValues,
     clearErrors,
     formState: { isDirty },
   } = useForm<Record<string, ApplyAnswerValue>>({
@@ -223,13 +314,7 @@ export function ProjectApplyModal({
     return map
   }, [sections, sectionEnabled])
 
-  async function handleLeaveConfirm() {
-    try {
-      const answers = buildAnswerPayload(getValues(), sections)
-      await saveApplicationDraft(projectId, answers)
-    } catch {
-      // 임시저장 실패 시에도 이탈은 허용
-    }
+  function handleLeaveConfirm() {
     setIsLeaveModalOpen(false)
     onBack()
   }
@@ -242,12 +327,22 @@ export function ProjectApplyModal({
     }
   }
 
-  async function onValid(formValues: Record<string, ApplyAnswerValue>) {
+  function onValid(formValues: Record<string, ApplyAnswerValue>) {
+    pendingFormValuesRef.current = formValues
+    setIsSubmitConfirmModalOpen(true)
+  }
+
+  async function handleSubmitConfirm() {
+    const formValues = pendingFormValuesRef.current
+    if (!formValues) return
+    setIsSubmitConfirmModalOpen(false)
     setIsSubmitting(true)
     try {
-      const answers = buildAnswerPayload(formValues, sections)
-      await saveApplicationDraft(projectId, answers)
-      await submitApplication(projectId)
+      if (!import.meta.env.VITE_DEV_MATCHING_ROUND_ID) {
+        const answers = buildAnswerPayload(formValues, sections)
+        await saveApplicationDraft(projectId, answers)
+        await submitApplication(projectId)
+      }
       setIsCompleteModalOpen(true)
     } catch {
       addToast({
@@ -259,6 +354,7 @@ export function ProjectApplyModal({
       })
     } finally {
       setIsSubmitting(false)
+      pendingFormValuesRef.current = null
     }
   }
 
@@ -364,19 +460,66 @@ export function ProjectApplyModal({
       case "file":
         return (
           <FileAnswerField
-            value={typeof value === "string" ? value : null}
-            onChange={(name) => onChange(name)}
+            value={isUploadedFileValue(value) ? value : null}
+            onChange={onChange}
+            onUploadError={(message) =>
+              addToast({
+                message,
+                color: "red",
+                variant: "deep",
+                type: "default",
+                duration: 3000,
+              })
+            }
             error={error}
           />
         )
-      case "portfolio":
+      case "portfolio": {
+        const portfolio = isApplyPortfolioValue(value) ? value : null
+        const fieldValue: PortfolioValue | null =
+          portfolio?.kind === "file"
+            ? { kind: "file", name: portfolio.fileName }
+            : portfolio
         return (
           <PortfolioField
-            value={isPortfolioValue(value) ? value : null}
-            onChange={(val: PortfolioValue | null) => onChange(val)}
+            value={fieldValue}
+            onChange={(val: PortfolioValue | null) => {
+              if (val == null) {
+                onChange(null)
+                return
+              }
+              if (val.kind === "link") {
+                onChange({ kind: "link", url: val.url })
+                return
+              }
+              if (val.file) {
+                void uploadPortfolioFile(val.file)
+                  .then((uploaded) =>
+                    onChange({
+                      kind: "file",
+                      fileId: uploaded.fileId,
+                      fileName: uploaded.fileName,
+                    }),
+                  )
+                  .catch((err) =>
+                    addToast({
+                      message: extractUploadErrorMessage(
+                        err,
+                        "포트폴리오 업로드에 실패했습니다. 다시 시도해 주세요.",
+                        PORTFOLIO_ALLOWED_LABEL,
+                      ),
+                      color: "red",
+                      variant: "deep",
+                      type: "default",
+                      duration: 3000,
+                    }),
+                  )
+              }
+            }}
             error={error}
           />
         )
+      }
     }
   }
 
@@ -387,13 +530,12 @@ export function ProjectApplyModal({
     <>
       <div className="flex w-232 flex-col">
         <div className="flex w-full">
-          <ProjectTitleCard
-            size="sm"
+          <ApplyProjectTitleCard
             projectName={data.title}
             subtitle={data.authorSchoolLine}
           />
         </div>
-        <div className="flex w-full flex-col rounded-b-2xl bg-white">
+        <div className="shadow-drop-neutral-3 flex w-full flex-col rounded-2xl bg-white">
           <div className="scrollbar-none max-h-[75vh] overflow-y-auto px-11.5 py-9">
             <div className="flex items-start gap-6 self-stretch px-1 py-5">
               <p className="text-body-1-regular text-teal-gray-600 flex-1">
@@ -517,9 +659,9 @@ export function ProjectApplyModal({
                 </Modal.Title>
               </div>
               <Modal.Description className="text-subtitle-3-semibold text-teal-gray-800">
-                작성 중인 지원서가 있습니다.
+                작성 중인 내용이 저장되지 않습니다.
                 <br />
-                임시저장 후 나가시겠습니까?
+                정말 나가시겠습니까?
               </Modal.Description>
             </div>
             <div className="flex justify-end gap-3">
@@ -531,8 +673,8 @@ export function ProjectApplyModal({
               >
                 돌아가기
               </Button>
-              <Button size="s" onClick={() => void handleLeaveConfirm()}>
-                임시저장 후 나가기
+              <Button size="s" onClick={handleLeaveConfirm}>
+                나가기
               </Button>
             </div>
           </Modal.Content>
@@ -560,6 +702,48 @@ export function ProjectApplyModal({
             <div className="flex justify-end">
               <Button size="s" onClick={onSubmitSuccess}>
                 확인
+              </Button>
+            </div>
+          </Modal.Content>
+        </Modal.Portal>
+      </Modal.Root>
+
+      <Modal.Root
+        open={isSubmitConfirmModalOpen}
+        onOpenChange={setIsSubmitConfirmModalOpen}
+      >
+        <Modal.Portal>
+          <Modal.Overlay tone="light" />
+          <Modal.Content className={SUB_MODAL_CLASS}>
+            <div className="flex flex-col items-start gap-4">
+              <div className="flex items-center gap-2">
+                <WarningTriangleIcon className="h-6 w-6 text-teal-500" />
+                <Modal.Title className="text-subtitle-1-semibold text-teal-500">
+                  최종 제출
+                </Modal.Title>
+              </div>
+              <Modal.Description className="text-subtitle-3-semibold text-teal-gray-800">
+                제출 후에는 답변을 수정할 수 없습니다.
+                <br />
+                이대로 제출하시겠어요?
+              </Modal.Description>
+            </div>
+            <div className="flex justify-end gap-3">
+              <Button
+                variant="weak"
+                color="neutral"
+                size="s"
+                onClick={() => setIsSubmitConfirmModalOpen(false)}
+                disabled={isSubmitting}
+              >
+                돌아가기
+              </Button>
+              <Button
+                size="s"
+                onClick={() => void handleSubmitConfirm()}
+                disabled={isSubmitting}
+              >
+                제출하기
               </Button>
             </div>
           </Modal.Content>

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -157,11 +157,13 @@ function FileAnswerField({
   value,
   onChange,
   onUploadError,
+  onUploadingChange,
   error,
 }: {
   value: UploadedFileValue | null
   onChange: (v: UploadedFileValue | null) => void
   onUploadError: (message: string) => void
+  onUploadingChange?: (uploading: boolean) => void
   error?: string
 }) {
   const inputRef = useRef<HTMLInputElement>(null)
@@ -169,6 +171,7 @@ function FileAnswerField({
 
   async function handleSelect(file: File) {
     setIsUploading(true)
+    onUploadingChange?.(true)
     try {
       const { fileId } = await uploadFileFlow(file, FILE_UPLOAD_CATEGORY)
       onChange({ fileId, fileName: file.name })
@@ -182,6 +185,7 @@ function FileAnswerField({
       )
     } finally {
       setIsUploading(false)
+      onUploadingChange?.(false)
     }
   }
 
@@ -240,6 +244,7 @@ export function ProjectApplyModal({
     () => Object.fromEntries(sections.map((s) => [s.id, s.isEnabled])),
   )
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isFileUploading, setIsFileUploading] = useState(false)
   const [isPortfolioUploading, setIsPortfolioUploading] = useState(false)
   const portfolioUploadTokenRef = useRef(0)
   const [isLeaveModalOpen, setIsLeaveModalOpen] = useState(false)
@@ -476,6 +481,7 @@ export function ProjectApplyModal({
                 duration: 3000,
               })
             }
+            onUploadingChange={setIsFileUploading}
             error={error}
           />
         )
@@ -651,7 +657,7 @@ export function ProjectApplyModal({
             </Button>
             <Button
               size="xl"
-              disabled={isSubmitting || isPortfolioUploading}
+              disabled={isSubmitting || isFileUploading || isPortfolioUploading}
               onClick={() => {
                 void handleSubmit(onValid, onInvalid)()
               }}

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod"
+import { AxiosError } from "axios"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { Controller, useForm } from "react-hook-form"
 
@@ -22,6 +23,12 @@ import { QuestionItemTitle } from "@/shared/ui/question-field/QuestionItemTitle"
 import { TextQuestionField } from "@/shared/ui/question-field/TextQuestionField"
 
 import {
+  type ApplicationAnswerItem,
+  createApplicationDraft,
+  saveApplicationDraft,
+  submitApplication,
+} from "../../api/matchingProject"
+import {
   buildApplyAnswersSchema,
   defaultByFieldType,
 } from "../../model/applyValidation"
@@ -44,6 +51,49 @@ const COMMON_SECTION_ID = "common"
 
 function isPortfolioValue(v: ApplyAnswerValue): v is PortfolioValue {
   return v !== null && typeof v === "object" && !Array.isArray(v)
+}
+
+function buildAnswerPayload(
+  formValues: Record<string, ApplyAnswerValue>,
+  sections: Section[],
+): ApplicationAnswerItem[] {
+  const questionMap = new Map<string, Question>()
+  sections.forEach((s) => s.questions.forEach((q) => questionMap.set(q.id, q)))
+
+  return Object.entries(formValues).flatMap(([questionId, value]) => {
+    const question = questionMap.get(questionId)
+    if (!question) return []
+
+    const base = { questionId: Number(questionId) }
+
+    if (question.fieldType === "text") {
+      return [{ ...base, textValue: typeof value === "string" ? value : "" }]
+    }
+
+    if (question.fieldType === "radio") {
+      if (typeof value !== "string" || !value) return [base]
+      const idx = question.options.indexOf(value)
+      const optionId = idx !== -1 ? (question.optionIds?.[idx] ?? 0) : 0
+      return [{ ...base, selectedOptionIds: [optionId] }]
+    }
+
+    if (question.fieldType === "checkbox") {
+      if (!Array.isArray(value) || value.length === 0) return [base]
+      const selectedIds = value.flatMap((content) => {
+        const idx = question.options.indexOf(content)
+        return idx !== -1 ? [question.optionIds?.[idx] ?? 0] : []
+      })
+      return [{ ...base, selectedOptionIds: selectedIds }]
+    }
+
+    if (question.fieldType === "portfolio") {
+      if (!isPortfolioValue(value)) return [base]
+      if (value.kind === "link") return [{ ...base, textValue: value.url }]
+      return [base]
+    }
+
+    return [base]
+  })
 }
 
 function FileAnswerField({
@@ -79,23 +129,55 @@ function FileAnswerField({
 
 interface ProjectApplyModalProps {
   data: MatchingProject
+  projectId: number
+  matchingRoundId: number
   sections: Section[]
   canToggleSection?: boolean
   onBack: () => void
-  onSubmit: (answers: Record<string, ApplyAnswerValue>) => void
+  onSubmitSuccess: () => void
 }
 
 export function ProjectApplyModal({
   data,
+  projectId,
+  matchingRoundId,
   sections,
   canToggleSection = false,
   onBack,
-  onSubmit,
+  onSubmitSuccess,
 }: ProjectApplyModalProps) {
   const addToast = useToastStore((s) => s.addToast)
   const [sectionEnabled, setSectionEnabled] = useState<Record<string, boolean>>(
     () => Object.fromEntries(sections.map((s) => [s.id, s.isEnabled])),
   )
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isLeaveModalOpen, setIsLeaveModalOpen] = useState(false)
+  const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false)
+  const draftInitializedRef = useRef(false)
+
+  useEffect(() => {
+    if (draftInitializedRef.current) return
+    draftInitializedRef.current = true
+    async function initDraft() {
+      try {
+        await createApplicationDraft(projectId, matchingRoundId)
+      } catch (err) {
+        if (err instanceof AxiosError && err.response?.status === 409) {
+          return
+        }
+        addToast({
+          message: "지원서 생성에 실패했습니다. 다시 시도해 주세요.",
+          color: "red",
+          variant: "deep",
+          type: "default",
+          duration: 3000,
+        })
+        onBack()
+      }
+    }
+    void initDraft()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const schema = useMemo(
     () => buildApplyAnswersSchema(sections, sectionEnabled),
@@ -115,6 +197,7 @@ export function ProjectApplyModal({
   const {
     control,
     handleSubmit,
+    getValues,
     clearErrors,
     formState: { isDirty },
   } = useForm<Record<string, ApplyAnswerValue>>({
@@ -122,9 +205,6 @@ export function ProjectApplyModal({
     mode: "onChange",
     defaultValues,
   })
-
-  const [isLeaveModalOpen, setIsLeaveModalOpen] = useState(false)
-  const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false)
 
   useEffect(() => {
     clearErrors()
@@ -143,6 +223,17 @@ export function ProjectApplyModal({
     return map
   }, [sections, sectionEnabled])
 
+  async function handleLeaveConfirm() {
+    try {
+      const answers = buildAnswerPayload(getValues(), sections)
+      await saveApplicationDraft(projectId, answers)
+    } catch {
+      // 임시저장 실패 시에도 이탈은 허용
+    }
+    setIsLeaveModalOpen(false)
+    onBack()
+  }
+
   function handleBackClick() {
     if (isDirty) {
       setIsLeaveModalOpen(true)
@@ -151,9 +242,24 @@ export function ProjectApplyModal({
     }
   }
 
-  function onValid(data: Record<string, ApplyAnswerValue>) {
-    onSubmit(data)
-    setIsCompleteModalOpen(true)
+  async function onValid(formValues: Record<string, ApplyAnswerValue>) {
+    setIsSubmitting(true)
+    try {
+      const answers = buildAnswerPayload(formValues, sections)
+      await saveApplicationDraft(projectId, answers)
+      await submitApplication(projectId)
+      setIsCompleteModalOpen(true)
+    } catch {
+      addToast({
+        message: "지원서 제출에 실패했습니다. 다시 시도해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
   }
 
   function onInvalid(errs: FieldErrors<Record<string, ApplyAnswerValue>>) {
@@ -382,11 +488,13 @@ export function ProjectApplyModal({
               color="neutral"
               size="xl"
               onClick={handleBackClick}
+              disabled={isSubmitting}
             >
               돌아가기
             </Button>
             <Button
               size="xl"
+              disabled={isSubmitting}
               onClick={() => {
                 void handleSubmit(onValid, onInvalid)()
               }}
@@ -411,7 +519,7 @@ export function ProjectApplyModal({
               <Modal.Description className="text-subtitle-3-semibold text-teal-gray-800">
                 작성 중인 지원서가 있습니다.
                 <br />
-                나가시겠습니까?
+                임시저장 후 나가시겠습니까?
               </Modal.Description>
             </div>
             <div className="flex justify-end gap-3">
@@ -423,8 +531,8 @@ export function ProjectApplyModal({
               >
                 돌아가기
               </Button>
-              <Button size="s" onClick={onBack}>
-                나가기
+              <Button size="s" onClick={() => void handleLeaveConfirm()}>
+                임시저장 후 나가기
               </Button>
             </div>
           </Modal.Content>
@@ -450,7 +558,7 @@ export function ProjectApplyModal({
               </Modal.Description>
             </div>
             <div className="flex justify-end">
-              <Button size="s" onClick={onBack}>
+              <Button size="s" onClick={onSubmitSuccess}>
                 확인
               </Button>
             </div>

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -241,6 +241,7 @@ export function ProjectApplyModal({
   )
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isPortfolioUploading, setIsPortfolioUploading] = useState(false)
+  const portfolioUploadTokenRef = useRef(0)
   const [isLeaveModalOpen, setIsLeaveModalOpen] = useState(false)
   const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false)
   const [isSubmitConfirmModalOpen, setIsSubmitConfirmModalOpen] =
@@ -489,23 +490,27 @@ export function ProjectApplyModal({
             value={fieldValue}
             onChange={(val: PortfolioValue | null) => {
               if (val == null) {
+                portfolioUploadTokenRef.current++
                 onChange(null)
                 return
               }
               if (val.kind === "link") {
+                portfolioUploadTokenRef.current++
                 onChange({ kind: "link", url: val.url })
                 return
               }
               if (val.file) {
+                const token = ++portfolioUploadTokenRef.current
                 setIsPortfolioUploading(true)
                 void uploadPortfolioFile(val.file)
-                  .then((uploaded) =>
+                  .then((uploaded) => {
+                    if (token !== portfolioUploadTokenRef.current) return
                     onChange({
                       kind: "file",
                       fileId: uploaded.fileId,
                       fileName: uploaded.fileName,
-                    }),
-                  )
+                    })
+                  })
                   .catch((err) =>
                     addToast({
                       message: extractUploadErrorMessage(
@@ -519,7 +524,11 @@ export function ProjectApplyModal({
                       duration: 3000,
                     }),
                   )
-                  .finally(() => setIsPortfolioUploading(false))
+                  .finally(() => {
+                    if (token === portfolioUploadTokenRef.current) {
+                      setIsPortfolioUploading(false)
+                    }
+                  })
               }
             }}
             error={error}

--- a/src/features/project/list/ui/apply-modal/RecruitQuestionsViewModal.tsx
+++ b/src/features/project/list/ui/apply-modal/RecruitQuestionsViewModal.tsx
@@ -5,13 +5,13 @@ import { FormHeader } from "@/shared/ui/FormHeader"
 import { CheckboxList } from "@/shared/ui/input/checkbox/CheckboxList"
 import { RadioList } from "@/shared/ui/input/radio/RadioList"
 import MemberCount from "@/shared/ui/MemberCount"
-import { ProjectTitleCard } from "@/shared/ui/ProjectTitleCard"
 import { FileUploadField } from "@/shared/ui/question-field/FileUploadField"
 import { PortfolioField } from "@/shared/ui/question-field/PortfolioField"
 import { QuestionItemTitle } from "@/shared/ui/question-field/QuestionItemTitle"
 import { TextQuestionField } from "@/shared/ui/question-field/TextQuestionField"
 
 import { isRecruitDone } from "../../model/matchingProject"
+import { ApplyProjectTitleCard } from "./ApplyProjectTitleCard"
 
 import type {
   Question,
@@ -46,15 +46,14 @@ export function RecruitQuestionsViewModal({
   }, [sections])
 
   return (
-    <div className="flex w-232 flex-col">
+    <div className="w-232 flex-col">
       <div className="flex w-full">
-        <ProjectTitleCard
-          size="sm"
+        <ApplyProjectTitleCard
           projectName={data.title}
           subtitle={data.authorSchoolLine}
         />
       </div>
-      <div className="flex w-full flex-col rounded-b-2xl bg-white">
+      <div className="shadow-drop-neutral-3 flex w-full flex-col rounded-2xl bg-white">
         <div className="scrollbar-none max-h-[75vh] overflow-y-auto px-11.5 py-9">
           <div className="flex items-start gap-6 self-stretch px-1 py-5">
             <p className="text-body-1-regular text-teal-gray-600 flex-1">

--- a/src/features/project/list/ui/apply-modal/RecruitQuestionsViewModal.tsx
+++ b/src/features/project/list/ui/apply-modal/RecruitQuestionsViewModal.tsx
@@ -46,7 +46,7 @@ export function RecruitQuestionsViewModal({
   }, [sections])
 
   return (
-    <div className="w-232 flex-col">
+    <div className="flex w-232 flex-col">
       <div className="flex w-full">
         <ApplyProjectTitleCard
           projectName={data.title}

--- a/src/features/project/new/api/adapters.ts
+++ b/src/features/project/new/api/adapters.ts
@@ -121,7 +121,9 @@ export function mapApplicationFormToSections(
             fieldType: API_FIELD_TYPE_TO_UI[apiQ.type],
             required: apiQ.isRequired ?? false,
             options: sortedOptions.map((o) => o.content),
-            optionIds: sortedOptions.map((o) => o.optionId ?? 0),
+            optionIds: sortedOptions
+              .map((o) => o.optionId)
+              .filter((id): id is number => id != null),
           }
         })
 

--- a/src/features/project/new/api/adapters.ts
+++ b/src/features/project/new/api/adapters.ts
@@ -110,17 +110,20 @@ export function mapApplicationFormToSections(
       const questions: Question[] = apiSection.questions
         .slice()
         .sort((a, b) => (a.orderNo ?? 0) - (b.orderNo ?? 0))
-        .map((apiQ) => ({
-          id: String(apiQ.questionId),
-          title: apiQ.title,
-          caption: apiQ.description ?? "",
-          fieldType: API_FIELD_TYPE_TO_UI[apiQ.type],
-          required: apiQ.isRequired ?? false,
-          options: apiQ.options
+        .map((apiQ) => {
+          const sortedOptions = apiQ.options
             .slice()
             .sort((a, b) => (a.orderNo ?? 0) - (b.orderNo ?? 0))
-            .map((o) => o.content),
-        }))
+          return {
+            id: String(apiQ.questionId),
+            title: apiQ.title,
+            caption: apiQ.description ?? "",
+            fieldType: API_FIELD_TYPE_TO_UI[apiQ.type],
+            required: apiQ.isRequired ?? false,
+            options: sortedOptions.map((o) => o.content),
+            optionIds: sortedOptions.map((o) => o.optionId ?? 0),
+          }
+        })
 
       return {
         id,

--- a/src/features/project/new/model/applicationQuestion.ts
+++ b/src/features/project/new/model/applicationQuestion.ts
@@ -7,6 +7,7 @@ export interface Question {
   fieldType: FieldType
   required: boolean
   options: string[]
+  optionIds?: number[]
 }
 
 export interface Section {

--- a/src/shared/ui/question-field/PortfolioField.tsx
+++ b/src/shared/ui/question-field/PortfolioField.tsx
@@ -8,7 +8,7 @@ const MAX_FILE_BYTES = 150 * 1024 * 1024
 
 export type PortfolioValue =
   | { kind: "link"; url: string }
-  | { kind: "file"; name: string; file: File }
+  | { kind: "file"; name: string; file?: File }
 
 function isValidUrl(value: string): boolean {
   try {

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -186,10 +186,10 @@
 }
 
 @utility text-display-2-medium {
-  font-size: var(--text-display-2-medium-size);
-  font-weight: var(--text-display-2-medium-weight);
-  line-height: var(--text-display-2-medium-leading);
-  letter-spacing: var(--text-display-2-medium-tracking);
+  font-size: var(--text-display-medium-2-size);
+  font-weight: var(--text-display-medium-2-weight);
+  line-height: var(--text-display-medium-2-leading);
+  letter-spacing: var(--text-display-medium-2-tracking);
 }
 
 @utility text-heading-1-bold {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,4 +21,13 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  server: {
+    proxy: {
+      "/api": {
+        target: "https://dev.api.umc.it.kr",
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
 })


### PR DESCRIPTION
## 📸 작업 내용

> 챌린저(지원자)가 매칭 프로젝트에 지원하는 전체 플로우를 구현합니다.

- 프로젝트 상세 카드에서 지원 CTA 버튼 동작 구현 (지원하기 / 내 지원서 확인하기 / 차단 상태)
- 지원 모달: 지원 양식 렌더링, 파일/포트폴리오 업로드, 최종 제출 확인
- 내 지원서 확인 모달: 제출된 답변 열람, 지원 취소 기능
- 이미 다른 프로젝트에 지원한 경우 / 합격자인 경우 지원 차단 처리

## 🎞️ 주요 코드 설명

### 지원 CTA 모드 분기 (`projectDetailCta.ts`)

```TypeScript
export function resolveProjectDetailCtaMode({
  isApplied,
  hasOtherActiveApplication,
  isAlreadyApproved,
  ...
}: ResolveCtaParams): ProjectDetailCtaMode {
  if (isApplied) return "my-application"
  if (isAlreadyApproved) return "apply-blocked-approved"
  if (hasOtherActiveApplication) return "apply-blocked-other"
  return "apply"
}
```

- 비즈니스 룰(차수당 1회 지원, 합격자 추가 지원 차단)을 순수 함수로 분리
- `apply-blocked-other` / `apply-blocked-approved` 모드: "모집 문항 보기"(활성) + "지원하기"(비활성) 표시

### 매칭 차수 ID 타입 수정 (`matchingProject.ts`)

```TypeScript
export type ActiveMatchingRound = {
  id: number | string  // API 응답이 문자열로 올 수 있어 union 타입 처리
  chapterId: number | string
  ...
}
```

- API가 `id: "2"` 형태의 문자열을 반환하는 경우 대응
- 비교 시 `Number()` 변환으로 통일

### 포트폴리오 파일 업로드 race condition 방지 (`ProjectApplyModal.tsx`)

```TypeScript
const [isPortfolioUploading, setIsPortfolioUploading] = useState(false)

// 업로드 시작 시 플래그 on, 완료/실패 시 off
setIsPortfolioUploading(true)
void uploadPortfolioFile(val.file)
  .then(...)
  .finally(() => setIsPortfolioUploading(false))

// 제출 버튼
disabled={isSubmitting || isPortfolioUploading}
```

- 파일 선택 후 업로드 완료 전 제출 시 `fileId` 없이 제출되는 문제 방지

### 사다리꼴 타이틀 헤더 (`ApplyProjectTitleCard.tsx`)

```TypeScript
const TRAPEZOID_CLIP_PATH = [
  "polygon(",
  "12px 0,",
  "calc(100% - 63px) 0,",   // top edge
  // 원호 근사 (r=12, 중심 (W-63.1, 12)) — 올바른 접선 기반 계산
  "calc(100% - 61px) 0.2px,",
  "calc(100% - 59px) 0.6px,",
  "calc(100% - 57.5px) 1.4px,",
  "calc(100% - 56px) 2.4px,",
  "calc(100% - 54.5px) 3.7px,",
  "100% 100%,",
  ...
).join(" ")
```

- `clip-path: polygon()`으로 사다리꼴 형태 구현
- 우측 상단 코너: 수평 → 사선 전환 지점의 접선 기반 원호 근사(r=12px)로 매끄럽게 처리
- 좌측 상단 코너: 동일한 r=12 원호 근사

## 🖥️ 구현화면

> 스크린샷은 PR 리뷰 시 첨부 예정입니다.

|           지원하기 모달            |           내 지원서 확인 모달            |
| :-------------------------: | :-------------------------: |
| <img src="" width="250"> | <img src="" width="250"> |

## 🔗 연결된 이슈

- Closes #155
- Closes #156
- Closes #157
- Closes #158
- Closes #159

## 💬 기타 더 이야기해볼 점

- 백엔드 이슈: 지원 취소 후 재지원 시 `SURVEY-0027` 에러 반환 (폼 응답이 SUBMITTED 상태로 남음). 백엔드 수정 필요.
- `isSameBranch` 로직이 현재 `!userIsOperator`로 단순화되어 있어, 지부 비교 로직 추가 시 별도 작업 필요.