### PR TITLE
♻️ refactor: 매칭 메인 영역 컨테이너 간격·테두리·패딩 일관성 통일

### DIFF
--- a/src/features/notice/ui/NoticePublishForm.tsx
+++ b/src/features/notice/ui/NoticePublishForm.tsx
@@ -258,8 +258,8 @@ export function NoticePublishForm({
 
   return (
     <>
-      <section className="w-full pt-8">
-        <div className="border-teal-gray-100 flex w-full flex-col items-center rounded-[12px] border bg-white px-8.5 py-8">
+      <section className="w-full">
+        <div className="border-teal-gray-100 flex w-full flex-col items-center rounded-[12px] border bg-white px-8.5 pt-8 pb-10">
           <div className="flex w-full justify-start pb-2.5">
             <button
               type="button"

--- a/src/features/project/list/ui/MatchingProjectsListPage.tsx
+++ b/src/features/project/list/ui/MatchingProjectsListPage.tsx
@@ -62,7 +62,7 @@ export function MatchingProjectsListPage() {
   >(null)
 
   return (
-    <section className="relative flex w-full flex-col items-start justify-start pt-8">
+    <section className="relative flex w-full flex-col items-start justify-start">
       {openFilterId && (
         <button
           type="button"
@@ -71,7 +71,7 @@ export function MatchingProjectsListPage() {
           onClick={() => setOpenFilterId(null)}
         />
       )}
-      <div className="border-teal-gray-150 relative z-30 flex h-full w-288 flex-col gap-5 rounded-xl border bg-white px-8.5 pt-8 pb-10">
+      <div className="border-teal-gray-100 relative z-30 flex h-full w-288 flex-col gap-5 rounded-[12px] border bg-white px-8.5 pt-8 pb-10">
         <div className="flex flex-col items-start gap-1.5">
           <span className="text-heading-6-semibold text-teal-gray-900">
             프로젝트 목록

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -92,8 +92,8 @@ export function ProjectManagementPage() {
   if (!isOp && !isPm) return null
 
   return (
-    <section className="relative flex w-full flex-col items-start justify-start pt-8">
-      <div className="border-teal-gray-150 relative z-30 flex h-full min-w-242 flex-col gap-6 rounded-xl border bg-white px-8.5 py-8">
+    <section className="relative flex w-full flex-col items-start justify-start">
+      <div className="border-teal-gray-100 relative z-30 flex h-full min-w-242 flex-col gap-6 rounded-[12px] border bg-white px-8.5 pt-8 pb-10">
         <div className="flex flex-col items-start gap-1.5">
           <span className="text-heading-6-semibold text-teal-gray-900">
             프로젝트 관리

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -40,8 +40,8 @@ function MatchingApplicationsPage() {
   const pmProjectInfo = challenger.projectInfo
 
   return (
-    <section className="flex w-full flex-col pt-10">
-      <div className="border-teal-gray-100 flex w-6xl flex-col rounded-xl border bg-white px-8.5 py-8">
+    <section className="flex w-full flex-col">
+      <div className="border-teal-gray-100 flex w-6xl flex-col rounded-[12px] border bg-white px-8.5 pt-8 pb-10">
         <div className="flex flex-col gap-1.5">
           <h1 className="text-heading-6-semibold text-teal-gray-900">
             지원 현황

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -277,7 +277,7 @@ function TeamMatchingAnnouncePage() {
   }, [focusedNoticeId, navigate, notices, safePage])
 
   return (
-    <section className="w-full pt-8">
+    <section className="w-full">
       <div className="border-teal-gray-100 flex min-h-213 w-full flex-col items-center justify-between rounded-[12px] border bg-white px-8.5 pt-8 pb-10">
         <div className="flex w-full flex-col gap-6 pb-10">
           <div className="flex w-full flex-col items-start gap-1.5">

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -276,7 +276,7 @@ function ProjectSettingsAnnouncePage() {
   }, [focusedNoticeId, navigate, notices, safePage])
 
   return (
-    <section className="w-full pt-8">
+    <section className="w-full">
       <div className="border-teal-gray-100 flex min-h-213 w-full flex-col items-center justify-between rounded-[12px] border bg-white px-8.5 pt-8 pb-10">
         <div className="flex w-full flex-col gap-6 pb-10">
           <div className="flex w-full flex-col items-start gap-1.5">

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -349,8 +349,8 @@ function ProjectRegisterPage() {
   }
 
   return (
-    <section className="flex w-full flex-col items-start justify-start pt-10">
-      <div className="border-teal-gray-150 flex h-full w-242 flex-col gap-2.5 rounded-[12px] border bg-white px-8.5 py-8">
+    <section className="flex w-full flex-col items-start justify-start">
+      <div className="border-teal-gray-100 flex h-full w-242 flex-col gap-2.5 rounded-[12px] border bg-white px-8.5 pt-8 pb-10">
         <div className="flex flex-col items-start gap-1.5">
           <span className="text-heading-6-semibold text-teal-gray-900">
             프로젝트 등록

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -133,7 +133,7 @@ function MatchingRoundsPage() {
   }
 
   return (
-    <section className="flex w-full flex-col gap-6 pt-10">
+    <section className="flex w-full flex-col gap-6">
       {/* 화이트 카드 */}
       <div className="border-teal-gray-100 flex w-272.5 flex-col gap-6 rounded-xl border bg-white p-8">
         {/* 타이틀 */}
@@ -153,7 +153,7 @@ function MatchingRoundsPage() {
             items={MATCHING_TYPES.map((t) => ({ value: t, label: t }))}
             value={matchingType}
             onValueChange={(v) => setMatchingType(v as MatchingType)}
-            className="w-[734px]"
+            className="w-183.5"
             itemClassName="flex-1"
           />
 

--- a/src/routes/matching/route.tsx
+++ b/src/routes/matching/route.tsx
@@ -22,7 +22,7 @@ function MatchingLayout() {
           <div className="px-8.5 pt-14.5">
             <MatchingSegmentRegion />
           </div>
-          <div className="min-h-100vh flex min-w-0 flex-1 flex-col px-8.5 pt-8">
+          <div className="flex min-h-screen min-w-0 flex-1 flex-col px-8.5 pt-8">
             <Outlet />
           </div>
         </div>

--- a/src/routes/matching/route.tsx
+++ b/src/routes/matching/route.tsx
@@ -22,7 +22,7 @@ function MatchingLayout() {
           <div className="px-8.5 pt-14.5">
             <MatchingSegmentRegion />
           </div>
-          <div className="min-h-100vh flex min-w-0 flex-1 flex-col px-8.5">
+          <div className="min-h-100vh flex min-w-0 flex-1 flex-col px-8.5 pt-8">
             <Outlet />
           </div>
         </div>

--- a/src/routes/matching/status.tsx
+++ b/src/routes/matching/status.tsx
@@ -40,8 +40,8 @@ function MatchingStatusPage() {
   const displayStats = stats
 
   return (
-    <section className="flex w-full flex-col pt-10">
-      <div className="border-teal-gray-100 flex w-288 flex-col rounded-xl border bg-white px-8.5 py-8">
+    <section className="flex w-full flex-col">
+      <div className="border-teal-gray-100 flex w-288 flex-col rounded-[12px] border bg-white px-8.5 pt-8 pb-10">
         {/* 페이지 헤더 */}
         <div className="flex flex-col gap-1.5">
           <h1 className="text-heading-6-semibold text-teal-gray-900">


### PR DESCRIPTION
## 📸 작업 내용

> 우측 main 영역의 페이지 간 시각적 불일치를 통일하여 UX 일관성을 확보했습니다.

- 세그먼트↔컨테이너 간격을 **32px**로 통일 (레이아웃 단일 제어로 전환)
- 메인 컨테이너 border 색 `teal-gray-100` + radius `rounded-[12px]`로 통일
- 메인 컨테이너 내부 패딩을 `px-8.5 pt-8 pb-10`(팀 매칭 공지 기준)로 통일
- 차수 설정(rounds)은 캘린더+폼 2단 레이아웃이라 테두리/패딩 통일에서 예외 처리

## 🎞️ 주요 코드 설명

> 간격을 페이지마다 지정하던 방식에서, 레이아웃 Outlet 래퍼 한 곳에서 제어하도록 변경

### 레이아웃 단일 제어

```TypeScript
// src/routes/matching/route.tsx
<div className="min-h-100vh flex min-w-0 flex-1 flex-col px-8.5 pt-8">
  <Outlet />
</div>
```

- 각 페이지 `<section>`의 개별 `pt-*`를 제거해 간격 중첩을 방지하고, 신규 페이지도 자동으로 32px가 적용되도록 함

  

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요!

- Connected: #169
