### PR TITLE
feat: 프로젝트 기획안 링크 등록 및 기획 보기 연동

### DIFF
--- a/src/features/project/list/model/matchingProject.mock.ts
+++ b/src/features/project/list/model/matchingProject.mock.ts
@@ -62,7 +62,6 @@ function buildBulkMatchingMocks(
       title: `데모 프로젝트 ${n}`,
       description: `${school} · ${branch} 지부 연합 데모 목 데이터입니다.`,
       authorSchoolLine: `닉네임/이름 · ${school}`,
-      externalLink: "https://issac.app",
       coverImage:
         n % 3 !== 0
           ? {
@@ -85,6 +84,7 @@ const RAW_MOCK_PROJECTS: MatchingProjectMock[] = [
     description:
       "프로젝트 한 줄 소개가 여기에 표시됩니다. 초과 내용 ... 처리 없이 설명 전문이 표시됩니다. 본문 내용 공백 포함 200자 이내 약 4줄 표시됩니다. 프로젝트 한 줄 소개가 여기에 표시됩니다. 초과 내용 ... 처리 없이 설명 전문이 표시됩니다. 본문 내용 공백 포함 200자 이내 약 4줄 표시됩니다. 프로젝트 한줄 소개가 여기에 표시됩니다. 초과 내용 ... 처리 없이 설명 전문이 표시됩",
     authorSchoolLine: "닉네임/이름 · 한양대 ERICA",
+    externalLink: "https://issac.app",
     coverImage: {
       src: "https://picsum.photos/seed/umc-matching-1/696/368",
       alt: "프로젝트 대표 이미지",
@@ -332,11 +332,7 @@ const RAW_MOCK_PROJECTS: MatchingProjectMock[] = [
 ]
 
 /** 목록 그리드, 카드에서 동일하게 사용하는 목 데이터 리스트 */
-export const MOCK_MATCHING_PROJECTS: MatchingProjectMock[] =
-  RAW_MOCK_PROJECTS.map((p) => ({
-    ...p,
-    externalLink: p.externalLink ?? "https://issac.app",
-  }))
+export const MOCK_MATCHING_PROJECTS: MatchingProjectMock[] = RAW_MOCK_PROJECTS
 
 /** 카드 단독 사용 시 기본값 */
 export const DEFAULT_MATCHING_PROJECT_MOCK = MOCK_MATCHING_PROJECTS[0]! // Selenium (임시 지부로 설정)

--- a/src/features/project/list/model/matchingProject.mock.ts
+++ b/src/features/project/list/model/matchingProject.mock.ts
@@ -62,6 +62,7 @@ function buildBulkMatchingMocks(
       title: `데모 프로젝트 ${n}`,
       description: `${school} · ${branch} 지부 연합 데모 목 데이터입니다.`,
       authorSchoolLine: `닉네임/이름 · ${school}`,
+      externalLink: "https://issac.app",
       coverImage:
         n % 3 !== 0
           ? {
@@ -75,8 +76,7 @@ function buildBulkMatchingMocks(
   return projects
 }
 
-/** 목록 그리드, 카드에서 동일하게 사용하는 목 데이터 리스트 */
-export const MOCK_MATCHING_PROJECTS: MatchingProjectMock[] = [
+const RAW_MOCK_PROJECTS: MatchingProjectMock[] = [
   {
     id: "mock-matching-1",
     branch: "Selenium",
@@ -330,6 +330,13 @@ export const MOCK_MATCHING_PROJECTS: MatchingProjectMock[] = [
   },
   ...buildBulkMatchingMocks(16, 45),
 ]
+
+/** 목록 그리드, 카드에서 동일하게 사용하는 목 데이터 리스트 */
+export const MOCK_MATCHING_PROJECTS: MatchingProjectMock[] =
+  RAW_MOCK_PROJECTS.map((p) => ({
+    ...p,
+    externalLink: p.externalLink ?? "https://issac.app",
+  }))
 
 /** 카드 단독 사용 시 기본값 */
 export const DEFAULT_MATCHING_PROJECT_MOCK = MOCK_MATCHING_PROJECTS[0]! // Selenium (임시 지부로 설정)

--- a/src/features/project/list/model/matchingProject.ts
+++ b/src/features/project/list/model/matchingProject.ts
@@ -27,4 +27,5 @@ export type MatchingProject = {
   recruitRows: ProjectRecruitRow[]
   partQuotaStatus?: PartQuotaStatus
   isApplied?: boolean
+  externalLink?: string | null
 }

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -111,6 +111,7 @@ function toMatchingProject(detail: ProjectDetail): MatchingProject {
       total: q.quota,
       done: q.status === "COMPLETED",
     })),
+    externalLink: detail.externalLink,
   }
 }
 
@@ -372,11 +373,11 @@ export function ProjectDetailCard({
               variant="weak"
               color="primary"
               className="flex-1"
-              disabled={!detail?.externalLink}
+              disabled={!data.externalLink}
               onClick={() => {
-                if (detail?.externalLink)
+                if (data.externalLink)
                   window.open(
-                    detail.externalLink,
+                    data.externalLink,
                     "_blank",
                     "noopener,noreferrer",
                   )

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -77,11 +77,17 @@ export function ProjectManagementMoreMenu({
 
   const handlePlanViewClick = async () => {
     setPopoverOpen(false)
+    const newWindow = window.open(
+      "about:blank",
+      "_blank",
+      "noopener,noreferrer",
+    )
     try {
       const detail = await getProjectDetail(Number(projectId))
       if (detail.externalLink) {
-        window.open(detail.externalLink, "_blank", "noopener,noreferrer")
+        if (newWindow) newWindow.location.href = detail.externalLink
       } else {
+        if (newWindow) newWindow.close()
         addToast({
           message: "등록된 기획안 링크가 없습니다.",
           color: "red",
@@ -91,6 +97,7 @@ export function ProjectManagementMoreMenu({
         })
       }
     } catch {
+      if (newWindow) newWindow.close()
       addToast({
         message: "기획 보기를 불러오는 데 실패했습니다.",
         color: "red",

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -5,6 +5,7 @@ import { useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
 import { ApplicationDetailModal } from "@/features/application/ui/ApplicationDetailModal"
+import { getProjectDetail } from "@/features/project/list/api/matchingProject"
 import { deleteProject } from "@/features/project/management/api"
 import MoreVerticalIcon from "@/shared/assets/icon/more/MoreVerticalIcon"
 import { DropdownItem } from "@/shared/ui/dropdown/DropdownItem"
@@ -74,9 +75,35 @@ export function ProjectManagementMoreMenu({
     })
   }
 
+  const handlePlanViewClick = async () => {
+    setPopoverOpen(false)
+    try {
+      const detail = await getProjectDetail(Number(projectId))
+      if (detail.externalLink) {
+        window.open(detail.externalLink, "_blank", "noopener,noreferrer")
+      } else {
+        addToast({
+          message: "등록된 기획안 링크가 없습니다.",
+          color: "red",
+          variant: "deep",
+          type: "default",
+          duration: 3000,
+        })
+      }
+    } catch {
+      addToast({
+        message: "기획 보기를 불러오는 데 실패했습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    }
+  }
+
   const MENU_ITEMS = [
     { label: "지원 현황 확인하기", onClick: handleApplicationClick },
-    { label: "기획 보기", onClick: () => {} },
+    { label: "기획 보기", onClick: () => void handlePlanViewClick() },
     { label: "프로젝트 수정하기", onClick: handleEditClick },
     { label: "팀원 구성 보기", onClick: () => {} },
   ]

--- a/src/features/project/new/api/storage.ts
+++ b/src/features/project/new/api/storage.ts
@@ -43,7 +43,7 @@ export async function confirmUpload(fileId: string): Promise<void> {
 export async function uploadFileFlow(
   file: File,
   category: UploadCategory,
-): Promise<{ fileId: string }> {
+): Promise<{ fileId: string; downloadUrl: string }> {
   const prepared = await prepareUpload({
     fileName: file.name,
     contentType: file.type,
@@ -62,5 +62,8 @@ export async function uploadFileFlow(
     file,
   )
   await confirmUpload(prepared.fileId)
-  return { fileId: prepared.fileId }
+  return {
+    fileId: prepared.fileId,
+    downloadUrl: prepared.uploadUrl.split("?")[0] ?? prepared.uploadUrl,
+  }
 }

--- a/src/features/project/new/model/basicInfoSchema.ts
+++ b/src/features/project/new/model/basicInfoSchema.ts
@@ -33,9 +33,12 @@ export const basicInfoSchema = z.object({
     .string()
     .refine(
       (v) => {
-        if (!v.trim()) return true
+        const trimmed = v.trim()
+        if (!trimmed) return true
         try {
-          const normalized = /^https?:\/\//i.test(v) ? v : `https://${v}`
+          const normalized = /^https?:\/\//i.test(trimmed)
+            ? trimmed
+            : `https://${trimmed}`
           new URL(normalized)
           return true
         } catch {

--- a/src/features/project/new/model/basicInfoSchema.ts
+++ b/src/features/project/new/model/basicInfoSchema.ts
@@ -29,6 +29,22 @@ export const basicInfoSchema = z.object({
       }
     })
     .optional(),
+  externalLink: z
+    .string()
+    .refine(
+      (v) => {
+        if (!v.trim()) return true
+        try {
+          const normalized = /^https?:\/\//i.test(v) ? v : `https://${v}`
+          new URL(normalized)
+          return true
+        } catch {
+          return false
+        }
+      },
+      { message: "올바른 URL을 입력해 주세요." },
+    )
+    .optional(),
 })
 
 export type BasicInfoFormData = z.infer<typeof basicInfoSchema>

--- a/src/features/project/new/model/draftHydrator.ts
+++ b/src/features/project/new/model/draftHydrator.ts
@@ -23,6 +23,7 @@ export function hydrateDraftIntoStore(draft: DraftProjectResponse): void {
   store.setBasicDraftFields({
     title: draft.name ?? "",
     description: draft.description ?? "",
+    externalLink: draft.externalLink ?? "",
   })
 
   store.setUploaded({

--- a/src/features/project/new/model/projectDetailHydrator.ts
+++ b/src/features/project/new/model/projectDetailHydrator.ts
@@ -36,6 +36,7 @@ export function hydrateProjectDetailIntoStore(
   store.setBasicDraftFields({
     title: detail.name ?? "",
     description: detail.description ?? "",
+    externalLink: detail.externalLink ?? "",
   })
 
   store.setUploaded({

--- a/src/features/project/new/model/useProjectRegisterStore.ts
+++ b/src/features/project/new/model/useProjectRegisterStore.ts
@@ -29,6 +29,7 @@ interface UploadedFileIds {
 interface BasicDraftFields {
   title: string
   description: string
+  externalLink: string
 }
 
 interface ProjectRegisterState {

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -27,6 +27,7 @@ import InfoCircleIcon from "@/shared/assets/icon/infomation/InfoCircleIcon"
 import { formatSchoolName } from "@/shared/lib/formatSchoolName"
 import { Button } from "@/shared/ui/Button"
 import { ImageUploader } from "@/shared/ui/ImageUploader"
+import { InputBox } from "@/shared/ui/input/InputBox"
 
 import {
   type BasicInfoFormData,
@@ -131,6 +132,14 @@ export const BasicInfoForm = forwardRef<
   const thumbnailRef = useRef<HTMLButtonElement>(null)
   const logoRef = useRef<HTMLButtonElement>(null)
 
+  const normalizeExternalLink = (
+    url: string | undefined,
+  ): string | undefined => {
+    if (!url?.trim()) return undefined
+    const trimmed = url.trim()
+    return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`
+  }
+
   const {
     register,
     handleSubmit,
@@ -213,10 +222,12 @@ export const BasicInfoForm = forwardRef<
 
   useEffect(() => {
     if (!basicDraftFields) return
-    const { title, description } = basicDraftFields
+    const { title, description, externalLink } = basicDraftFields
     if (title) setValue("title", title, { shouldDirty: false })
     if (description)
       setValue("description", description, { shouldDirty: false })
+    if (externalLink)
+      setValue("externalLink", externalLink, { shouldDirty: false })
   }, [basicDraftFields, setValue])
 
   useEffect(() => {
@@ -315,6 +326,7 @@ export const BasicInfoForm = forwardRef<
         description: values.description,
         thumbnailFileId: thumbnailFileId ?? undefined,
         logoFileId: logoFileId ?? undefined,
+        externalLink: normalizeExternalLink(values.externalLink),
       })
 
       const prevPm2Id = savedSnapshot?.pm2?.id
@@ -494,6 +506,28 @@ export const BasicInfoForm = forwardRef<
             setValue("logo", file, { shouldDirty: true, shouldValidate: true })
             setUploaded({ logoFileId: null, logoUrl: null })
           }}
+        />
+      </div>
+      <div className="flex flex-col gap-4">
+        <SectionHeader index={3} title="프로젝트 기획안" />
+        <InputBox
+          value={watch("externalLink") ?? ""}
+          onChange={(e) => {
+            setValue("externalLink", e.target.value, {
+              shouldDirty: true,
+              shouldValidate: true,
+            })
+          }}
+          type="clear"
+          onClear={() => {
+            setValue("externalLink", "", {
+              shouldDirty: true,
+              shouldValidate: true,
+            })
+          }}
+          state={errors.externalLink ? "error" : "default"}
+          placeholder="Notion, Figma 등 기획안 링크를 첨부하세요."
+          className="w-full"
         />
       </div>
       <div className="flex justify-between">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
   server: {
     proxy: {
       "/api": {
-        target: "https://dev.api.umc.it.kr",
+        target: "https://dev.api.university.neordinary.com",
         changeOrigin: true,
         secure: false,
       },


### PR DESCRIPTION
## 📸 작업 내용

- 프로젝트 등록 1단계 '기본 정보 입력'에 Section 03 **프로젝트 기획안** URL 입력 필드 추가
- `externalLink` 필드를 `basicInfoSchema`, store, draft/detail hydrator, API 요청 바디에 반영
- 입력값 저장 시 `https://` prefix 자동 추가 (`normalizeExternalLink`)
- 프로젝트 목록 카드 상세 모달의 '기획 보기' 버튼을 서버 `externalLink` 기반으로 활성화
- 운영 메뉴 '기획 보기' 클릭 시 lazy fetch로 링크 열기 (`ProjectManagementMoreMenu`)
- dev API 도메인을 `university.neordinary.com`으로 변경 (`vite.config.ts`)

## 🎞️ 주요 코드 설명

**`normalizeExternalLink`** — `https://` 없이 입력해도 저장 시 자동으로 prefix를 붙여주는 유틸 함수. `basicInfoSchema`의 transform과 save 시점 양쪽에서 적용.

**`ProjectManagementMoreMenu` lazy fetch** — 운영 메뉴에서 '기획 보기' 클릭 시 프로젝트 상세를 lazy하게 fetch하여 `externalLink`를 가져와 새 탭으로 오픈. 목록 로드 시점에 불필요한 API 호출 방지.

**`ProjectDetailCard` `toMatchingProject`** — 서버 응답의 `externalLink`를 `MatchingProject` 타입에 매핑. 버튼 disabled 조건을 `!data.externalLink`로 판단.

## 🖥️ 구현화면

**프로젝트 등록 1단계 — 기본 정보 입력 (Section 03 기획안 링크)**

<!-- 아래에 project-register-basic-info.png 업로드 -->

**프로젝트 목록 카드 — 기획 보기 버튼 활성화**

<!-- 아래에 plan-button-active.png 업로드 -->

## 🔗 연결된 이슈

Closes #164