### PR TITLE
[FIX] 매칭 프로젝트 설정 권한 기반 CRUD에 대한 전반적인 QA

### DIFF
--- a/src/components/sidebar/MatchingSegmentRegion.tsx
+++ b/src/components/sidebar/MatchingSegmentRegion.tsx
@@ -2,7 +2,11 @@ import { useRouterState } from "@tanstack/react-router"
 import { useMemo } from "react"
 
 import { useMe } from "@/features/auth/hooks/useMe"
-import { isOperator } from "@/features/auth/model/identity"
+import {
+  canAccessProjectSettings,
+  canManageProjects,
+  isOperator,
+} from "@/features/auth/model/identity"
 import { SIDEBAR_ITEMS } from "@/shared/config/navigation"
 import { resolveNavigationFromPathname } from "@/shared/config/navigationResolve"
 import { Segment, type SegmentItem } from "@/shared/ui/segment/Segment"
@@ -12,11 +16,18 @@ import { filterSectionsByPermission } from "./utils"
 export function MatchingSegmentRegion() {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const { data: me } = useMe()
-  const canManageRecruitment = isOperator(me)
+  const canAccessSettings = canAccessProjectSettings(me)
+  const canManage = canManageProjects(me)
+  const canRecruit = isOperator(me)
 
   const visibleSections = useMemo(
-    () => filterSectionsByPermission(SIDEBAR_ITEMS, canManageRecruitment),
-    [canManageRecruitment],
+    () =>
+      filterSectionsByPermission(SIDEBAR_ITEMS, {
+        canAccessProjectSettings: canAccessSettings,
+        canManageProjects: canManage,
+        canManageRecruitment: canRecruit,
+      }),
+    [canAccessSettings, canManage, canRecruit],
   )
 
   const resolved = resolveNavigationFromPathname(pathname, visibleSections)

--- a/src/components/sidebar/SideBar.tsx
+++ b/src/components/sidebar/SideBar.tsx
@@ -1,7 +1,12 @@
 import { useEffect, useMemo, useState } from "react"
 
 import { useMe } from "@/features/auth/hooks/useMe"
-import { isCurrentTermPm, isOperator } from "@/features/auth/model/identity"
+import {
+  canAccessProjectSettings,
+  canManageProjects,
+  isCurrentTermPm,
+  isOperator,
+} from "@/features/auth/model/identity"
 import { SIDEBAR_ITEMS } from "@/shared/config/navigation"
 import { cn } from "@/shared/lib/utils"
 
@@ -17,11 +22,18 @@ const DEMO_DAY_EDITION = 10
 
 export default function SideBar({ className }: SideBarProps) {
   const { data: me, isLoading: isMeLoading } = useMe()
-  const canManageRecruitment = isOperator(me) || isCurrentTermPm(me)
+  const canAccessSettings = canAccessProjectSettings(me)
+  const canManage = canManageProjects(me)
+  const canRecruit = isOperator(me) || isCurrentTermPm(me)
 
   const visibleSections = useMemo(
-    () => filterSectionsByPermission(SIDEBAR_ITEMS, canManageRecruitment),
-    [canManageRecruitment],
+    () =>
+      filterSectionsByPermission(SIDEBAR_ITEMS, {
+        canAccessProjectSettings: canAccessSettings,
+        canManageProjects: canManage,
+        canManageRecruitment: canRecruit,
+      }),
+    [canAccessSettings, canManage, canRecruit],
   )
 
   const [openSectionId, setOpenSectionId] = useState<string>(

--- a/src/components/sidebar/utils.test.ts
+++ b/src/components/sidebar/utils.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+
+import { SIDEBAR_ITEMS } from "@/shared/config/navigation"
+
+import { filterSectionsByPermission } from "./utils"
+
+const ALL = {
+  canAccessProjectSettings: true,
+  canManageProjects: true,
+  canManageRecruitment: true,
+}
+
+function sectionIds(sections: ReturnType<typeof filterSectionsByPermission>) {
+  return sections.map((s) => s.id)
+}
+function menuIds(
+  sections: ReturnType<typeof filterSectionsByPermission>,
+  sectionId: string,
+) {
+  return sections.find((s) => s.id === sectionId)?.menus.map((m) => m.id) ?? []
+}
+
+describe("filterSectionsByPermission", () => {
+  it("전부 허용이면 모든 섹션·항목 노출", () => {
+    const result = filterSectionsByPermission(SIDEBAR_ITEMS, ALL)
+    expect(sectionIds(result)).toContain("project-settings")
+    expect(menuIds(result, "project-settings")).toEqual([
+      "project-announce",
+      "project-register",
+      "project-management",
+    ])
+    expect(menuIds(result, "team-matching")).toContain("matching-rounds")
+  })
+
+  it("그룹 접근 불가면 [프로젝트 설정] 섹션 제거", () => {
+    const result = filterSectionsByPermission(SIDEBAR_ITEMS, {
+      ...ALL,
+      canAccessProjectSettings: false,
+    })
+    expect(sectionIds(result)).not.toContain("project-settings")
+  })
+
+  it("그룹 접근 불가면 canManageProjects 값에 무관하게 섹션 제거", () => {
+    const result = filterSectionsByPermission(SIDEBAR_ITEMS, {
+      canAccessProjectSettings: false,
+      canManageProjects: true,
+      canManageRecruitment: true,
+    })
+    expect(sectionIds(result)).not.toContain("project-settings")
+  })
+
+  it("그룹은 보되 관리 불가면 등록·관리 항목만 숨김(공지는 노출)", () => {
+    const result = filterSectionsByPermission(SIDEBAR_ITEMS, {
+      ...ALL,
+      canManageProjects: false,
+    })
+    expect(menuIds(result, "project-settings")).toEqual(["project-announce"])
+  })
+
+  it("recruitment 불가면 매칭 차수 설정 항목 제거", () => {
+    const result = filterSectionsByPermission(SIDEBAR_ITEMS, {
+      ...ALL,
+      canManageRecruitment: false,
+    })
+    expect(menuIds(result, "team-matching")).not.toContain("matching-rounds")
+  })
+})

--- a/src/components/sidebar/utils.ts
+++ b/src/components/sidebar/utils.ts
@@ -1,20 +1,47 @@
 import { SIDEBAR_ID, type SideBarSection } from "@/shared/config/navigation"
 
+export interface SidebarPermissions {
+  canAccessProjectSettings: boolean
+  canManageProjects: boolean
+  canManageRecruitment: boolean
+}
+
 export function filterSectionsByPermission(
   sections: readonly SideBarSection[],
-  canManageRecruitment: boolean,
+  {
+    canAccessProjectSettings,
+    canManageProjects,
+    canManageRecruitment,
+  }: SidebarPermissions,
 ): SideBarSection[] {
-  if (canManageRecruitment) return [...sections]
-
   return sections
-    .filter((section) => section.id !== SIDEBAR_ID.section.projectSettings)
+    .filter((section) =>
+      section.id === SIDEBAR_ID.section.projectSettings
+        ? canAccessProjectSettings
+        : true,
+    )
     .map((section) => {
-      if (section.id !== SIDEBAR_ID.section.teamMatching) return section
-      return {
-        ...section,
-        menus: section.menus.filter(
-          (menu) => menu.id !== SIDEBAR_ID.item.matchingRounds,
-        ),
+      if (section.id === SIDEBAR_ID.section.projectSettings) {
+        return {
+          ...section,
+          menus: section.menus.filter((menu) =>
+            menu.id === SIDEBAR_ID.item.projectRegister ||
+            menu.id === SIDEBAR_ID.item.projectManagement
+              ? canManageProjects
+              : true,
+          ),
+        }
       }
+      if (section.id === SIDEBAR_ID.section.teamMatching) {
+        return {
+          ...section,
+          menus: section.menus.filter((menu) =>
+            menu.id === SIDEBAR_ID.item.matchingRounds
+              ? canManageRecruitment
+              : true,
+          ),
+        }
+      }
+      return section
     })
 }

--- a/src/features/application/ui/ApplicationDetailModal.tsx
+++ b/src/features/application/ui/ApplicationDetailModal.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useMemo, useState } from "react"
 
+import { useResourcePermissionsBatch } from "@/features/auth/hooks/useResourcePermissionsBatch"
 import { Modal } from "@/shared/ui/Modal"
 
 import { updateApplicationDecision } from "../api/applicationApi"
@@ -9,6 +10,8 @@ import { useApplicationDetail } from "../hooks/useApplications"
 import { toApplicantFormData, toServerStatus } from "../model/mappers"
 import { ModalApplicantPanel } from "./detail-modal/ModalApplicantPanel"
 import { ModalFormPanel } from "./detail-modal/ModalFormPanel"
+
+import type { ResourcePermissionQuery } from "@/features/auth/api/permissions"
 
 import type { ProjectApplication, StatusValue } from "../model/types"
 
@@ -19,6 +22,11 @@ interface ApplicationDetailModalProps {
   onOpenChange: (open: boolean) => void
   /** 현재 활성 차수 (이전 차수의 상태 칩 disabled 처리) */
   currentRound?: number
+}
+
+function toApplicationId(applicantId: string): number | null {
+  const id = Number(applicantId)
+  return Number.isFinite(id) && id > 0 ? id : null
 }
 
 export function ApplicationDetailModal({
@@ -36,6 +44,44 @@ export function ApplicationDetailModal({
   const [statusOverrides, setStatusOverrides] = useState<
     Record<string, StatusValue>
   >({})
+
+  const applicationIds = useMemo(() => {
+    const ids = new Set<number>()
+    for (const applicant of project.applicants) {
+      const id = toApplicationId(applicant.id)
+      if (id !== null) ids.add(id)
+    }
+    return Array.from(ids)
+  }, [project.applicants])
+
+  const approvePermissionQueries = useMemo<ResourcePermissionQuery[]>(
+    () => [
+      {
+        resourceType: "PROJECT_APPLICATION",
+        resourceIds: applicationIds,
+        permissionTypes: ["APPROVE"],
+      },
+    ],
+    [applicationIds],
+  )
+
+  const approvePermissionsQuery = useResourcePermissionsBatch(
+    approvePermissionQueries,
+    { enabled: open },
+  )
+
+  const isApprovePermissionLoading =
+    open && applicationIds.length > 0 && approvePermissionsQuery.isPending
+
+  const canApproveApplicant = (applicantId: string): boolean => {
+    const applicationId = toApplicationId(applicantId)
+    if (applicationId === null) return false
+    return approvePermissionsQuery.hasPermission({
+      resourceType: "PROJECT_APPLICATION",
+      resourceId: applicationId,
+      permissionType: "APPROVE",
+    })
+  }
 
   const projectWithOverrides = useMemo(() => {
     if (Object.keys(statusOverrides).length === 0) return project
@@ -77,11 +123,6 @@ export function ApplicationDetailModal({
     },
   })
 
-  const handleStatusChange = (appId: string, status: StatusValue) => {
-    setStatusOverrides((prev) => ({ ...prev, [appId]: status }))
-    decisionMutation.mutate({ appId: Number(appId), status })
-  }
-
   // 서버 formResponse -> 프론트 ApplicantFormData 변환
   const formData = useMemo(() => {
     if (!detailQuery.data?.formResponse || !selectedApplicantId) return null
@@ -92,6 +133,27 @@ export function ApplicationDetailModal({
   }, [detailQuery.data, selectedApplicantId])
 
   const hasPanel = selectedApplicant !== null
+
+  const canChangeApplicantStatus = (
+    applicantId: string,
+    applicantRound: number,
+  ): boolean =>
+    !isApprovePermissionLoading &&
+    canApproveApplicant(applicantId) &&
+    !(currentRound != null && applicantRound < currentRound)
+
+  const handleApplicantStatusChange = (
+    applicantId: string,
+    status: StatusValue,
+  ) => {
+    const applicant = projectWithOverrides.applicants.find(
+      (item) => item.id === applicantId,
+    )
+    if (!applicant) return
+    if (!canChangeApplicantStatus(applicant.id, applicant.round)) return
+    setStatusOverrides((prev) => ({ ...prev, [applicant.id]: status }))
+    decisionMutation.mutate({ appId: Number(applicant.id), status })
+  }
 
   const handleClose = () => {
     onOpenChange(false)
@@ -137,9 +199,11 @@ export function ApplicationDetailModal({
               onStatusFilterChange={setStatusFilter}
               selectedApplicantId={selectedApplicantId}
               onApplicantClick={setSelectedApplicantId}
-              onStatusChange={handleStatusChange}
+              onStatusChange={handleApplicantStatusChange}
               onClose={handleClose}
               currentRound={currentRound}
+              canApproveApplicant={canApproveApplicant}
+              approvePermissionLoading={isApprovePermissionLoading}
             />
           </div>
 
@@ -152,11 +216,14 @@ export function ApplicationDetailModal({
               challengerName={project.challengerName}
               challengerUniversity={project.challengerUniversity}
               onStatusChange={(status) =>
-                handleStatusChange(selectedApplicantId!, status)
+                handleApplicantStatusChange(selectedApplicant.id, status)
               }
               onClose={handlePanelClose}
               statusDisabled={
-                currentRound != null && selectedApplicant.round < currentRound
+                !canChangeApplicantStatus(
+                  selectedApplicant.id,
+                  selectedApplicant.round,
+                )
               }
               className="max-h-[calc(100vh-60px)] shadow-xl"
             />

--- a/src/features/application/ui/detail-modal/ApplicantRoleSection.tsx
+++ b/src/features/application/ui/detail-modal/ApplicantRoleSection.tsx
@@ -13,6 +13,8 @@ interface ApplicantRoleSectionProps {
   onApplicantClick: (id: string) => void
   onStatusChange?: (applicantId: string, status: StatusValue) => void
   currentRound?: number
+  canApproveApplicant: (applicantId: string) => boolean
+  approvePermissionLoading: boolean
   className?: string
 }
 
@@ -24,6 +26,8 @@ export function ApplicantRoleSection({
   onApplicantClick,
   onStatusChange,
   currentRound,
+  canApproveApplicant,
+  approvePermissionLoading,
   className,
 }: ApplicantRoleSectionProps) {
   const roundCounts = applicants.reduce<Record<number, number>>((acc, a) => {
@@ -61,23 +65,28 @@ export function ApplicantRoleSection({
 
       {/* 행 */}
       <div className="mt-2">
-        {applicants.map((applicant) => (
-          <ApplicantRow
-            key={applicant.id}
-            name={applicant.name}
-            university={applicant.university}
-            round={applicant.round}
-            status={applicant.status}
-            processedAt={applicant.processedAt}
-            appliedAt={applicant.appliedAt}
-            isSelected={selectedApplicantId === applicant.id}
-            onClick={() => onApplicantClick(applicant.id)}
-            onStatusChange={(s) => onStatusChange?.(applicant.id, s)}
-            statusDisabled={
-              currentRound != null && applicant.round < currentRound
-            }
-          />
-        ))}
+        {applicants.map((applicant) => {
+          const statusDisabled =
+            approvePermissionLoading ||
+            !canApproveApplicant(applicant.id) ||
+            (currentRound != null && applicant.round < currentRound)
+
+          return (
+            <ApplicantRow
+              key={applicant.id}
+              name={applicant.name}
+              university={applicant.university}
+              round={applicant.round}
+              status={applicant.status}
+              processedAt={applicant.processedAt}
+              appliedAt={applicant.appliedAt}
+              isSelected={selectedApplicantId === applicant.id}
+              onClick={() => onApplicantClick(applicant.id)}
+              onStatusChange={(s) => onStatusChange?.(applicant.id, s)}
+              statusDisabled={statusDisabled}
+            />
+          )
+        })}
       </div>
     </div>
   )

--- a/src/features/application/ui/detail-modal/ModalApplicantPanel.tsx
+++ b/src/features/application/ui/detail-modal/ModalApplicantPanel.tsx
@@ -29,6 +29,8 @@ interface ModalApplicantPanelProps {
   onStatusChange?: (applicantId: string, status: StatusValue) => void
   onClose: () => void
   currentRound?: number
+  canApproveApplicant: (applicantId: string) => boolean
+  approvePermissionLoading: boolean
   className?: string
 }
 
@@ -44,6 +46,8 @@ export function ModalApplicantPanel({
   onStatusChange,
   onClose,
   currentRound,
+  canApproveApplicant,
+  approvePermissionLoading,
   className,
 }: ModalApplicantPanelProps) {
   const filteredApplicants = useMemo(() => {
@@ -216,6 +220,8 @@ export function ModalApplicantPanel({
             onApplicantClick={onApplicantClick}
             onStatusChange={onStatusChange}
             currentRound={currentRound}
+            canApproveApplicant={canApproveApplicant}
+            approvePermissionLoading={approvePermissionLoading}
           />
         ))}
 

--- a/src/features/application/ui/detail-modal/ModalFormPanel.tsx
+++ b/src/features/application/ui/detail-modal/ModalFormPanel.tsx
@@ -137,13 +137,25 @@ export function ModalFormPanel({
                     statusDisabled && "pointer-events-none",
                   )}
                 >
-                  <OptionButton value="pass" className="h-7.5 gap-0.5">
+                  <OptionButton
+                    value="pass"
+                    disabled={statusDisabled}
+                    className="h-7.5 gap-0.5"
+                  >
                     합격
                   </OptionButton>
-                  <OptionButton value="fail" className="h-7.5 gap-0.5">
+                  <OptionButton
+                    value="fail"
+                    disabled={statusDisabled}
+                    className="h-7.5 gap-0.5"
+                  >
                     불합격
                   </OptionButton>
-                  <OptionButton value="pending" className="h-7.5 gap-0.5">
+                  <OptionButton
+                    value="pending"
+                    disabled={statusDisabled}
+                    className="h-7.5 gap-0.5"
+                  >
                     대기
                   </OptionButton>
                 </OptionButtonGroup>

--- a/src/features/auth/api/permissions.ts
+++ b/src/features/auth/api/permissions.ts
@@ -9,16 +9,31 @@ export type ResourceType = NonNullable<
 export type PermissionType = NonNullable<
   components["schemas"]["PermissionInfo"]["permissionType"]
 >
+export type ResourcePermissionQuery =
+  components["schemas"]["ResourcePermissionQueryRequest"]
 export type ResourcePermissionResponse =
   components["schemas"]["ResourcePermissionResponse"]
+export type BatchResourcePermissionResponse =
+  components["schemas"]["BatchResourcePermissionResponse"]
 
 export async function getResourcePermission(params: {
   resourceType: ResourceType
   resourceId?: number
+  permissionType?: PermissionType
 }): Promise<ResourcePermissionResponse> {
   const { data } = await api.get<ApiResponse<ResourcePermissionResponse>>(
     "/v1/authorization/resource-permission",
     { params },
+  )
+  return data.result
+}
+
+export async function batchGetResourcePermission(
+  queries: ResourcePermissionQuery[],
+): Promise<BatchResourcePermissionResponse> {
+  const { data } = await api.post<ApiResponse<BatchResourcePermissionResponse>>(
+    "/v1/authorization/resource-permissions/batch",
+    { queries },
   )
   return data.result
 }

--- a/src/features/auth/hooks/useResourcePermission.ts
+++ b/src/features/auth/hooks/useResourcePermission.ts
@@ -5,30 +5,43 @@ import {
   type PermissionType,
   type ResourceType,
 } from "@/features/auth/api/permissions"
+import { hasGrantedPermission } from "@/features/auth/model/resourcePermission"
 import { useAuthStore } from "@/features/auth/store/authStore"
+
+interface UseResourcePermissionOptions {
+  enabled?: boolean
+  permissionType?: PermissionType
+  allowTypeLevel?: boolean
+}
 
 export function useResourcePermission(
   resourceType: ResourceType,
   resourceId?: number,
-  options?: { enabled?: boolean },
+  options?: UseResourcePermissionOptions,
 ) {
   const isAuthed = useAuthStore((s) => s.isAuthed)
+  const canRequest =
+    resourceId !== undefined || options?.allowTypeLevel === true
   const query = useQuery({
     queryKey: [
       "authorization",
       "resource-permission",
       resourceType,
       resourceId,
+      options?.permissionType,
     ],
-    queryFn: () => getResourcePermission({ resourceType, resourceId }),
-    enabled: isAuthed && resourceId !== undefined && (options?.enabled ?? true),
+    queryFn: () =>
+      getResourcePermission({
+        resourceType,
+        resourceId,
+        permissionType: options?.permissionType,
+      }),
+    enabled: isAuthed && canRequest && (options?.enabled ?? true),
     staleTime: 0,
   })
 
   const hasPermission = (type: PermissionType): boolean =>
-    query.data?.permissions?.some(
-      (p) => p.permissionType === type && p.hasPermission === true,
-    ) ?? false
+    hasGrantedPermission(query.data, type)
 
   return {
     ...query,

--- a/src/features/auth/hooks/useResourcePermission.ts
+++ b/src/features/auth/hooks/useResourcePermission.ts
@@ -20,8 +20,7 @@ export function useResourcePermission(
   options?: UseResourcePermissionOptions,
 ) {
   const isAuthed = useAuthStore((s) => s.isAuthed)
-  const canRequest =
-    resourceId !== undefined || options?.allowTypeLevel === true
+  const canRequest = resourceId != null || options?.allowTypeLevel === true
   const query = useQuery({
     queryKey: [
       "authorization",

--- a/src/features/auth/hooks/useResourcePermissionsBatch.ts
+++ b/src/features/auth/hooks/useResourcePermissionsBatch.ts
@@ -1,0 +1,62 @@
+import { useQuery } from "@tanstack/react-query"
+
+import {
+  batchGetResourcePermission,
+  type PermissionType,
+  type ResourcePermissionQuery,
+  type ResourceType,
+} from "@/features/auth/api/permissions"
+import { hasGrantedResourcePermission } from "@/features/auth/model/resourcePermission"
+import { useAuthStore } from "@/features/auth/store/authStore"
+
+interface UseResourcePermissionsBatchOptions {
+  enabled?: boolean
+}
+
+function normalizeResourcePermissionQueries(
+  queries: ResourcePermissionQuery[],
+): ResourcePermissionQuery[] {
+  return queries
+    .filter(
+      (query) =>
+        query.resourceIds === undefined || query.resourceIds.length > 0,
+    )
+    .map((query) => ({
+      ...query,
+      permissionTypes:
+        query.permissionTypes !== undefined && query.permissionTypes.length > 0
+          ? query.permissionTypes
+          : undefined,
+    }))
+}
+
+export function useResourcePermissionsBatch(
+  queries: ResourcePermissionQuery[],
+  options?: UseResourcePermissionsBatchOptions,
+) {
+  const isAuthed = useAuthStore((s) => s.isAuthed)
+  const normalizedQueries = normalizeResourcePermissionQueries(queries)
+  const query = useQuery({
+    queryKey: [
+      "authorization",
+      "resource-permissions",
+      "batch",
+      normalizedQueries,
+    ],
+    queryFn: () => batchGetResourcePermission(normalizedQueries),
+    enabled:
+      isAuthed && normalizedQueries.length > 0 && (options?.enabled ?? true),
+    staleTime: 0,
+  })
+
+  const hasPermission = (params: {
+    resourceType: ResourceType
+    resourceId?: number
+    permissionType: PermissionType
+  }): boolean => hasGrantedResourcePermission(query.data?.results, params)
+
+  return {
+    ...query,
+    hasPermission,
+  }
+}

--- a/src/features/auth/model/identity.test.ts
+++ b/src/features/auth/model/identity.test.ts
@@ -104,6 +104,32 @@ describe("canAccessProjectSettings", () => {
       ),
     ).toBe(false)
   })
+  it("최신 기수의 part가 PLAN이 아니면 false (이전 기수 PLAN 무시)", () => {
+    expect(
+      canAccessProjectSettings(
+        makeMe(
+          ["CHALLENGER"],
+          [
+            { gisuId: "9", part: "PLAN" },
+            { gisuId: "10", part: "IOS" },
+          ],
+        ),
+      ),
+    ).toBe(false)
+  })
+  it("이전 기수가 비PLAN이어도 최신 기수가 PLAN이면 true", () => {
+    expect(
+      canAccessProjectSettings(
+        makeMe(
+          ["CHALLENGER"],
+          [
+            { gisuId: "9", part: "IOS" },
+            { gisuId: "10", part: "PLAN" },
+          ],
+        ),
+      ),
+    ).toBe(true)
+  })
 })
 
 describe("canManageProjects", () => {
@@ -111,6 +137,7 @@ describe("canManageProjects", () => {
     expect(canManageProjects(makeMe(["SCHOOL_VICE_PRESIDENT"]))).toBe(true)
     expect(canManageProjects(makeMe(["CHAPTER_PRESIDENT"]))).toBe(true)
     expect(canManageProjects(makeMe(["CENTRAL_PRESIDENT"]))).toBe(true)
+    expect(canManageProjects(makeMe(["SUPER_ADMIN"]))).toBe(true)
   })
   it("학교 파트장·기타운영진은 false(등록·관리 제외)", () => {
     expect(canManageProjects(makeMe(["SCHOOL_PART_LEADER"]))).toBe(false)

--- a/src/features/auth/model/identity.test.ts
+++ b/src/features/auth/model/identity.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   canAccessProjectSettings,
   canManageProjects,
+  getProjectPmSearchScope,
   isAnyOperator,
   isSchoolLeadership,
 } from "./identity"
@@ -15,19 +16,26 @@ import type {
   RoleType,
 } from "@/features/challenger/model/types"
 
+type RoleSpec = RoleType | { roleType: RoleType; organizationId: string }
+
 function makeMe(
-  roleTypes: RoleType[],
+  roleSpecs: RoleSpec[],
   records: Array<{ gisuId: string; part: Part }> = [],
+  overrides: Partial<MemberInfoResponse> = {},
 ): MemberInfoResponse {
-  const roles: ChallengerRoleResponse[] = roleTypes.map((roleType) => ({
-    challengerRoleId: "0",
-    challengerId: "0",
-    roleType,
-    organizationType: "CENTRAL",
-    organizationId: "0",
-    gisuId: "10",
-    gisu: "10",
-  }))
+  const roles: ChallengerRoleResponse[] = roleSpecs.map((spec) => {
+    const roleType = typeof spec === "string" ? spec : spec.roleType
+    const organizationId = typeof spec === "string" ? "0" : spec.organizationId
+    return {
+      challengerRoleId: "0",
+      challengerId: "0",
+      roleType,
+      organizationType: "CENTRAL",
+      organizationId,
+      gisuId: "10",
+      gisu: "10",
+    }
+  })
 
   const challengerRecords: ChallengerInfoResponse[] = records.map((r) => ({
     challengerId: "0",
@@ -56,6 +64,7 @@ function makeMe(
     status: "ACTIVE",
     roles,
     challengerRecords,
+    ...overrides,
   }
 }
 
@@ -154,5 +163,51 @@ describe("canManageProjects", () => {
         makeMe(["CHALLENGER"], [{ gisuId: "10", part: "NODEJS" }]),
       ),
     ).toBe(false)
+  })
+})
+
+describe("getProjectPmSearchScope", () => {
+  it("SUPER_ADMIN은 빈 객체 반환", () => {
+    expect(getProjectPmSearchScope(makeMe(["SUPER_ADMIN"]))).toEqual({})
+  })
+
+  it("중앙 운영진(CENTRAL_PRESIDENT)은 빈 객체 반환", () => {
+    expect(getProjectPmSearchScope(makeMe(["CENTRAL_PRESIDENT"]))).toEqual({})
+  })
+
+  it("CHAPTER_PRESIDENT는 해당 역할의 organizationId를 chapterId로 반환", () => {
+    expect(
+      getProjectPmSearchScope(
+        makeMe([{ roleType: "CHAPTER_PRESIDENT", organizationId: "77" }]),
+      ),
+    ).toEqual({ chapterId: "77" })
+  })
+
+  it("SCHOOL_PRESIDENT는 schoolId를 문자열로 반환", () => {
+    expect(
+      getProjectPmSearchScope(
+        makeMe(["SCHOOL_PRESIDENT"], [], { schoolId: 12 }),
+      ),
+    ).toEqual({ schoolId: "12" })
+  })
+
+  it("SCHOOL_VICE_PRESIDENT도 schoolId를 문자열로 반환", () => {
+    expect(
+      getProjectPmSearchScope(
+        makeMe(["SCHOOL_VICE_PRESIDENT"], [], { schoolId: 5 }),
+      ),
+    ).toEqual({ schoolId: "5" })
+  })
+
+  it("순수 PM(현기수 PLAN, 운영 역할 없음)은 빈 객체 반환", () => {
+    expect(
+      getProjectPmSearchScope(
+        makeMe(["CHALLENGER"], [{ gisuId: "10", part: "PLAN" }]),
+      ),
+    ).toEqual({})
+  })
+
+  it("undefined는 빈 객체 반환", () => {
+    expect(getProjectPmSearchScope(undefined)).toEqual({})
   })
 })

--- a/src/features/auth/model/identity.test.ts
+++ b/src/features/auth/model/identity.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  canAccessProjectSettings,
+  canManageProjects,
+  isAnyOperator,
+  isSchoolLeadership,
+} from "./identity"
+
+import type { MemberInfoResponse } from "@/features/auth/api/me"
+import type {
+  ChallengerInfoResponse,
+  ChallengerRoleResponse,
+  Part,
+  RoleType,
+} from "@/features/challenger/model/types"
+
+function makeMe(
+  roleTypes: RoleType[],
+  records: Array<{ gisuId: string; part: Part }> = [],
+): MemberInfoResponse {
+  const roles: ChallengerRoleResponse[] = roleTypes.map((roleType) => ({
+    challengerRoleId: "0",
+    challengerId: "0",
+    roleType,
+    organizationType: "CENTRAL",
+    organizationId: "0",
+    gisuId: "10",
+    gisu: "10",
+  }))
+
+  const challengerRecords: ChallengerInfoResponse[] = records.map((r) => ({
+    challengerId: "0",
+    memberId: "0",
+    gisuId: r.gisuId,
+    gisu: r.gisuId,
+    chapterId: "0",
+    chapterName: "테스트 지부",
+    part: r.part,
+    challengerStatus: "ACTIVE",
+    name: "테스트",
+    nickname: "테스트",
+    email: null,
+    schoolId: "0",
+    schoolName: "테스트 학교",
+  }))
+
+  return {
+    id: 0,
+    name: "테스트",
+    nickname: "테스트",
+    email: "test@test.com",
+    schoolId: 0,
+    schoolName: "테스트 학교",
+    profileImageLink: "",
+    status: "ACTIVE",
+    roles,
+    challengerRecords,
+  }
+}
+
+describe("isSchoolLeadership", () => {
+  it("학교 회장·부회장은 true", () => {
+    expect(isSchoolLeadership(makeMe(["SCHOOL_PRESIDENT"]))).toBe(true)
+    expect(isSchoolLeadership(makeMe(["SCHOOL_VICE_PRESIDENT"]))).toBe(true)
+  })
+  it("학교 파트장·기타운영진은 false", () => {
+    expect(isSchoolLeadership(makeMe(["SCHOOL_PART_LEADER"]))).toBe(false)
+    expect(isSchoolLeadership(makeMe(["SCHOOL_ETC_ADMIN"]))).toBe(false)
+  })
+  it("undefined는 false", () => {
+    expect(isSchoolLeadership(undefined)).toBe(false)
+  })
+})
+
+describe("isAnyOperator", () => {
+  it("중앙/지부/학교 4종 모두 true", () => {
+    expect(isAnyOperator(makeMe(["SUPER_ADMIN"]))).toBe(true)
+    expect(isAnyOperator(makeMe(["CENTRAL_OPERATING_TEAM_MEMBER"]))).toBe(true)
+    expect(isAnyOperator(makeMe(["CHAPTER_PRESIDENT"]))).toBe(true)
+    expect(isAnyOperator(makeMe(["SCHOOL_PART_LEADER"]))).toBe(true)
+    expect(isAnyOperator(makeMe(["SCHOOL_ETC_ADMIN"]))).toBe(true)
+  })
+  it("일반 챌린저는 false", () => {
+    expect(isAnyOperator(makeMe(["CHALLENGER"]))).toBe(false)
+  })
+})
+
+describe("canAccessProjectSettings", () => {
+  it("학교 기타운영진은 true(그룹 노출)", () => {
+    expect(canAccessProjectSettings(makeMe(["SCHOOL_ETC_ADMIN"]))).toBe(true)
+  })
+  it("현기수 PM(최신 기수 PLAN)은 true", () => {
+    expect(
+      canAccessProjectSettings(
+        makeMe(["CHALLENGER"], [{ gisuId: "10", part: "PLAN" }]),
+      ),
+    ).toBe(true)
+  })
+  it("비PM 일반 챌린저는 false", () => {
+    expect(
+      canAccessProjectSettings(
+        makeMe(["CHALLENGER"], [{ gisuId: "10", part: "IOS" }]),
+      ),
+    ).toBe(false)
+  })
+})
+
+describe("canManageProjects", () => {
+  it("학교 회장단·중앙·지부장은 true", () => {
+    expect(canManageProjects(makeMe(["SCHOOL_VICE_PRESIDENT"]))).toBe(true)
+    expect(canManageProjects(makeMe(["CHAPTER_PRESIDENT"]))).toBe(true)
+    expect(canManageProjects(makeMe(["CENTRAL_PRESIDENT"]))).toBe(true)
+  })
+  it("학교 파트장·기타운영진은 false(등록·관리 제외)", () => {
+    expect(canManageProjects(makeMe(["SCHOOL_PART_LEADER"]))).toBe(false)
+    expect(canManageProjects(makeMe(["SCHOOL_ETC_ADMIN"]))).toBe(false)
+  })
+  it("현기수 PM은 true, 비PM 챌린저는 false", () => {
+    expect(
+      canManageProjects(
+        makeMe(["CHALLENGER"], [{ gisuId: "10", part: "PLAN" }]),
+      ),
+    ).toBe(true)
+    expect(
+      canManageProjects(
+        makeMe(["CHALLENGER"], [{ gisuId: "10", part: "NODEJS" }]),
+      ),
+    ).toBe(false)
+  })
+})

--- a/src/features/auth/model/identity.ts
+++ b/src/features/auth/model/identity.ts
@@ -27,6 +27,11 @@ const SCHOOL_ROLE_TYPES: RoleType[] = [
   "SCHOOL_ETC_ADMIN",
 ]
 
+const SCHOOL_LEADERSHIP_ROLE_TYPES: RoleType[] = [
+  "SCHOOL_PRESIDENT",
+  "SCHOOL_VICE_PRESIDENT",
+]
+
 export function hasAnyRoleType(
   me: MemberInfoResponse | undefined,
   types: RoleType[],
@@ -55,6 +60,26 @@ export function isSchoolStaff(me: MemberInfoResponse | undefined): boolean {
 
 export function isOperator(me: MemberInfoResponse | undefined): boolean {
   return hasAnyRoleType(me, ADMIN_ROLE_TYPES)
+}
+
+export function isSchoolLeadership(
+  me: MemberInfoResponse | undefined,
+): boolean {
+  return hasAnyRoleType(me, SCHOOL_LEADERSHIP_ROLE_TYPES)
+}
+
+export function isAnyOperator(me: MemberInfoResponse | undefined): boolean {
+  return isOperator(me) || isSchoolStaff(me)
+}
+
+export function canAccessProjectSettings(
+  me: MemberInfoResponse | undefined,
+): boolean {
+  return isAnyOperator(me) || isCurrentTermPm(me)
+}
+
+export function canManageProjects(me: MemberInfoResponse | undefined): boolean {
+  return isOperator(me) || isSchoolLeadership(me) || isCurrentTermPm(me)
 }
 
 export function isCurrentTermPm(me: MemberInfoResponse | undefined): boolean {

--- a/src/features/auth/model/identity.ts
+++ b/src/features/auth/model/identity.ts
@@ -82,6 +82,23 @@ export function canManageProjects(me: MemberInfoResponse | undefined): boolean {
   return isOperator(me) || isSchoolLeadership(me) || isCurrentTermPm(me)
 }
 
+export function getProjectPmSearchScope(me: MemberInfoResponse | undefined): {
+  chapterId?: string
+  schoolId?: string
+} {
+  if (isSuperAdmin(me) || isCentralStaff(me)) return {}
+  if (isChapterPresident(me)) {
+    const chapterId = me?.roles?.find(
+      (r) => r.roleType === "CHAPTER_PRESIDENT",
+    )?.organizationId
+    return chapterId ? { chapterId } : {}
+  }
+  if (isSchoolLeadership(me)) {
+    return me?.schoolId != null ? { schoolId: String(me.schoolId) } : {}
+  }
+  return {}
+}
+
 export function isCurrentTermPm(me: MemberInfoResponse | undefined): boolean {
   if (!me?.challengerRecords?.length) return false
   const latest = latestRecord(me.challengerRecords)

--- a/src/features/auth/model/resourcePermission.test.ts
+++ b/src/features/auth/model/resourcePermission.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  hasGrantedPermission,
+  hasGrantedResourcePermission,
+} from "./resourcePermission"
+
+import type { ResourcePermissionResponse } from "@/features/auth/api/permissions"
+
+describe("hasGrantedPermission", () => {
+  it("권한 응답이 없으면 false", () => {
+    expect(hasGrantedPermission(undefined, "EDIT")).toBe(false)
+  })
+
+  it("hasPermission true인 권한만 true", () => {
+    const response: ResourcePermissionResponse = {
+      resourceType: "PROJECT",
+      resourceId: 1,
+      permissions: [
+        { permissionType: "EDIT", hasPermission: true },
+        { permissionType: "DELETE", hasPermission: false },
+      ],
+    }
+
+    expect(hasGrantedPermission(response, "EDIT")).toBe(true)
+    expect(hasGrantedPermission(response, "DELETE")).toBe(false)
+    expect(hasGrantedPermission(response, "MANAGE")).toBe(false)
+  })
+})
+
+describe("hasGrantedResourcePermission", () => {
+  const responses: ResourcePermissionResponse[] = [
+    {
+      resourceType: "PROJECT",
+      resourceId: 1,
+      permissions: [{ permissionType: "EDIT", hasPermission: true }],
+    },
+    {
+      resourceType: "PROJECT",
+      resourceId: 2,
+      permissions: [{ permissionType: "EDIT", hasPermission: false }],
+    },
+    {
+      resourceType: "PROJECT_APPLICATION",
+      resourceId: 1,
+      permissions: [{ permissionType: "APPROVE", hasPermission: true }],
+    },
+  ]
+
+  it("resourceType과 resourceId가 모두 일치해야 true", () => {
+    expect(
+      hasGrantedResourcePermission(responses, {
+        resourceType: "PROJECT",
+        resourceId: 1,
+        permissionType: "EDIT",
+      }),
+    ).toBe(true)
+  })
+
+  it("resourceId가 다른 결과는 false", () => {
+    expect(
+      hasGrantedResourcePermission(responses, {
+        resourceType: "PROJECT",
+        resourceId: 2,
+        permissionType: "EDIT",
+      }),
+    ).toBe(false)
+  })
+
+  it("resourceType이 다른 결과는 false", () => {
+    expect(
+      hasGrantedResourcePermission(responses, {
+        resourceType: "PROJECT",
+        resourceId: 1,
+        permissionType: "APPROVE",
+      }),
+    ).toBe(false)
+  })
+})

--- a/src/features/auth/model/resourcePermission.test.ts
+++ b/src/features/auth/model/resourcePermission.test.ts
@@ -76,4 +76,22 @@ describe("hasGrantedResourcePermission", () => {
       }),
     ).toBe(false)
   })
+
+  it("서버가 문자열 resourceId를 반환해도 number 조회와 매칭된다 (id 타입 불일치 회귀 방지)", () => {
+    const stringIdResponses = [
+      {
+        resourceType: "PROJECT",
+        resourceId: "92",
+        permissions: [{ permissionType: "EDIT", hasPermission: true }],
+      },
+    ] as unknown as ResourcePermissionResponse[]
+
+    expect(
+      hasGrantedResourcePermission(stringIdResponses, {
+        resourceType: "PROJECT",
+        resourceId: 92,
+        permissionType: "EDIT",
+      }),
+    ).toBe(true)
+  })
 })

--- a/src/features/auth/model/resourcePermission.ts
+++ b/src/features/auth/model/resourcePermission.ts
@@ -1,0 +1,35 @@
+import type {
+  PermissionType,
+  ResourcePermissionResponse,
+  ResourceType,
+} from "@/features/auth/api/permissions"
+
+export function hasGrantedPermission(
+  permissionResponse: ResourcePermissionResponse | undefined,
+  permissionType: PermissionType,
+): boolean {
+  return (
+    permissionResponse?.permissions?.some(
+      (permission) =>
+        permission.permissionType === permissionType &&
+        permission.hasPermission === true,
+    ) ?? false
+  )
+}
+
+export function hasGrantedResourcePermission(
+  permissionResponses: ResourcePermissionResponse[] | undefined,
+  params: {
+    resourceType: ResourceType
+    resourceId?: number
+    permissionType: PermissionType
+  },
+): boolean {
+  const permissionResponse = permissionResponses?.find(
+    (response) =>
+      response.resourceType === params.resourceType &&
+      response.resourceId === params.resourceId,
+  )
+
+  return hasGrantedPermission(permissionResponse, params.permissionType)
+}

--- a/src/features/auth/model/resourcePermission.ts
+++ b/src/features/auth/model/resourcePermission.ts
@@ -25,11 +25,15 @@ export function hasGrantedResourcePermission(
     permissionType: PermissionType
   },
 ): boolean {
-  const permissionResponse = permissionResponses?.find(
-    (response) =>
-      response.resourceType === params.resourceType &&
-      String(response.resourceId) === String(params.resourceId),
-  )
+  const permissionResponse = permissionResponses?.find((response) => {
+    const responseId =
+      response.resourceId == null ? undefined : String(response.resourceId)
+    const paramId =
+      params.resourceId == null ? undefined : String(params.resourceId)
+    return (
+      response.resourceType === params.resourceType && responseId === paramId
+    )
+  })
 
   return hasGrantedPermission(permissionResponse, params.permissionType)
 }

--- a/src/features/auth/model/resourcePermission.ts
+++ b/src/features/auth/model/resourcePermission.ts
@@ -28,7 +28,7 @@ export function hasGrantedResourcePermission(
   const permissionResponse = permissionResponses?.find(
     (response) =>
       response.resourceType === params.resourceType &&
-      response.resourceId === params.resourceId,
+      String(response.resourceId) === String(params.resourceId),
   )
 
   return hasGrantedPermission(permissionResponse, params.permissionType)

--- a/src/features/project/hooks/useProjectPermissions.ts
+++ b/src/features/project/hooks/useProjectPermissions.ts
@@ -1,0 +1,22 @@
+import { useResourcePermission } from "@/features/auth/hooks/useResourcePermission"
+
+interface UseProjectPermissionsOptions {
+  enabled?: boolean
+}
+
+export function useProjectPermissions(
+  projectId?: number,
+  options?: UseProjectPermissionsOptions,
+) {
+  const query = useResourcePermission("PROJECT", projectId, {
+    enabled: options?.enabled,
+  })
+
+  return {
+    ...query,
+    canDelete: query.hasPermission("DELETE"),
+    canEdit: query.hasPermission("EDIT"),
+    canManage: query.hasPermission("MANAGE"),
+    canRead: query.hasPermission("READ"),
+  }
+}

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -5,7 +5,9 @@ import { useEffect, useMemo, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
 import { useMe } from "@/features/auth/hooks/useMe"
+import { useResourcePermission } from "@/features/auth/hooks/useResourcePermission"
 import { isCurrentTermPm, isOperator } from "@/features/auth/model/identity"
+import { useProjectPermissions } from "@/features/project/hooks/useProjectPermissions"
 import {
   getApplicationForm,
   mapApplicationFormToSections,
@@ -46,6 +48,8 @@ interface ProjectDetailCardProps {
   projectId: number | string
   logo?: ProjectDetailCardLogo
   showEditCta?: boolean
+  canEditProject?: boolean
+  editPermissionLoading?: boolean
 }
 
 function ProjectDetailCardSkeleton() {
@@ -119,12 +123,45 @@ export function ProjectDetailCard({
   projectId: projectIdProp,
   logo = "on",
   showEditCta = false,
+  canEditProject,
+  editPermissionLoading,
 }: ProjectDetailCardProps) {
   const projectId = Number(projectIdProp)
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const { data: me } = useMe()
   const addToast = useToastStore((s) => s.addToast)
+  const userIsOperator = isOperator(me)
+  const userIsPm = isCurrentTermPm(me)
+  const shouldQueryEditPermission =
+    showEditCta && canEditProject === undefined && Number.isFinite(projectId)
+  const projectPermissionsQuery = useProjectPermissions(projectId, {
+    enabled: shouldQueryEditPermission,
+  })
+  const shouldQueryApplicationWritePermission =
+    !showEditCta &&
+    Number.isFinite(projectId) &&
+    me !== undefined &&
+    !userIsOperator &&
+    !userIsPm
+  const applicationWritePermissionQuery = useResourcePermission(
+    "PROJECT_APPLICATION",
+    projectId,
+    {
+      enabled: shouldQueryApplicationWritePermission,
+      permissionType: "WRITE",
+    },
+  )
+  const resolvedCanEditProject =
+    canEditProject ?? projectPermissionsQuery.canEdit
+  const resolvedEditPermissionLoading =
+    editPermissionLoading ??
+    (shouldQueryEditPermission && projectPermissionsQuery.isPending)
+  const canWriteProjectApplication =
+    applicationWritePermissionQuery.hasPermission("WRITE")
+  const isApplicationWritePermissionLoading =
+    shouldQueryApplicationWritePermission &&
+    applicationWritePermissionQuery.isPending
   const [isTeamModalOpen, setIsTeamModalOpen] = useState(false)
   const [isApplyModalOpen, setIsApplyModalOpen] = useState(false)
   const [isMyApplicationModalOpen, setIsMyApplicationModalOpen] =
@@ -144,9 +181,6 @@ export function ProjectDetailCard({
       return res.gisuId ?? null
     },
   })
-
-  const userIsOperator = isOperator(me)
-  const userIsPm = isCurrentTermPm(me)
 
   const { data: myApplications } = useQuery({
     queryKey: ["myApplications", activeGisuId],
@@ -286,6 +320,8 @@ export function ProjectDetailCard({
     ? { src: detail.thumbnailImageUrl }
     : null
   const showLogo = logo === "on"
+  const shouldShowEditCta =
+    showEditCta && (resolvedEditPermissionLoading || resolvedCanEditProject)
 
   if (isDetailLoading) {
     return <ProjectDetailCardSkeleton />
@@ -386,17 +422,28 @@ export function ProjectDetailCard({
               기획 보기
             </Button>
             {showEditCta ? (
-              <Button
-                className="flex-1"
-                onClick={() =>
-                  navigate({
-                    to: "/matching/projects/new",
-                    search: { projectId },
-                  })
-                }
-              >
-                프로젝트 수정하기
-              </Button>
+              shouldShowEditCta ? (
+                <Button
+                  className="flex-1"
+                  disabled={
+                    resolvedEditPermissionLoading || !resolvedCanEditProject
+                  }
+                  isLoading={resolvedEditPermissionLoading}
+                  onClick={() => {
+                    if (
+                      resolvedEditPermissionLoading ||
+                      !resolvedCanEditProject
+                    )
+                      return
+                    navigate({
+                      to: "/matching/projects/new",
+                      search: { projectId },
+                    })
+                  }}
+                >
+                  프로젝트 수정하기
+                </Button>
+              ) : null
             ) : (
               <>
                 {ctaMode === "recruit-questions" && (
@@ -418,38 +465,52 @@ export function ProjectDetailCard({
                     내 지원서 확인하기
                   </Button>
                 )}
-                {ctaMode === "apply" && (
-                  <Button
-                    className="flex-1"
-                    isLoading={isDetailLoading}
-                    disabled={!isDetailLoading && !detail?.applicationFormId}
-                    onClick={() => {
-                      if (!detail?.applicationFormId) {
-                        addToast({
-                          message: "지원 양식이 등록되지 않은 프로젝트입니다.",
-                          color: "red",
-                          variant: "deep",
-                          type: "default",
-                          duration: 3000,
-                        })
-                        return
+                {ctaMode === "apply" &&
+                  (isApplicationWritePermissionLoading ||
+                    canWriteProjectApplication) && (
+                    <Button
+                      className="flex-1"
+                      isLoading={
+                        isDetailLoading || isApplicationWritePermissionLoading
                       }
-                      if (!activeMatchingRound) {
-                        addToast({
-                          message: "매칭 기간이 아닙니다!",
-                          color: "red",
-                          variant: "deep",
-                          type: "default",
-                          duration: 3000,
-                        })
-                        return
+                      disabled={
+                        (!isDetailLoading && !detail?.applicationFormId) ||
+                        isApplicationWritePermissionLoading ||
+                        !canWriteProjectApplication
                       }
-                      setIsApplyModalOpen(true)
-                    }}
-                  >
-                    지원하기
-                  </Button>
-                )}
+                      onClick={() => {
+                        if (
+                          isApplicationWritePermissionLoading ||
+                          !canWriteProjectApplication
+                        )
+                          return
+                        if (!detail?.applicationFormId) {
+                          addToast({
+                            message:
+                              "지원 양식이 등록되지 않은 프로젝트입니다.",
+                            color: "red",
+                            variant: "deep",
+                            type: "default",
+                            duration: 3000,
+                          })
+                          return
+                        }
+                        if (!activeMatchingRound) {
+                          addToast({
+                            message: "매칭 기간이 아닙니다!",
+                            color: "red",
+                            variant: "deep",
+                            type: "default",
+                            duration: 3000,
+                          })
+                          return
+                        }
+                        setIsApplyModalOpen(true)
+                      }}
+                    >
+                      지원하기
+                    </Button>
+                  )}
                 {(ctaMode === "apply-blocked-other" ||
                   ctaMode === "apply-blocked-approved") && (
                   <>

--- a/src/features/project/list/ui/apply-modal/MyApplicationModal.tsx
+++ b/src/features/project/list/ui/apply-modal/MyApplicationModal.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery } from "@tanstack/react-query"
 import { useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
+import { useResourcePermission } from "@/features/auth/hooks/useResourcePermission"
 import WarningTriangleIcon from "@/shared/assets/icon/infomation/WarningTriangleIcon"
 import { Button } from "@/shared/ui/Button"
 import { RecruitStatusChip } from "@/shared/ui/chip/RecruitStatusChip"
@@ -49,6 +50,11 @@ export function MyApplicationModal({
 }: MyApplicationModalProps) {
   const addToast = useToastStore((s) => s.addToast)
   const [isCancelConfirmOpen, setIsCancelConfirmOpen] = useState(false)
+  const deletePermissionQuery = useResourcePermission(
+    "PROJECT_APPLICATION",
+    applicationId,
+    { permissionType: "DELETE" },
+  )
 
   const {
     data: detail,
@@ -86,7 +92,15 @@ export function MyApplicationModal({
 
   const isCancellableStatus =
     detail?.status === "DRAFT" || detail?.status === "SUBMITTED"
-  const canCancel = isRoundOpen && isCancellableStatus
+  const canDeleteApplication = deletePermissionQuery.hasPermission("DELETE")
+  const isDeletePermissionLoading = deletePermissionQuery.isPending
+  const shouldShowCancelButton =
+    isCancellableStatus && (isDeletePermissionLoading || canDeleteApplication)
+  const canCancel =
+    isRoundOpen &&
+    isCancellableStatus &&
+    canDeleteApplication &&
+    !isDeletePermissionLoading
 
   return (
     <div className="flex w-232 flex-col">
@@ -198,7 +212,7 @@ export function MyApplicationModal({
             <Button variant="weak" color="neutral" size="xl" onClick={onClose}>
               닫기
             </Button>
-            {isCancellableStatus && (
+            {shouldShowCancelButton && (
               <Button
                 color="primary"
                 size="xl"
@@ -251,8 +265,11 @@ export function MyApplicationModal({
               </Button>
               <Button
                 size="s"
-                onClick={() => cancelMutation.mutate()}
-                disabled={cancelMutation.isPending}
+                onClick={() => {
+                  if (!canCancel) return
+                  cancelMutation.mutate()
+                }}
+                disabled={!canCancel || cancelMutation.isPending}
               >
                 지원 취소하기
               </Button>

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -6,6 +6,7 @@ import { Controller, useForm } from "react-hook-form"
 import { useToastStore } from "@/components/toast/useToastStore"
 import { useResourcePermission } from "@/features/auth/hooks/useResourcePermission"
 import { uploadFileFlow } from "@/features/project/new/api/storage"
+import { getActiveGisu } from "@/shared/api/gisu"
 import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
 import WarningTriangleIcon from "@/shared/assets/icon/infomation/WarningTriangleIcon"
 import { Button } from "@/shared/ui/Button"
@@ -26,6 +27,7 @@ import { TextQuestionField } from "@/shared/ui/question-field/TextQuestionField"
 import {
   type ApplicationAnswerItem,
   createApplicationDraft,
+  getMyApplications,
   saveApplicationDraft,
   submitApplication,
 } from "../../api/matchingProject"
@@ -283,6 +285,14 @@ export function ProjectApplyModal({
         setApplicationId(draft.applicationId)
       } catch (err) {
         if (err instanceof AxiosError && err.response?.status === 409) {
+          const gisu = await getActiveGisu().catch(() => null)
+          if (gisu) {
+            const apps = await getMyApplications(Number(gisu.gisuId)).catch(
+              () => [],
+            )
+            const existing = apps.find((a) => Number(a.projectId) === projectId)
+            if (existing) setApplicationId(Number(existing.applicationId))
+          }
           return
         }
         addToast({

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import { Controller, useForm } from "react-hook-form"
 
 import { useToastStore } from "@/components/toast/useToastStore"
+import { useResourcePermission } from "@/features/auth/hooks/useResourcePermission"
 import { uploadFileFlow } from "@/features/project/new/api/storage"
 import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
 import WarningTriangleIcon from "@/shared/assets/icon/infomation/WarningTriangleIcon"
@@ -240,9 +241,11 @@ export function ProjectApplyModal({
   onSubmitSuccess,
 }: ProjectApplyModalProps) {
   const addToast = useToastStore((s) => s.addToast)
+  const isDevMatchingRound = Boolean(import.meta.env.VITE_DEV_MATCHING_ROUND_ID)
   const [sectionEnabled, setSectionEnabled] = useState<Record<string, boolean>>(
     () => Object.fromEntries(sections.map((s) => [s.id, s.isEnabled])),
   )
+  const [applicationId, setApplicationId] = useState<number | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isFileUploading, setIsFileUploading] = useState(false)
   const [isPortfolioUploading, setIsPortfolioUploading] = useState(false)
@@ -255,14 +258,29 @@ export function ProjectApplyModal({
     null,
   )
   const draftInitializedRef = useRef(false)
+  const applicationEditPermissionQuery = useResourcePermission(
+    "PROJECT_APPLICATION",
+    applicationId ?? undefined,
+    {
+      enabled: applicationId !== null && !isDevMatchingRound,
+      permissionType: "EDIT",
+    },
+  )
+  const isApplicationEditPermissionLoading =
+    applicationId !== null &&
+    !isDevMatchingRound &&
+    applicationEditPermissionQuery.isPending
+  const canEditApplication =
+    isDevMatchingRound || applicationEditPermissionQuery.hasPermission("EDIT")
 
   useEffect(() => {
     if (draftInitializedRef.current) return
     draftInitializedRef.current = true
     async function initDraft() {
-      if (import.meta.env.VITE_DEV_MATCHING_ROUND_ID) return
+      if (isDevMatchingRound) return
       try {
-        await createApplicationDraft(projectId, matchingRoundId)
+        const draft = await createApplicationDraft(projectId, matchingRoundId)
+        setApplicationId(draft.applicationId)
       } catch (err) {
         if (err instanceof AxiosError && err.response?.status === 409) {
           return
@@ -348,7 +366,17 @@ export function ProjectApplyModal({
     setIsSubmitConfirmModalOpen(false)
     setIsSubmitting(true)
     try {
-      if (!import.meta.env.VITE_DEV_MATCHING_ROUND_ID) {
+      if (!isDevMatchingRound) {
+        if (!applicationId || !canEditApplication) {
+          addToast({
+            message: "지원서 제출에 실패했습니다. 다시 시도해 주세요.",
+            color: "red",
+            variant: "deep",
+            type: "default",
+            duration: 3000,
+          })
+          return
+        }
         const answers = buildAnswerPayload(formValues, sections)
         await saveApplicationDraft(projectId, answers)
         await submitApplication(projectId)
@@ -657,7 +685,13 @@ export function ProjectApplyModal({
             </Button>
             <Button
               size="xl"
-              disabled={isSubmitting || isFileUploading || isPortfolioUploading}
+              disabled={
+                isSubmitting ||
+                isFileUploading ||
+                isPortfolioUploading ||
+                isApplicationEditPermissionLoading ||
+                !canEditApplication
+              }
               onClick={() => {
                 void handleSubmit(onValid, onInvalid)()
               }}
@@ -762,7 +796,11 @@ export function ProjectApplyModal({
               <Button
                 size="s"
                 onClick={() => void handleSubmitConfirm()}
-                disabled={isSubmitting}
+                disabled={
+                  isSubmitting ||
+                  isApplicationEditPermissionLoading ||
+                  !canEditApplication
+                }
               >
                 제출하기
               </Button>

--- a/src/features/project/management/api.ts
+++ b/src/features/project/management/api.ts
@@ -12,10 +12,11 @@ export type { ManagedProjectSummaryResponse }
 
 export async function getManagedProjects(
   gisuId: number,
+  options?: { size?: number },
 ): Promise<ManagedProjectSummaryResponse[]> {
   const { data } = await api.get<
     ApiResponse<PageResponseManagedProjectSummaryResponse>
-  >("/v1/projects/me/managed", { params: { gisuId } })
+  >("/v1/projects/me/managed", { params: { gisuId, size: options?.size } })
   return data.result.content ?? []
 }
 

--- a/src/features/project/management/ui/ProjectManagementCard.tsx
+++ b/src/features/project/management/ui/ProjectManagementCard.tsx
@@ -13,9 +13,17 @@ import type { MatchingProject } from "../../list/model/matchingProject"
 
 interface ProjectManagementCardProps {
   data: MatchingProject
+  canDeleteProject: boolean
+  canEditProject: boolean
+  isPermissionLoading: boolean
 }
 
-export function ProjectManagementCard({ data }: ProjectManagementCardProps) {
+export function ProjectManagementCard({
+  data,
+  canDeleteProject,
+  canEditProject,
+  isPermissionLoading,
+}: ProjectManagementCardProps) {
   const cover = data.coverImage
   const [open, setOpen] = useState(false)
 
@@ -62,6 +70,9 @@ export function ProjectManagementCard({ data }: ProjectManagementCardProps) {
                   projectId={data.id}
                   projectName={data.title}
                   chapterName={data.branch}
+                  canDeleteProject={canDeleteProject}
+                  canEditProject={canEditProject}
+                  isPermissionLoading={isPermissionLoading}
                 />
               </div>
             </div>
@@ -105,7 +116,12 @@ export function ProjectManagementCard({ data }: ProjectManagementCardProps) {
           <Modal.Overlay tone="deep" />
           <Modal.Content className="shadow-drop-neutral-3 rounded-2xl">
             <Modal.Title className="sr-only">{data.title}</Modal.Title>
-            <ProjectDetailCard projectId={Number(data.id)} showEditCta />
+            <ProjectDetailCard
+              projectId={Number(data.id)}
+              showEditCta
+              canEditProject={canEditProject}
+              editPermissionLoading={isPermissionLoading}
+            />
           </Modal.Content>
         </Modal.Portal>
       </Modal.Root>

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -96,6 +96,9 @@ export function ProjectManagementMoreMenu({
     onSuccess: () => {
       setDeleteOpen(false)
       void queryClient.invalidateQueries({ queryKey: ["project", "managed"] })
+      void queryClient.invalidateQueries({
+        queryKey: [...applicationKeys.all, "managed"],
+      })
       addToast({
         message: "프로젝트가 삭제되었습니다.",
         color: "primary",

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -24,12 +24,18 @@ interface ProjectManagementMoreMenuProps {
   projectId: string
   projectName: string
   chapterName: string
+  canDeleteProject: boolean
+  canEditProject: boolean
+  isPermissionLoading: boolean
 }
 
 export function ProjectManagementMoreMenu({
   projectId,
   projectName,
   chapterName,
+  canDeleteProject,
+  canEditProject,
+  isPermissionLoading,
 }: ProjectManagementMoreMenuProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
@@ -110,6 +116,7 @@ export function ProjectManagementMoreMenu({
   })
 
   const handleDeleteClick = () => {
+    if (!canDeleteProject || isPermissionLoading) return
     setPopoverOpen(false)
     setDeleteOpen(true)
   }
@@ -120,6 +127,7 @@ export function ProjectManagementMoreMenu({
   }
 
   const handleEditClick = () => {
+    if (!canEditProject || isPermissionLoading) return
     setPopoverOpen(false)
     navigate({
       to: "/matching/projects/new",
@@ -160,12 +168,18 @@ export function ProjectManagementMoreMenu({
     }
   }
 
-  const MENU_ITEMS = [
+  const menuItems = [
     { label: "지원 현황 확인하기", onClick: handleApplicationClick },
     { label: "기획 보기", onClick: () => void handlePlanViewClick() },
-    { label: "프로젝트 수정하기", onClick: handleEditClick },
     { label: "팀원 구성 보기", onClick: () => {} },
   ]
+
+  if (isPermissionLoading || canEditProject) {
+    menuItems.splice(2, 0, {
+      label: "프로젝트 수정하기",
+      onClick: handleEditClick,
+    })
+  }
 
   return (
     <>
@@ -188,14 +202,24 @@ export function ProjectManagementMoreMenu({
             </span>
 
             <div className="flex w-full flex-col">
-              {MENU_ITEMS.map(({ label, onClick }) => (
-                <DropdownItem key={label} label={label} onClick={onClick} />
+              {menuItems.map(({ label, onClick }) => (
+                <DropdownItem
+                  key={label}
+                  label={label}
+                  disabled={
+                    label === "프로젝트 수정하기" && isPermissionLoading
+                  }
+                  onClick={onClick}
+                />
               ))}
-              <DropdownItem
-                label="삭제"
-                onClick={handleDeleteClick}
-                className="text-error-500"
-              />
+              {(isPermissionLoading || canDeleteProject) && (
+                <DropdownItem
+                  label="삭제"
+                  disabled={isPermissionLoading}
+                  onClick={handleDeleteClick}
+                  className="text-error-500"
+                />
+              )}
             </div>
           </Popover.Content>
         </Popover.Portal>

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from "react"
 
 import { getAllProjects } from "@/features/application/api/applicationApi"
 import { useMe } from "@/features/auth/hooks/useMe"
+import { useResourcePermissionsBatch } from "@/features/auth/hooks/useResourcePermissionsBatch"
 import {
   getViewerBranch,
   isCentralStaff,
@@ -23,6 +24,7 @@ import { getManagedProjects } from "../api"
 import { ProjectManagementCard } from "./ProjectManagementCard"
 import { ProjectManagementSubTitle } from "./ProjectManagementSubTitle"
 
+import type { ResourcePermissionQuery } from "@/features/auth/api/permissions"
 import type { MatchingProject } from "@/features/project/list/model/matchingProject"
 
 const FE_PART_LABELS = new Set(["Web", "iOS", "Android"])
@@ -91,6 +93,11 @@ function toMatchingProject(item: ProjectSummaryInput): MatchingProject {
         total: q.quota ?? 0,
       })),
   }
+}
+
+function toValidProjectId(project: MatchingProject): number | null {
+  const id = Number(project.id)
+  return Number.isFinite(id) && id > 0 ? id : null
 }
 
 export function ProjectManagementPage() {
@@ -173,6 +180,58 @@ export function ProjectManagementPage() {
     return map
   }, [adminProjects])
 
+  const permissionProjectIds = useMemo(() => {
+    const projects = isAdminScope ? adminProjects : pmProjects
+    const ids = new Set<number>()
+    for (const project of projects) {
+      const id = toValidProjectId(project)
+      if (id !== null) ids.add(id)
+    }
+    return Array.from(ids)
+  }, [adminProjects, isAdminScope, pmProjects])
+
+  const projectPermissionQueries = useMemo<ResourcePermissionQuery[]>(
+    () => [
+      {
+        resourceType: "PROJECT",
+        resourceIds: permissionProjectIds,
+        permissionTypes: ["EDIT", "MANAGE", "DELETE"],
+      },
+    ],
+    [permissionProjectIds],
+  )
+
+  const projectPermissionsQuery = useResourcePermissionsBatch(
+    projectPermissionQueries,
+    { enabled: hasAccess },
+  )
+
+  const isProjectPermissionLoading =
+    permissionProjectIds.length > 0 && projectPermissionsQuery.isPending
+
+  const getProjectActionPermissions = (project: MatchingProject) => {
+    const projectId = toValidProjectId(project)
+    if (projectId === null) {
+      return {
+        canDeleteProject: false,
+        canEditProject: false,
+      }
+    }
+
+    return {
+      canDeleteProject: projectPermissionsQuery.hasPermission({
+        resourceType: "PROJECT",
+        resourceId: projectId,
+        permissionType: "DELETE",
+      }),
+      canEditProject: projectPermissionsQuery.hasPermission({
+        resourceType: "PROJECT",
+        resourceId: projectId,
+        permissionType: "EDIT",
+      }),
+    }
+  }
+
   if (!hasAccess) return null
 
   return (
@@ -208,9 +267,17 @@ export function ProjectManagementPage() {
                 <div key={part} className="flex flex-col">
                   <ProjectManagementSubTitle title={part} className="pb-2" />
                   <div className="flex flex-col gap-4">
-                    {partProjects.map((project) => (
-                      <ProjectManagementCard key={project.id} data={project} />
-                    ))}
+                    {partProjects.map((project) => {
+                      const permissions = getProjectActionPermissions(project)
+                      return (
+                        <ProjectManagementCard
+                          key={project.id}
+                          data={project}
+                          isPermissionLoading={isProjectPermissionLoading}
+                          {...permissions}
+                        />
+                      )
+                    })}
                   </div>
                 </div>
               ))
@@ -226,9 +293,17 @@ export function ProjectManagementPage() {
               </p>
             ) : pmProjects.length > 0 ? (
               <div className="flex flex-col gap-3">
-                {pmProjects.map((project) => (
-                  <ProjectManagementCard key={project.id} data={project} />
-                ))}
+                {pmProjects.map((project) => {
+                  const permissions = getProjectActionPermissions(project)
+                  return (
+                    <ProjectManagementCard
+                      key={project.id}
+                      data={project}
+                      isPermissionLoading={isProjectPermissionLoading}
+                      {...permissions}
+                    />
+                  )
+                })}
               </div>
             ) : (
               <p className="text-body-2-medium text-teal-gray-400 py-10 text-center">

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -1,24 +1,11 @@
 import { useQuery } from "@tanstack/react-query"
-import { useMemo, useState } from "react"
+import { useMemo } from "react"
 
-import { getAllProjects } from "@/features/application/api/applicationApi"
 import { useMe } from "@/features/auth/hooks/useMe"
 import { useResourcePermissionsBatch } from "@/features/auth/hooks/useResourcePermissionsBatch"
-import {
-  getViewerBranch,
-  isCentralStaff,
-  isChapterPresident,
-  isCurrentTermPm,
-  isSchoolStaff,
-  isSuperAdmin,
-} from "@/features/auth/model/identity"
-import { getAllChapters } from "@/features/challenger/api/organization"
+import { isAnyOperator, isCurrentTermPm } from "@/features/auth/model/identity"
 import { gisuKeys } from "@/features/project/new/api/queryKeys"
 import { getActiveGisu } from "@/shared/api/gisu"
-import {
-  type Chapter,
-  ChapterSelector,
-} from "@/shared/ui/segment/ChapterSelector"
 
 import { getManagedProjects } from "../api"
 import { ProjectManagementCard } from "./ProjectManagementCard"
@@ -28,6 +15,7 @@ import type { ResourcePermissionQuery } from "@/features/auth/api/permissions"
 import type { MatchingProject } from "@/features/project/list/model/matchingProject"
 
 const FE_PART_LABELS = new Set(["Web", "iOS", "Android"])
+const MANAGED_PROJECTS_PAGE_SIZE = 200
 
 const PART_LABEL: Record<string, string> = {
   PLAN: "기획",
@@ -103,15 +91,9 @@ function toValidProjectId(project: MatchingProject): number | null {
 export function ProjectManagementPage() {
   const { data: me } = useMe()
 
-  const isCentral = isSuperAdmin(me) || isCentralStaff(me)
-  const isChapPres = isChapterPresident(me)
-  const isSchoolAdmin = isSchoolStaff(me)
+  const isAdminScope = isAnyOperator(me)
   const isPm = isCurrentTermPm(me)
-
-  const isAdminScope = isCentral || isChapPres || isSchoolAdmin
   const hasAccess = isAdminScope || isPm
-
-  const [selectedChapter, setSelectedChapter] = useState<Chapter>("Chromium")
 
   const gisuQuery = useQuery({
     queryKey: gisuKeys.active,
@@ -122,55 +104,22 @@ export function ProjectManagementPage() {
     ? Number(gisuQuery.data.gisuId)
     : undefined
 
-  // 중앙/지부장: 챕터명 → chapterId 매핑
-  const chaptersQuery = useQuery({
-    queryKey: ["chapters", "all"],
-    queryFn: getAllChapters,
-    enabled: isCentral || isChapPres,
-  })
-
-  const userChapterName = getViewerBranch(me)
-  const effectiveChapterName = isCentral ? selectedChapter : userChapterName
-
-  const effectiveChapterId = useMemo(() => {
-    if (!chaptersQuery.data || isSchoolAdmin) return undefined
-    return (
-      chaptersQuery.data.chapters.find((c) => c.name === effectiveChapterName)
-        ?.id ?? undefined
-    )
-  }, [chaptersQuery.data, effectiveChapterName, isSchoolAdmin])
-
-  // 어드민 프로젝트 쿼리 (중앙/지부장/학교 회장단)
-  const adminProjectsQuery = useQuery({
-    queryKey: ["projects", "admin", gisuId, effectiveChapterId],
-    queryFn: () =>
-      getAllProjects(gisuId!, {
-        chapterId: effectiveChapterId ? Number(effectiveChapterId) : undefined,
-        size: 200,
-      }),
-    enabled: isAdminScope && !!gisuId,
-  })
-
-  // PM 프로젝트 쿼리
   const managedQuery = useQuery({
     queryKey: ["project", "managed", "me", gisuId],
-    queryFn: () => getManagedProjects(gisuId!),
-    enabled: isPm && !isAdminScope && !!gisuId,
+    queryFn: () =>
+      getManagedProjects(gisuId!, { size: MANAGED_PROJECTS_PAGE_SIZE }),
+    enabled: hasAccess && !!gisuId,
   })
 
-  const adminProjects: MatchingProject[] = useMemo(
-    () => (adminProjectsQuery.data?.content ?? []).map(toMatchingProject),
-    [adminProjectsQuery.data],
-  )
-
-  const pmProjects: MatchingProject[] = useMemo(
+  const projects: MatchingProject[] = useMemo(
     () => (managedQuery.data ?? []).map(toMatchingProject),
     [managedQuery.data],
   )
 
   const partGroups = useMemo(() => {
+    if (!isAdminScope) return new Map<string, MatchingProject[]>()
     const map = new Map<string, MatchingProject[]>()
-    for (const project of adminProjects) {
+    for (const project of projects) {
       for (const row of project.recruitRows) {
         if (!FE_PART_LABELS.has(row.part)) continue
         if (!map.has(row.part)) map.set(row.part, [])
@@ -178,17 +127,16 @@ export function ProjectManagementPage() {
       }
     }
     return map
-  }, [adminProjects])
+  }, [isAdminScope, projects])
 
   const permissionProjectIds = useMemo(() => {
-    const projects = isAdminScope ? adminProjects : pmProjects
     const ids = new Set<number>()
     for (const project of projects) {
       const id = toValidProjectId(project)
       if (id !== null) ids.add(id)
     }
     return Array.from(ids)
-  }, [adminProjects, isAdminScope, pmProjects])
+  }, [projects])
 
   const projectPermissionQueries = useMemo<ResourcePermissionQuery[]>(
     () => [
@@ -248,21 +196,13 @@ export function ProjectManagementPage() {
           </span>
         </div>
 
-        {isCentral && (
-          <ChapterSelector
-            selectedChapter={selectedChapter}
-            onChapterChange={setSelectedChapter}
-            className="mt-2.5"
-          />
-        )}
-
         <div className="flex flex-col gap-10">
-          {isAdminScope ? (
-            adminProjectsQuery.isLoading ? (
-              <p className="text-body-2-regular text-teal-gray-400 py-10 text-center">
-                데이터를 불러오는 중...
-              </p>
-            ) : partGroups.size > 0 ? (
+          {managedQuery.isLoading ? (
+            <p className="text-body-2-regular text-teal-gray-400 py-10 text-center">
+              데이터를 불러오는 중...
+            </p>
+          ) : isAdminScope ? (
+            partGroups.size > 0 ? (
               Array.from(partGroups.entries()).map(([part, partProjects]) => (
                 <div key={part} className="flex flex-col">
                   <ProjectManagementSubTitle title={part} className="pb-2" />
@@ -286,31 +226,25 @@ export function ProjectManagementPage() {
                 등록된 프로젝트가 없습니다.
               </p>
             )
-          ) : isPm ? (
-            managedQuery.isLoading ? (
-              <p className="text-body-2-regular text-teal-gray-400 py-10 text-center">
-                데이터를 불러오는 중...
-              </p>
-            ) : pmProjects.length > 0 ? (
-              <div className="flex flex-col gap-3">
-                {pmProjects.map((project) => {
-                  const permissions = getProjectActionPermissions(project)
-                  return (
-                    <ProjectManagementCard
-                      key={project.id}
-                      data={project}
-                      isPermissionLoading={isProjectPermissionLoading}
-                      {...permissions}
-                    />
-                  )
-                })}
-              </div>
-            ) : (
-              <p className="text-body-2-medium text-teal-gray-400 py-10 text-center">
-                등록된 프로젝트가 없습니다.
-              </p>
-            )
-          ) : null}
+          ) : projects.length > 0 ? (
+            <div className="flex flex-col gap-3">
+              {projects.map((project) => {
+                const permissions = getProjectActionPermissions(project)
+                return (
+                  <ProjectManagementCard
+                    key={project.id}
+                    data={project}
+                    isPermissionLoading={isProjectPermissionLoading}
+                    {...permissions}
+                  />
+                )
+              })}
+            </div>
+          ) : (
+            <p className="text-body-2-medium text-teal-gray-400 py-10 text-center">
+              등록된 프로젝트가 없습니다.
+            </p>
+          )}
         </div>
       </div>
     </section>

--- a/src/features/project/new/api/index.ts
+++ b/src/features/project/new/api/index.ts
@@ -17,7 +17,11 @@ export {
   updateProjectDraft,
 } from "./projectDraft"
 
-export { addProjectMember, transferOwnership } from "./projectMembers"
+export {
+  addProjectMember,
+  removeProjectMember,
+  transferOwnership,
+} from "./projectMembers"
 
 export { publishProject } from "./projectPublish"
 

--- a/src/features/project/new/api/projectMembers.ts
+++ b/src/features/project/new/api/projectMembers.ts
@@ -14,6 +14,15 @@ export async function addProjectMember(
   await api.post<ApiResponse<void>>(`/v1/projects/${projectId}/members`, body)
 }
 
+export async function removeProjectMember(
+  projectId: number,
+  memberId: number,
+): Promise<void> {
+  await api.delete<ApiResponse<void>>(
+    `/v1/projects/${projectId}/members/${memberId}`,
+  )
+}
+
 export async function transferOwnership(
   projectId: number,
   body: TransferProjectOwnershipRequest,

--- a/src/features/project/new/model/basicInfoSchema.test.ts
+++ b/src/features/project/new/model/basicInfoSchema.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest"
+
+import { basicInfoSchema } from "./basicInfoSchema"
+
+function parseLink(value: string | undefined) {
+  return basicInfoSchema.safeParse({
+    title: "t",
+    description: "d",
+    externalLink: value,
+  })
+}
+
+describe("basicInfoSchema title 검증", () => {
+  it('공백만 있는 title("   ")은 실패하고 title 경로에 issue 생성', () => {
+    const result = basicInfoSchema.safeParse({ title: "   ", description: "d" })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues.some((i) => i.path.includes("title"))).toBe(
+        true,
+      )
+    }
+  })
+})
+
+describe("basicInfoSchema externalLink 검증", () => {
+  describe("유효한 값은 통과", () => {
+    it('빈 문자열("")은 통과', () => {
+      expect(parseLink("").success).toBe(true)
+    })
+
+    it('"figma.com/qa-test"는 통과', () => {
+      expect(parseLink("figma.com/qa-test").success).toBe(true)
+    })
+
+    it('"https://notion.so/project"는 통과', () => {
+      expect(parseLink("https://notion.so/project").success).toBe(true)
+    })
+
+    it('"www.example.com"은 통과', () => {
+      expect(parseLink("www.example.com").success).toBe(true)
+    })
+
+    it('"sub.domain.co.kr"는 통과', () => {
+      expect(parseLink("sub.domain.co.kr").success).toBe(true)
+    })
+  })
+
+  describe("유효하지 않은 값은 실패하고 externalLink 경로에 issue 생성", () => {
+    it('"이상한 링크 텍스트" (공백 포함)는 실패', () => {
+      const result = parseLink("이상한 링크 텍스트")
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(
+          result.error.issues.some((i) => i.path.includes("externalLink")),
+        ).toBe(true)
+      }
+    })
+
+    it('"hello world" (공백 포함)는 실패', () => {
+      const result = parseLink("hello world")
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(
+          result.error.issues.some((i) => i.path.includes("externalLink")),
+        ).toBe(true)
+      }
+    })
+
+    it('"justtext" (점 없음, TLD 없음)는 실패', () => {
+      const result = parseLink("justtext")
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(
+          result.error.issues.some((i) => i.path.includes("externalLink")),
+        ).toBe(true)
+      }
+    })
+
+    it('"no-dot-host" (점 없음)는 실패', () => {
+      const result = parseLink("no-dot-host")
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(
+          result.error.issues.some((i) => i.path.includes("externalLink")),
+        ).toBe(true)
+      }
+    })
+  })
+})

--- a/src/features/project/new/model/basicInfoSchema.ts
+++ b/src/features/project/new/model/basicInfoSchema.ts
@@ -7,11 +7,9 @@ const MAX_FILE_SIZE = 10 * 1024 * 1024
 export const basicInfoSchema = z.object({
   title: z
     .string()
-    .min(1)
-    .max(16)
-    .refine((v) => v.trim().length > 0, {
-      message: "프로젝트 이름을 입력해 주세요.",
-    }),
+    .trim()
+    .min(1, { message: "프로젝트 이름을 입력해 주세요." })
+    .max(16),
   description: z.string().min(1).max(200),
   thumbnail: z
     .instanceof(File)

--- a/src/features/project/new/model/basicInfoSchema.ts
+++ b/src/features/project/new/model/basicInfoSchema.ts
@@ -5,7 +5,13 @@ const LOGO_ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/svg+xml"]
 const MAX_FILE_SIZE = 10 * 1024 * 1024
 
 export const basicInfoSchema = z.object({
-  title: z.string().min(1).max(16),
+  title: z
+    .string()
+    .min(1)
+    .max(16)
+    .refine((v) => v.trim().length > 0, {
+      message: "프로젝트 이름을 입력해 주세요.",
+    }),
   description: z.string().min(1).max(200),
   thumbnail: z
     .instanceof(File)
@@ -35,12 +41,13 @@ export const basicInfoSchema = z.object({
       (v) => {
         const trimmed = v.trim()
         if (!trimmed) return true
+        if (/\s/.test(trimmed)) return false
         try {
           const normalized = /^https?:\/\//i.test(trimmed)
             ? trimmed
             : `https://${trimmed}`
-          new URL(normalized)
-          return true
+          const url = new URL(normalized)
+          return /^[a-z0-9-]+(\.[a-z0-9-]+)+$/i.test(url.hostname)
         } catch {
           return false
         }

--- a/src/features/project/new/model/projectDetailHydrator.ts
+++ b/src/features/project/new/model/projectDetailHydrator.ts
@@ -55,7 +55,7 @@ export function hydrateProjectDetailIntoStore(
     const mapping = PART_TO_ROLE[quota.part as ApiPart]
     if (!mapping) continue
     recruitInfo[mapping.role] = {
-      count: quota.quota ?? 0,
+      count: Number(quota.quota ?? 0),
       stack: mapping.stack,
     }
   }

--- a/src/features/project/new/model/useApplicationForm.ts
+++ b/src/features/project/new/model/useApplicationForm.ts
@@ -71,7 +71,6 @@ export function useApplicationForm() {
     setApplication({
       commonQuestions: insertAfter(commonQuestions, afterId, newQ),
     })
-    setFocusedId(newQ.id)
   }
 
   function updateSection(sectionId: string, patch: Partial<Section>) {
@@ -112,7 +111,6 @@ export function useApplicationForm() {
           : { ...s, questions: insertAfter(s.questions, afterId, newQ) },
       ),
     })
-    setFocusedId(newQ.id)
   }
 
   function appendSectionQuestion(sectionId: string) {

--- a/src/features/project/new/ui/application/ApplicationForm.tsx
+++ b/src/features/project/new/ui/application/ApplicationForm.tsx
@@ -40,6 +40,8 @@ interface ApplicationFormProps {
   isEditMode?: boolean
   isHydrated?: boolean
   isSubmitting?: boolean
+  canCreateProject?: boolean
+  createPermissionLoading?: boolean
 }
 
 export const ApplicationForm = forwardRef<
@@ -52,6 +54,8 @@ export const ApplicationForm = forwardRef<
     isEditMode = false,
     isHydrated = true,
     isSubmitting = false,
+    canCreateProject = true,
+    createPermissionLoading = false,
   },
   ref,
 ) {
@@ -134,7 +138,10 @@ export const ApplicationForm = forwardRef<
     },
   }))
 
-  const canTempSave = !saveAppMutation.isPending && (isDirty || !hasSavedOnce)
+  const canCreateDraft =
+    projectId !== null || (canCreateProject && !createPermissionLoading)
+  const canTempSave =
+    !saveAppMutation.isPending && (isDirty || !hasSavedOnce) && canCreateDraft
   const tempSaveLabel =
     hasSavedOnce && !isDirty && !saveAppMutation.isPending
       ? "저장 완료"
@@ -176,6 +183,16 @@ export const ApplicationForm = forwardRef<
   }
 
   const handleTempSave = () => {
+    if (!canCreateDraft) {
+      addToast({
+        message: "임시 저장에 실패했습니다. 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return
+    }
     saveAppMutation.mutate()
   }
 

--- a/src/features/project/new/ui/application/QuestionCard.tsx
+++ b/src/features/project/new/ui/application/QuestionCard.tsx
@@ -1,6 +1,8 @@
 import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
+import { useState } from "react"
 
+import { CtaModal } from "@/shared/ui/modal/CtaModal"
 import { CheckboxFieldList } from "@/shared/ui/question-field/CheckboxFieldList"
 import { FileUploadField } from "@/shared/ui/question-field/FileUploadField"
 import { PortfolioField } from "@/shared/ui/question-field/PortfolioField"
@@ -89,11 +91,23 @@ export function QuestionCard({
     transition,
     isDragging,
   } = useSortable({ id: question.id })
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
+  }
+
+  const hasContent =
+    question.title.trim().length > 0 || (question.options?.length ?? 0) > 0
+
+  const handleDeleteRequest = () => {
+    if (hasContent) {
+      setConfirmDeleteOpen(true)
+      return
+    }
+    onDelete()
   }
 
   return (
@@ -115,7 +129,7 @@ export function QuestionCard({
           required={question.required}
           onRequiredChange={(required) => onUpdate({ required })}
           canDelete={canDelete}
-          onDelete={onDelete}
+          onDelete={handleDeleteRequest}
           dragHandleProps={{ ...attributes, ...listeners }}
         >
           <QuestionFieldRenderer
@@ -124,6 +138,21 @@ export function QuestionCard({
           />
         </QuestionForm>
       </div>
+
+      <CtaModal
+        open={confirmDeleteOpen}
+        title="질문 삭제"
+        content="삭제한 질문은 되돌릴 수 없습니다. 질문을 삭제하시겠습니까?"
+        cancelText="돌아가기"
+        confirmText="삭제하기"
+        variant="error"
+        onOpenChange={setConfirmDeleteOpen}
+        onCancel={() => setConfirmDeleteOpen(false)}
+        onConfirm={() => {
+          onDelete()
+          setConfirmDeleteOpen(false)
+        }}
+      />
     </div>
   )
 }

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -181,32 +181,6 @@ export const BasicInfoForm = forwardRef<
     shouldFocusError: false,
   })
 
-  const validateImages = (thumbnail: unknown, logo: unknown): boolean => {
-    if (!(thumbnail instanceof File) && !uploaded.thumbnailUrl) {
-      addToast({
-        message: "프로젝트 대표 이미지를 업로드해 주세요.",
-        color: "red",
-        variant: "deep",
-        type: "default",
-        duration: 3000,
-      })
-      setTimeout(() => thumbnailRef.current?.focus(), 0)
-      return false
-    }
-    if (!(logo instanceof File) && !uploaded.logoUrl) {
-      addToast({
-        message: "프로젝트 로고를 업로드해 주세요.",
-        color: "red",
-        variant: "deep",
-        type: "default",
-        duration: 3000,
-      })
-      setTimeout(() => logoRef.current?.focus(), 0)
-      return false
-    }
-    return true
-  }
-
   const runReadingOrderValidation = async (): Promise<boolean> => {
     const titleOk = await trigger("title")
     if (!titleOk) {
@@ -232,8 +206,6 @@ export const BasicInfoForm = forwardRef<
       setTimeout(() => setFocus("description"), 0)
       return false
     }
-    const values = getValues()
-    if (!validateImages(values.thumbnail, values.logo)) return false
     const imagesValid = await trigger(["thumbnail", "logo"])
     if (!imagesValid) {
       addToast({

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -46,13 +46,18 @@ export interface BasicInfoFormHandle {
 }
 
 interface BasicInfoFormProps {
+  canCreateProject?: boolean
+  createPermissionLoading?: boolean
   onNext: () => void
 }
 
 export const BasicInfoForm = forwardRef<
   BasicInfoFormHandle,
   BasicInfoFormProps
->(function BasicInfoForm({ onNext }, ref) {
+>(function BasicInfoForm(
+  { canCreateProject = true, createPermissionLoading = false, onNext },
+  ref,
+) {
   const { data: meData } = useMe()
   const isPm = isCurrentTermPm(meData)
   const activeGisuQuery = useQuery({
@@ -272,7 +277,9 @@ export const BasicInfoForm = forwardRef<
 
   const hasDirtyFields = Object.keys(dirtyFields).length > 0
   const hasUnsavedChanges = hasDirtyFields || isPmChanged
-  const canTempSave = hasUnsavedChanges && !isSaving
+  const canCreateDraft =
+    projectId !== null || (canCreateProject && !createPermissionLoading)
+  const canTempSave = hasUnsavedChanges && !isSaving && canCreateDraft
   const tempSaveLabel =
     hasSavedOnce && !hasUnsavedChanges ? "저장 완료" : "임시 저장"
 
@@ -281,6 +288,16 @@ export const BasicInfoForm = forwardRef<
   }): Promise<boolean> => {
     const silent = options?.silent ?? false
     if (!hasUnsavedChanges) return true
+    if (!canCreateDraft) {
+      addToast({
+        message: "임시 저장에 실패했습니다. 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return false
+    }
     const values = getValues()
     if (!projectId && !pm1Member) {
       addToast({

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useQuery } from "@tanstack/react-query"
+import { isAxiosError } from "axios"
 import {
   forwardRef,
   useEffect,
@@ -12,12 +13,16 @@ import { useForm } from "react-hook-form"
 
 import { useToastStore } from "@/components/toast/useToastStore"
 import { useMe } from "@/features/auth/hooks/useMe"
-import { isCurrentTermPm } from "@/features/auth/model/identity"
+import {
+  getProjectPmSearchScope,
+  isCurrentTermPm,
+} from "@/features/auth/model/identity"
 import { searchMembers } from "@/features/challenger/api/member"
 import { Dropdown } from "@/features/challenger/ui/shared/Dropdown"
 import {
   addProjectMember,
   createProjectDraft,
+  removeProjectMember,
   updateProjectDraft,
   uploadFileFlow,
 } from "@/features/project/new/api"
@@ -38,6 +43,14 @@ import { SectionHeader } from "../shared/SectionHeader"
 import { ProjectCardForm } from "./ProjectCardForm"
 
 import type { MemberItem } from "@/shared/ui/searchbar/MemberSearchBar"
+
+function extractApiErrorCode(error: unknown): string | undefined {
+  if (!isAxiosError(error)) return undefined
+  const data = error.response?.data
+  if (typeof data !== "object" || data === null) return undefined
+  const code = (data as { code?: unknown }).code
+  return typeof code === "string" ? code : undefined
+}
 
 export interface BasicInfoFormHandle {
   validate: () => Promise<boolean>
@@ -67,13 +80,20 @@ export const BasicInfoForm = forwardRef<
   })
   const activeGisuId = activeGisuQuery.data?.gisuId
 
+  const pmSearchScope = useMemo(() => getProjectPmSearchScope(meData), [meData])
+
   const pmListQuery = useQuery({
-    queryKey: ["member", "list", { part: "PLAN", gisuId: activeGisuId }],
+    queryKey: [
+      "member",
+      "list",
+      { part: "PLAN", gisuId: activeGisuId, ...pmSearchScope },
+    ],
     queryFn: () =>
       searchMembers({
         part: "PLAN",
         gisuId: activeGisuId != null ? String(activeGisuId) : undefined,
         size: 200,
+        ...pmSearchScope,
       }),
     enabled: activeGisuId != null,
     staleTime: 60 * 1000,
@@ -136,6 +156,7 @@ export const BasicInfoForm = forwardRef<
 
   const thumbnailRef = useRef<HTMLButtonElement>(null)
   const logoRef = useRef<HTMLButtonElement>(null)
+  const externalLinkRef = useRef<HTMLInputElement>(null)
 
   const normalizeExternalLink = (
     url: string | undefined,
@@ -147,14 +168,12 @@ export const BasicInfoForm = forwardRef<
 
   const {
     register,
-    handleSubmit,
     setValue,
     setFocus,
     getValues,
     reset,
     watch,
     trigger,
-    formState,
     formState: { errors, dirtyFields },
   } = useForm<BasicInfoFormData>({
     resolver: zodResolver(basicInfoSchema),
@@ -188,39 +207,83 @@ export const BasicInfoForm = forwardRef<
     return true
   }
 
+  const runReadingOrderValidation = async (): Promise<boolean> => {
+    const titleOk = await trigger("title")
+    if (!titleOk) {
+      addToast({
+        message: "프로젝트 이름을 입력해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      setTimeout(() => setFocus("title"), 0)
+      return false
+    }
+    const descOk = await trigger("description")
+    if (!descOk) {
+      addToast({
+        message: "프로젝트 한 줄 소개를 입력해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      setTimeout(() => setFocus("description"), 0)
+      return false
+    }
+    const values = getValues()
+    if (!validateImages(values.thumbnail, values.logo)) return false
+    const imagesValid = await trigger(["thumbnail", "logo"])
+    if (!imagesValid) {
+      addToast({
+        message: "이미지 형식 또는 크기(10MB 이하)를 확인해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return false
+    }
+    if (!pm1Member) {
+      setPm1Error(true)
+      addToast({
+        message: "PM을 선택해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return false
+    }
+    if (isMultiPm && !pm2Member) {
+      setPm2Error(true)
+      addToast({
+        message: "모든 PM을 선택해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return false
+    }
+    const linkOk = await trigger("externalLink")
+    if (!linkOk) {
+      addToast({
+        message: "올바른 URL을 입력해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      setTimeout(() => externalLinkRef.current?.focus(), 0)
+      return false
+    }
+    return true
+  }
+
   useImperativeHandle(ref, () => ({
-    validate: async () => {
-      if (!pm1Member) {
-        setPm1Error(true)
-        addToast({
-          message: "PM을 선택해 주세요.",
-          color: "red",
-          variant: "deep",
-          type: "default",
-          duration: 3000,
-        })
-        return false
-      }
-      if (isMultiPm && !pm2Member) {
-        setPm2Error(true)
-        addToast({
-          message: "모든 PM을 선택해 주세요.",
-          color: "red",
-          variant: "deep",
-          type: "default",
-          duration: 3000,
-        })
-        return false
-      }
-      const valid = await trigger()
-      if (!valid) {
-        onInvalid(formState.errors)
-        return false
-      }
-      const values = getValues()
-      if (!validateImages(values.thumbnail, values.logo)) return false
-      return true
-    },
+    validate: () => runReadingOrderValidation(),
     save: () => handleTempSave({ silent: false }),
     getIsDirty: () => hasUnsavedChanges,
   }))
@@ -245,29 +308,6 @@ export const BasicInfoForm = forwardRef<
       isMultiPm: storePmInfo.isMultiPm,
     })
   }, [storePmInfo])
-
-  const onInvalid = (fieldErrors: typeof errors) => {
-    let message = "모든 항목을 입력해 주세요."
-    let focusFn: (() => void) | null = null
-
-    if (fieldErrors.title) {
-      message = "프로젝트 이름을 입력해 주세요."
-      focusFn = () => setFocus("title")
-    } else if (fieldErrors.description) {
-      message = "프로젝트 한 줄 소개를 입력해 주세요."
-      focusFn = () => setFocus("description")
-    }
-
-    addToast({
-      message,
-      color: "red",
-      variant: "deep",
-      type: "default",
-      duration: 3000,
-    })
-
-    if (focusFn) setTimeout(focusFn, 0)
-  }
 
   const isPmChanged = savedSnapshot
     ? pm1Member !== savedSnapshot.pm1 ||
@@ -348,6 +388,9 @@ export const BasicInfoForm = forwardRef<
 
       const prevPm2Id = savedSnapshot?.pm2?.id
       const currPm2Id = pm2Member?.id
+      if (prevPm2Id && prevPm2Id !== currPm2Id) {
+        await removeProjectMember(resolvedProjectId, Number(prevPm2Id))
+      }
       if (currPm2Id && currPm2Id !== prevPm2Id) {
         await addProjectMember(resolvedProjectId, {
           memberId: Number(currPm2Id),
@@ -369,9 +412,13 @@ export const BasicInfoForm = forwardRef<
         })
       }
       return true
-    } catch {
+    } catch (error) {
+      const code = extractApiErrorCode(error)
       addToast({
-        message: "임시 저장에 실패했습니다. 다시 시도해주세요.",
+        message:
+          code === "PROJECT-0012"
+            ? "선택한 PM의 프로젝트를 생성할 권한이 없습니다. 담당 범위 내 PM을 선택해 주세요."
+            : "임시 저장에 실패했습니다. 다시 시도해주세요.",
         color: "red",
         variant: "deep",
         type: "default",
@@ -383,11 +430,14 @@ export const BasicInfoForm = forwardRef<
     }
   }
 
-  const onSubmit = async (data: BasicInfoFormData) => {
-    if (!validateImages(data.thumbnail, data.logo)) return
+  const handleFormSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const ok = await runReadingOrderValidation()
+    if (!ok) return
+    const values = getValues()
     if (hasUnsavedChanges) {
-      const ok = await handleTempSave({ silent: true })
-      if (!ok) return
+      const saved = await handleTempSave({ silent: true })
+      if (!saved) return
       addToast({
         message: "작성한 내용이 저장되었습니다.",
         color: "primary",
@@ -396,35 +446,8 @@ export const BasicInfoForm = forwardRef<
         duration: 3000,
       })
     }
-    setBasicInfo(data)
+    setBasicInfo(values)
     onNext()
-  }
-
-  const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    if (!pm1Member) {
-      setPm1Error(true)
-      addToast({
-        message: "PM을 선택해 주세요.",
-        color: "red",
-        variant: "deep",
-        type: "default",
-        duration: 3000,
-      })
-      return
-    }
-    if (isMultiPm && !pm2Member) {
-      setPm2Error(true)
-      addToast({
-        message: "모든 PM을 선택해 주세요.",
-        color: "red",
-        variant: "deep",
-        type: "default",
-        duration: 3000,
-      })
-      return
-    }
-    void handleSubmit(onSubmit, onInvalid)(e)
   }
 
   const displayNickname = pm1Member?.nickname ?? meData?.nickname ?? "-"
@@ -523,11 +546,19 @@ export const BasicInfoForm = forwardRef<
             setValue("logo", file, { shouldDirty: true, shouldValidate: true })
             setUploaded({ logoFileId: null, logoUrl: null })
           }}
+          onRemove={() => {
+            setValue("logo", undefined, {
+              shouldDirty: true,
+              shouldValidate: true,
+            })
+            setUploaded({ logoFileId: null, logoUrl: null })
+          }}
         />
       </div>
       <div className="flex flex-col gap-4">
         <SectionHeader index={3} title="프로젝트 기획안" />
         <InputBox
+          ref={externalLinkRef}
           value={watch("externalLink") ?? ""}
           onChange={(e) => {
             setValue("externalLink", e.target.value, {

--- a/src/features/project/new/ui/basic-info/ProjectCardForm.tsx
+++ b/src/features/project/new/ui/basic-info/ProjectCardForm.tsx
@@ -74,6 +74,10 @@ export function ProjectCardForm({
           setValue("thumbnail", file, { shouldValidate: true })
           setUploaded({ thumbnailFileId: null, thumbnailUrl: null })
         }}
+        onRemove={() => {
+          setValue("thumbnail", undefined, { shouldValidate: true })
+          setUploaded({ thumbnailFileId: null, thumbnailUrl: null })
+        }}
       />
       <div className="h-fit w-full rounded-[12px] p-5">
         <div className="mb-2.5 flex items-center justify-between">

--- a/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
+++ b/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
@@ -7,8 +7,7 @@ import {
 } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
-import { useMe } from "@/features/auth/hooks/useMe"
-import { isOperator } from "@/features/auth/model/identity"
+import { useProjectPermissions } from "@/features/project/hooks/useProjectPermissions"
 import {
   buildPartQuotasEntries,
   updatePartQuotas,
@@ -73,8 +72,17 @@ export const RecruitInfoForm = forwardRef<
   const storeRecruitInfo = useProjectRegisterStore((s) => s.recruitInfo)
   const setRecruitInfo = useProjectRegisterStore((s) => s.setRecruitInfo)
   const projectId = useProjectRegisterStore((s) => s.projectId)
-  const { data: me } = useMe()
-  const canUpdatePartQuotas = isOperator(me)
+  const projectPermissionsQuery = useProjectPermissions(
+    projectId ?? undefined,
+    {
+      enabled: projectId !== null,
+    },
+  )
+  const canUpdatePartQuotas = projectPermissionsQuery.canManage
+  const isPartQuotaPermissionLoading =
+    projectId !== null && projectPermissionsQuery.isPending
+  const isReadOnly =
+    readOnly || isPartQuotaPermissionLoading || !canUpdatePartQuotas
 
   const [isSaving, setIsSaving] = useState(false)
   const [hasSavedOnce, setHasSavedOnce] = useState(false)
@@ -98,12 +106,13 @@ export const RecruitInfoForm = forwardRef<
 
   const hasUnsavedChanges =
     savedSnapshotRef.current !== JSON.stringify(roleStates)
-  const canTempSave = totalCount > 0 && hasUnsavedChanges && !isSaving
+  const canTempSave =
+    totalCount > 0 && hasUnsavedChanges && !isSaving && !isReadOnly
   const tempSaveLabel =
     hasSavedOnce && !hasUnsavedChanges ? "저장 완료" : "임시 저장"
 
   const savePartQuotas = async (silent = false): Promise<boolean> => {
-    if (!canUpdatePartQuotas) {
+    if (isReadOnly || !canUpdatePartQuotas) {
       setRecruitInfo(roleStates)
       return true
     }
@@ -157,7 +166,7 @@ export const RecruitInfoForm = forwardRef<
   }))
 
   const handleNext = async () => {
-    if (readOnly) {
+    if (isReadOnly) {
       onNext()
       return
     }
@@ -222,7 +231,7 @@ export const RecruitInfoForm = forwardRef<
               <Counter
                 value={roleStates[key].count}
                 onChange={(v) => updateCount(key, v)}
-                disabled={readOnly}
+                disabled={isReadOnly}
                 aria-label={`${label} 인원`}
               />
               {stacks.length > 0 && (
@@ -231,7 +240,7 @@ export const RecruitInfoForm = forwardRef<
                   allowDeselect
                   value={roleStates[key].stack}
                   onValueChange={(v) =>
-                    readOnly
+                    isReadOnly
                       ? undefined
                       : updateStack(key, v as RoleStack | undefined)
                   }
@@ -240,7 +249,7 @@ export const RecruitInfoForm = forwardRef<
                     <OptionButton
                       key={stack}
                       value={stack}
-                      disabled={readOnly || roleStates[key].count === 0}
+                      disabled={isReadOnly || roleStates[key].count === 0}
                     >
                       {stack}
                     </OptionButton>

--- a/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
+++ b/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
@@ -127,6 +127,22 @@ export const RecruitInfoForm = forwardRef<
       })
       return false
     }
+    const missingStackRole = ROLES.find(
+      ({ key, stacks }) =>
+        stacks.length > 0 &&
+        roleStates[key].count > 0 &&
+        !roleStates[key].stack,
+    )
+    if (missingStackRole) {
+      addToast({
+        message: `${missingStackRole.label} 스택을 선택해 주세요.`,
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return false
+    }
     const snapshotToSave = JSON.stringify(roleStates)
     setIsSaving(true)
     try {

--- a/src/routes/matching/projects/announce/route.tsx
+++ b/src/routes/matching/projects/announce/route.tsx
@@ -1,6 +1,15 @@
-import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
+
+import { ensureMe } from "@/features/auth/lib/ensureMe"
+import { canAccessProjectSettings } from "@/features/auth/model/identity"
 
 export const Route = createFileRoute("/matching/projects/announce")({
+  beforeLoad: async ({ context }) => {
+    const me = await ensureMe(context.queryClient)
+    if (!canAccessProjectSettings(me)) {
+      throw redirect({ to: "/matching/projects" })
+    }
+  },
   component: AnnounceLayout,
 })
 

--- a/src/routes/matching/projects/announce/route.tsx
+++ b/src/routes/matching/projects/announce/route.tsx
@@ -1,15 +1,6 @@
-import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
-
-import { ensureMe } from "@/features/auth/lib/ensureMe"
-import { canAccessProjectSettings } from "@/features/auth/model/identity"
+import { createFileRoute, Outlet } from "@tanstack/react-router"
 
 export const Route = createFileRoute("/matching/projects/announce")({
-  beforeLoad: async ({ context }) => {
-    const me = await ensureMe(context.queryClient)
-    if (!canAccessProjectSettings(me)) {
-      throw redirect({ to: "/matching/projects" })
-    }
-  },
   component: AnnounceLayout,
 })
 

--- a/src/routes/matching/projects/management.tsx
+++ b/src/routes/matching/projects/management.tsx
@@ -1,13 +1,13 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
 
 import { ensureMe } from "@/features/auth/lib/ensureMe"
-import { isCurrentTermPm, isOperator } from "@/features/auth/model/identity"
+import { canManageProjects } from "@/features/auth/model/identity"
 import { ProjectManagementPage } from "@/features/project/management"
 
 export const Route = createFileRoute("/matching/projects/management")({
   beforeLoad: async ({ context }) => {
     const me = await ensureMe(context.queryClient)
-    if (!isOperator(me) && !isCurrentTermPm(me)) throw redirect({ to: "/" })
+    if (!canManageProjects(me)) throw redirect({ to: "/matching/projects" })
   },
   component: ProjectManagementPage,
 })

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -12,7 +12,10 @@ import { getResourcePermission } from "@/features/auth/api/permissions"
 import { useMe } from "@/features/auth/hooks/useMe"
 import { useResourcePermission } from "@/features/auth/hooks/useResourcePermission"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
-import { isCurrentTermPm, isOperator } from "@/features/auth/model/identity"
+import {
+  canManageProjects,
+  isCurrentTermPm,
+} from "@/features/auth/model/identity"
 import { hasGrantedPermission } from "@/features/auth/model/resourcePermission"
 import { useProjectPermissions } from "@/features/project/hooks/useProjectPermissions"
 import { getManagedProjects } from "@/features/project/management/api"
@@ -49,10 +52,11 @@ export const Route = createFileRoute("/matching/projects/new")({
   beforeLoad: async ({ context, search }) => {
     const me = await ensureMe(context.queryClient)
 
+    if (!canManageProjects(me)) {
+      throw redirect({ to: "/matching/projects" })
+    }
+
     if (search.projectId !== undefined) {
-      if (!isOperator(me) && !isCurrentTermPm(me)) {
-        throw redirect({ to: "/matching/projects" })
-      }
       return
     }
 

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -8,9 +8,13 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
+import { getResourcePermission } from "@/features/auth/api/permissions"
 import { useMe } from "@/features/auth/hooks/useMe"
+import { useResourcePermission } from "@/features/auth/hooks/useResourcePermission"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
 import { isCurrentTermPm, isOperator } from "@/features/auth/model/identity"
+import { hasGrantedPermission } from "@/features/auth/model/resourcePermission"
+import { useProjectPermissions } from "@/features/project/hooks/useProjectPermissions"
 import { getManagedProjects } from "@/features/project/management/api"
 import {
   ApplicationForm,
@@ -42,11 +46,39 @@ import { CtaModal } from "@/shared/ui/modal/CtaModal"
 import type { BasicInfoFormHandle } from "@/features/project/new/ui/basic-info/BasicInfoForm"
 
 export const Route = createFileRoute("/matching/projects/new")({
-  beforeLoad: async ({ context }) => {
+  beforeLoad: async ({ context, search }) => {
     const me = await ensureMe(context.queryClient)
-    if (!isOperator(me) && !isCurrentTermPm(me)) {
+
+    if (search.projectId !== undefined) {
+      if (!isOperator(me) && !isCurrentTermPm(me)) {
+        throw redirect({ to: "/matching/projects" })
+      }
+      return
+    }
+
+    try {
+      const permission = await context.queryClient.ensureQueryData({
+        queryKey: [
+          "authorization",
+          "resource-permission",
+          "PROJECT",
+          undefined,
+          "WRITE",
+        ],
+        queryFn: () =>
+          getResourcePermission({
+            resourceType: "PROJECT",
+            permissionType: "WRITE",
+          }),
+        staleTime: 0,
+      })
+
+      if (hasGrantedPermission(permission, "WRITE")) return
+    } catch {
       throw redirect({ to: "/matching/projects" })
     }
+
+    throw redirect({ to: "/matching/projects" })
   },
   validateSearch: (search: Record<string, unknown>) => ({
     projectId:
@@ -79,7 +111,6 @@ function ProjectRegisterPage() {
   const queryClient = useQueryClient()
   const { data: me } = useMe()
   const isPm = isCurrentTermPm(me)
-
   const projectId = useProjectRegisterStore((s) => s.projectId)
   const application = useProjectRegisterStore((s) => s.application)
   const recruitInfo = useProjectRegisterStore((s) => s.recruitInfo)
@@ -88,6 +119,26 @@ function ProjectRegisterPage() {
   const setProjectId = useProjectRegisterStore((s) => s.setProjectId)
   const setGisuId = useProjectRegisterStore((s) => s.setGisuId)
   const setApplication = useProjectRegisterStore((s) => s.setApplication)
+  const projectWritePermissionQuery = useResourcePermission(
+    "PROJECT",
+    undefined,
+    {
+      allowTypeLevel: true,
+      enabled: !isEditMode,
+      permissionType: "WRITE",
+    },
+  )
+  const projectPermissionsQuery = useProjectPermissions(
+    projectId ?? undefined,
+    {
+      enabled: projectId !== null,
+    },
+  )
+  const canCreateProject =
+    isEditMode || projectWritePermissionQuery.hasPermission("WRITE")
+  const isCreatePermissionLoading =
+    !isEditMode && projectWritePermissionQuery.isPending
+  const canManageProject = projectPermissionsQuery.canManage
 
   const isStoreDirty = useProjectRegisterStore((s) => {
     const recruitTotal =
@@ -195,6 +246,9 @@ function ProjectRegisterPage() {
   const submitMutation = useMutation({
     mutationFn: async () => {
       if (!projectId) throw new Error("프로젝트 ID가 없습니다.")
+      if (!isEditMode && !canCreateProject) {
+        throw new Error("프로젝트 생성 권한이 없습니다.")
+      }
       if (applicationFormRef.current?.getIsDirty() ?? true) {
         const body = buildUpsertApplicationFormBody(
           application.commonQuestions,
@@ -205,7 +259,7 @@ function ProjectRegisterPage() {
       }
       if (isEditMode) return
       const result = await submitProject(projectId)
-      if (pmInfo.pm1) {
+      if (pmInfo.pm1 && canManageProject) {
         await transferOwnership(projectId, {
           newOwnerMemberId: Number(pmInfo.pm1.id),
         })
@@ -385,7 +439,12 @@ function ProjectRegisterPage() {
           openTooltipStep={tooltipTriggerStep}
         />
         {step === 1 && (
-          <BasicInfoForm ref={basicInfoRef} onNext={handleBasicInfoNext} />
+          <BasicInfoForm
+            ref={basicInfoRef}
+            canCreateProject={canCreateProject}
+            createPermissionLoading={isCreatePermissionLoading}
+            onNext={handleBasicInfoNext}
+          />
         )}
         {step === 2 && (
           <RecruitInfoForm
@@ -401,7 +460,9 @@ function ProjectRegisterPage() {
             ref={applicationFormRef}
             isEditMode={isEditMode}
             isHydrated={isEditMode ? applicationFormHydrated : true}
-            isSubmitting={submitMutation.isPending}
+            isSubmitting={submitMutation.isPending || isCreatePermissionLoading}
+            canCreateProject={canCreateProject}
+            createPermissionLoading={isCreatePermissionLoading}
             onPrev={handleApplicationFormPrev}
             onNext={handleRegister}
           />

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -143,6 +143,29 @@ function ProjectRegisterPage() {
   const isCreatePermissionLoading =
     !isEditMode && projectWritePermissionQuery.isPending
   const canManageProject = projectPermissionsQuery.canManage
+  const canEditRecruitStep = projectId !== null ? canManageProject : !isPm
+
+  const resolveCanEditRecruitStep = async (): Promise<boolean> => {
+    const pid = useProjectRegisterStore.getState().projectId
+    if (pid === null) return !isPm
+    try {
+      const permission = await queryClient.ensureQueryData({
+        queryKey: [
+          "authorization",
+          "resource-permission",
+          "PROJECT",
+          pid,
+          undefined,
+        ],
+        queryFn: () =>
+          getResourcePermission({ resourceType: "PROJECT", resourceId: pid }),
+        staleTime: 0,
+      })
+      return hasGrantedPermission(permission, "MANAGE")
+    } catch {
+      return !isPm
+    }
+  }
 
   const isStoreDirty = useProjectRegisterStore((s) => {
     const recruitTotal =
@@ -303,17 +326,19 @@ function ProjectRegisterPage() {
     )
   }
 
-  const handleBasicInfoNext = () => {
-    setStep(isPm ? 3 : 2)
+  const handleBasicInfoNext = async () => {
+    const canEdit = await resolveCanEditRecruitStep()
+    setStep(canEdit ? 2 : 3)
   }
 
-  const handleApplicationFormPrev = () => {
-    setStep(isPm ? 1 : 2)
+  const handleApplicationFormPrev = async () => {
+    const canEdit = await resolveCanEditRecruitStep()
+    setStep(canEdit ? 2 : 1)
   }
 
   const handleStepChange = async (idx: number) => {
     if (isEditMode) return
-    if (isPm && idx === 2) {
+    if (!canEditRecruitStep && idx === 2) {
       setStep(2)
       triggerStepTooltip(2)
       return
@@ -330,7 +355,7 @@ function ProjectRegisterPage() {
       }
       const saved = await basicInfoRef.current?.save()
       if (!saved) return
-    } else if (step === 2 && !isPm) {
+    } else if (step === 2 && canEditRecruitStep) {
       const total = Object.values(recruitInfo).reduce(
         (sum, { count }) => sum + count,
         0,
@@ -423,14 +448,14 @@ function ProjectRegisterPage() {
           disabledSteps={
             isEditMode
               ? [1, 2, 3].filter((idx) => idx !== step)
-              : isPm
+              : !canEditRecruitStep
                 ? [2]
                 : []
           }
           disabledTooltips={
             isEditMode
               ? {}
-              : isPm
+              : !canEditRecruitStep
                 ? {
                     2: "기술 스택 및 파트별 TO는 운영진이 수기로 조정합니다.",
                     3: "기본 정보를 입력한 뒤 작성할 수 있습니다.",
@@ -453,7 +478,7 @@ function ProjectRegisterPage() {
         {step === 2 && (
           <RecruitInfoForm
             ref={recruitInfoRef}
-            readOnly={isPm}
+            readOnly={!canEditRecruitStep}
             isHydrated={isEditMode ? detailQuery.isSuccess : true}
             onPrev={() => setStep(1)}
             onNext={() => setStep(3)}

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -304,7 +304,7 @@ function ProjectRegisterPage() {
       }
       if (isEditMode) return
       const result = await submitProject(projectId)
-      if (pmInfo.pm1 && canManageProject) {
+      if (pmInfo.pm1 && (await resolveCanEditRecruitStep())) {
         await transferOwnership(projectId, {
           newOwnerMemberId: Number(pmInfo.pm1.id),
         })

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -493,10 +493,11 @@ function ProjectRegisterPage() {
         variant="warning"
         title="페이지 이탈"
         content="저장되지 않았습니다. 저장 후 나가시겠습니까?"
-        cancelText="돌아가기"
+        cancelText="나가기"
         confirmText="저장 후 나가기"
         confirmLoading={isSavingAndLeaving}
-        onCancel={() => resetLeave?.()}
+        cancelOnDismiss={false}
+        onCancel={() => proceedLeave?.()}
         onConfirm={() => void handleSaveAndLeave()}
       />
     </section>

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -5,6 +5,7 @@ import {
   useBlocker,
   useNavigate,
 } from "@tanstack/react-router"
+import { isAxiosError } from "axios"
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
@@ -238,6 +239,23 @@ function ProjectRegisterPage() {
     }
   }, [detailQuery.data])
 
+  useEffect(() => {
+    if (!isEditMode || !detailQuery.isError) return
+    const status = isAxiosError(detailQuery.error)
+      ? detailQuery.error.response?.status
+      : undefined
+    if (status === 403 || status === 404) {
+      addToast({
+        message: "프로젝트에 접근할 권한이 없습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      navigate({ to: "/matching/projects/management", replace: true })
+    }
+  }, [isEditMode, detailQuery.isError, detailQuery.error, addToast, navigate])
+
   const draftQuery = useQuery({
     queryKey: projectKeys.draft(gisuId ?? 0),
     queryFn: () => getMyDraft(gisuId!),
@@ -298,11 +316,18 @@ function ProjectRegisterPage() {
       void queryClient.invalidateQueries({ queryKey: ["project", "managed"] })
       setShowSuccessModal(true)
     },
-    onError: () => {
+    onError: (error) => {
+      const status = isAxiosError(error) ? error.response?.status : undefined
+      const message =
+        status === 403
+          ? isEditMode
+            ? "프로젝트를 수정할 권한이 없습니다."
+            : "프로젝트를 등록할 권한이 없습니다."
+          : isEditMode
+            ? "프로젝트 수정에 실패했습니다. 다시 시도해주세요."
+            : "프로젝트 등록에 실패했습니다. 다시 시도해주세요."
       addToast({
-        message: isEditMode
-          ? "프로젝트 수정에 실패했습니다. 다시 시도해주세요."
-          : "프로젝트 등록에 실패했습니다. 다시 시도해주세요.",
+        message,
         color: "red",
         variant: "deep",
         type: "default",

--- a/src/shared/ui/ImageUploader.tsx
+++ b/src/shared/ui/ImageUploader.tsx
@@ -1,24 +1,35 @@
 import { forwardRef, useEffect, useRef, useState } from "react"
 
+import CloseCircleIcon from "@/shared/assets/icon/close/CloseCircleIcon"
 import UploadImageIcon from "@/shared/assets/icon/upload/UploadImageIcon"
 import { cn } from "@/shared/lib/utils"
 
 type ImageUploaderVariant = "thumbnail" | "logo"
 
-const variantClasses: Record<ImageUploaderVariant, string> = {
-  thumbnail: "h-71.5 w-135 rounded-t-[12px]",
-  logo: "h-50 w-50 rounded-[12px]",
+const variantSize: Record<ImageUploaderVariant, string> = {
+  thumbnail: "h-71.5 w-135",
+  logo: "h-50 w-50",
+}
+
+const variantRound: Record<ImageUploaderVariant, string> = {
+  thumbnail: "rounded-t-[12px]",
+  logo: "rounded-[12px]",
 }
 
 const variantLabels: Record<
   ImageUploaderVariant,
-  { upload: string; change: string }
+  { upload: string; change: string; remove: string }
 > = {
   thumbnail: {
     upload: "프로젝트 썸네일 업로드",
     change: "프로젝트 썸네일 변경",
+    remove: "프로젝트 썸네일 제거",
   },
-  logo: { upload: "프로젝트 로고 업로드", change: "프로젝트 로고 변경" },
+  logo: {
+    upload: "프로젝트 로고 업로드",
+    change: "프로젝트 로고 변경",
+    remove: "프로젝트 로고 제거",
+  },
 }
 
 const variantHint: Record<ImageUploaderVariant, string> = {
@@ -39,6 +50,7 @@ const variantAccept: Record<ImageUploaderVariant, string> = {
 interface ImageUploaderProps {
   variant?: ImageUploaderVariant
   onChange: (file: File) => void
+  onRemove?: () => void
   initialUrl?: string
   error?: string
   errorId?: string
@@ -51,6 +63,7 @@ export const ImageUploader = forwardRef<HTMLButtonElement, ImageUploaderProps>(
     {
       variant = "thumbnail",
       onChange,
+      onRemove,
       initialUrl,
       error,
       errorId,
@@ -80,6 +93,13 @@ export const ImageUploader = forwardRef<HTMLButtonElement, ImageUploaderProps>(
       onChange(file)
     }
 
+    const handleRemove = () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl)
+      setPreviewUrl(null)
+      if (fileInputRef.current) fileInputRef.current.value = ""
+      onRemove?.()
+    }
+
     const hoverContent = (
       <>
         <span className="text-label-1-medium flex items-center gap-2">
@@ -97,46 +117,60 @@ export const ImageUploader = forwardRef<HTMLButtonElement, ImageUploaderProps>(
 
     return (
       <>
-        <button
-          ref={ref}
-          type="button"
-          aria-label={activePreview ? labels.change : labels.upload}
-          aria-invalid={!!error}
-          aria-describedby={errorId}
-          data-focus-target={focusTarget}
-          onClick={() => fileInputRef.current?.click()}
-          className={cn(
-            "bg-teal-gray-200 hover:bg-teal-gray-400 group relative overflow-hidden transition-colors focus:ring-2 focus:outline-none focus:ring-inset",
-            error ? "focus:ring-error-400" : "focus:ring-teal-300",
-            variantClasses[variant],
-            variant === "logo" &&
-              activePreview &&
-              "border-teal-gray-150 border",
-            className,
-          )}
-        >
-          {activePreview ? (
-            <>
-              <img
-                src={activePreview}
-                alt={labels.change}
-                className="h-full w-full object-cover"
-              />
-              <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-black/40 opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100">
-                {hoverContent}
+        <div className={cn("relative", variantSize[variant], className)}>
+          <button
+            ref={ref}
+            type="button"
+            aria-label={activePreview ? labels.change : labels.upload}
+            aria-invalid={!!error}
+            aria-describedby={errorId}
+            data-focus-target={focusTarget}
+            onClick={() => fileInputRef.current?.click()}
+            className={cn(
+              "bg-teal-gray-200 hover:bg-teal-gray-400 group relative h-full w-full overflow-hidden transition-colors focus:ring-2 focus:outline-none focus:ring-inset",
+              error ? "focus:ring-error-400" : "focus:ring-teal-300",
+              variantRound[variant],
+              variant === "logo" &&
+                activePreview &&
+                "border-teal-gray-150 border",
+            )}
+          >
+            {activePreview ? (
+              <>
+                <img
+                  src={activePreview}
+                  alt={labels.change}
+                  className="h-full w-full object-cover"
+                />
+                <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-black/40 opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100">
+                  {hoverContent}
+                </div>
+              </>
+            ) : (
+              <div className="text-teal-gray-400 text-body-2-regular flex flex-col items-center justify-center">
+                <span className="text-center whitespace-pre transition-opacity duration-200 group-hover:opacity-0 group-focus-visible:opacity-0">
+                  {variantPlaceholder[variant]}
+                </span>
+                <span className="absolute flex flex-col items-center gap-1 opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100">
+                  {hoverContent}
+                </span>
               </div>
-            </>
-          ) : (
-            <div className="text-teal-gray-400 text-body-2-regular flex flex-col items-center justify-center">
-              <span className="text-center whitespace-pre transition-opacity duration-200 group-hover:opacity-0 group-focus-visible:opacity-0">
-                {variantPlaceholder[variant]}
-              </span>
-              <span className="absolute flex flex-col items-center gap-1 opacity-0 transition-opacity duration-200 group-hover:opacity-100 group-focus-visible:opacity-100">
-                {hoverContent}
-              </span>
-            </div>
+            )}
+          </button>
+          {activePreview && onRemove && (
+            <button
+              type="button"
+              aria-label={labels.remove}
+              onClick={(e) => {
+                e.stopPropagation()
+                handleRemove()
+              }}
+              className="text-teal-gray-600 hover:text-teal-gray-800 absolute top-2 right-2 z-10 flex h-6 w-6 items-center justify-center rounded-full bg-white/90 shadow-sm transition-colors hover:bg-white focus:ring-2 focus:ring-teal-300 focus:outline-none"
+            >
+              <CloseCircleIcon className="h-4.5 w-4.5" aria-hidden="true" />
+            </button>
           )}
-        </button>
+        </div>
         {error && (
           <p
             id={errorId}

--- a/src/shared/ui/dropdown/DropdownItem.tsx
+++ b/src/shared/ui/dropdown/DropdownItem.tsx
@@ -5,6 +5,7 @@ interface DropdownItemProps {
   label: string
   onClick: () => void
   isSelected?: boolean
+  disabled?: boolean
   className?: string
   size?: "xs" | "md"
 }
@@ -30,6 +31,7 @@ export function DropdownItem({
   label,
   onClick,
   isSelected = false,
+  disabled = false,
   className,
   size = "md",
 }: DropdownItemProps) {
@@ -37,14 +39,17 @@ export function DropdownItem({
     <button
       type="button"
       onClick={onClick}
+      disabled={disabled}
       className={cn(
         "flex w-full shrink-0 rounded-lg bg-white text-left transition-[background-color,color,box-shadow]",
         baseClass[size],
         isSelected ? paddingClass[size].selected : paddingClass[size].default,
-        isSelected
-          ? "shadow-inner-neutral-1 bg-teal-50"
-          : "hover:bg-teal-gray-50 hover:shadow-inner-neutral-2",
+        !disabled &&
+          (isSelected
+            ? "shadow-inner-neutral-1 bg-teal-50"
+            : "hover:bg-teal-gray-50 hover:shadow-inner-neutral-2"),
         className,
+        disabled && "text-teal-gray-300 cursor-not-allowed",
       )}
     >
       <span

--- a/src/shared/ui/modal/CtaModal.tsx
+++ b/src/shared/ui/modal/CtaModal.tsx
@@ -91,7 +91,7 @@ export function CtaModal({
               size="s"
               className="rounded-[10px]"
               isLoading={confirmLoading}
-              onClick={onConfirm}
+              onClick={confirmLoading ? undefined : onConfirm}
             >
               {confirmText}
             </Button>

--- a/src/shared/ui/modal/CtaModal.tsx
+++ b/src/shared/ui/modal/CtaModal.tsx
@@ -17,6 +17,7 @@ interface CtaModalProps {
   confirmLoading?: boolean
   variant?: CtaModalVariant
   overlayTone?: "light" | "deep"
+  cancelOnDismiss?: boolean
   onOpenChange: (open: boolean) => void
   onCancel?: () => void
   onConfirm: () => void
@@ -31,6 +32,7 @@ export function CtaModal({
   confirmLoading = false,
   variant = "warning",
   overlayTone = "light",
+  cancelOnDismiss = true,
   onOpenChange,
   onCancel,
   onConfirm,
@@ -49,7 +51,7 @@ export function CtaModal({
       open={open}
       onOpenChange={(nextOpen) => {
         onOpenChange(nextOpen)
-        if (!nextOpen) onCancel?.()
+        if (!nextOpen && cancelOnDismiss) onCancel?.()
       }}
     >
       <Modal.Portal>

--- a/src/shared/ui/question-field/QuestionForm.tsx
+++ b/src/shared/ui/question-field/QuestionForm.tsx
@@ -68,12 +68,13 @@ export function QuestionForm({
         />
       )}
 
-      {focused && (
+      {dragHandleProps && (
         <button
           type="button"
           className="mt-4 inline-flex cursor-grab items-center justify-center active:cursor-grabbing"
           aria-label="순서 변경 핸들"
           {...dragHandleProps}
+          onClick={(e) => e.stopPropagation()}
         >
           <DragAndDrop className="h-3 w-6" aria-hidden />
         </button>

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -130,8 +130,8 @@ export interface paths {
     }
     get?: never
     put?: never
-    /** [TEST-004] 웹훅 알람 전송 테스트 */
-    post: operations["sendWebhookAlarm"]
+    /** 웹훅 알람 전송 테스트 */
+    post: operations["TEST-004"]
     delete?: never
     options?: never
     head?: never
@@ -147,8 +147,8 @@ export interface paths {
     }
     get?: never
     put?: never
-    /** [TEST-005] 웹훅 알람 버퍼 전송 테스트 */
-    post: operations["sendBufferedWebhookAlarm"]
+    /** 웹훅 알람 버퍼 전송 테스트 */
+    post: operations["TEST-005"]
     delete?: never
     options?: never
     head?: never
@@ -165,14 +165,75 @@ export interface paths {
     get?: never
     put?: never
     /**
-     * [SEED-003] 프로젝트 시딩
+     * 프로젝트 시딩
      * @description 활성 기수(또는 지정 기수)의 같은 school 멤버 풀에서 PLAN 1 + 프론트엔드 5~6 +
      *     백엔드 5~6 의 멤버 슬롯을 추출해 프로젝트를 N 개 생성합니다.
      *     School 단위 round-robin 으로 채우며, 풀이 부족한 셀은 skip 합니다.
      *     PO 후보가 PLAN 챌린저로 등록되지 않은 경우 시딩 측에서 PLAN 챌린저로 등록한 뒤
      *     createDraft 를 호출합니다.
      */
-    post: operations["seedProjects"]
+    post: operations["SEED-003"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/test/seed/projects/scenarios": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * 프로젝트 시나리오 시딩
+     * @description 활성 기수에 대해 DRAFT / PENDING_REVIEW / IN_PROGRESS 중 하나의 상태까지 도달한
+     *     프로젝트를 N 개 생성합니다. SQL 직접 주입이 아니라 도메인 UseCase 시퀀스 호출로 만들기 때문에
+     *     도메인 가드를 모두 통과한 데이터가 됩니다.
+     *     productOwnerMemberIds 를 명시하면 그 리스트로만 PO 를 사용하고(size 가 projectCount 와
+     *     같아야 하며 각각 활성 기수 PLAN 챌린저여야 함), null 이면 활성 기수 PLAN 챌린저 풀에서
+     *     랜덤 픽 합니다. 시딩 측에서 챌린저를 강제로 만들지는 않습니다.
+     *     IN_PROGRESS 단계에서는 DESIGN×1~2 + FE 1 개×3~4 + BE 1 개×3~4 의 partQuota 가 자동 분배되고,
+     *     각 파트마다 PO 학교의 해당 파트 챌린저 풀에서 random(0, quota) 만큼 멤버가 충원됩니다.
+     */
+    post: operations["SEED-003-S"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/test/seed/project-applications": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * [SEED-006] 지원서 시나리오 시딩
+     * @description 지정 매칭 차수 + 지부를 기준으로, 아직 팀에 합류하지 않은 ACTIVE 챌린저들이
+     *     지부의 IN_PROGRESS 프로젝트에 지원서를 제출하는 시나리오를 실행합니다.
+     *
+     *     전제 조건:
+     *     - 매칭차수가 현재 OPEN 상태(startsAt <= now <= endsAt)여야 합니다.
+     *     - 지부 내 IN_PROGRESS 프로젝트가 존재해야 합니다. (SEED-003-S 선행 필요)
+     *     - 챌린저가 시딩되어 있어야 합니다. (SEED-002 선행 필요)
+     *
+     *     동작:
+     *     각 챌린저는 createDraft → fill → submit 까지 진행한 뒤, 최종 상태가
+     *     SUBMITTED / APPROVED / REJECTED 중 하나로 무작위 결정됩니다 (약 1/3 분포).
+     *     그 결과로 운영 화면의 "검토 대기 + 합격자 + 불합격자" 분포가 자연스럽게 채워집니다.
+     *
+     *     ProjectMember 등록은 시딩 책임 밖입니다. 매칭 완료(APPROVED → ProjectMember 일괄 등록)는
+     *     차수 종료 시점의 autoDecide 가 처리합니다.
+     */
+    post: operations["seedProjectApplications"]
     delete?: never
     options?: never
     head?: never
@@ -189,7 +250,7 @@ export interface paths {
     get?: never
     put?: never
     /**
-     * [SEED-005] Notice 시딩 (지부 · 학교 · 파트 분포)
+     * Notice 시딩 (지부 · 학교 · 파트 분포)
      * @description 활성 기수(또는 지정 기수)에 대해 다음 4 가지 scope 로 공지를 분포 시딩합니다.
      *       GLOBAL  : 기수 전체 대상 (작성자에게 중앙 총괄단 권한 필요)
      *       CHAPTER : 각 지부별        (작성자에게 해당 지부 회장 권한 필요)
@@ -199,7 +260,7 @@ export interface paths {
      *     포함되어 운영 화면에서 시딩 데이터 식별이 쉬워집니다.
      *     authorMemberId 의 권한이 부족한 scope 는 scopeBreakdown 의 failed 카운트에 잡힙니다.
      */
-    post: operations["seedNotice"]
+    post: operations["SEED-005"]
     delete?: never
     options?: never
     head?: never
@@ -216,14 +277,14 @@ export interface paths {
     get?: never
     put?: never
     /**
-     * [SEED-001] 더미 멤버 시딩
+     * 더미 멤버 시딩
      * @description ID/PW 더미 멤버를 N 명 즉시 생성합니다. 모든 더미 회원은 동일한 비밀번호
      *     (app.seed.default-password)를 사용합니다.
      *     force=false (기본) 이면 현재 회원 수가 임계값을 초과한 경우 시딩을 스킵합니다.
      *     force=true 이면 임계값 체크를 무시하고 무조건 시딩합니다.
      *     챌린저/프로젝트 시딩 전 호출이 필요합니다.
      */
-    post: operations["seedMembers"]
+    post: operations["SEED-001"]
     delete?: never
     options?: never
     head?: never
@@ -240,13 +301,13 @@ export interface paths {
     get?: never
     put?: never
     /**
-     * [SEED-004] Curriculum 시딩 (Curriculum · WeeklyCurriculum · OriginalWorkbook · Mission)
+     * Curriculum 시딩 (Curriculum · WeeklyCurriculum · OriginalWorkbook · Mission)
      * @description 활성 기수(또는 지정 기수)에 대해 ADMIN 제외 파트별로 다음 골격을 시딩합니다.
      *     Curriculum (1/파트) → WeeklyCurriculum (1~N 주차) → OriginalWorkbook (MAIN, READY) → Mission (M개).
      *     releaseRequesterMemberId 가 지정되면 모든 워크북을 READY → RELEASED 로 전환합니다.
      *     각 단계별로 실패 격리되며, 단계별 실패 카운트가 응답에 포함됩니다.
      */
-    post: operations["seedCurriculum"]
+    post: operations["SEED-004"]
     delete?: never
     options?: never
     head?: never
@@ -263,13 +324,13 @@ export interface paths {
     get?: never
     put?: never
     /**
-     * [SEED-002] 챌린저 분포 시딩
+     * 챌린저 분포 시딩
      * @description 특정 기수에 대해 (Chapter, School, Part) 셀마다 countPerPartPerSchool 명의 더미 회원 +
      *     챌린저를 함께 생성합니다.
      *     gisuId 가 null 이면 활성 기수, parts 가 null/empty 면 ADMIN 제외 전 파트,
      *     chapterIds 가 null/empty 면 해당 기수의 모든 Chapter 가 대상입니다.
      */
-    post: operations["seedChallengers"]
+    post: operations["SEED-002"]
     delete?: never
     options?: never
     head?: never
@@ -285,8 +346,8 @@ export interface paths {
     }
     get?: never
     put?: never
-    /** [TEST-002] FCM 푸시 알림 테스트 전송 */
-    post: operations["sendTestNotification"]
+    /** FCM 푸시 알림 테스트 전송 */
+    post: operations["TEST-002"]
     delete?: never
     options?: never
     head?: never
@@ -686,6 +747,27 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/api/v1/user-feedbacks/responses": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * 사용자 피드백 응답 제출
+     * @description 지정한 피드백 템플릿에 대한 응답을 즉시 제출합니다.
+     *     동일 폼에 이미 응답한 경우 Survey 도메인에서 중복 응답 예외가 발생합니다.
+     */
+    post: operations["submit"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/api/v1/trophies": {
     parameters: {
       query?: never
@@ -900,7 +982,7 @@ export interface paths {
      * [PROJECT-107] 프로젝트 제출
      * @description DRAFT 상태의 프로젝트를 제출하여 PENDING_REVIEW로 전이합니다. 작성자(creator)만 호출 가능.
      */
-    post: operations["submit"]
+    post: operations["submit_1"]
     delete?: never
     options?: never
     head?: never
@@ -1007,7 +1089,27 @@ export interface paths {
      * [APPLY-003] 챌린저 지원서 최종 제출
      * @description DRAFT -> SUBMITTED 전이. 필수 답변 누락 시 400. 본인의 DRAFT 지원서에서만 호출 가능.
      */
-    post: operations["submit_1"]
+    post: operations["submit_2"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/projects/{projectId}/abort": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * [PROJECT-110] 프로젝트 중단
+     * @description IN_PROGRESS 상태의 프로젝트를 ABORTED 로 전이합니다. ACTIVE ProjectMember 는 WITHDRAWN, 진행 중(DRAFT/SUBMITTED) ProjectApplication 은 CANCELLED 로 일괄 동기화. 운영진(본인 지부장 또는 Central Core) 만 호출 가능.
+     */
+    post: operations["abort"]
     delete?: never
     options?: never
     head?: never
@@ -1736,6 +1838,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/api/v1/authorization/resource-permissions/batch": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * [PERMISSION-002] 리소스 권한 배치 조회
+     * @description 여러 리소스에 대해 현재 사용자의 권한을 한 번에 조회합니다. 유효하지 않은 query가 하나라도 있으면 요청 전체가 실패합니다.
+     */
+    post: operations["batchGetResourcePermission"]
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/api/v1/authorization/challenger-role": {
     parameters: {
       query?: never
@@ -1877,7 +1999,7 @@ export interface paths {
     get?: never
     put?: never
     /**
-     * [LOGIN-006] 이메일/PW 로그인
+     * [LOGIN-011] 이메일/PW 로그인
      * @description email/password 로 인증하여 AccessToken/RefreshToken 을 발급받습니다. clientType(ANDROID, IOS, WEB)을 함께 전달하면 AccessToken claim 으로 반영됩니다.
      */
     post: operations["loginByEmail"]
@@ -2657,7 +2779,11 @@ export interface paths {
     get: operations["getDetail"]
     put?: never
     post?: never
-    delete?: never
+    /**
+     * [PROJECT-109] 프로젝트 삭제
+     * @description DRAFT / PENDING_REVIEW 상태의 프로젝트를 hard delete 합니다. 연관 ProjectMember / PartQuota / ApplicationForm + survey Form 까지 cascade 삭제. PO 본인 또는 운영진(본인 지부장 / 해당 기수 총괄단)만 호출 가능. IN_PROGRESS 이상은 abort 엔드포인트 사용.
+     */
+    delete: operations["delete_2"]
     options?: never
     head?: never
     /**
@@ -2707,7 +2833,7 @@ export interface paths {
      *     - 지부장은 본인 지부의 매칭 차수만 삭제할 수 있습니다.
      *     - 해당 매칭 차수를 참조하는 지원서가 하나라도 있으면 삭제할 수 없으며 409를 반환합니다.
      */
-    delete: operations["delete_2"]
+    delete: operations["delete_3"]
     options?: never
     head?: never
     /**
@@ -2983,8 +3109,8 @@ export interface paths {
       path?: never
       cookie?: never
     }
-    /** [TEST-003] AOP로 전송하는 알람 테스트 */
-    get: operations["sendAopWebhookAlarm"]
+    /** AOP로 전송하는 알람 테스트 */
+    get: operations["TEST-003"]
     put?: never
     post?: never
     delete?: never
@@ -3000,8 +3126,8 @@ export interface paths {
       path?: never
       cookie?: never
     }
-    /** [TEST-008] RefreshToken 발급 */
-    get: operations["getRefreshToken"]
+    /** RefreshToken 발급 */
+    get: operations["TEST-008"]
     put?: never
     post?: never
     delete?: never
@@ -3017,8 +3143,8 @@ export interface paths {
       path?: never
       cookie?: never
     }
-    /** [TEST-010] oAuthVerificationToken 발급 */
-    get: operations["getOAuthVerificationToken"]
+    /** oAuthVerificationToken 발급 */
+    get: operations["TEST-010"]
     put?: never
     post?: never
     delete?: never
@@ -3034,8 +3160,8 @@ export interface paths {
       path?: never
       cookie?: never
     }
-    /** [TEST-009] EmailVerificationToken 발급 */
-    get: operations["getEmailVerification"]
+    /** EmailVerificationToken 발급 */
+    get: operations["TEST-009"]
     put?: never
     post?: never
     delete?: never
@@ -3051,8 +3177,8 @@ export interface paths {
       path?: never
       cookie?: never
     }
-    /** [TEST-007] AccessToken 발급 */
-    get: operations["getAccessToken"]
+    /** AccessToken 발급 */
+    get: operations["TEST-007"]
     put?: never
     post?: never
     delete?: never
@@ -3084,8 +3210,8 @@ export interface paths {
       path?: never
       cookie?: never
     }
-    /** [TEST-011] 헬스 체크 API */
-    get: operations["healthCheck"]
+    /** 헬스 체크 API */
+    get: operations["TEST-011"]
     put?: never
     post?: never
     delete?: never
@@ -3102,12 +3228,12 @@ export interface paths {
       cookie?: never
     }
     /**
-     * [TEST-001] [개발용] 파일 ID를 기반으로 접근 가능한 URL을 조회합니다.
+     * [개발용] 파일 ID를 기반으로 접근 가능한 URL을 조회합니다.
      * @description local 및 development 환경에서만 사용 가능합니다.
      *
      *     크롤링을 방지하기 위한 절차입니다. 파일이 정상적으로 업로드되었는지 확인하는 용도로만 사용하세요.
      */
-    get: operations["getFile"]
+    get: operations["TEST-001"]
     put?: never
     post?: never
     delete?: never
@@ -3124,10 +3250,10 @@ export interface paths {
       cookie?: never
     }
     /**
-     * [TEST-012] 인증된 사용자인지 여부를 확인합니다.
+     * 인증된 사용자인지 여부를 확인합니다.
      * @description 인증되지 않은 사용자인 경우 401을 반환합니다.
      */
-    get: operations["checkAuthenticated"]
+    get: operations["TEST-012"]
     put?: never
     post?: never
     delete?: never
@@ -3143,8 +3269,8 @@ export interface paths {
       path?: never
       cookie?: never
     }
-    /** [TEST-006] Apple Client Secret 생성 */
-    get: operations["getAppleClientSecret"]
+    /** Apple Client Secret 생성 */
+    get: operations["TEST-006"]
     put?: never
     post?: never
     delete?: never
@@ -3262,6 +3388,65 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/api/v2/member/search": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * [MEMBER-202] 회원 검색 v2
+     * @description 회원 단위 검색 결과를 반환합니다.
+     *
+     *     - `currentChallenger` : 활성 기수 챌린저 우선, 없으면 최신 기수 챌린저
+     *     - `challengerRecords` : 회원이 보유한 모든 챌린저 이력 요약
+     *     - `isAdminInActiveGisu` : 회원이 현재 활성 기수에 운영진 ChallengerRole을 하나라도 보유하는지
+     *
+     *     검색 조건/필터는 v1과 동일합니다.
+     *
+     *     검색 결과에는 본인 외 회원이 포함되므로, 로그인 식별자인 이메일은 평문 노출을 피하기 위해
+     *     컨트롤러 단에서 마스킹 처리되어 응답됩니다.
+     */
+    get: operations["searchMembersV2"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v2/member/me": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * [MEMBER-201] 내 종합 정보 조회
+     * @description 현재 로그인한 사용자의 통합 정보를 반환합니다.
+     *
+     *     - 기본 프로필 및 소셜 링크
+     *     - 모든 참여 기수의 활동 기간을 합산한 `totalActivityDays`
+     *     - `currentGisuMemberInfo`
+     *       - 활성 기수 정보 (gisuId, generation)
+     *       - 활성 기수에 ACTIVE 상태인 챌린저 신분 (없으면 null)
+     *       - 활성 기수에 운영진 ChallengerRole 하나라도 보유 여부 (`isAdmin`)
+     *       - 보유 운영진 RoleType 목록
+     *       - 휴지기에는 `currentGisuMemberInfo = null`
+     *     - `challengerHistory` : 모든 기수의 챌린저 이력 (최신 기수 우선). 기수별 상벌점 포함.
+     */
+    get: operations["getMySummary"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/api/v2/curriculums/weekly-best-workbooks": {
     parameters: {
       query?: never
@@ -3353,6 +3538,61 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/api/v2/challenger/search": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * [CHALLENGER-201] 챌린저 검색 v2
+     * @description 챌린저 단위 페이지네이션 검색입니다.
+     *
+     *     - 같은 회원이 여러 기수에 참여했다면 기수별 챌린저가 각각 별도 row로 반환됩니다.
+     *     - v1 회원 검색 응답에 더해 다음 두 필드를 제공합니다.
+     *       - `challengerStatus`: 해당 행 챌린저의 상태 (ACTIVE/GRADUATED/EXPELLED/WITHDRAWN)
+     *       - `isAdminInActiveGisu`: 회원이 현재 활성 기수에 운영진 ChallengerRole을 하나라도 보유하는지
+     *     - 검색 결과에는 본인 외 회원이 포함되므로, 로그인 식별자인 이메일은 평문 노출을 피하기 위해
+     *       컨트롤러 단에서 마스킹 처리되어 응답됩니다.
+     *     - 회원 단위로 묶인 검색이 필요하다면 `/api/v2/member/search` 를 사용해 주세요.
+     */
+    get: operations["searchChallengersV2"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/user-feedbacks/templates": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * 사용자 피드백 템플릿 조회
+     * @description 요청자의 챌린저 이력 및 운영진 역할을 기반으로 TargetType을 자동 판별하여,
+     *     해당 context에 맞는 활성 피드백 템플릿(Survey 폼 전체 구조 포함)을 반환합니다.
+     *     활성 기수가 없거나 해당 context + targetType 조합의 템플릿이 없으면 result = null.
+     *
+     *     [조건부 렌더링 - ADMIN / APPLICATION_MONITORING 템플릿]
+     *     현재 Survey 엔진은 조건부 렌더링을 지원하지 않으므로, 프론트엔드에서 직접 처리해야 합니다.
+     *     questions 및 options 배열은 orderNo 기준 오름차순으로 정렬되어 내려오며, 조건에 따라 숨길 질문도 포함되어 있습니다.
+     *     (예: '필요한 정보를 찾는 데 어려움이 있었나요?' 질문에서 '조금 있었어요' 또는 '많이 있었어요' 선택 시 자유 서술 텍스트 박스 표시)
+     */
+    get: operations["getTemplate"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/api/v1/terms/{termsId}": {
     parameters: {
       query?: never
@@ -3379,6 +3619,23 @@ export interface paths {
     }
     /** [TERM-101] 약관 유형으로 약관 조회 */
     get: operations["getTerms"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  "/api/v1/terms/consent-status/me": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** [TERM-103] 내 필수 약관 재동의 상태 조회 */
+    get: operations["getMyRequiredTermConsentStatus"]
     put?: never
     post?: never
     delete?: never
@@ -3505,6 +3762,32 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/api/v1/projects/{projectId}/statistics": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * [PROJECT-STAT-001] 단건 프로젝트 지원/매칭 현황 조회
+     * @description 프로젝트 ID와 함께 멤버 목록을 포함하고 있고, FE단 재가공을 최소화해드리기 위해서 `roundApplicationStatistics` 및 `schoolApplicationStatistics` 필드를 두고 있습니다.
+     *
+     *     각 항목이 매칭 차수별 지원률, N차 매칭에서의 학교별 및 총 지원자 수를 포함하고 있습니다.
+     *     프로젝트 멤버 목록의 경우 각 멤버가 해당 프로젝트에 작성한 지원 이력을 포함하고 있으며,
+     *     없거나 (강제배정/랜덤매칭) 여러 건 (떨어지고 재 지원하는 경우) 이 존재할 수 있어 배열로 구성되어 있습니다.
+     *
+     *     지원자 목록은(특정 프로젝트에 대한 지원서 조회) `/api/v1/projects/{projectId}/applications`를 호출하셔서 활용하셔야 합니다.
+     */
+    get: operations["getProjectStatistics"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/api/v1/projects/{projectId}/applications/{applicationId}": {
     parameters: {
       query?: never
@@ -3555,6 +3838,41 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  "/api/v1/projects/statistics": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * [PROJECT-STAT-002] 지부 전체 프로젝트 지원/매칭 현황 조회
+     * @description chapterId에 속한 전체 프로젝트를 대상으로 ACTIVE ProjectMember 목록과
+     *     각 멤버가 해당 프로젝트에 작성한 지원 이력을 프로젝트별로 반환합니다.
+     *     summary에는 차수별 지원 완료 인원/지원 가능 총원, 학교 순위, 학교별 매칭 인원,
+     *     프로젝트별 차수 인원 수를 함께 반환합니다.
+     *
+     *     지부 내 회장단 이상의 운영진이 매칭 통계를 조회할 때 활용합니다.
+     *
+     *     지부 내 모든 프로젝트 목록 및 각 프로젝트에 대한 프로젝트 멤버를 포함하고 있으며,
+     *     이는 `/api/v1/projects/{projectId}/statistics` 에서 제공하는 것과 동일한 형태입니다.
+     *
+     *     추가로 BFF 패턴을 적용하여 FE단 데이터 가공 책임을 줄이기 위해 `summary` 필드를 제공하고 있습니다.
+     *
+     *     - roundApplicationStatistics: N차 매칭 지원 현황 카드에 활용합니다. 각 매칭 차수별 정보 (매칭 종류 및 차수) 와 각 차수별 지원자 수 & 지원 가능했던 인원
+     *     - roundSchoolRankings: N차 매칭 지원 Top N에 활용합니다. 각 차수별로, 각 학교별 지원자 수
+     *     - schoolMatchingStatistics: 총원 N명 카드에 활용합니다. 차수와 무관하게, 각 학교별 총 매칭 완료 인원 & 지원 가능 총원
+     *     - projectRoundStatistics: 프로젝트별 지원 현황 필드에 활용합니다. 각 프로젝트별로, 각 매칭 차수별 정보 (매칭 종류 & 차수) 와 지원자 수
+     */
+    get: operations["listChapterProjectStatistics"]
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   "/api/v1/projects/members": {
     parameters: {
       query?: never
@@ -3563,7 +3881,7 @@ export interface paths {
       cookie?: never
     }
     /**
-     * [PROJECT-004] 프로젝트 팀원 구성 일괄 조회
+     * [PROJECT-007] 프로젝트 팀원 구성 일괄 조회
      * @description 복수의 projectId에 대한 팀원 구성을 조회합니다. 권한이 없거나 조회에 실패한 프로젝트는 결과에서 제외됩니다.
      */
     get: operations["getBatchMembers"]
@@ -3807,7 +4125,10 @@ export interface paths {
     }
     /**
      * [MEMBER-103] 회원 검색
-     * @description 이름, 닉네임, 이메일, 학교명으로 검색, 기수/파트/지부/학교별 필터링
+     * @description 이름, 닉네임, 이메일, 학교명으로 검색하며 기수/파트/지부/학교별 필터링을 지원합니다.
+     *
+     *     검색 결과에는 본인 외 회원이 포함되므로, 로그인 식별자인 이메일은 평문 노출을 피하기 위해
+     *     컨트롤러 단에서 마스킹 처리되어 응답됩니다.
      */
     get: operations["searchMembers"]
     put?: never
@@ -4103,7 +4424,7 @@ export interface paths {
     }
     /**
      * [PERMISSION-001] 리소스 권한 조회
-     * @description 특정 리소스에 대해 현재 사용자가 가진 권한 목록을 조회합니다.
+     * @description 특정 리소스에 대해 현재 사용자가 가진 권한을 조회합니다. permissionType을 지정하면 해당 권한만 평가합니다.
      */
     get: operations["getResourcePermission"]
     put?: never
@@ -4201,7 +4522,7 @@ export interface paths {
       cookie?: never
     }
     /** [FIGMA-009] 폴링 대상 파일 단건 조회 (sync 상태 포함) */
-    get: operations["getFile_1"]
+    get: operations["getFile"]
     put?: never
     post?: never
     /** [FIGMA-004] 폴링 대상 파일 비활성화 */
@@ -4677,6 +4998,119 @@ export interface components {
       schoolId?: number
       reason?: string
     }
+    SeedProjectScenariosRequest: {
+      /** @enum {string} */
+      targetStatus: "DRAFT" | "PENDING_REVIEW" | "IN_PROGRESS"
+      /** Format: int32 */
+      projectCount?: number
+      productOwnerMemberIds?: number[]
+    }
+    CreatedProject: {
+      /** Format: int64 */
+      projectId?: number
+      /** @enum {string} */
+      finalStatus?: "DRAFT" | "PENDING_REVIEW" | "IN_PROGRESS"
+      /** Format: int64 */
+      productOwnerMemberId?: number
+      /** Format: int64 */
+      chapterId?: number
+      /** Format: int64 */
+      schoolId?: number
+      /** Format: int64 */
+      applicationFormId?: number
+      partFills?: components["schemas"]["PartFill"][]
+    }
+    FailedProject: {
+      /** Format: int64 */
+      projectId?: number
+      /** @enum {string} */
+      reachedStatus?: "DRAFT" | "PENDING_REVIEW" | "IN_PROGRESS"
+      /** @enum {string} */
+      intendedStatus?: "DRAFT" | "PENDING_REVIEW" | "IN_PROGRESS"
+      failedStep?: string
+      reason?: string
+    }
+    PartFill: {
+      /** @enum {string} */
+      part?:
+        | "PLAN"
+        | "DESIGN"
+        | "WEB"
+        | "ANDROID"
+        | "IOS"
+        | "NODEJS"
+        | "SPRINGBOOT"
+        | "ADMIN"
+      /** Format: int64 */
+      quota?: number
+      /** Format: int64 */
+      filled?: number
+    }
+    SeedProjectScenariosResponse: {
+      createdProjects?: components["schemas"]["CreatedProject"][]
+      failedProjects?: components["schemas"]["FailedProject"][]
+    }
+    SeedProjectApplicationsRequest: {
+      /** Format: int64 */
+      matchingRoundId: number
+      /** Format: int64 */
+      chapterId: number
+    }
+    ApplicationEntry: {
+      /** Format: int64 */
+      applicationId?: number
+      /** Format: int64 */
+      applicantMemberId?: number
+      /** @enum {string} */
+      part?:
+        | "PLAN"
+        | "DESIGN"
+        | "WEB"
+        | "ANDROID"
+        | "IOS"
+        | "NODEJS"
+        | "SPRINGBOOT"
+        | "ADMIN"
+      /** @enum {string} */
+      finalStatus?:
+        | "DRAFT"
+        | "SUBMITTED"
+        | "APPROVED"
+        | "REJECTED"
+        | "CANCELLED"
+    }
+    Counts: {
+      /** Format: int32 */
+      submittedTotal?: number
+      /** Format: int32 */
+      approvedTotal?: number
+      /** Format: int32 */
+      rejectedTotal?: number
+      /** Format: int32 */
+      failedTotal?: number
+    }
+    FailedApplication: {
+      /** Format: int64 */
+      applicantMemberId?: number
+      /** Format: int64 */
+      projectId?: number
+      /** Format: int64 */
+      applicationId?: number
+      failedStep?: string
+      reason?: string
+    }
+    ProjectApplications: {
+      /** Format: int64 */
+      projectId?: number
+      applications?: components["schemas"]["ApplicationEntry"][]
+    }
+    SeedProjectApplicationsResponse: {
+      /** Format: int64 */
+      matchingRoundId?: number
+      createdApplications?: components["schemas"]["ProjectApplications"][]
+      failedApplications?: components["schemas"]["FailedApplication"][]
+      counts?: components["schemas"]["Counts"]
+    }
     SeedNoticeRequest: {
       /** Format: int64 */
       gisuId?: number
@@ -5132,6 +5566,25 @@ export interface components {
       hasFeedback?: boolean
       feedbacks?: components["schemas"]["MissionFeedbackResponse"][]
     }
+    SubmitUserFeedbackResponseRequest: {
+      /** Format: int64 */
+      templateId: number
+      answers: components["schemas"]["UserFeedbackAnswerItem"][]
+    }
+    UserFeedbackAnswerItem: {
+      /** Format: int64 */
+      questionId: number
+      /** @description SHORT_TEXT / LONG_TEXT 타입에서 사용 */
+      textValue?: string
+      /** @description RADIO / CHECKBOX / DROPDOWN 타입에서 사용 */
+      selectedOptionIds?: number[]
+      /** @description FILE 타입에서 사용 */
+      fileIds?: string[]
+    }
+    UserFeedbackSubmitResponse: {
+      /** Format: int64 */
+      formResponseId?: number
+    }
     CreateTrophyRequest: {
       /** Format: int32 */
       week?: number
@@ -5397,6 +5850,9 @@ export interface components {
     CreateProjectApplicationRequest: {
       /** Format: int64 */
       matchingRoundId: number
+    }
+    AbortProjectRequest: {
+      reason: string
     }
     CreateProjectMatchingRoundRequest: {
       name: string
@@ -5926,9 +6382,9 @@ export interface components {
     }
     CreateChallengerInfoRequest: {
       /** Format: int64 */
-      memberId?: number
+      memberId: number
       /** @enum {string} */
-      part?:
+      part:
         | "PLAN"
         | "DESIGN"
         | "WEB"
@@ -5938,7 +6394,7 @@ export interface components {
         | "SPRINGBOOT"
         | "ADMIN"
       /** Format: int64 */
-      gisuId?: number
+      gisuId: number
     }
     ChallengerInfoResponse: {
       /** Format: int64 */
@@ -6050,7 +6506,7 @@ export interface components {
     }
     GrantChallengerPointRequest: {
       /** @enum {string} */
-      pointType?:
+      pointType:
         | "BEST_WORKBOOK"
         | "WARNING"
         | "OUT"
@@ -6075,20 +6531,20 @@ export interface components {
     }
     DeactivateChallengerRequest: {
       /** @enum {string} */
-      deactivationType?: "WITHDRAW" | "EXPEL"
+      deactivationType: "WITHDRAW" | "EXPEL"
       /** Format: int64 */
-      modifiedBy?: number
-      reason?: string
+      modifiedBy: number
+      reason: string
     }
     CreateChallengerRecordRequest: {
       /** Format: int64 */
-      gisuId?: number
+      gisuId: number
       /** Format: int64 */
-      chapterId?: number
+      chapterId: number
       /** Format: int64 */
-      schoolId?: number
+      schoolId: number
       /** @enum {string} */
-      part?:
+      part:
         | "PLAN"
         | "DESIGN"
         | "WEB"
@@ -6097,7 +6553,7 @@ export interface components {
         | "NODEJS"
         | "SPRINGBOOT"
         | "ADMIN"
-      memberName?: string
+      memberName: string
       /** @enum {string} */
       challengerRoleType?:
         | "SUPER_ADMIN"
@@ -6150,7 +6606,104 @@ export interface components {
       organizationId?: number
     }
     AddChallengerRecordToMemberRequest: {
-      code?: string
+      code: string
+    }
+    BatchResourcePermissionRequest: {
+      queries: components["schemas"]["ResourcePermissionQueryRequest"][]
+    }
+    ResourcePermissionQueryRequest: {
+      /** @enum {string} */
+      resourceType:
+        | "AUDIT"
+        | "SCHEDULE"
+        | "ATTENDANCE"
+        | "ATTENDANCE_SHEET"
+        | "ATTENDANCE_RECORD"
+        | "NOTICE"
+        | "CURRICULUM"
+        | "WORKBOOK_SUBMISSION"
+        | "ORIGINAL_WORKBOOK"
+        | "GISU"
+        | "CHAPTER"
+        | "SCHOOL"
+        | "STUDY_GROUP"
+        | "COMMUNITY_POST"
+        | "COMMUNITY_COMMENT"
+        | "RECRUITMENT"
+        | "MEMBER"
+        | "ANALYTICS"
+        | "TERM"
+        | "CHALLENGER"
+        | "CHALLENGER_ROLE"
+        | "CHALLENGER_POINT"
+        | "CHALLENGER_RECORD"
+        | "FCM"
+        | "PROJECT"
+        | "PROJECT_APPLICATION"
+        | "FIGMA"
+      resourceIds?: number[]
+      permissionTypes?: (
+        | "READ"
+        | "WRITE"
+        | "EDIT"
+        | "DELETE"
+        | "FORCE_DELETE"
+        | "APPROVE"
+        | "CHECK"
+        | "MANAGE"
+        | "RELEASE"
+      )[]
+    }
+    BatchResourcePermissionResponse: {
+      results?: components["schemas"]["ResourcePermissionResponse"][]
+    }
+    PermissionInfo: {
+      /** @enum {string} */
+      permissionType?:
+        | "READ"
+        | "WRITE"
+        | "EDIT"
+        | "DELETE"
+        | "FORCE_DELETE"
+        | "APPROVE"
+        | "CHECK"
+        | "MANAGE"
+        | "RELEASE"
+      hasPermission?: boolean
+    }
+    ResourcePermissionResponse: {
+      /** @enum {string} */
+      resourceType?:
+        | "AUDIT"
+        | "SCHEDULE"
+        | "ATTENDANCE"
+        | "ATTENDANCE_SHEET"
+        | "ATTENDANCE_RECORD"
+        | "NOTICE"
+        | "CURRICULUM"
+        | "WORKBOOK_SUBMISSION"
+        | "ORIGINAL_WORKBOOK"
+        | "GISU"
+        | "CHAPTER"
+        | "SCHOOL"
+        | "STUDY_GROUP"
+        | "COMMUNITY_POST"
+        | "COMMUNITY_COMMENT"
+        | "RECRUITMENT"
+        | "MEMBER"
+        | "ANALYTICS"
+        | "TERM"
+        | "CHALLENGER"
+        | "CHALLENGER_ROLE"
+        | "CHALLENGER_POINT"
+        | "CHALLENGER_RECORD"
+        | "FCM"
+        | "PROJECT"
+        | "PROJECT_APPLICATION"
+        | "FIGMA"
+      /** Format: int64 */
+      resourceId?: number
+      permissions?: components["schemas"]["PermissionInfo"][]
     }
     CreateChallengerRoleRequest: {
       /** Format: int64 */
@@ -6722,7 +7275,7 @@ export interface components {
     }
     EditChallengerPartRequest: {
       /** @enum {string} */
-      newPart?:
+      newPart:
         | "PLAN"
         | "DESIGN"
         | "WEB"
@@ -6733,7 +7286,7 @@ export interface components {
         | "ADMIN"
     }
     EditChallengerPointRequest: {
-      newDescription?: string
+      newDescription: string
     }
     ChangePasswordRequest: {
       currentPassword: string
@@ -6916,6 +7469,165 @@ export interface components {
       /** Format: int32 */
       maxParticipantCount?: number
     }
+    /** @description 대표 챌린저. 활성 기수 챌린저 우선, 없으면 최신 기수 */
+    CurrentChallengerResponse: {
+      /** Format: int64 */
+      challengerId?: number
+      /** Format: int64 */
+      gisuId?: number
+      /** Format: int64 */
+      generation?: number
+      /** @enum {string} */
+      part?:
+        | "PLAN"
+        | "DESIGN"
+        | "WEB"
+        | "ANDROID"
+        | "IOS"
+        | "NODEJS"
+        | "SPRINGBOOT"
+        | "ADMIN"
+      /** @enum {string} */
+      challengerStatus?: "ACTIVE" | "GRADUATED" | "EXPELLED" | "WITHDRAWN"
+    }
+    PageResponseSearchMemberV2ItemResponse: {
+      content?: components["schemas"]["SearchMemberV2ItemResponse"][]
+      /** Format: int32 */
+      page?: number
+      /** Format: int32 */
+      size?: number
+      /** Format: int64 */
+      totalElements?: number
+      /** Format: int32 */
+      totalPages?: number
+      hasNext?: boolean
+      hasPrevious?: boolean
+    }
+    SearchMemberV2ItemResponse: {
+      /** Format: int64 */
+      memberId?: number
+      name?: string
+      nickname?: string
+      email?: string
+      /** Format: int64 */
+      schoolId?: number
+      schoolName?: string
+      profileImageLink?: string
+      currentChallenger?: components["schemas"]["CurrentChallengerResponse"]
+      /** @description 이 회원이 현재 활성 기수에 운영진 ChallengerRole을 하나라도 보유하는지 */
+      isAdminInActiveGisu?: boolean
+      /** @description 회원이 보유한 모든 챌린저 이력 요약 (최신 기수 우선) */
+      challengerRecords?: components["schemas"]["ChallengerRecordResponse"][]
+    }
+    SearchMemberV2Response: {
+      /** Format: int64 */
+      totalCount?: number
+      page?: components["schemas"]["PageResponseSearchMemberV2ItemResponse"]
+    }
+    /** @description 활성 기수에서 현재 ACTIVE 상태인 챌린저 신분. ACTIVE가 아니면 null */
+    ActiveChallenger: {
+      /** Format: int64 */
+      challengerId?: number
+      /** @enum {string} */
+      part?:
+        | "PLAN"
+        | "DESIGN"
+        | "WEB"
+        | "ANDROID"
+        | "IOS"
+        | "NODEJS"
+        | "SPRINGBOOT"
+        | "ADMIN"
+      /** @enum {string} */
+      challengerStatus?: "ACTIVE" | "GRADUATED" | "EXPELLED" | "WITHDRAWN"
+      points?: components["schemas"]["ChallengerPointInfo"][]
+      /** Format: double */
+      totalPoints?: number
+    }
+    /** @description 모든 챌린저 기록 (최신 기수 우선) */
+    ChallengerHistoryV2: {
+      /** Format: int64 */
+      challengerId?: number
+      /** Format: int64 */
+      gisuId?: number
+      /** Format: int64 */
+      generation?: number
+      /** Format: int64 */
+      chapterId?: number
+      chapterName?: string
+      /** @enum {string} */
+      part?:
+        | "PLAN"
+        | "DESIGN"
+        | "WEB"
+        | "ANDROID"
+        | "IOS"
+        | "NODEJS"
+        | "SPRINGBOOT"
+        | "ADMIN"
+      /** @enum {string} */
+      challengerStatus?: "ACTIVE" | "GRADUATED" | "EXPELLED" | "WITHDRAWN"
+      points?: components["schemas"]["ChallengerPointInfo"][]
+      /** Format: double */
+      totalPoints?: number
+      roleTypes?: (
+        | "SUPER_ADMIN"
+        | "CENTRAL_PRESIDENT"
+        | "CENTRAL_VICE_PRESIDENT"
+        | "CENTRAL_OPERATING_TEAM_MEMBER"
+        | "CENTRAL_EDUCATION_TEAM_MEMBER"
+        | "CHAPTER_PRESIDENT"
+        | "SCHOOL_PRESIDENT"
+        | "SCHOOL_VICE_PRESIDENT"
+        | "SCHOOL_PART_LEADER"
+        | "SCHOOL_ETC_ADMIN"
+      )[]
+    }
+    /** @description 현재 활성 기수에 대한 챌린저 정보 */
+    CurrentGisuMemberInfo: {
+      /** Format: int64 */
+      gisuId?: number
+      /** Format: int64 */
+      generation?: number
+      challenger?: components["schemas"]["ActiveChallenger"]
+      /** @description 활성 기수에 운영진 ChallengerRole이 하나라도 존재하는지 */
+      isAdmin?: boolean
+      /** @description 활성 기수에 가지고 있는 역할 목록 */
+      roleTypes?: (
+        | "SUPER_ADMIN"
+        | "CENTRAL_PRESIDENT"
+        | "CENTRAL_VICE_PRESIDENT"
+        | "CENTRAL_OPERATING_TEAM_MEMBER"
+        | "CENTRAL_EDUCATION_TEAM_MEMBER"
+        | "CHAPTER_PRESIDENT"
+        | "SCHOOL_PRESIDENT"
+        | "SCHOOL_VICE_PRESIDENT"
+        | "SCHOOL_PART_LEADER"
+        | "SCHOOL_ETC_ADMIN"
+      )[]
+    }
+    MemberSummaryV2Response: {
+      /** Format: int64 */
+      id?: number
+      name?: string
+      nickname?: string
+      email?: string
+      /** Format: int64 */
+      schoolId?: number
+      schoolName?: string
+      profileImageLink?: string
+      /** @enum {string} */
+      status?: "ACTIVE" | "INACTIVE" | "WITHDRAWN"
+      profile?: components["schemas"]["MemberProfileInfo"]
+      /**
+       * Format: int64
+       * @description 챌린저로 활동한 총 일수
+       */
+      totalActivityDays?: number
+      currentGisuMemberInfo?: components["schemas"]["CurrentGisuMemberInfo"]
+      /** @description 모든 챌린저 기록 (최신 기수 우선) */
+      challengerHistory?: components["schemas"]["ChallengerHistoryV2"][]
+    }
     BestWorkbookResponse: {
       /** Format: int64 */
       weeklyBestWorkbookEntityId?: number
@@ -7038,11 +7750,135 @@ export interface components {
       releasedMemberId?: number
       missions?: components["schemas"]["OriginalWorkbookMissionResponse"]
     }
+    ChallengerSearchV2ItemResponse: {
+      /** Format: int64 */
+      memberId?: number
+      name?: string
+      nickname?: string
+      email?: string
+      /** Format: int64 */
+      schoolId?: number
+      schoolName?: string
+      profileImageLink?: string
+      /** Format: int64 */
+      challengerId?: number
+      /** Format: int64 */
+      gisuId?: number
+      /** Format: int64 */
+      generation?: number
+      /** @enum {string} */
+      part?:
+        | "PLAN"
+        | "DESIGN"
+        | "WEB"
+        | "ANDROID"
+        | "IOS"
+        | "NODEJS"
+        | "SPRINGBOOT"
+        | "ADMIN"
+      /**
+       * @description 검색 결과 행의 챌린저 상태
+       * @enum {string}
+       */
+      challengerStatus?: "ACTIVE" | "GRADUATED" | "EXPELLED" | "WITHDRAWN"
+      roleTypes?: (
+        | "SUPER_ADMIN"
+        | "CENTRAL_PRESIDENT"
+        | "CENTRAL_VICE_PRESIDENT"
+        | "CENTRAL_OPERATING_TEAM_MEMBER"
+        | "CENTRAL_EDUCATION_TEAM_MEMBER"
+        | "CHAPTER_PRESIDENT"
+        | "SCHOOL_PRESIDENT"
+        | "SCHOOL_VICE_PRESIDENT"
+        | "SCHOOL_PART_LEADER"
+        | "SCHOOL_ETC_ADMIN"
+      )[]
+      /** @description 이 회원이 현재 활성 기수에 운영진 ChallengerRole을 하나라도 보유하는지 */
+      isAdminInActiveGisu?: boolean
+    }
+    ChallengerSearchV2Response: {
+      /** Format: int64 */
+      totalCount?: number
+      page?: components["schemas"]["PageResponseChallengerSearchV2ItemResponse"]
+    }
+    PageResponseChallengerSearchV2ItemResponse: {
+      content?: components["schemas"]["ChallengerSearchV2ItemResponse"][]
+      /** Format: int32 */
+      page?: number
+      /** Format: int32 */
+      size?: number
+      /** Format: int64 */
+      totalElements?: number
+      /** Format: int32 */
+      totalPages?: number
+      hasNext?: boolean
+      hasPrevious?: boolean
+    }
+    FeedbackForm: {
+      /** Format: int64 */
+      formId?: number
+      title?: string
+      description?: string
+      sections?: components["schemas"]["FeedbackSection"][]
+    }
+    FeedbackOption: {
+      /** Format: int64 */
+      optionId?: number
+      content?: string
+      /** Format: int64 */
+      orderNo?: number
+      isOther?: boolean
+    }
+    FeedbackQuestion: {
+      /** Format: int64 */
+      questionId?: number
+      title?: string
+      description?: string
+      /** @enum {string} */
+      type?:
+        | "SHORT_TEXT"
+        | "LONG_TEXT"
+        | "RADIO"
+        | "CHECKBOX"
+        | "DROPDOWN"
+        | "SCHEDULE"
+        | "FILE"
+        | "PORTFOLIO"
+      isRequired?: boolean
+      /** Format: int64 */
+      orderNo?: number
+      options?: components["schemas"]["FeedbackOption"][]
+    }
+    FeedbackSection: {
+      /** Format: int64 */
+      sectionId?: number
+      title?: string
+      description?: string
+      /** Format: int64 */
+      orderNo?: number
+      questions?: components["schemas"]["FeedbackQuestion"][]
+    }
+    GetUserFeedbackTemplateResponse: {
+      /** Format: int64 */
+      templateId?: number
+      /** @enum {string} */
+      context?:
+        | "APPLICATION_SUBMITTED"
+        | "MATCHING_COMPLETED"
+        | "APPLICATION_MONITORING"
+      /** @enum {string} */
+      targetType?: "NEW_CHALLENGER" | "EXPERIENCED_CHALLENGER" | "ADMIN"
+      form?: components["schemas"]["FeedbackForm"]
+    }
     TermResponse: {
       /** Format: int64 */
       id?: number
       link?: string
       isMandatory?: boolean
+    }
+    RequiredTermConsentStatusResponse: {
+      needsReconsent?: boolean
+      missingRequiredTerms?: components["schemas"]["TermResponse"][]
     }
     /** @description 시스템 점검 상태 */
     SystemStatusResponse: {
@@ -7295,6 +8131,118 @@ export interface components {
       /** Format: int64 */
       applicationFormId?: number
     }
+    /** @description 지원서가 연결된 매칭 차수 정보 */
+    ProjectMatchingRoundStatisticsResponse: {
+      /**
+       * Format: int64
+       * @description 매칭 차수 ID
+       */
+      matchingRoundId?: number
+      /**
+       * @description 매칭 유형
+       * @enum {string}
+       */
+      type?: "PLAN_DESIGN" | "PLAN_DEVELOPER"
+      /**
+       * @description 매칭 차수
+       * @enum {string}
+       */
+      phase?: "FIRST" | "SECOND" | "THIRD"
+    }
+    /** @description 프로젝트 멤버의 차수별 지원 이력 */
+    ProjectMemberApplicationStatisticsResponse: {
+      /**
+       * Format: int64
+       * @description 지원서 ID
+       */
+      applicationId?: number
+      /**
+       * @description 지원서 상태
+       * @enum {string}
+       */
+      status?: "DRAFT" | "SUBMITTED" | "APPROVED" | "REJECTED" | "CANCELLED"
+      matchingRound?: components["schemas"]["ProjectMatchingRoundStatisticsResponse"]
+    }
+    /** @description 프로젝트 멤버별 지원 이력 */
+    ProjectMemberStatisticsResponse: {
+      /**
+       * Format: int64
+       * @description 프로젝트 멤버 ID
+       */
+      projectMemberId?: number
+      /**
+       * Format: int64
+       * @description 멤버 ID
+       */
+      memberId?: number
+      /**
+       * @description 프로젝트 내 파트
+       * @enum {string}
+       */
+      part?:
+        | "PLAN"
+        | "DESIGN"
+        | "WEB"
+        | "ANDROID"
+        | "IOS"
+        | "NODEJS"
+        | "SPRINGBOOT"
+        | "ADMIN"
+      /**
+       * @description 프로젝트 멤버 상태
+       * @enum {string}
+       */
+      status?: "ACTIVE" | "COMPLETED" | "WITHDRAWN" | "DISMISSED"
+      /** @description 해당 멤버가 이 프로젝트에 작성한 지원 이력. 강제 배정이면 빈 목록입니다. */
+      applications?: components["schemas"]["ProjectMemberApplicationStatisticsResponse"][]
+    }
+    /** @description 프로젝트 지원/매칭 현황 통합 응답 */
+    ProjectStatisticsResponse: {
+      /**
+       * Format: int64
+       * @description 프로젝트 ID
+       */
+      projectId?: number
+      /** @description 프로젝트에 최종 합류한 활성 멤버 목록 */
+      projectMembers?: components["schemas"]["ProjectMemberStatisticsResponse"][]
+      /** @description 매칭 차수별 지원 완료 인원 수와 지원 가능 인원 수 */
+      roundApplicationStatistics?: components["schemas"]["RoundApplicationStatisticsResponse"][]
+      /** @description 매칭 차수별 지원자 학교 인원 수 */
+      schoolApplicationStatistics?: components["schemas"]["RoundSchoolApplicationStatisticsResponse"][]
+    }
+    /** @description 매칭 차수별 지원 완료 인원 수와 지원 가능 인원 수 */
+    RoundApplicationStatisticsResponse: {
+      matchingRound?: components["schemas"]["ProjectMatchingRoundStatisticsResponse"]
+      /**
+       * Format: int64
+       * @description 지원 완료 인원 수
+       */
+      appliedMemberCount?: number
+      /**
+       * Format: int64
+       * @description 지원 가능 인원 수
+       */
+      availableMemberCount?: number
+    }
+    /** @description 매칭 차수별 지원자 학교 인원 수 */
+    RoundSchoolApplicationStatisticsResponse: {
+      matchingRound?: components["schemas"]["ProjectMatchingRoundStatisticsResponse"]
+      /** @description 학교별 지원자 수 */
+      schools?: components["schemas"]["SchoolApplicationStatisticsResponse"][]
+    }
+    /** @description 학교별 지원자 수 */
+    SchoolApplicationStatisticsResponse: {
+      /**
+       * Format: int64
+       * @description 학교 ID
+       */
+      schoolId?: number
+      /**
+       * Format: int64
+       * @description 지원자 수
+       */
+      applicantCount?: number
+    }
     PartGroup: {
       /** @enum {string} */
       part?:
@@ -7464,6 +8412,70 @@ export interface components {
       title?: string
       description?: string
       sections?: components["schemas"]["ApplicationFormSection"][]
+    }
+    /** @description 지부 전체 프로젝트 지원/매칭 현황 BFF 응답 */
+    ChapterProjectStatisticsResponse: {
+      /**
+       * Format: int64
+       * @description 지부 ID
+       */
+      chapterId?: number
+      /** @description 지부 내 프로젝트별 기존 지원/매칭 현황 */
+      projects?: components["schemas"]["ProjectStatisticsResponse"][]
+      summary?: components["schemas"]["ChapterProjectStatisticsSummaryResponse"]
+    }
+    /** @description 지부 단위 지원/매칭 요약 */
+    ChapterProjectStatisticsSummaryResponse: {
+      /** @description 매칭 차수별 지원 완료 인원 수와 지원 가능 총원 */
+      roundApplicationStatistics?: components["schemas"]["RoundApplicationStatisticsResponse"][]
+      /** @description 매칭 차수별 지원자 학교 순위 */
+      roundSchoolRankings?: components["schemas"]["RoundSchoolApplicationStatisticsResponse"][]
+      /** @description 학교별 총 매칭 인원 수와 총원 */
+      schoolMatchingStatistics?: components["schemas"]["SchoolMatchingStatisticsResponse"][]
+      /** @description 프로젝트별 매칭 차수 인원 수 */
+      projectRoundStatistics?: components["schemas"]["ProjectRoundMemberStatisticsResponse"][]
+    }
+    /** @description 프로젝트 내 특정 매칭 차수의 지원 완료 인원 수와 매칭 완료 인원 수 */
+    ProjectRoundMemberCountResponse: {
+      matchingRound?: components["schemas"]["ProjectMatchingRoundStatisticsResponse"]
+      /**
+       * Format: int64
+       * @description 지원 완료 인원 수
+       */
+      appliedMemberCount?: number
+      /**
+       * Format: int64
+       * @description 매칭 완료 인원 수
+       */
+      matchedMemberCount?: number
+    }
+    /** @description 프로젝트별 매칭 차수 인원 수 */
+    ProjectRoundMemberStatisticsResponse: {
+      /**
+       * Format: int64
+       * @description 프로젝트 ID
+       */
+      projectId?: number
+      /** @description 매칭 차수별 인원 수 */
+      matchingRounds?: components["schemas"]["ProjectRoundMemberCountResponse"][]
+    }
+    /** @description 학교별 총 매칭 인원 수와 총원 */
+    SchoolMatchingStatisticsResponse: {
+      /**
+       * Format: int64
+       * @description 학교 ID
+       */
+      schoolId?: number
+      /**
+       * Format: int64
+       * @description 매칭 완료 인원 수
+       */
+      matchedMemberCount?: number
+      /**
+       * Format: int64
+       * @description 학교별 지원 가능 총원
+       */
+      totalMemberCount?: number
     }
     ManagedProjectSummaryResponse: {
       /** Format: int64 */
@@ -8153,54 +9165,6 @@ export interface components {
       cursor?: components["schemas"]["CursorResponseSearchChallengerItemResponse"]
       partCounts?: components["schemas"]["PartCountResponse"][]
     }
-    PermissionInfo: {
-      /** @enum {string} */
-      permissionType?:
-        | "READ"
-        | "WRITE"
-        | "EDIT"
-        | "DELETE"
-        | "FORCE_DELETE"
-        | "APPROVE"
-        | "CHECK"
-        | "MANAGE"
-        | "RELEASE"
-      hasPermission?: boolean
-    }
-    ResourcePermissionResponse: {
-      /** @enum {string} */
-      resourceType?:
-        | "AUDIT"
-        | "SCHEDULE"
-        | "ATTENDANCE"
-        | "ATTENDANCE_SHEET"
-        | "ATTENDANCE_RECORD"
-        | "NOTICE"
-        | "CURRICULUM"
-        | "WORKBOOK_SUBMISSION"
-        | "ORIGINAL_WORKBOOK"
-        | "GISU"
-        | "CHAPTER"
-        | "SCHOOL"
-        | "STUDY_GROUP"
-        | "COMMUNITY_POST"
-        | "COMMUNITY_COMMENT"
-        | "RECRUITMENT"
-        | "MEMBER"
-        | "ANALYTICS"
-        | "TERM"
-        | "CHALLENGER"
-        | "CHALLENGER_ROLE"
-        | "CHALLENGER_POINT"
-        | "CHALLENGER_RECORD"
-        | "FCM"
-        | "PROJECT"
-        | "PROJECT_APPLICATION"
-        | "FIGMA"
-      /** Format: int64 */
-      resourceId?: number
-      permissions?: components["schemas"]["PermissionInfo"][]
-    }
     EmailAvailabilityResponse: {
       email?: string
       available?: boolean
@@ -8542,6 +9506,7 @@ export interface components {
         | "LLM"
         | "ANALYTICS"
         | "MAINTENANCE"
+        | "FEEDBACK"
       /** @enum {string} */
       action?:
         | "CREATE"
@@ -8564,10 +9529,10 @@ export interface components {
       createdAt?: string
     }
     PageAuditLogInfo: {
-      /** Format: int64 */
-      totalElements?: number
       /** Format: int32 */
       totalPages?: number
+      /** Format: int64 */
+      totalElements?: number
       /** Format: int32 */
       size?: number
       content?: components["schemas"]["AuditLogInfo"][]
@@ -8814,7 +9779,7 @@ export interface operations {
       }
     }
   }
-  sendWebhookAlarm: {
+  "TEST-004": {
     parameters: {
       query: {
         title: string
@@ -8835,7 +9800,7 @@ export interface operations {
       }
     }
   }
-  sendBufferedWebhookAlarm: {
+  "TEST-005": {
     parameters: {
       query: {
         title: string
@@ -8857,7 +9822,7 @@ export interface operations {
       }
     }
   }
-  seedProjects: {
+  "SEED-003": {
     parameters: {
       query?: never
       header?: never
@@ -8881,7 +9846,55 @@ export interface operations {
       }
     }
   }
-  seedNotice: {
+  "SEED-003-S": {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SeedProjectScenariosRequest"]
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["SeedProjectScenariosResponse"]
+        }
+      }
+    }
+  }
+  seedProjectApplications: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SeedProjectApplicationsRequest"]
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["SeedProjectApplicationsResponse"]
+        }
+      }
+    }
+  }
+  "SEED-005": {
     parameters: {
       query?: never
       header?: never
@@ -8905,7 +9918,7 @@ export interface operations {
       }
     }
   }
-  seedMembers: {
+  "SEED-001": {
     parameters: {
       query?: never
       header?: never
@@ -8929,7 +9942,7 @@ export interface operations {
       }
     }
   }
-  seedCurriculum: {
+  "SEED-004": {
     parameters: {
       query?: never
       header?: never
@@ -8953,7 +9966,7 @@ export interface operations {
       }
     }
   }
-  seedChallengers: {
+  "SEED-002": {
     parameters: {
       query?: never
       header?: never
@@ -8977,7 +9990,7 @@ export interface operations {
       }
     }
   }
-  sendTestNotification: {
+  "TEST-002": {
     parameters: {
       query?: never
       header?: never
@@ -9460,6 +10473,30 @@ export interface operations {
       }
     }
   }
+  submit: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SubmitUserFeedbackResponseRequest"]
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["UserFeedbackSubmitResponse"]
+        }
+      }
+    }
+  }
   getTrophies: {
     parameters: {
       query?: {
@@ -9807,7 +10844,7 @@ export interface operations {
       }
     }
   }
-  submit: {
+  submit_1: {
     parameters: {
       query?: never
       header?: never
@@ -9960,7 +10997,7 @@ export interface operations {
       }
     }
   }
-  submit_1: {
+  submit_2: {
     parameters: {
       query?: never
       header?: never
@@ -9979,6 +11016,30 @@ export interface operations {
         content: {
           "*/*": components["schemas"]["ProjectApplicationStatusResponse"]
         }
+      }
+    }
+  }
+  abort: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        projectId: number
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["AbortProjectRequest"]
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
       }
     }
   }
@@ -11041,6 +12102,30 @@ export interface operations {
         }
         content: {
           "*/*": number[]
+        }
+      }
+    }
+  }
+  batchGetResourcePermission: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["BatchResourcePermissionRequest"]
+      }
+    }
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["BatchResourcePermissionResponse"]
         }
       }
     }
@@ -12452,6 +13537,26 @@ export interface operations {
       }
     }
   }
+  delete_2: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        projectId: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
   update_1: {
     parameters: {
       query?: never
@@ -12505,7 +13610,7 @@ export interface operations {
       }
     }
   }
-  delete_2: {
+  delete_3: {
     parameters: {
       query?: never
       header?: never
@@ -13072,7 +14177,7 @@ export interface operations {
       }
     }
   }
-  sendAopWebhookAlarm: {
+  "TEST-003": {
     parameters: {
       query: {
         title: string
@@ -13095,7 +14200,7 @@ export interface operations {
       }
     }
   }
-  getRefreshToken: {
+  "TEST-008": {
     parameters: {
       query: {
         memberId: number
@@ -13117,7 +14222,7 @@ export interface operations {
       }
     }
   }
-  getOAuthVerificationToken: {
+  "TEST-010": {
     parameters: {
       query: {
         provider: "GOOGLE" | "APPLE" | "KAKAO"
@@ -13141,7 +14246,7 @@ export interface operations {
       }
     }
   }
-  getEmailVerification: {
+  "TEST-009": {
     parameters: {
       query: {
         email: string
@@ -13164,7 +14269,7 @@ export interface operations {
       }
     }
   }
-  getAccessToken: {
+  "TEST-007": {
     parameters: {
       query: {
         memberId: number
@@ -13205,7 +14310,7 @@ export interface operations {
       }
     }
   }
-  healthCheck: {
+  "TEST-011": {
     parameters: {
       query?: never
       header?: never
@@ -13225,7 +14330,7 @@ export interface operations {
       }
     }
   }
-  getFile: {
+  "TEST-001": {
     parameters: {
       query?: never
       header?: never
@@ -13247,7 +14352,7 @@ export interface operations {
       }
     }
   }
-  checkAuthenticated: {
+  "TEST-012": {
     parameters: {
       query?: never
       header?: never
@@ -13267,7 +14372,7 @@ export interface operations {
       }
     }
   }
-  getAppleClientSecret: {
+  "TEST-006": {
     parameters: {
       query: {
         clientType: "ANDROID" | "IOS" | "WEB"
@@ -13451,6 +14556,66 @@ export interface operations {
       }
     }
   }
+  searchMembersV2: {
+    parameters: {
+      query?: {
+        /** @description Zero-based page index (0..N) */
+        page?: number
+        /** @description The size of the page to be returned */
+        size?: number
+        /** @description Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported. */
+        sort?: string[]
+        keyword?: string
+        gisuId?: number
+        part?:
+          | "PLAN"
+          | "DESIGN"
+          | "WEB"
+          | "ANDROID"
+          | "IOS"
+          | "NODEJS"
+          | "SPRINGBOOT"
+          | "ADMIN"
+        chapterId?: number
+        schoolId?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["SearchMemberV2Response"]
+        }
+      }
+    }
+  }
+  getMySummary: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["MemberSummaryV2Response"]
+        }
+      }
+    }
+  }
   getBestWorkbooks: {
     parameters: {
       query?: {
@@ -13540,6 +14705,71 @@ export interface operations {
       }
     }
   }
+  searchChallengersV2: {
+    parameters: {
+      query?: {
+        /** @description Zero-based page index (0..N) */
+        page?: number
+        /** @description The size of the page to be returned */
+        size?: number
+        /** @description Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported. */
+        sort?: string[]
+        keyword?: string
+        gisuId?: number
+        part?:
+          | "PLAN"
+          | "DESIGN"
+          | "WEB"
+          | "ANDROID"
+          | "IOS"
+          | "NODEJS"
+          | "SPRINGBOOT"
+          | "ADMIN"
+        chapterId?: number
+        schoolId?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["ChallengerSearchV2Response"]
+        }
+      }
+    }
+  }
+  getTemplate: {
+    parameters: {
+      query: {
+        context:
+          | "APPLICATION_SUBMITTED"
+          | "MATCHING_COMPLETED"
+          | "APPLICATION_MONITORING"
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["GetUserFeedbackTemplateResponse"]
+        }
+      }
+    }
+  }
   getTermsById: {
     parameters: {
       query?: never
@@ -13580,6 +14810,26 @@ export interface operations {
         }
         content: {
           "*/*": components["schemas"]["TermResponse"]
+        }
+      }
+    }
+  }
+  getMyRequiredTermConsentStatus: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["RequiredTermConsentStatusResponse"]
         }
       }
     }
@@ -13729,6 +14979,29 @@ export interface operations {
       }
     }
   }
+  getProjectStatistics: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description 프로젝트 ID */
+        projectId: number
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["ProjectStatisticsResponse"]
+        }
+      }
+    }
+  }
   getApplicationDetail: {
     parameters: {
       query?: never
@@ -13772,6 +15045,29 @@ export interface operations {
         }
         content: {
           "*/*": components["schemas"]["ProjectApplicationStatusResponse"]
+        }
+      }
+    }
+  }
+  listChapterProjectStatistics: {
+    parameters: {
+      query: {
+        /** @description 지부 ID */
+        chapterId: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          "*/*": components["schemas"]["ChapterProjectStatisticsResponse"]
         }
       }
     }
@@ -14653,6 +15949,16 @@ export interface operations {
           | "PROJECT_APPLICATION"
           | "FIGMA"
         resourceId?: number
+        permissionType?:
+          | "READ"
+          | "WRITE"
+          | "EDIT"
+          | "DELETE"
+          | "FORCE_DELETE"
+          | "APPROVE"
+          | "CHECK"
+          | "MANAGE"
+          | "RELEASE"
       }
       header?: never
       path?: never
@@ -14788,7 +16094,7 @@ export interface operations {
       }
     }
   }
-  getFile_1: {
+  getFile: {
     parameters: {
       query?: never
       header?: never
@@ -15046,6 +16352,7 @@ export interface operations {
           | "LLM"
           | "ANALYTICS"
           | "MAINTENANCE"
+          | "FEEDBACK"
         action?:
           | "CREATE"
           | "UPDATE"


### PR DESCRIPTION
## 📸 작업 내용

> 매칭 프로젝트 설정(등록·수정·관리)을 서버 Resource Permission API 기반 권한 제어로 정렬하고,
> 등록·수정·삭제 플로우의 버그·사용성을 실측 QA·수정했습니다.

- **권한 모델**: 매칭 액션(수정/삭제/승인)을 Resource Permission API 기반으로 전환, 프로젝트 설정 접근 판별 헬퍼 + 라우트 가드 + LNB 2티어 필터
- **핵심 버그(#187)**: `resourceId` 문자열↔숫자 비교 실패로 권한 보유자에게 버튼이 안 보이던 문제 수정
- **등록(Step1)**: 이미지 선택사항화·타입/크기 검증, PM 검색 스코프, 기획서 링크·제목 검증, 이탈 모달
- **모집(Step2)**: 권한 기반 단계 접근, 총원 하이드레이션 숫자 변환("0233" 버그), 스택 미선택 안내 정정
- **지원 문항(Step3)**: 삭제 확인 모달, 접힌 카드 드래그 핸들, 작성 중 포커스 유지
- **삭제**: 권한·상태(공개/중단) 검증, 모달 중복 제출 차단, 삭제 후 목록 캐시 무효화
- **미권한 접근**: 권한 없는 프로젝트 수정 진입 시 안내·리다이렉트(403/404)

## 🎞️ 주요 코드 설명

### resourceId 타입 불일치 수정 — 권한 버튼 미노출 핵심 버그

```TypeScript
// features/auth/model/resourcePermission.ts
const permissionResponse = permissionResponses?.find(
  (response) =>
    response.resourceType === params.resourceType &&
-   response.resourceId === params.resourceId,
+   String(response.resourceId) === String(params.resourceId),
)
```

서버가 `resourceId`를 문자열(`"92"`)로 반환하는데 number(`92`)로 비교 → 항상 false → `canEditProject`/`canDeleteProject`가 고정 false. `String()` 정규화로 해결.

### 모집 스택 미선택 안내 정정

```TypeScript
// features/project/new/ui/recruit-info/RecruitInfoForm.tsx (savePartQuotas)
const missingStackRole = ROLES.find(
  ({ key, stacks }) =>
    stacks.length > 0 && roleStates[key].count > 0 && !roleStates[key].stack,
)
if (missingStackRole) {
  addToast({ message: `${missingStackRole.label} 스택을 선택해 주세요.` })
  return false
}
```

`count>0`인데 스택 미선택이면 `buildPartQuotasEntries`가 throw → "임시 저장 실패" 오안내였음. 저장 전 명시적 검증으로 정정.

## 🖥️ 구현화면

> 로컬 dev API 기반으로 역할별(중앙/지부장/학교회장/PM) 버튼 노출·삭제·등록/수정 플로우를 실측 QA했습니다. (스크린샷은 리뷰 시 보강)

## 🔗 연결된 이슈

- Connected: #187

## 💬 기타 더 이야기해볼 점

- 학교 운영진(학교회장) EDIT/DELETE 권한이 서버에서 false 반환 — 의도된 정책인지 백엔드 확인 필요
- Create(등록 제출)의 이미지 업로드(S3 PUT) 끝단은 로컬 CORS로 막혀 배포 dev에서만 최종 검증 가능
