### PR TITLE
fix: 헤더 권한별 네비게이션 분기 및 로그인 후 랜딩 페이지 개선

### DIFF
--- a/src/components/sidebar/SideBar.tsx
+++ b/src/components/sidebar/SideBar.tsx
@@ -1,3 +1,4 @@
+import { useRouterState } from "@tanstack/react-router"
 import { useEffect, useMemo, useState } from "react"
 
 import { useMe } from "@/features/auth/hooks/useMe"
@@ -8,6 +9,7 @@ import {
   isOperator,
 } from "@/features/auth/model/identity"
 import { SIDEBAR_ITEMS } from "@/shared/config/navigation"
+import { resolveNavigationFromPathname } from "@/shared/config/navigationResolve"
 import { cn } from "@/shared/lib/utils"
 
 import { SideBarMenu } from "./menu/SideBarMenu"
@@ -19,6 +21,7 @@ interface SideBarProps {
 }
 
 export default function SideBar({ className }: SideBarProps) {
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
   const { data: me, isLoading: isMeLoading } = useMe()
   const canAccessSettings = canAccessProjectSettings(me)
   const canManage = canManageProjects(me)
@@ -34,9 +37,13 @@ export default function SideBar({ className }: SideBarProps) {
     [canAccessSettings, canManage, canRecruit],
   )
 
-  const [openSectionId, setOpenSectionId] = useState<string>(
-    visibleSections[0]?.id ?? SIDEBAR_ITEMS[0]?.id ?? "",
-  )
+  // 현재 경로에 해당하는 섹션을 초기값으로 사용
+  const [openSectionId, setOpenSectionId] = useState<string>(() => {
+    const active = resolveNavigationFromPathname(pathname, visibleSections)
+    return (
+      active?.section.id ?? visibleSections[0]?.id ?? SIDEBAR_ITEMS[0]?.id ?? ""
+    )
+  })
 
   useEffect(() => {
     const ids = new Set(visibleSections.map((section) => section.id))

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -23,9 +23,16 @@ export const Route = createFileRoute("/")({
       throw redirect({ to: "/matching/projects" })
     }
 
-    // Plan Challenger(PM): 프로젝트 설정 > 공지
+    // Plan Challenger(PM): 프로젝트 설정 > 공지 (본인 지부)
     if (isCurrentTermPm(me)) {
-      throw redirect({ to: "/matching/projects/announce" })
+      const pmChapter = getViewerBranch(me)
+      throw redirect({
+        to: "/matching/projects/announce",
+        search: {
+          chapter: isChapter(pmChapter) ? pmChapter : CHAPTERS[0],
+          page: 1,
+        },
+      })
     }
 
     // Design/FE/BE Challenger: 팀 매칭 > 공지 (본인 지부)

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,7 +1,11 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
 
 import { ensureMe } from "@/features/auth/lib/ensureMe"
-import { getViewerBranch, isOperator } from "@/features/auth/model/identity"
+import {
+  getViewerBranch,
+  isCurrentTermPm,
+  isOperator,
+} from "@/features/auth/model/identity"
 import { type Chapter, CHAPTERS } from "@/features/notice"
 
 function isChapter(value: unknown): value is Chapter {
@@ -14,10 +18,17 @@ export const Route = createFileRoute("/")({
   beforeLoad: async ({ context }) => {
     const me = await ensureMe(context.queryClient)
 
+    // Admin(운영진): 팀 매칭 > 프로젝트 목록
     if (isOperator(me)) {
       throw redirect({ to: "/matching/projects" })
     }
 
+    // Plan Challenger(PM): 프로젝트 설정 > 공지
+    if (isCurrentTermPm(me)) {
+      throw redirect({ to: "/matching/projects/announce" })
+    }
+
+    // Design/FE/BE Challenger: 팀 매칭 > 공지 (본인 지부)
     const userChapter = getViewerBranch(me)
     if (isChapter(userChapter)) {
       throw redirect({

--- a/src/routes/matching/status.tsx
+++ b/src/routes/matching/status.tsx
@@ -4,7 +4,7 @@ import { useState } from "react"
 import { ApplicationStatsSection } from "@/features/application/ui/ApplicationStatsSection"
 import { useMe } from "@/features/auth/hooks/useMe"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
-import { isOperator } from "@/features/auth/model/identity"
+import { getViewerBranch, isOperator } from "@/features/auth/model/identity"
 import { useMatchingStatusData } from "@/features/matching/hooks/useMatchingStatusData"
 import { MatchingPartSection } from "@/features/matching/ui/MatchingPartSection"
 import { MatchingResultRow } from "@/features/matching/ui/MatchingResultRow"
@@ -22,7 +22,16 @@ export const Route = createFileRoute("/matching/status")({
 function MatchingStatusPage() {
   const { data: me } = useMe()
   const isAdmin = isOperator(me)
-  const [selectedChapter, setSelectedChapter] = useState<Chapter>("Chromium")
+
+  // 챌린저(Plan/Others)는 본인 지부를 초기 탭으로, 운영진은 첫 번째 지부로
+  const userChapter = getViewerBranch(me)
+  const defaultChapter: Chapter =
+    !isAdmin && CHAPTERS.includes(userChapter as Chapter)
+      ? (userChapter as Chapter)
+      : CHAPTERS[0]
+
+  const [selectedChapter, setSelectedChapter] =
+    useState<Chapter>(defaultChapter)
 
   const {
     matchingParts,


### PR DESCRIPTION
## 📸 작업 내용
- 헤더 권한별 네비게이션 분기 및 로그인 후 랜딩 페이지 개선  

## 🔗 연결된 이슈

- Closed #196 