### PR TITLE
✨ feat: 사용자 조사 매칭 설문 문항 추가 및 입력칸 정렬

### DIFF
--- a/src/features/usability-survey/model/variants.ts
+++ b/src/features/usability-survey/model/variants.ts
@@ -146,6 +146,7 @@ export const SURVEY_VARIANTS: Record<SurveyVariantKey, SurveyVariantConfig> = {
         items: [
           DIFFICULTY_SCALE,
           MATCHING_PROCESS_PREV,
+          REUSE_CHOICE,
           FEEDBACK_TEXT,
           EXTRA_TEXT,
         ],
@@ -166,6 +167,7 @@ export const SURVEY_VARIANTS: Record<SurveyVariantKey, SurveyVariantConfig> = {
             "만족스러워요",
             "아쉬워요",
           ),
+          REUSE_CHOICE,
           FEEDBACK_TEXT,
           EXTRA_TEXT,
         ],

--- a/src/features/usability-survey/ui/EmojiScaleWithTextQuestion.tsx
+++ b/src/features/usability-survey/ui/EmojiScaleWithTextQuestion.tsx
@@ -50,14 +50,14 @@ export const EmojiScaleWithTextQuestion = ({
         )}
       >
         <div className="overflow-hidden">
-          <div className="flex w-full pt-6">
+          <div className="flex w-full justify-center pt-6">
             <InputBox
               value={textValue}
               onChange={(e: ChangeEvent<HTMLInputElement>) =>
                 onTextChange(e.target.value)
               }
               placeholder={textPlaceholder}
-              className="flex-1"
+              className="w-full"
             />
           </div>
         </div>

--- a/src/features/usability-survey/ui/EmojiScaleWithTextQuestion.tsx
+++ b/src/features/usability-survey/ui/EmojiScaleWithTextQuestion.tsx
@@ -57,7 +57,7 @@ export const EmojiScaleWithTextQuestion = ({
                 onTextChange(e.target.value)
               }
               placeholder={textPlaceholder}
-              className="w-full"
+              className="w-full max-w-75"
             />
           </div>
         </div>

--- a/src/features/usability-survey/ui/QuestionField.tsx
+++ b/src/features/usability-survey/ui/QuestionField.tsx
@@ -74,7 +74,7 @@ export const QuestionField = ({
               onAnswer(question.id, e.target.value)
             }
             placeholder={question.placeholder}
-            className="flex-1"
+            className="w-full max-w-none"
           />
         </div>
       )

--- a/src/features/usability-survey/ui/UsabilitySurveyModal.tsx
+++ b/src/features/usability-survey/ui/UsabilitySurveyModal.tsx
@@ -36,7 +36,7 @@ export const UsabilitySurveyModal = ({
         <Modal.Content
           aria-describedby={undefined}
           style={{ background: CARD_BACKGROUND }}
-          className="top-29.5 flex max-h-[80vh] w-150 translate-y-0 flex-col items-center rounded-[9.2px] border-[0.8px] border-white pt-13.5 pr-8 pb-9.5 pl-9.5 shadow-[0_4.6px_15.333px_0_#E4E4E4]"
+          className="top-29.5 flex max-h-[80vh] w-full max-w-150 translate-y-0 flex-col items-center rounded-[9.2px] border-[0.8px] border-white pt-13.5 pr-8 pb-9.5 pl-9.5 shadow-[0_4.6px_15.333px_0_#E4E4E4]"
           onEscapeKeyDown={
             preventClose ? (event) => event.preventDefault() : undefined
           }

--- a/src/features/usability-survey/ui/UsabilitySurveyModal.tsx
+++ b/src/features/usability-survey/ui/UsabilitySurveyModal.tsx
@@ -36,7 +36,7 @@ export const UsabilitySurveyModal = ({
         <Modal.Content
           aria-describedby={undefined}
           style={{ background: CARD_BACKGROUND }}
-          className="top-29.5 flex max-h-[80vh] w-full max-w-150 translate-y-0 flex-col items-center rounded-[9.2px] border-[0.8px] border-white pt-13.5 pr-8 pb-9.5 pl-9.5 shadow-[0_4.6px_15.333px_0_#E4E4E4]"
+          className="top-29.5 flex max-h-[80vh] w-[calc(100%-2rem)] max-w-150 translate-y-0 flex-col items-center rounded-[9.2px] border-[0.8px] border-white pt-13.5 pr-8 pb-9.5 pl-9.5 shadow-[0_4.6px_15.333px_0_#E4E4E4]"
           onEscapeKeyDown={
             preventClose ? (event) => event.preventDefault() : undefined
           }


### PR DESCRIPTION
## 📸 작업 내용

> 사용자 조사(설문) 모달의 매칭 케이스를 시안에 맞춰 보완하고, 입력칸 너비·정렬을 정리했습니다.

- 매칭 설문(이전/새 기수, case 3·4)에 **"다음에도 이 방식으로 이용하고 싶으신가요?"** 문항 추가 → 지원 설문(4문항)과 매칭 설문(5문항) 구조를 구분
- 텍스트 입력칸을 컨테이너 전체 너비로 정렬 (case 1~4)
- 운영진 멀티스텝 설문(case 5)의 척도+텍스트 문항 입력칸을 가운데 정렬
- 사용성 조사 모달에 반응형 폭 적용 (`w-150` → `w-full max-w-150`)

## 🎞️ 주요 코드 설명

### 매칭 설문 재이용 의향 문항 추가

이미 정의돼 있던 `REUSE_CHOICE`("좋아요"/"아니요")를 매칭 variant의 매칭 과정 문항 뒤에 배치했습니다.

\`\`\`TypeScript
"prev-gisu-general-matching": {
  steps: [{
    items: [DIFFICULTY_SCALE, MATCHING_PROCESS_PREV, REUSE_CHOICE, FEEDBACK_TEXT, EXTRA_TEXT],
    footer: "submit-only",
    progressive: true,
  }],
}
\`\`\`

### 입력칸 너비 정리

InputBox 기본 \`max-width\` 제약으로 좁아지던 입력칸을 문항 성격에 맞게 보정했습니다.

\`\`\`TypeScript
// 일반 텍스트 문항(case 1~4): 컨테이너 전체 너비
<div className="flex w-full">
  <InputBox className="w-full max-w-none" ... />
</div>

// 척도+텍스트 문항(case 5): 가운데 정렬
<div className="flex w-full justify-center">
  <InputBox className="w-full" ... />
</div>
\`\`\`

## 🖥️ 구현화면

> localhost 캡쳐 사진을 첨부해 주세요.

| 매칭 설문 (case 3·4) | 입력칸 정렬 |
| :-: | :-: |
| <img src="" width="250"> | <img src="" width="250"> |

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요!

- Connected: #160