### PR TITLE
fix: 지원 모달 스켈레톤 타이틀 카드를 ApplyProjectTitleCard와 동기화

### DIFF
--- a/src/features/project/list/ui/apply-modal/ApplyFormSkeleton.tsx
+++ b/src/features/project/list/ui/apply-modal/ApplyFormSkeleton.tsx
@@ -23,7 +23,7 @@ export function ApplyFormSkeleton() {
     <div className="flex w-232 flex-col">
       <div className="flex w-full translate-y-3.5 items-end">
         <div
-          className="flex h-15 w-fit max-w-[calc(100%-1rem)] min-w-69.5 shrink-0 items-center gap-3.5 bg-teal-100 bg-linear-to-r py-2.5 pr-14 pl-4"
+          className="flex h-15 w-fit max-w-[calc(100%-1rem)] min-w-69.5 shrink-0 items-center gap-3.5 bg-teal-100 py-2.5 pr-14 pl-4"
           style={{ clipPath: TRAPEZOID_CLIP_PATH }}
         >
           <div className="bg-teal-gray-200 size-8 shrink-0 animate-pulse rounded-lg" />

--- a/src/features/project/list/ui/apply-modal/ApplyFormSkeleton.tsx
+++ b/src/features/project/list/ui/apply-modal/ApplyFormSkeleton.tsx
@@ -1,15 +1,41 @@
+const TRAPEZOID_CLIP_PATH = [
+  "polygon(",
+  "12px 0,",
+  "calc(100% - 63px) 0,",
+  "calc(100% - 61px) 0.2px,",
+  "calc(100% - 59px) 0.6px,",
+  "calc(100% - 57.5px) 1.4px,",
+  "calc(100% - 56px) 2.4px,",
+  "calc(100% - 54.5px) 3.7px,",
+  "100% 100%,",
+  "0 100%,",
+  "0 12px,",
+  "0.5px 9px,",
+  "1.5px 6px,",
+  "3.5px 3.5px,",
+  "6px 1.5px,",
+  "9px 0.5px",
+  ")",
+].join(" ")
+
 export function ApplyFormSkeleton() {
   return (
     <div className="flex w-232 flex-col">
-      <div className="flex w-full items-end">
-        <div className="clip-trapezoid-sm flex h-15 w-69.5 items-center gap-3.5 bg-teal-100 py-2.5 pr-14 pl-4">
+      <div
+        className="flex w-full items-end"
+        style={{ transform: "translateY(14px)" }}
+      >
+        <div
+          className="flex h-15 w-fit max-w-[calc(100%-1rem)] min-w-69.5 shrink-0 items-center gap-3.5 bg-teal-100 bg-linear-to-r py-2.5 pr-14 pl-4"
+          style={{ clipPath: TRAPEZOID_CLIP_PATH }}
+        >
           <div className="bg-teal-gray-200 size-8 shrink-0 animate-pulse rounded-lg" />
           <div className="flex flex-col gap-1.5">
             <div className="bg-teal-gray-200 h-3 w-40 animate-pulse rounded" />
             <div className="bg-teal-gray-200 h-2.5 w-28 animate-pulse rounded" />
           </div>
         </div>
-        <div className="-ml-1.5 h-1.75 flex-1 rounded-tr-xl bg-teal-100" />
+        <div className="-ml-14 h-3.5 flex-1 rounded-tr-xl bg-teal-100" />
       </div>
 
       <div className="shadow-drop-neutral-3 flex w-full flex-col rounded-2xl bg-white">

--- a/src/features/project/list/ui/apply-modal/ApplyFormSkeleton.tsx
+++ b/src/features/project/list/ui/apply-modal/ApplyFormSkeleton.tsx
@@ -1,22 +1,4 @@
-const TRAPEZOID_CLIP_PATH = [
-  "polygon(",
-  "12px 0,",
-  "calc(100% - 63px) 0,",
-  "calc(100% - 61px) 0.2px,",
-  "calc(100% - 59px) 0.6px,",
-  "calc(100% - 57.5px) 1.4px,",
-  "calc(100% - 56px) 2.4px,",
-  "calc(100% - 54.5px) 3.7px,",
-  "100% 100%,",
-  "0 100%,",
-  "0 12px,",
-  "0.5px 9px,",
-  "1.5px 6px,",
-  "3.5px 3.5px,",
-  "6px 1.5px,",
-  "9px 0.5px",
-  ")",
-].join(" ")
+import { TRAPEZOID_CLIP_PATH } from "./ApplyProjectTitleCard"
 
 export function ApplyFormSkeleton() {
   return (

--- a/src/features/project/list/ui/apply-modal/ApplyFormSkeleton.tsx
+++ b/src/features/project/list/ui/apply-modal/ApplyFormSkeleton.tsx
@@ -21,10 +21,7 @@ const TRAPEZOID_CLIP_PATH = [
 export function ApplyFormSkeleton() {
   return (
     <div className="flex w-232 flex-col">
-      <div
-        className="flex w-full items-end"
-        style={{ transform: "translateY(14px)" }}
-      >
+      <div className="flex w-full translate-y-3.5 items-end">
         <div
           className="flex h-15 w-fit max-w-[calc(100%-1rem)] min-w-69.5 shrink-0 items-center gap-3.5 bg-teal-100 bg-linear-to-r py-2.5 pr-14 pl-4"
           style={{ clipPath: TRAPEZOID_CLIP_PATH }}

--- a/src/features/project/list/ui/apply-modal/ApplyProjectTitleCard.tsx
+++ b/src/features/project/list/ui/apply-modal/ApplyProjectTitleCard.tsx
@@ -8,7 +8,7 @@ interface ApplyProjectTitleCardProps {
   className?: string
 }
 
-const TRAPEZOID_CLIP_PATH = [
+export const TRAPEZOID_CLIP_PATH = [
   "polygon(",
   "12px 0,",
   "calc(100% - 63px) 0,",


### PR DESCRIPTION
## 📸 작업 내용

`ApplyFormSkeleton`의 타이틀 카드 영역이 실제 `ApplyProjectTitleCard` 컴포넌트와 불일치하던 문제를 수정합니다.

- `clip-trapezoid-sm` Tailwind 클래스 → `ApplyProjectTitleCard`와 동일한 `TRAPEZOID_CLIP_PATH` inline style로 교체
- `translateY(14px)` transform 추가 — 실제 컴포넌트와 동일하게 탭이 흰 카드 영역으로 14px 내려와 겹치도록
- 타이틀 카드 너비 `w-69.5` → `w-fit max-w-[calc(100%-1rem)] min-w-69.5` (유동 폭)
- 트레일링 바 `-ml-1.5 h-1.75` → `-ml-14 h-3.5` (실제 컴포넌트와 일치)

## 🎞️ 주요 코드 설명

### TRAPEZOID_CLIP_PATH 동기화

```TypeScript
const TRAPEZOID_CLIP_PATH = [
  "polygon(",
  "12px 0,",
  "calc(100% - 63px) 0,",
  // ...
].join(" ")

// 기존: clip-trapezoid-sm 클래스 (정의 불일치 위험)
// 변경: ApplyProjectTitleCard와 동일한 inline clipPath
<div style={{ clipPath: TRAPEZOID_CLIP_PATH }} ... />
```

### translateY(14px) 추가

```TypeScript
// 기존: transform 없음 → 탭이 흰 카드와 분리됨
// 변경: 실제 ApplyProjectTitleCard와 동일한 14px 오프셋
<div
  className="flex w-full items-end"
  style={{ transform: "translateY(14px)" }}
>
```

## 🖥️ 구현화면


> 스켈레톤 타이틀 카드가 실제 `ApplyProjectTitleCard`의 레이아웃과 동일하게 렌더링됩니다.

## 🔗 연결된 이슈

- Connected: #165