### PR TITLE
fix: 매칭/지원현황 하드코딩 제거 및 API 연동 수정

### DIFF
--- a/src/features/application/api/applicationKeys.ts
+++ b/src/features/application/api/applicationKeys.ts
@@ -35,6 +35,19 @@ export const applicationKeys = {
       projectIds,
     ] as const,
 
+  matchingMembers: (
+    gisuId: number,
+    chapterId?: number,
+    projectIds?: number[],
+  ) =>
+    [
+      ...applicationKeys.all,
+      "matching-members",
+      gisuId,
+      chapterId,
+      projectIds,
+    ] as const,
+
   // 통계 API
   projectStatistics: (projectId: number) =>
     [...applicationKeys.all, "statistics", "project", projectId] as const,

--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -65,6 +65,16 @@ export function useChallengerPageData() {
     enabled: gisuId > 0,
   })
 
+  // 매칭 차수 조회 (PM은 챕터 선택 없으므로 전체 조회)
+  const roundsQuery = useQuery({
+    queryKey: applicationKeys.matchingRounds(undefined),
+    queryFn: () => getMatchingRounds(),
+  })
+  const currentRound = useMemo(
+    () => getCurrentRound(roundsQuery.data ?? []),
+    [roundsQuery.data],
+  )
+
   // 프로젝트 목록이 로드되면 각 프로젝트의 지원자 목록도 함께 조회
   const projects = useMemo(
     () => projectsQuery.data?.content ?? [],
@@ -114,8 +124,10 @@ export function useChallengerPageData() {
   return {
     projects: transformed,
     projectInfo,
+    currentRound,
     isLoading:
       gisuQuery.isLoading ||
+      roundsQuery.isLoading ||
       projectsQuery.isLoading ||
       applicantsQuery.isLoading,
     isError: gisuQuery.isError || projectsQuery.isError,

--- a/src/features/application/model/mappers.ts
+++ b/src/features/application/model/mappers.ts
@@ -140,7 +140,9 @@ export function toProjectApplication(
     id: String(project.id),
     projectName: project.name,
     role: "plan", // PM 프로젝트이므로 기본값
-    challengerName: `${project.productOwner.nickname}/${project.productOwner.name}`,
+    challengerName: project.productOwner.nickname
+      ? `${project.productOwner.nickname}/${project.productOwner.name}`
+      : project.productOwner.name,
     challengerUniversity: project.productOwner.schoolName,
     statusLabel,
     designCount: getQuotaCount(project.partQuotas, "DESIGN"),

--- a/src/features/application/model/mappers.ts
+++ b/src/features/application/model/mappers.ts
@@ -140,7 +140,7 @@ export function toProjectApplication(
     id: String(project.id),
     projectName: project.name,
     role: "plan", // PM 프로젝트이므로 기본값
-    challengerName: project.productOwner.nickname || project.productOwner.name,
+    challengerName: `${project.productOwner.nickname}/${project.productOwner.name}`,
     challengerUniversity: project.productOwner.schoolName,
     statusLabel,
     designCount: getQuotaCount(project.partQuotas, "DESIGN"),

--- a/src/features/application/ui/ApplicationDetailModal.tsx
+++ b/src/features/application/ui/ApplicationDetailModal.tsx
@@ -1,9 +1,12 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useMemo, useState } from "react"
 
 import { Modal } from "@/shared/ui/Modal"
 
+import { updateApplicationDecision } from "../api/applicationApi"
+import { applicationKeys } from "../api/applicationKeys"
 import { useApplicationDetail } from "../hooks/useApplications"
-import { toApplicantFormData } from "../model/mappers"
+import { toApplicantFormData, toServerStatus } from "../model/mappers"
 import { ModalApplicantPanel } from "./detail-modal/ModalApplicantPanel"
 import { ModalFormPanel } from "./detail-modal/ModalFormPanel"
 
@@ -55,6 +58,22 @@ export function ApplicationDetailModal({
   const projectId = Number(project.id)
   const applicationId = selectedApplicantId ? Number(selectedApplicantId) : 0
   const detailQuery = useApplicationDetail(projectId, applicationId)
+
+  const queryClient = useQueryClient()
+  const decisionMutation = useMutation({
+    mutationFn: ({ appId, status }: { appId: number; status: StatusValue }) =>
+      updateApplicationDecision(projectId, appId, {
+        status: toServerStatus(status),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: applicationKeys.all })
+    },
+  })
+
+  const handleStatusChange = (appId: string, status: StatusValue) => {
+    setStatusOverrides((prev) => ({ ...prev, [appId]: status }))
+    decisionMutation.mutate({ appId: Number(appId), status })
+  }
 
   // 서버 formResponse -> 프론트 ApplicantFormData 변환
   const formData = useMemo(() => {
@@ -111,9 +130,7 @@ export function ApplicationDetailModal({
               onStatusFilterChange={setStatusFilter}
               selectedApplicantId={selectedApplicantId}
               onApplicantClick={setSelectedApplicantId}
-              onStatusChange={(id, status) =>
-                setStatusOverrides((prev) => ({ ...prev, [id]: status }))
-              }
+              onStatusChange={handleStatusChange}
               onClose={handleClose}
               currentRound={currentRound}
             />
@@ -128,10 +145,7 @@ export function ApplicationDetailModal({
               challengerName={project.challengerName}
               challengerUniversity={project.challengerUniversity}
               onStatusChange={(status) =>
-                setStatusOverrides((prev) => ({
-                  ...prev,
-                  [selectedApplicantId!]: status,
-                }))
+                handleStatusChange(selectedApplicantId!, status)
               }
               onClose={handlePanelClose}
               statusDisabled={

--- a/src/features/application/ui/ApplicationDetailModal.tsx
+++ b/src/features/application/ui/ApplicationDetailModal.tsx
@@ -68,6 +68,13 @@ export function ApplicationDetailModal({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: applicationKeys.all })
     },
+    onError: (_error, variables) => {
+      setStatusOverrides((prev) => {
+        const next = { ...prev }
+        delete next[variables.appId]
+        return next
+      })
+    },
   })
 
   const handleStatusChange = (appId: string, status: StatusValue) => {

--- a/src/features/application/ui/ApplicationTableSection.tsx
+++ b/src/features/application/ui/ApplicationTableSection.tsx
@@ -64,6 +64,8 @@ interface ApplicationTableSectionProps {
   visibleFilters?: FilterName[]
   /** 현재 활성 차수 (이전 차수의 상태 칩 disabled 처리) */
   currentRound?: number
+  /** 현재 선택된 챕터 이름 (상세 모달 전달용) */
+  chapterName?: string
   className?: string
 }
 
@@ -80,6 +82,7 @@ export function ApplicationTableSection({
   searchPlaceholder = "프로젝트 명으로 검색하세요.",
   visibleFilters = DEFAULT_FILTERS,
   currentRound,
+  chapterName,
   className,
 }: ApplicationTableSectionProps) {
   const [searchQuery, setSearchQuery] = useState("")
@@ -342,7 +345,7 @@ export function ApplicationTableSection({
       {selectedProject && (
         <ApplicationDetailModal
           project={selectedProject}
-          chapterName="Chromium"
+          chapterName={chapterName ?? ""}
           open={detailModalOpen}
           onOpenChange={setDetailModalOpen}
           currentRound={currentRound}

--- a/src/features/application/ui/ChallengerApplicationView.tsx
+++ b/src/features/application/ui/ChallengerApplicationView.tsx
@@ -10,6 +10,7 @@ import type { ProjectApplication } from "../model/types"
 
 interface ChallengerApplicationViewProps {
   projects: ProjectApplication[]
+  currentRound?: number
   className?: string
 }
 
@@ -61,11 +62,11 @@ function computeStats(projects: ProjectApplication[]): ChallengerStats {
 
 export function ChallengerApplicationView({
   projects,
+  currentRound,
   className,
 }: ChallengerApplicationViewProps) {
   const stats = useMemo(() => computeStats(projects), [projects])
 
-  // TODO: API 연동 시 현재 활성 차수를 서버에서 받아오도록 변경
   return (
     <div className={cn("flex flex-col gap-[57px] pl-4", className)}>
       <ChallengerStatsSection stats={stats} />
@@ -73,7 +74,7 @@ export function ChallengerApplicationView({
         projects={projects}
         searchPlaceholder="닉네임/이름으로 검색하세요."
         visibleFilters={["round", "part", "school", "appStatus"]}
-        currentRound={2}
+        currentRound={currentRound}
       />
     </div>
   )

--- a/src/features/application/ui/ProjectStatusRow.tsx
+++ b/src/features/application/ui/ProjectStatusRow.tsx
@@ -72,7 +72,7 @@ export function ProjectStatusRow({
         </div>
 
         {/* 챌린저 */}
-        <div className="flex h-12.5 w-50 items-center rounded-lg px-16">
+        <div className="flex h-12.5 w-50 items-center justify-center rounded-lg px-4">
           <div className="flex flex-col whitespace-nowrap">
             <span className="text-body-2-medium text-teal-gray-900">
               {challengerName}

--- a/src/features/application/ui/ProjectStatusRow.tsx
+++ b/src/features/application/ui/ProjectStatusRow.tsx
@@ -72,7 +72,7 @@ export function ProjectStatusRow({
         </div>
 
         {/* 챌린저 */}
-        <div className="flex h-12.5 w-50 items-center rounded-lg px-4">
+        <div className="flex h-12.5 w-50 items-center rounded-lg px-16">
           <div className="flex flex-col whitespace-nowrap">
             <span className="text-body-2-medium text-teal-gray-900">
               {challengerName}
@@ -84,7 +84,7 @@ export function ProjectStatusRow({
         </div>
 
         {/* 상태 */}
-        <div className="flex h-12.5 w-34 items-center px-2.5">
+        <div className="flex h-12.5 w-34 items-center justify-center px-2.5">
           <span className="text-label-2-medium shadow-drop-neutral-2 inline-flex h-6 items-center justify-center rounded-md bg-teal-100 px-2 py-0.5 text-teal-600">
             {statusLabel}
           </span>

--- a/src/features/application/ui/detail-modal/ApplicantRow.tsx
+++ b/src/features/application/ui/detail-modal/ApplicantRow.tsx
@@ -58,7 +58,6 @@ export function ApplicantRow({
             </span>
           </div>
           <div className="flex h-12.5 w-25 flex-col items-start justify-center px-2.5">
-            {/* TODO: API 연동 시 차수별 마감 여부로 disabled 분기 */}
             {statusDisabled ? (
               <StatusChipTag value={status} type="chip" disabled />
             ) : (

--- a/src/features/auth/model/identity.ts
+++ b/src/features/auth/model/identity.ts
@@ -11,6 +11,15 @@ const CENTRAL_ROLE_TYPES: RoleType[] = [
   "CENTRAL_EDUCATION_TEAM_MEMBER",
 ]
 
+const ADMIN_ROLE_TYPES: RoleType[] = [
+  "SUPER_ADMIN",
+  "CENTRAL_PRESIDENT",
+  "CENTRAL_VICE_PRESIDENT",
+  "CENTRAL_OPERATING_TEAM_MEMBER",
+  "CENTRAL_EDUCATION_TEAM_MEMBER",
+  "CHAPTER_PRESIDENT",
+]
+
 const SCHOOL_ROLE_TYPES: RoleType[] = [
   "SCHOOL_PRESIDENT",
   "SCHOOL_VICE_PRESIDENT",
@@ -45,7 +54,7 @@ export function isSchoolStaff(me: MemberInfoResponse | undefined): boolean {
 }
 
 export function isOperator(me: MemberInfoResponse | undefined): boolean {
-  return !!me?.roles?.length
+  return hasAnyRoleType(me, ADMIN_ROLE_TYPES)
 }
 
 export function isCurrentTermPm(me: MemberInfoResponse | undefined): boolean {

--- a/src/features/matching/hooks/useMatchingStatusData.ts
+++ b/src/features/matching/hooks/useMatchingStatusData.ts
@@ -17,6 +17,7 @@ import {
   toRoundNumber,
 } from "@/features/application/model/mappers"
 import { getAllSchools } from "@/features/challenger/api/organization"
+import { getProjectMembers } from "@/features/project/list/api/matchingProject"
 import { useViewModeStore } from "@/shared/view-mode"
 
 import { toMatchingPartDataList } from "../model/matchingStatusMapper"
@@ -145,10 +146,35 @@ export function useMatchingStatusData(chapterName?: string) {
     return ids
   }, [applicantsQuery.data])
 
+  // 프로젝트별 팀원 조회 (수동 배정 멤버 포함)
+  const membersQuery = useQuery({
+    queryKey: applicationKeys.matchingMembers(
+      gisuId,
+      chapterId,
+      projects.map((p) => p.id),
+    ),
+    queryFn: async () => {
+      const results = await Promise.all(
+        projects.map(async (p) => {
+          const members = await getProjectMembers(p.id)
+          return { projectId: p.id, members }
+        }),
+      )
+      return new Map(results.map((r) => [r.projectId, r.members]))
+    },
+    enabled: projects.length > 0,
+  })
+
   // 매칭 현황 데이터 변환 (매칭 결과 시트용)
   const matchingParts = useMemo(
-    () => toMatchingPartDataList(projects, applicantsQuery.data ?? new Map()),
-    [projects, applicantsQuery.data],
+    () =>
+      toMatchingPartDataList(
+        projects,
+        applicantsQuery.data ?? new Map(),
+        membersQuery.data ?? new Map(),
+        currentRound,
+      ),
+    [projects, applicantsQuery.data, membersQuery.data, currentRound],
   )
 
   // 통계: summary 기반 (universities는 schoolMatchingStatistics + schools API로 계산)

--- a/src/features/matching/model/matchingStatusMapper.ts
+++ b/src/features/matching/model/matchingStatusMapper.ts
@@ -116,7 +116,7 @@ function toMatchingProject(
   return {
     projectId: project.id,
     projectName: project.name,
-    challengerName: project.productOwner.nickname || project.productOwner.name,
+    challengerName: `${project.productOwner.nickname}/${project.productOwner.name}`,
     challengerUniversity: project.productOwner.schoolName,
     backendPart,
     roleRows,

--- a/src/features/matching/model/matchingStatusMapper.ts
+++ b/src/features/matching/model/matchingStatusMapper.ts
@@ -37,12 +37,24 @@ function phaseToBlock(
   }
 }
 
-// 서버 part -> 역할 행 라벨
+// 서버 part -> 역할 행 라벨 (ANDROID/IOS도 Frontend 행으로 표시)
 const PART_TO_ROLE: Record<string, string> = {
   DESIGN: "Design",
   WEB: "Frontend",
+  ANDROID: "Frontend",
+  IOS: "Frontend",
   SPRINGBOOT: "Backend",
   NODEJS: "Backend",
+}
+
+// 섹션 헤더용 FE 플랫폼 분류
+const FE_PLATFORM_ORDER = ["Web", "iOS", "Android"] as const
+type FEPlatform = (typeof FE_PLATFORM_ORDER)[number]
+
+const PART_TO_FE_PLATFORM: Record<string, FEPlatform> = {
+  WEB: "Web",
+  ANDROID: "Android",
+  IOS: "iOS",
 }
 
 // 프로젝트 + 지원자 -> MatchingProjectData 변환
@@ -65,7 +77,10 @@ function toMatchingProject(
   // partQuotas에서 역할별 quota 추출
   const designQuota =
     project.partQuotas.find((q) => q.part === "DESIGN")?.quota ?? 0
-  const feQuota = project.partQuotas.find((q) => q.part === "WEB")?.quota ?? 0
+  // WEB/ANDROID/IOS 중 해당 프로젝트의 FE 파트 quota 합산
+  const feQuota = project.partQuotas
+    .filter((q) => q.part === "WEB" || q.part === "ANDROID" || q.part === "IOS")
+    .reduce((sum, q) => sum + q.quota, 0)
   const beQuota = project.partQuotas
     .filter((q) => q.part === "SPRINGBOOT" || q.part === "NODEJS")
     .reduce((sum, q) => sum + q.quota, 0)
@@ -143,24 +158,37 @@ function computeMaxCols(
   return maxCols
 }
 
-// TODO: 서버에 productOwner.part 필드 추가되면 PM 파트별 그룹핑으로 전환
 export function toMatchingPartDataList(
   projects: ManagedProjectSummaryResponse[],
   applicantsByProject: Map<number, ProjectApplicantResponse[]>,
 ): MatchingPartData[] {
   if (projects.length === 0) return []
 
-  const maxCols = computeMaxCols(projects)
+  // FE 플랫폼별 프로젝트 그룹핑 (quota > 0인 파트 기준)
+  const byPlatform = new Map<FEPlatform, ManagedProjectSummaryResponse[]>()
+  for (const p of projects) {
+    const addedPlatforms = new Set<FEPlatform>()
+    for (const q of p.partQuotas) {
+      const platform = PART_TO_FE_PLATFORM[q.part]
+      if (platform && q.quota > 0 && !addedPlatforms.has(platform)) {
+        addedPlatforms.add(platform)
+        const list = byPlatform.get(platform) ?? []
+        list.push(p)
+        byPlatform.set(platform, list)
+      }
+    }
+  }
 
-  const matchingProjects = projects.map((p) =>
-    toMatchingProject(p, applicantsByProject.get(p.id) ?? [], maxCols),
-  )
-
-  // 현재 PM 파트 정보 없으므로 전체 프로젝트를 단일 섹션으로 표시
-  return [
-    {
-      partName: "전체",
-      projects: matchingProjects,
+  return FE_PLATFORM_ORDER.filter((platform) => byPlatform.has(platform)).map(
+    (platform) => {
+      const platformProjects = byPlatform.get(platform)!
+      const maxCols = computeMaxCols(platformProjects)
+      return {
+        partName: platform,
+        projects: platformProjects.map((p) =>
+          toMatchingProject(p, applicantsByProject.get(p.id) ?? [], maxCols),
+        ),
+      }
     },
-  ]
+  )
 }

--- a/src/features/matching/model/matchingStatusMapper.ts
+++ b/src/features/matching/model/matchingStatusMapper.ts
@@ -66,36 +66,65 @@ function toMatchingProject(
   maxColsByRole: Record<string, number>,
   currentRound: number,
 ): MatchingProjectData {
-  // APPROVED 지원자만 블록에 표시
-  const approvedByRole = new Map<string, ProjectApplicantResponse[]>()
+  // memberId -> APPROVED 지원서 매핑 (차수 태그 조회용)
   // 서버가 memberId를 string으로 내려주는 경우 대비해 String으로 정규화
-  const approvedMemberIds = new Set<string>()
+  const approvedAppByMemberId = new Map<string, ProjectApplicantResponse>()
   for (const app of applicants) {
     if (app.status !== "APPROVED") continue
-    const role = PART_TO_ROLE[app.applicant.part]
-    if (!role) continue
-    const list = approvedByRole.get(role) ?? []
-    list.push(app)
-    approvedByRole.set(role, list)
-    approvedMemberIds.add(String(app.applicant.memberId))
+    approvedAppByMemberId.set(String(app.applicant.memberId), app)
   }
 
-  // 수동 배정 멤버: partGroups에 있지만 APPROVED 지원서가 없는 멤버
-  const manualByRole = new Map<
-    string,
-    { memberId: number; nickname: string; name: string }[]
-  >()
+  const roundVariantMap: Record<number, "round2" | "round3" | "random"> = {
+    2: "round2",
+    3: "round3",
+  }
+
+  // partGroups를 현재 멤버 기준으로 사용 - 매칭 해제 시 즉시 반영
+  // members 미로딩 시 APPROVED 지원서 기반으로 폴백
+  const blocksByRole = new Map<string, MatchingBlockData[]>()
   if (members) {
     for (const group of members.partGroups) {
       const role = PART_TO_ROLE[group.part]
       if (!role) continue
       for (const member of group.members) {
-        if (!approvedMemberIds.has(String(member.memberId))) {
-          const list = manualByRole.get(role) ?? []
-          list.push(member)
-          manualByRole.set(role, list)
-        }
+        const app = approvedAppByMemberId.get(String(member.memberId))
+        const block: MatchingBlockData = app
+          ? {
+              ...phaseToBlock(
+                toRoundNumber(app.matchingRound.phase),
+                `${member.nickname}/${member.name}`,
+                String(app.applicationId),
+              ),
+              memberId: member.memberId,
+            }
+          : {
+              type:
+                currentRound === 1 ? ("round1" as const) : ("filled" as const),
+              name: `${member.nickname}/${member.name}`,
+              tagVariant: roundVariantMap[currentRound] ?? "random",
+              memberId: member.memberId,
+            }
+        const list = blocksByRole.get(role) ?? []
+        list.push(block)
+        blocksByRole.set(role, list)
       }
+    }
+  } else {
+    // members 미로딩 폴백: APPROVED 지원서 기반
+    for (const [, app] of approvedAppByMemberId) {
+      const role = PART_TO_ROLE[app.applicant.part]
+      if (!role) continue
+      const block: MatchingBlockData = {
+        ...phaseToBlock(
+          toRoundNumber(app.matchingRound.phase),
+          `${app.applicant.nickname}/${app.applicant.name}`,
+          String(app.applicationId),
+        ),
+        memberId: app.applicant.memberId,
+      }
+      const list = blocksByRole.get(role) ?? []
+      list.push(block)
+      blocksByRole.set(role, list)
     }
   }
 
@@ -115,31 +144,8 @@ function toMatchingProject(
     quota: number,
     maxCols: number,
   ): MatchingRoleRow {
-    const approved = approvedByRole.get(role) ?? []
-    const manual = manualByRole.get(role) ?? []
-
-    const approvedBlocks: MatchingBlockData[] = approved.map((app) => ({
-      ...phaseToBlock(
-        toRoundNumber(app.matchingRound.phase),
-        `${app.applicant.nickname}/${app.applicant.name}`,
-        String(app.applicationId),
-      ),
-      memberId: app.applicant.memberId,
-    }))
-    // 수동 배정 멤버는 현재 차수 태그로 표시
-    const roundVariantMap: Record<number, "round2" | "round3" | "random"> = {
-      2: "round2",
-      3: "round3",
-    }
-    const manualBlocks: MatchingBlockData[] = manual.map((member) => ({
-      type: currentRound === 1 ? ("round1" as const) : ("filled" as const),
-      name: `${member.nickname}/${member.name}`,
-      tagVariant: roundVariantMap[currentRound] ?? "random",
-      memberId: member.memberId,
-    }))
-
-    const totalFilled = approved.length + manual.length
-    const emptyCount = Math.max(0, quota - totalFilled)
+    const filledBlocks = blocksByRole.get(role) ?? []
+    const emptyCount = Math.max(0, quota - filledBlocks.length)
     const emptyBlocks: MatchingBlockData[] = Array.from(
       { length: emptyCount },
       () => ({ type: "none" }),
@@ -149,15 +155,7 @@ function toMatchingProject(
       { length: blockedCount },
       () => ({ type: "blocked" }),
     )
-    return {
-      role,
-      blocks: [
-        ...approvedBlocks,
-        ...manualBlocks,
-        ...emptyBlocks,
-        ...blockedBlocks,
-      ],
-    }
+    return { role, blocks: [...filledBlocks, ...emptyBlocks, ...blockedBlocks] }
   }
 
   const roleRows = [

--- a/src/features/matching/model/matchingStatusMapper.ts
+++ b/src/features/matching/model/matchingStatusMapper.ts
@@ -92,7 +92,9 @@ function toMatchingProject(
           ? {
               ...phaseToBlock(
                 toRoundNumber(app.matchingRound.phase),
-                `${member.nickname}/${member.name}`,
+                member.nickname
+                  ? `${member.nickname}/${member.name}`
+                  : member.name,
                 String(app.applicationId),
               ),
               memberId: member.memberId,
@@ -100,7 +102,9 @@ function toMatchingProject(
           : {
               type:
                 currentRound === 1 ? ("round1" as const) : ("filled" as const),
-              name: `${member.nickname}/${member.name}`,
+              name: member.nickname
+                ? `${member.nickname}/${member.name}`
+                : member.name,
               tagVariant: roundVariantMap[currentRound] ?? "random",
               memberId: member.memberId,
             }
@@ -117,7 +121,9 @@ function toMatchingProject(
       const block: MatchingBlockData = {
         ...phaseToBlock(
           toRoundNumber(app.matchingRound.phase),
-          `${app.applicant.nickname}/${app.applicant.name}`,
+          app.applicant.nickname
+            ? `${app.applicant.nickname}/${app.applicant.name}`
+            : app.applicant.name,
           String(app.applicationId),
         ),
         memberId: app.applicant.memberId,
@@ -177,7 +183,9 @@ function toMatchingProject(
   return {
     projectId: project.id,
     projectName: project.name,
-    challengerName: `${project.productOwner.nickname}/${project.productOwner.name}`,
+    challengerName: project.productOwner.nickname
+      ? `${project.productOwner.nickname}/${project.productOwner.name}`
+      : project.productOwner.name,
     challengerUniversity: project.productOwner.schoolName,
     backendPart,
     roleRows,

--- a/src/features/matching/model/matchingStatusMapper.ts
+++ b/src/features/matching/model/matchingStatusMapper.ts
@@ -6,6 +6,7 @@ import type {
   ManagedProjectSummaryResponse,
   ProjectApplicantResponse,
 } from "@/features/application/model/apiTypes"
+import type { ProjectMembersResponse } from "@/features/project/list/api/matchingProject"
 
 import type {
   MatchingBlockData,
@@ -57,14 +58,18 @@ const PART_TO_FE_PLATFORM: Record<string, FEPlatform> = {
   IOS: "iOS",
 }
 
-// 프로젝트 + 지원자 -> MatchingProjectData 변환
+// 프로젝트 + 지원자 + 팀원 -> MatchingProjectData 변환
 function toMatchingProject(
   project: ManagedProjectSummaryResponse,
   applicants: ProjectApplicantResponse[],
+  members: ProjectMembersResponse | undefined,
   maxColsByRole: Record<string, number>,
+  currentRound: number,
 ): MatchingProjectData {
   // APPROVED 지원자만 블록에 표시
   const approvedByRole = new Map<string, ProjectApplicantResponse[]>()
+  // 서버가 memberId를 string으로 내려주는 경우 대비해 String으로 정규화
+  const approvedMemberIds = new Set<string>()
   for (const app of applicants) {
     if (app.status !== "APPROVED") continue
     const role = PART_TO_ROLE[app.applicant.part]
@@ -72,6 +77,26 @@ function toMatchingProject(
     const list = approvedByRole.get(role) ?? []
     list.push(app)
     approvedByRole.set(role, list)
+    approvedMemberIds.add(String(app.applicant.memberId))
+  }
+
+  // 수동 배정 멤버: partGroups에 있지만 APPROVED 지원서가 없는 멤버
+  const manualByRole = new Map<
+    string,
+    { memberId: number; nickname: string; name: string }[]
+  >()
+  if (members) {
+    for (const group of members.partGroups) {
+      const role = PART_TO_ROLE[group.part]
+      if (!role) continue
+      for (const member of group.members) {
+        if (!approvedMemberIds.has(String(member.memberId))) {
+          const list = manualByRole.get(role) ?? []
+          list.push(member)
+          manualByRole.set(role, list)
+        }
+      }
+    }
   }
 
   // partQuotas에서 역할별 quota 추출
@@ -91,15 +116,30 @@ function toMatchingProject(
     maxCols: number,
   ): MatchingRoleRow {
     const approved = approvedByRole.get(role) ?? []
-    const filledBlocks: MatchingBlockData[] = approved.map((app) => ({
+    const manual = manualByRole.get(role) ?? []
+
+    const approvedBlocks: MatchingBlockData[] = approved.map((app) => ({
       ...phaseToBlock(
         toRoundNumber(app.matchingRound.phase),
-        app.applicant.nickname || app.applicant.name,
+        `${app.applicant.nickname}/${app.applicant.name}`,
         String(app.applicationId),
       ),
       memberId: app.applicant.memberId,
     }))
-    const emptyCount = Math.max(0, quota - approved.length)
+    // 수동 배정 멤버는 현재 차수 태그로 표시
+    const roundVariantMap: Record<number, "round2" | "round3" | "random"> = {
+      2: "round2",
+      3: "round3",
+    }
+    const manualBlocks: MatchingBlockData[] = manual.map((member) => ({
+      type: currentRound === 1 ? ("round1" as const) : ("filled" as const),
+      name: `${member.nickname}/${member.name}`,
+      tagVariant: roundVariantMap[currentRound] ?? "random",
+      memberId: member.memberId,
+    }))
+
+    const totalFilled = approved.length + manual.length
+    const emptyCount = Math.max(0, quota - totalFilled)
     const emptyBlocks: MatchingBlockData[] = Array.from(
       { length: emptyCount },
       () => ({ type: "none" }),
@@ -109,7 +149,15 @@ function toMatchingProject(
       { length: blockedCount },
       () => ({ type: "blocked" }),
     )
-    return { role, blocks: [...filledBlocks, ...emptyBlocks, ...blockedBlocks] }
+    return {
+      role,
+      blocks: [
+        ...approvedBlocks,
+        ...manualBlocks,
+        ...emptyBlocks,
+        ...blockedBlocks,
+      ],
+    }
   }
 
   const roleRows = [
@@ -161,6 +209,8 @@ function computeMaxCols(
 export function toMatchingPartDataList(
   projects: ManagedProjectSummaryResponse[],
   applicantsByProject: Map<number, ProjectApplicantResponse[]>,
+  membersByProject: Map<number, ProjectMembersResponse>,
+  currentRound: number,
 ): MatchingPartData[] {
   if (projects.length === 0) return []
 
@@ -186,7 +236,13 @@ export function toMatchingPartDataList(
       return {
         partName: platform,
         projects: platformProjects.map((p) =>
-          toMatchingProject(p, applicantsByProject.get(p.id) ?? [], maxCols),
+          toMatchingProject(
+            p,
+            applicantsByProject.get(p.id) ?? [],
+            membersByProject.get(p.id),
+            maxCols,
+            currentRound,
+          ),
         ),
       }
     },

--- a/src/features/matching/ui/AssignmentModal.tsx
+++ b/src/features/matching/ui/AssignmentModal.tsx
@@ -220,7 +220,7 @@ export function AssignmentModal({
                   filtered.map((m) => (
                     <AssignmentChallengerRow
                       key={m.memberId}
-                      nickname={m.nickname}
+                      nickname={`${m.nickname}/${m.name}`}
                       university={m.schoolName}
                       partRole={
                         (m.part?.toLowerCase() ??

--- a/src/features/matching/ui/AssignmentModal.tsx
+++ b/src/features/matching/ui/AssignmentModal.tsx
@@ -36,7 +36,7 @@ interface AssignmentModalProps {
   gisuId?: number
   chapterId?: number
   approvedMemberIds?: Set<string>
-  onAssign: (challenger: AssignableChallenger) => void
+  onAssign: (challenger: AssignableChallenger) => Promise<void>
 }
 
 export function AssignmentModal({
@@ -88,18 +88,26 @@ export function AssignmentModal({
     return items.filter((m) => !approvedMemberIds.has(m.memberId))
   }, [data, approvedMemberIds])
 
-  const handleAssign = () => {
+  const [isAssigning, setIsAssigning] = useState(false)
+
+  const handleAssign = async () => {
     const member = filtered.find((m) => m.memberId === selectedId)
     if (!member) return
-    // SearchMemberItem -> AssignableChallenger 변환
-    onAssign({
-      id: member.memberId,
-      nickname: member.nickname,
-      university: member.schoolName,
-      partRole: (member.part?.toLowerCase() ??
-        "web") as AssignableChallenger["partRole"],
-    })
-    setShowComplete(true)
+    setIsAssigning(true)
+    try {
+      await onAssign({
+        id: member.memberId,
+        nickname: member.nickname,
+        university: member.schoolName,
+        partRole: (member.part?.toLowerCase() ??
+          "web") as AssignableChallenger["partRole"],
+      })
+      setShowComplete(true)
+    } catch {
+      // 서버 오류 - 완료 모달 미표시
+    } finally {
+      setIsAssigning(false)
+    }
   }
 
   const handleClose = () => {
@@ -247,6 +255,7 @@ export function AssignmentModal({
                 color="primary"
                 size="lg"
                 onClick={handleAssign}
+                isLoading={isAssigning}
                 className="w-50 rounded-[10px]"
               >
                 해당 프로젝트에 배정

--- a/src/features/matching/ui/AssignmentModal.tsx
+++ b/src/features/matching/ui/AssignmentModal.tsx
@@ -91,7 +91,7 @@ export function AssignmentModal({
   const [isAssigning, setIsAssigning] = useState(false)
 
   const handleAssign = async () => {
-    const member = filtered.find((m) => m.memberId === selectedId)
+    const member = filtered.find((m) => String(m.memberId) === selectedId)
     if (!member) return
     setIsAssigning(true)
     try {

--- a/src/features/matching/ui/AssignmentModal.tsx
+++ b/src/features/matching/ui/AssignmentModal.tsx
@@ -96,7 +96,7 @@ export function AssignmentModal({
     setIsAssigning(true)
     try {
       await onAssign({
-        id: member.memberId,
+        id: String(member.memberId),
         nickname: member.nickname,
         university: member.schoolName,
         partRole: (member.part?.toLowerCase() ??

--- a/src/features/matching/ui/MatchingResultRow.tsx
+++ b/src/features/matching/ui/MatchingResultRow.tsx
@@ -57,6 +57,7 @@ interface MatchingResultRowProps {
   gisuId?: number
   chapterId?: number
   approvedMemberIds?: Set<string>
+  chapterName?: string
   className?: string
 }
 
@@ -74,6 +75,7 @@ export function MatchingResultRow({
   gisuId,
   chapterId,
   approvedMemberIds,
+  chapterName,
   className,
 }: MatchingResultRowProps) {
   const [selectedApplicantId, setSelectedApplicantId] = useState<string | null>(
@@ -242,7 +244,7 @@ export function MatchingResultRow({
         applicantId={selectedApplicantId}
         projectId={projectId}
         memberId={selectedMemberId ?? undefined}
-        chapterName="Chromium"
+        chapterName={chapterName ?? ""}
         projectName={projectName}
         challengerName={challengerName}
         challengerUniversity={challengerUniversity}

--- a/src/features/matching/ui/MatchingResultRow.tsx
+++ b/src/features/matching/ui/MatchingResultRow.tsx
@@ -279,9 +279,9 @@ export function MatchingResultRow({
           gisuId={gisuId}
           chapterId={chapterId}
           approvedMemberIds={approvedMemberIds}
-          onAssign={(challenger) => {
-            if (!assignTarget) return
-            // 로컬 UI 즉시 반영
+          onAssign={async (challenger) => {
+            if (!assignTarget || !projectId) return
+            // 로컬 UI 즉시 반영 (optimistic update)
             setLocalRoleRows((prev) =>
               prev.map((row, rIdx) =>
                 rIdx === assignTarget.rowIdx
@@ -302,14 +302,12 @@ export function MatchingResultRow({
                   : row,
               ),
             )
-            // 서버 API 호출
-            if (projectId) {
-              const part = roleToPart(assignTarget.role, backendPart)
-              assignMutation.mutate({
-                memberId: Number(challenger.id),
-                part,
-              })
-            }
+            // 서버 API 호출 - 실패 시 throw해서 AssignmentModal에서 완료 모달 미표시
+            const part = roleToPart(assignTarget.role, backendPart)
+            await assignMutation.mutateAsync({
+              memberId: Number(challenger.id),
+              part,
+            })
           }}
         />
       )}

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -83,7 +83,11 @@ function MatchingApplicationsPage() {
                     dataUpdatedAt={admin.dataUpdatedAt}
                     currentRound={admin.currentRound}
                   />
-                  <ApplicationTableSection projects={adminProjects} />
+                  <ApplicationTableSection
+                    projects={adminProjects}
+                    currentRound={admin.currentRound}
+                    chapterName={selectedChapter}
+                  />
                 </div>
               )}
             </>
@@ -98,7 +102,10 @@ function MatchingApplicationsPage() {
                   </p>
                 </div>
               ) : (
-                <ChallengerApplicationView projects={pmProjects} />
+                <ChallengerApplicationView
+                  projects={pmProjects}
+                  currentRound={challenger.currentRound}
+                />
               )}
             </>
           )}

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -370,7 +370,7 @@ function MatchingRoundsPage() {
     })
     if (hasInvalidRange) {
       addToast({
-        message: "종료 일시는 시작 일시 이후로 설정해 주세요.",
+        message: "종료 날짜는 시작 날짜 이후로 설정해 주세요.",
         color: "red",
         variant: "deep",
         type: "default",

--- a/src/routes/matching/status.tsx
+++ b/src/routes/matching/status.tsx
@@ -106,6 +106,7 @@ function MatchingStatusPage() {
                           gisuId={gisuId}
                           chapterId={chapterId}
                           approvedMemberIds={approvedMemberIds}
+                          chapterName={selectedChapter}
                         />
                       ))}
                     </MatchingPartSection>


### PR DESCRIPTION
## 📸 작업 내용
- 매칭 결과 시트에 닉네임/이름 형식으로 표시하고, partGroups 기반 플랫폼별(Web/iOS/Android) 구분 렌더링으로 변경
- 팀원 수동 배정 모달 검색 결과를 닉네임/이름 형식으로 수정, `mutateAsync` 기반으로 배정 API 연동 및 실패 시 완료 모달 미표시 처리                                                                                                                 
- 지원 현황 상세 모달에서 합불 처리 시 서버 API(`updateApplicationDecision`) 호출하도록 연동
- `isOperator` 권한 범위를 roles 존재 여부가 아닌 실제 운영진 역할(SUPER_ADMIN~CHAPTER_PRESIDENT)로 제한
- 지원 현황 테이블 챌린저/상태 칼럼 정렬 수정
- `currentRound={2}`, `chapterName="Chromium"` 하드코딩을 서버 API 응답 기반으로 대체

## 🎞️  주요 코드 설명
### `isOperator 권한 범위 수정`

```TypeScript
  const ADMIN_ROLE_TYPES: RoleType[] = [
    "SUPER_ADMIN",
    "CENTRAL_PRESIDENT",
    "CENTRAL_VICE_PRESIDENT",
    "CENTRAL_OPERATING_TEAM_MEMBER",
    "CENTRAL_EDUCATION_TEAM_MEMBER",
    "CHAPTER_PRESIDENT",
  ]

  export function isOperator(me: MemberInfoResponse | undefined): boolean {
    return hasAnyRoleType(me, ADMIN_ROLE_TYPES)
  }
```

### `매칭 결과 시트 partGroups 기반 렌더링`

```typescript
  // members API의 partGroups 기반으로 플랫폼별 구분
  if (members) {
    for (const group of members.partGroups) {
      const role = PART_TO_ROLE[group.part]
      if (!role) continue
      for (const member of group.members) {
        const app = approvedAppByMemberId.get(String(member.memberId))
        // ...블록 생성
      }
    }
  }
```

- APPROVED 지원서 목록 대신 getProjectMembers API의 partGroups를 사용하여 수동 배정 멤버도 즉시 반영
- Android/iOS도 Frontend 행으로 통합하되 섹션 헤더로 플랫폼 구분


## 🖥️ 구현화면

|           지원자 목록            |           매칭 결과 시트            |
| :-------------------------: | :-------------------------: |
| <img width="891" height="576" alt="image" src="https://github.com/user-attachments/assets/9223c869-720e-452d-ba5e-c9135471f579" /> |  <img width="547" height="675" alt="image" src="https://github.com/user-attachments/assets/1d81c9ab-a3fa-43a0-bd41-a0526955a6af" /> |

## 🔗 연결된 이슈
- Closed #101 
- Closed #102 
- Closed #119 
- Closed #167 