### PR TITLE
task: 프로젝트 관리 페이지 개선

### DIFF
--- a/src/features/project/list/model/matchingProjectList.ts
+++ b/src/features/project/list/model/matchingProjectList.ts
@@ -77,13 +77,10 @@ export function useMatchingProjectListFilters() {
 
   const { data: gisuData } = useQuery({
     queryKey: ["gisu", "active"],
-    queryFn: async () => {
-      const res = await getActiveGisu()
-      return res.gisuId ?? null
-    },
+    queryFn: getActiveGisu,
   })
 
-  const activeGisuId = gisuData ?? undefined
+  const activeGisuId = gisuData?.gisuId ? Number(gisuData.gisuId) : undefined
 
   const userGisuId = useMemo(() => {
     const records = me?.challengerRecords

--- a/src/features/project/management/ui/ProjectManagementCard.tsx
+++ b/src/features/project/management/ui/ProjectManagementCard.tsx
@@ -9,19 +9,13 @@ import { Modal } from "@/shared/ui/Modal"
 import { isRecruitDone } from "../../list/model/matchingProject"
 import { ProjectManagementMoreMenu } from "./ProjectManagementMoreMenu"
 
-import type { ProjectApplication } from "@/features/application/model/types"
-
 import type { MatchingProject } from "../../list/model/matchingProject"
 
 interface ProjectManagementCardProps {
   data: MatchingProject
-  projectApplication: ProjectApplication
 }
 
-export function ProjectManagementCard({
-  data,
-  projectApplication,
-}: ProjectManagementCardProps) {
+export function ProjectManagementCard({ data }: ProjectManagementCardProps) {
   const cover = data.coverImage
   const [open, setOpen] = useState(false)
 
@@ -36,7 +30,7 @@ export function ProjectManagementCard({
           if (e.key === "Enter" || e.key === " ") setOpen(true)
         }}
       >
-        <div className="bg-teal-gray-200 text-teal-gray-400 flex h-[10.5625rem] w-80 shrink-0 items-center justify-center overflow-hidden rounded-[0.625rem] text-center text-sm">
+        <div className="bg-teal-gray-200 flex h-[10.5625rem] w-80 shrink-0 overflow-hidden rounded-[0.625rem]">
           {cover?.src ? (
             <img
               src={cover.src}
@@ -46,7 +40,11 @@ export function ProjectManagementCard({
               decoding="async"
             />
           ) : (
-            "프로젝트 대표 이미지 320*169"
+            <div className="text-body-2-medium text-teal-gray-400 flex h-full w-full items-center justify-center text-center">
+              프로젝트 대표 이미지
+              <br />
+              320*169
+            </div>
           )}
         </div>
 
@@ -63,7 +61,6 @@ export function ProjectManagementCard({
                 <ProjectManagementMoreMenu
                   projectId={data.id}
                   projectName={data.title}
-                  projectApplication={projectApplication}
                   chapterName={data.branch}
                 />
               </div>

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -60,7 +60,7 @@ export function ProjectManagementMoreMenu({
     const getCount = (parts: string[]): AssignmentCount => {
       let current = 0
       let total = 0
-      for (const q of detail.partQuotas) {
+      for (const q of detail.partQuotas ?? []) {
         if (parts.includes(q.part)) {
           current += q.currentCount
           total += q.quota
@@ -73,8 +73,9 @@ export function ProjectManagementMoreMenu({
       id: String(detail.id),
       projectName: detail.name,
       role: "plan" as Role,
-      challengerName: detail.productOwner.nickname || detail.productOwner.name,
-      challengerUniversity: detail.productOwner.schoolName,
+      challengerName:
+        detail.productOwner?.nickname || detail.productOwner?.name || "",
+      challengerUniversity: detail.productOwner?.schoolName || "",
       statusLabel:
         detail.partQuotaStatus === "RECRUITING" ? "모집 중" : "모집 완료",
       designCount: getCount(["DESIGN"]),

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -1,9 +1,12 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import { Popover } from "radix-ui"
-import { useState } from "react"
+import { useMemo, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
+import { getProjectApplications } from "@/features/application/api/applicationApi"
+import { applicationKeys } from "@/features/application/api/applicationKeys"
+import { toApplicantDetail } from "@/features/application/model/mappers"
 import { ApplicationDetailModal } from "@/features/application/ui/ApplicationDetailModal"
 import { getProjectDetail } from "@/features/project/list/api/matchingProject"
 import { deleteProject } from "@/features/project/management/api"
@@ -11,19 +14,21 @@ import MoreVerticalIcon from "@/shared/assets/icon/more/MoreVerticalIcon"
 import { DropdownItem } from "@/shared/ui/dropdown/DropdownItem"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
 
-import type { ProjectApplication } from "@/features/application/model/types"
+import type {
+  AssignmentCount,
+  ProjectApplication,
+  Role,
+} from "@/features/application/model/types"
 
 interface ProjectManagementMoreMenuProps {
   projectId: string
   projectName: string
-  projectApplication: ProjectApplication
   chapterName: string
 }
 
 export function ProjectManagementMoreMenu({
   projectId,
   projectName,
-  projectApplication,
   chapterName,
 }: ProjectManagementMoreMenuProps) {
   const navigate = useNavigate()
@@ -32,6 +37,52 @@ export function ProjectManagementMoreMenu({
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [applicationOpen, setApplicationOpen] = useState(false)
   const addToast = useToastStore((s) => s.addToast)
+
+  const numericProjectId = Number(projectId)
+
+  const projectDetailQuery = useQuery({
+    queryKey: ["projectDetail", numericProjectId],
+    queryFn: () => getProjectDetail(numericProjectId),
+    enabled: applicationOpen && numericProjectId > 0,
+  })
+
+  const applicantsQuery = useQuery({
+    queryKey: applicationKeys.applicants(numericProjectId),
+    queryFn: () => getProjectApplications(numericProjectId),
+    enabled: applicationOpen && numericProjectId > 0,
+  })
+
+  const projectApplication = useMemo((): ProjectApplication | null => {
+    const detail = projectDetailQuery.data
+    const applicants = applicantsQuery.data
+    if (!detail || !applicants) return null
+
+    const getCount = (parts: string[]): AssignmentCount => {
+      let current = 0
+      let total = 0
+      for (const q of detail.partQuotas) {
+        if (parts.includes(q.part)) {
+          current += q.currentCount
+          total += q.quota
+        }
+      }
+      return { current, total }
+    }
+
+    return {
+      id: String(detail.id),
+      projectName: detail.name,
+      role: "plan" as Role,
+      challengerName: detail.productOwner.nickname || detail.productOwner.name,
+      challengerUniversity: detail.productOwner.schoolName,
+      statusLabel:
+        detail.partQuotaStatus === "RECRUITING" ? "모집 중" : "모집 완료",
+      designCount: getCount(["DESIGN"]),
+      feCount: getCount(["WEB"]),
+      beCount: getCount(["SPRINGBOOT", "NODEJS"]),
+      applicants: applicants.map(toApplicantDetail),
+    }
+  }, [projectDetailQuery.data, applicantsQuery.data])
 
   const deleteMutation = useMutation({
     mutationFn: () => deleteProject(Number(projectId)),
@@ -149,12 +200,14 @@ export function ProjectManagementMoreMenu({
         </Popover.Portal>
       </Popover.Root>
 
-      <ApplicationDetailModal
-        project={projectApplication}
-        chapterName={chapterName}
-        open={applicationOpen}
-        onOpenChange={setApplicationOpen}
-      />
+      {projectApplication && (
+        <ApplicationDetailModal
+          project={projectApplication}
+          chapterName={chapterName}
+          open={applicationOpen}
+          onOpenChange={setApplicationOpen}
+        />
+      )}
 
       <CtaModal
         open={deleteOpen}

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -1,10 +1,17 @@
 import { useQuery } from "@tanstack/react-query"
 import { useMemo, useState } from "react"
 
-import { MOCK_PROJECTS } from "@/features/application/model/applicationMock"
+import { getAllProjects } from "@/features/application/api/applicationApi"
 import { useMe } from "@/features/auth/hooks/useMe"
-import { isCurrentTermPm, isOperator } from "@/features/auth/model/identity"
-import { MOCK_MATCHING_PROJECTS } from "@/features/project/list/model/matchingProject.mock"
+import {
+  getViewerBranch,
+  isCentralStaff,
+  isChapterPresident,
+  isCurrentTermPm,
+  isSchoolStaff,
+  isSuperAdmin,
+} from "@/features/auth/model/identity"
+import { getAllChapters } from "@/features/challenger/api/organization"
 import { gisuKeys } from "@/features/project/new/api/queryKeys"
 import { getActiveGisu } from "@/shared/api/gisu"
 import {
@@ -12,15 +19,45 @@ import {
   ChapterSelector,
 } from "@/shared/ui/segment/ChapterSelector"
 
-import { getManagedProjects, type ManagedProjectSummaryResponse } from "../api"
+import { getManagedProjects } from "../api"
 import { ProjectManagementCard } from "./ProjectManagementCard"
 import { ProjectManagementSubTitle } from "./ProjectManagementSubTitle"
 
 import type { MatchingProject } from "@/features/project/list/model/matchingProject"
 
-function toMatchingProject(
-  item: ManagedProjectSummaryResponse,
-): MatchingProject {
+const FE_PART_LABELS = new Set(["Web", "iOS", "Android"])
+
+const PART_LABEL: Record<string, string> = {
+  WEB: "Web",
+  IOS: "iOS",
+  ANDROID: "Android",
+  DESIGN: "Design",
+  SPRINGBOOT: "SpringBoot",
+  NODEJS: "Node.js",
+  PLAN: "기획",
+  ADMIN: "운영",
+}
+
+type ProjectSummaryInput = {
+  id?: number | null
+  name?: string | null
+  description?: string | null
+  thumbnailImageUrl?: string | null
+  productOwner?: {
+    nickname?: string | null
+    name?: string | null
+    schoolName?: string | null
+  } | null
+  partQuotas?:
+    | {
+        part?: string | null
+        currentCount?: number | null
+        quota?: number | null
+      }[]
+    | null
+}
+
+function toMatchingProject(item: ProjectSummaryInput): MatchingProject {
   const owner = item.productOwner
   const ownerLine = [
     owner?.nickname && owner?.name
@@ -40,7 +77,7 @@ function toMatchingProject(
     authorSchoolLine: ownerLine,
     coverImage: item.thumbnailImageUrl ? { src: item.thumbnailImageUrl } : null,
     recruitRows: (item.partQuotas ?? []).map((q) => ({
-      part: q.part ?? "",
+      part: PART_LABEL[q.part ?? ""] ?? q.part ?? "",
       current: q.currentCount ?? 0,
       total: q.quota ?? 0,
     })),
@@ -49,47 +86,85 @@ function toMatchingProject(
 
 export function ProjectManagementPage() {
   const { data: me } = useMe()
+
+  const isCentral = isSuperAdmin(me) || isCentralStaff(me)
+  const isChapPres = isChapterPresident(me)
+  const isSchoolAdmin = isSchoolStaff(me)
   const isPm = isCurrentTermPm(me)
-  const isOp = isOperator(me)
-  const canManage = isOp
+
+  const isAdminScope = isCentral || isChapPres || isSchoolAdmin
+  const hasAccess = isAdminScope || isPm
+
   const [selectedChapter, setSelectedChapter] = useState<Chapter>("Chromium")
 
   const gisuQuery = useQuery({
     queryKey: gisuKeys.active,
     queryFn: getActiveGisu,
-    enabled: isPm,
+    enabled: hasAccess,
   })
   const gisuId = gisuQuery.data?.gisuId
     ? Number(gisuQuery.data.gisuId)
     : undefined
 
+  // 중앙/지부장: 챕터명 → chapterId 매핑
+  const chaptersQuery = useQuery({
+    queryKey: ["chapters", "all"],
+    queryFn: getAllChapters,
+    enabled: isCentral || isChapPres,
+  })
+
+  const userChapterName = getViewerBranch(me)
+  const effectiveChapterName = isCentral ? selectedChapter : userChapterName
+
+  const effectiveChapterId = useMemo(() => {
+    if (!chaptersQuery.data || isSchoolAdmin) return undefined
+    return (
+      chaptersQuery.data.chapters.find((c) => c.name === effectiveChapterName)
+        ?.id ?? undefined
+    )
+  }, [chaptersQuery.data, effectiveChapterName, isSchoolAdmin])
+
+  // 어드민 프로젝트 쿼리 (중앙/지부장/학교 회장단)
+  const adminProjectsQuery = useQuery({
+    queryKey: ["projects", "admin", gisuId, effectiveChapterId],
+    queryFn: () =>
+      getAllProjects(gisuId!, {
+        chapterId: effectiveChapterId ? Number(effectiveChapterId) : undefined,
+        size: 200,
+      }),
+    enabled: isAdminScope && !!gisuId,
+  })
+
+  // PM 프로젝트 쿼리
   const managedQuery = useQuery({
     queryKey: ["project", "managed", "me", gisuId],
     queryFn: () => getManagedProjects(gisuId!),
-    enabled: isPm && !!gisuId,
+    enabled: isPm && !isAdminScope && !!gisuId,
   })
+
+  const adminProjects: MatchingProject[] = useMemo(
+    () => (adminProjectsQuery.data?.content ?? []).map(toMatchingProject),
+    [adminProjectsQuery.data],
+  )
 
   const pmProjects: MatchingProject[] = useMemo(
     () => (managedQuery.data ?? []).map(toMatchingProject),
     [managedQuery.data],
   )
 
-  const opProjects = useMemo(() => {
-    return MOCK_MATCHING_PROJECTS.filter((p) => p.branch === selectedChapter)
-  }, [selectedChapter])
-
   const partGroups = useMemo(() => {
-    const map = new Map<string, typeof opProjects>()
-    for (const project of opProjects) {
+    const map = new Map<string, MatchingProject[]>()
+    for (const project of adminProjects) {
       for (const row of project.recruitRows) {
+        if (!FE_PART_LABELS.has(row.part)) continue
         if (!map.has(row.part)) map.set(row.part, [])
         map.get(row.part)!.push(project)
       }
     }
     return map
-  }, [opProjects])
+  }, [adminProjects])
 
-  if (!isOp && !isPm) return null
+  if (!hasAccess) return null
 
   return (
     <section className="relative flex w-full flex-col items-start justify-start pt-8">
@@ -105,7 +180,7 @@ export function ProjectManagementPage() {
           </span>
         </div>
 
-        {canManage && (
+        {isCentral && (
           <ChapterSelector
             selectedChapter={selectedChapter}
             onChapterChange={setSelectedChapter}
@@ -114,27 +189,25 @@ export function ProjectManagementPage() {
         )}
 
         <div className="flex flex-col gap-10">
-          {canManage ? (
-            partGroups.size > 0 ? (
+          {isAdminScope ? (
+            adminProjectsQuery.isLoading ? (
+              <p className="text-body-2-regular text-teal-gray-400 py-10 text-center">
+                데이터를 불러오는 중...
+              </p>
+            ) : partGroups.size > 0 ? (
               Array.from(partGroups.entries()).map(([part, partProjects]) => (
                 <div key={part} className="flex flex-col">
                   <ProjectManagementSubTitle title={part} className="pb-2" />
                   <div className="flex flex-col gap-4">
-                    {partProjects.map((project, i) => (
-                      <ProjectManagementCard
-                        key={project.id}
-                        data={project}
-                        projectApplication={
-                          MOCK_PROJECTS[i % MOCK_PROJECTS.length]!
-                        }
-                      />
+                    {partProjects.map((project) => (
+                      <ProjectManagementCard key={project.id} data={project} />
                     ))}
                   </div>
                 </div>
               ))
             ) : (
               <p className="text-body-2-medium text-teal-gray-400 py-10 text-center">
-                해당 챕터에 등록된 프로젝트가 없습니다.
+                등록된 프로젝트가 없습니다.
               </p>
             )
           ) : isPm ? (
@@ -144,14 +217,8 @@ export function ProjectManagementPage() {
               </p>
             ) : pmProjects.length > 0 ? (
               <div className="flex flex-col gap-3">
-                {pmProjects.map((project, i) => (
-                  <ProjectManagementCard
-                    key={project.id}
-                    data={project}
-                    projectApplication={
-                      MOCK_PROJECTS[i % MOCK_PROJECTS.length]!
-                    }
-                  />
+                {pmProjects.map((project) => (
+                  <ProjectManagementCard key={project.id} data={project} />
                 ))}
               </div>
             ) : (

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -28,15 +28,17 @@ import type { MatchingProject } from "@/features/project/list/model/matchingProj
 const FE_PART_LABELS = new Set(["Web", "iOS", "Android"])
 
 const PART_LABEL: Record<string, string> = {
+  PLAN: "기획",
+  DESIGN: "Design",
   WEB: "Web",
   IOS: "iOS",
   ANDROID: "Android",
-  DESIGN: "Design",
   SPRINGBOOT: "SpringBoot",
   NODEJS: "Node.js",
-  PLAN: "기획",
   ADMIN: "운영",
 }
+
+const PART_KEYS = Object.keys(PART_LABEL)
 
 type ProjectSummaryInput = {
   id?: number | null
@@ -76,11 +78,18 @@ function toMatchingProject(item: ProjectSummaryInput): MatchingProject {
     description: item.description ?? "",
     authorSchoolLine: ownerLine,
     coverImage: item.thumbnailImageUrl ? { src: item.thumbnailImageUrl } : null,
-    recruitRows: (item.partQuotas ?? []).map((q) => ({
-      part: PART_LABEL[q.part ?? ""] ?? q.part ?? "",
-      current: q.currentCount ?? 0,
-      total: q.quota ?? 0,
-    })),
+    recruitRows: (item.partQuotas ?? [])
+      .slice()
+      .sort((a, b) => {
+        const ai = PART_KEYS.indexOf(a.part ?? "")
+        const bi = PART_KEYS.indexOf(b.part ?? "")
+        return (ai === -1 ? Infinity : ai) - (bi === -1 ? Infinity : bi)
+      })
+      .map((q) => ({
+        part: PART_LABEL[q.part ?? ""] ?? q.part ?? "",
+        current: q.currentCount ?? 0,
+        total: q.quota ?? 0,
+      })),
   }
 }
 


### PR DESCRIPTION
## 📸 작업 내용

> 프로젝트 관리 페이지 mock 데이터 제거 및 실제 API 연결

- 프로젝트 목록을 mock에서 실제 API(getAllProjects, getManagedProjects)로 교체
- 어드민 권한을 중앙/지부장/학교 회장단/PM 세분화 반영하여 각 권한에 맞는 데이터 조회
- 프로젝트 섹션 분류를 FE 플랫폼(Web / iOS / Android)으로만 표시하도록 필터링
- 지원현황 데이터를 카드 prop 주입 방식에서 MoreMenu 내부 lazy 조회 방식으로 변경

## 🎞️ 주요 코드 설명

> 설명이 필요한 코드 위주로 작성해주세요

### 1. 권한별 분기 조회

```TypeScript
const isCentral = isSuperAdmin(me) || isCentralStaff(me)
const isChapPres = isChapterPresident(me)
const isSchoolAdmin = isSchoolStaff(me)
const isPm = isCurrentTermPm(me)

const adminProjectsQuery = useQuery({
  queryFn: () => getAllProjects(gisuId!, {
    chapterId: effectiveChapterId ? Number(effectiveChapterId) : undefined,
    size: 200,
  }),
  enabled: isAdminScope && !!gisuId,
})

```

- 중앙은 챕터 셀렉터로 선택한 챕터 기준, 지부장은 본인 챕터 고정, 학교 회장단은 서버 auth 기반으로 필터링


### 2. FE 플랫폼 섹션 분류

```TypeScript
const FE_PART_LABELS = new Set(["Web", "iOS", "Android"])

const partGroups = useMemo(() => {
  const map = new Map<string, MatchingProject[]>()
  for (const project of adminProjects) {
    for (const row of project.recruitRows) {
      if (!FE_PART_LABELS.has(row.part)) continue
      if (!map.has(row.part)) map.set(row.part, [])
      map.get(row.part)!.push(project)
    }
  }
  return map
}, [adminProjects])

```

- 카드 내부에는 모든 파트(Design, SpringBoot 등) 표시하되, 섹션 그룹핑은 FE 파트만 사용


### 3. 지원현황 lazy 조회

```TypeScript
const projectApplication = useMemo((): ProjectApplication | null => {
  const detail = projectDetailQuery.data
  const applicants = applicantsQuery.data
  if (!detail || !applicants) return null
  // ...
}, [projectDetailQuery.data, applicantsQuery.data])
```

- 기존에는 부모 컴포넌트가 mock 데이터를 prop으로 주입했으나, MoreMenu가 열릴 때(enabled: applicationOpen) 직접 조회하도록 변경하여 불필요한 데이터 의존성 제거


## 🖥️ 구현화면

> localhost 캡쳐 사진을 첨부해 주세요.
<img width="730" height="625" alt="image" src="https://github.com/user-attachments/assets/7dcc14c0-327d-46f3-bfc5-65510bdc8951" />


## 🔗 연결된 이슈

- Connected: #173 