### PR TITLE
✨ feat: 사용성 조사 모달 노출·스크롤 개선 및 전 case 강제 제출

### DIFF
--- a/src/features/usability-survey/model/types.ts
+++ b/src/features/usability-survey/model/types.ts
@@ -59,11 +59,7 @@ export interface SurveyDivider {
 
 export type SurveyItem = SurveyQuestion | SurveyDivider
 
-export type SurveyFooter =
-  | "close-submit"
-  | "submit-only"
-  | "next-only"
-  | "back-submit"
+export type SurveyFooter = "submit-only" | "next-only" | "back-submit"
 
 export type SurveyRevealMode = "optional-group"
 

--- a/src/features/usability-survey/model/variants.ts
+++ b/src/features/usability-survey/model/variants.ts
@@ -100,6 +100,7 @@ export type SurveyVariantKey =
 
 export const SURVEY_VARIANTS: Record<SurveyVariantKey, SurveyVariantConfig> = {
   "prev-gisu-general-apply": {
+    preventClose: true,
     steps: [
       {
         title: "새롭게 바뀐 지원 경험이 어떠셨나요?",
@@ -114,12 +115,13 @@ export const SURVEY_VARIANTS: Record<SurveyVariantKey, SurveyVariantConfig> = {
           FEEDBACK_TEXT,
           EXTRA_TEXT,
         ],
-        footer: "close-submit",
+        footer: "submit-only",
         reveal: "optional-group",
       },
     ],
   },
   "new-gisu-general-apply": {
+    preventClose: true,
     steps: [
       {
         title: "프로젝트 지원 경험이 어떠셨나요?",
@@ -134,12 +136,13 @@ export const SURVEY_VARIANTS: Record<SurveyVariantKey, SurveyVariantConfig> = {
           FEEDBACK_TEXT,
           EXTRA_TEXT,
         ],
-        footer: "close-submit",
+        footer: "submit-only",
         reveal: "optional-group",
       },
     ],
   },
   "prev-gisu-general-matching": {
+    preventClose: true,
     steps: [
       {
         title: "새롭게 바뀐 매칭 경험이 어떠셨나요?",
@@ -156,6 +159,7 @@ export const SURVEY_VARIANTS: Record<SurveyVariantKey, SurveyVariantConfig> = {
     ],
   },
   "new-gisu-general-matching": {
+    preventClose: true,
     steps: [
       {
         title: "전반적인 매칭 경험이 어떠셨나요?",

--- a/src/features/usability-survey/ui/EmojiScaleWithTextQuestion.tsx
+++ b/src/features/usability-survey/ui/EmojiScaleWithTextQuestion.tsx
@@ -9,8 +9,6 @@ import type { ChangeEvent } from "react"
 
 import type { RatingScore } from "@/shared/assets/icon/emoji"
 
-const REVEAL_MS = 450
-
 export interface EmojiScaleWithTextQuestionProps {
   scores: RatingScore[]
   labels: string[]
@@ -40,18 +38,7 @@ export const EmojiScaleWithTextQuestion = ({
     const input = inputRef.current
     if (!input) return
     input.focus({ preventScroll: true })
-    const prefersReducedMotion =
-      window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false
-    const timer = setTimeout(
-      () => {
-        input.scrollIntoView({
-          block: "nearest",
-          behavior: prefersReducedMotion ? "auto" : "smooth",
-        })
-      },
-      prefersReducedMotion ? 0 : REVEAL_MS,
-    )
-    return () => clearTimeout(timer)
+    input.scrollIntoView({ block: "end", behavior: "instant" })
   }, [showText])
 
   return (
@@ -67,7 +54,7 @@ export const EmojiScaleWithTextQuestion = ({
         aria-hidden={!showText}
         inert={!showText || undefined}
         className={cn(
-          "grid transition-[grid-template-rows,opacity] duration-450 ease-out motion-reduce:transition-none",
+          "grid",
           showText
             ? "grid-rows-[1fr] opacity-100"
             : "grid-rows-[0fr] opacity-0",

--- a/src/features/usability-survey/ui/EmojiScaleWithTextQuestion.tsx
+++ b/src/features/usability-survey/ui/EmojiScaleWithTextQuestion.tsx
@@ -38,7 +38,7 @@ export const EmojiScaleWithTextQuestion = ({
     const input = inputRef.current
     if (!input) return
     input.focus({ preventScroll: true })
-    input.scrollIntoView({ block: "end", behavior: "instant" })
+    input.scrollIntoView({ block: "end", behavior: "auto" })
   }, [showText])
 
   return (

--- a/src/features/usability-survey/ui/SurveyQuestionList.tsx
+++ b/src/features/usability-survey/ui/SurveyQuestionList.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from "react"
+
 import { cn } from "@/shared/lib/utils"
 
 import { isItemAnswered } from "../model/types"
@@ -16,6 +18,51 @@ export type { SurveyAnswers, SurveyAnswerValue } from "../model/types"
 
 const REVEAL_DURATION = "duration-[1500ms]"
 const REVEAL_EASE = "ease-[cubic-bezier(0.22,1,0.36,1)]"
+const SLOW_SCROLL_MS = 1500
+
+const getScrollParent = (el: HTMLElement | null): HTMLElement | null => {
+  let node = el?.parentElement ?? null
+  while (node) {
+    const overflowY = getComputedStyle(node).overflowY
+    if (overflowY === "auto" || overflowY === "scroll") return node
+    node = node.parentElement
+  }
+  return null
+}
+
+const animateScrollToBottom = (
+  container: HTMLElement,
+  durationMs: number,
+): (() => void) => {
+  const maxTop = () => container.scrollHeight - container.clientHeight
+  const prefersReducedMotion =
+    window.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false
+
+  if (prefersReducedMotion || durationMs <= 0) {
+    container.scrollTop = maxTop()
+    return () => {}
+  }
+
+  let rafId = 0
+  const startTime = performance.now()
+  const startTop = container.scrollTop
+
+  const tick = (now: number) => {
+    const progress = Math.min(1, (now - startTime) / durationMs)
+    const eased =
+      progress < 0.5
+        ? 4 * progress ** 3
+        : 1 - Math.pow(-2 * progress + 2, 3) / 2
+    container.scrollTop = startTop + (maxTop() - startTop) * eased
+    if (progress < 1) {
+      rafId = requestAnimationFrame(tick)
+    } else {
+      container.scrollTop = maxTop()
+    }
+  }
+  rafId = requestAnimationFrame(tick)
+  return () => cancelAnimationFrame(rafId)
+}
 
 interface SurveyQuestionListProps {
   items: SurveyItem[]
@@ -37,6 +84,8 @@ export const SurveyQuestionList = ({
   startNumber = 1,
   reveal,
 }: SurveyQuestionListProps) => {
+  const trailingRef = useRef<HTMLDivElement>(null)
+
   let runningNumber = startNumber
   const numbered: NumberedItem[] = items.map((item) => {
     if (item.kind === "divider") return { item, number: 0 }
@@ -44,6 +93,24 @@ export const SurveyQuestionList = ({
     runningNumber += 1
     return { item, number }
   })
+
+  const lastRequiredIndex = items.reduce(
+    (last, item, index) =>
+      item.kind !== "divider" && !item.optional ? index : last,
+    -1,
+  )
+  const leading = numbered.slice(0, lastRequiredIndex + 1)
+  const trailing = numbered.slice(lastRequiredIndex + 1)
+  const revealed =
+    reveal === "optional-group" &&
+    leading.every((entry) => isItemAnswered(entry.item, answers))
+
+  useEffect(() => {
+    if (!revealed) return
+    const container = getScrollParent(trailingRef.current)
+    if (!container) return
+    return animateScrollToBottom(container, SLOW_SCROLL_MS)
+  }, [revealed])
 
   const renderItem = ({ item, number }: NumberedItem) => {
     if (item.kind === "divider") {
@@ -58,17 +125,6 @@ export const SurveyQuestionList = ({
   }
 
   if (reveal === "optional-group") {
-    const lastRequiredIndex = items.reduce(
-      (last, item, index) =>
-        item.kind !== "divider" && !item.optional ? index : last,
-      -1,
-    )
-    const leading = numbered.slice(0, lastRequiredIndex + 1)
-    const trailing = numbered.slice(lastRequiredIndex + 1)
-    const revealed = leading.every((entry) =>
-      isItemAnswered(entry.item, answers),
-    )
-
     return (
       <div className="flex w-full flex-col">
         <div className="flex w-full flex-col gap-12">
@@ -79,12 +135,11 @@ export const SurveyQuestionList = ({
 
         {trailing.length > 0 && (
           <div
+            ref={trailingRef}
             aria-hidden={!revealed}
             inert={!revealed || undefined}
             className={cn(
-              "grid transition-[grid-template-rows] motion-reduce:transition-none",
-              REVEAL_DURATION,
-              REVEAL_EASE,
+              "grid",
               revealed ? "grid-rows-[1fr]" : "grid-rows-[0fr]",
             )}
           >

--- a/src/routes/test/usability-survey.tsx
+++ b/src/routes/test/usability-survey.tsx
@@ -84,16 +84,6 @@ function UsabilitySurveyTestPage() {
         </Button>
       )
     }
-    if (footerKind === "close-submit") {
-      return (
-        <>
-          <Button variant="weak" color="neutral" onClick={() => setOpen(false)}>
-            닫기
-          </Button>
-          {submitButton}
-        </>
-      )
-    }
     if (footerKind === "back-submit") {
       return (
         <div className="flex gap-3">


### PR DESCRIPTION
## 📸 작업 내용

> 사용성 조사 모달의 노출/스크롤 인터랙션을 다듬고, 전 case를 강제 제출(닫기·ESC·배경 차단)로 변경했습니다.

- 선택 문항을 순차가 아닌 **한 번에 동시 노출** (높이 즉시 전환 + opacity 페이드)
- step1 정보탐색 입력칸: **즉시 노출 + 즉시 스크롤**(지연 없음, 제일 빠르게)
- step2 선택 그룹: 노출 후 **약 1.5초 느린 스크롤**로 끝까지 (커스텀 rAF, ease-in-out)
- 전 case `preventClose` 적용 → **ESC·배경 클릭 닫기 차단**, case1·2 닫기 버튼 제거 (강제 피드백)
- 미사용 `close-submit` 푸터 타입·분기 제거
- `prefers-reduced-motion` 대응

## 🎞️ 주요 코드 설명

### 단계별 스크롤 속도 구분

step1은 입력칸 즉시 노출 후 네이티브 instant 스크롤(가장 빠름), step2는 지속시간을 지정한 커스텀 rAF 스크롤(`SLOW_SCROLL_MS = 1500`, ease-in-out)로 끝까지 천천히 이동한다.

```TypeScript
const animateScrollToBottom = (container: HTMLElement, durationMs: number) => {
  const maxTop = () => container.scrollHeight - container.clientHeight
  // ... requestAnimationFrame 루프 + ease-in-out, 매 프레임 maxTop 추적
}
```

## 🖥️ 구현화면

> localhost 캡처 첨부 예정

|       선택 문항 동시 노출/스크롤       |        전 case 강제 제출(닫기 없음)        |
| :-----------------------------------: | :--------------------------------------: |
|       <img src="" width="250">       |        <img src="" width="250">         |

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요!

- 관련: #178 (사용성 조사 모달 UX 개선)

## 💬 기타 더 이야기해볼 점

- step2 스크롤 속도는 `SLOW_SCROLL_MS`(현재 1500ms)로 조정 가능합니다.
- 모달은 테스트 페이지(`/test/usability-survey`) 데모 연결 상태이며, 실제 앱 통합·API 연동·유효성 검증은 별도 후속 이슈에서 진행 예정입니다.
