### PR TITLE
bug: PM 학교 리스트 10개 및 내부 스크롤

### DIFF
--- a/src/features/project/list/model/matchingProjectList.ts
+++ b/src/features/project/list/model/matchingProjectList.ts
@@ -38,7 +38,10 @@ export type MatchingProjectListFilterDescriptor = {
 
 const FILTER_LAYOUT = {
   branch: { className: "w-fit min-w-20", dropdownClassName: "w-[9.5rem]" },
-  school: { className: "w-fit min-w-20", dropdownClassName: "w-[9.5rem]" },
+  school: {
+    className: "w-fit min-w-20",
+    dropdownClassName: "w-[9.5rem] max-h-[25.25rem] overflow-y-auto",
+  },
   part: { className: "w-fit min-w-20", dropdownClassName: "w-[9.125rem]" },
   status: {
     className: "w-[7.125rem]",
@@ -115,7 +118,9 @@ export function useMatchingProjectListFilters() {
             chaptersData?.chapters.find((ch) => ch.chapterId === selectedBranch)
               ?.schools ?? []
           ).map((s) => ({ value: s.schoolId, label: s.schoolName }))
-        : [],
+        : (chaptersData?.chapters ?? []).flatMap((ch) =>
+            ch.schools.map((s) => ({ value: s.schoolId, label: s.schoolName })),
+          ),
     [chaptersData, selectedBranch],
   )
 


### PR DESCRIPTION
## 📸 작업 내용

> 지부 드롭다운 선택 전에 PM 학교를 클릭했을 때, 전체 학교 리스트가 표시되도록 구현했습니다.
목록이 길어질 경우를 고려해 10개까지만 노출하고, 이후 항목은 내부 스크롤로 확인할 수 있도록 처리했습니다.


## 🖥️ 구현화면

> localhost 캡쳐 사진을 첨부해 주세요.
<img width="1189" height="638" alt="image" src="https://github.com/user-attachments/assets/587b462a-85d7-4e45-a2a4-ad05c406ded8" />


## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #135 