### PR TITLE
[FIX] 프로젝트 관리 페이지 지부장 목록 미노출 및 수정 후 캐시 미갱신

### DIFF
--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -652,7 +652,10 @@ export function ProjectDetailCard({
       <Modal.Root open={isApplyModalOpen} onOpenChange={setIsApplyModalOpen}>
         <Modal.Portal>
           <Modal.Overlay tone="deep" />
-          <Modal.Content>
+          <Modal.Content
+            onInteractOutside={(e) => e.preventDefault()}
+            onEscapeKeyDown={(e) => e.preventDefault()}
+          >
             {showFormSkeleton ? (
               <ApplyFormSkeleton />
             ) : applicationForm == null ? (

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -699,8 +699,7 @@ export function ProjectApplyModal({
                 isSubmitting ||
                 isFileUploading ||
                 isPortfolioUploading ||
-                isApplicationEditPermissionLoading ||
-                !canEditApplication
+                isApplicationEditPermissionLoading
               }
               onClick={() => {
                 void handleSubmit(onValid, onInvalid)()
@@ -806,11 +805,7 @@ export function ProjectApplyModal({
               <Button
                 size="s"
                 onClick={() => void handleSubmitConfirm()}
-                disabled={
-                  isSubmitting ||
-                  isApplicationEditPermissionLoading ||
-                  !canEditApplication
-                }
+                disabled={isSubmitting || isApplicationEditPermissionLoading}
               >
                 제출하기
               </Button>

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -3,7 +3,12 @@ import { useMemo } from "react"
 
 import { useMe } from "@/features/auth/hooks/useMe"
 import { useResourcePermissionsBatch } from "@/features/auth/hooks/useResourcePermissionsBatch"
-import { isAnyOperator, isCurrentTermPm } from "@/features/auth/model/identity"
+import {
+  isAnyOperator,
+  isCentralStaff,
+  isCurrentTermPm,
+  isSuperAdmin,
+} from "@/features/auth/model/identity"
 import { gisuKeys } from "@/features/project/new/api/queryKeys"
 import { getActiveGisu } from "@/shared/api/gisu"
 
@@ -94,6 +99,7 @@ export function ProjectManagementPage() {
   const isAdminScope = isAnyOperator(me)
   const isPm = isCurrentTermPm(me)
   const hasAccess = isAdminScope || isPm
+  const useGroupedView = isCentralStaff(me) || isSuperAdmin(me)
 
   const gisuQuery = useQuery({
     queryKey: gisuKeys.active,
@@ -117,7 +123,7 @@ export function ProjectManagementPage() {
   )
 
   const partGroups = useMemo(() => {
-    if (!isAdminScope) return new Map<string, MatchingProject[]>()
+    if (!useGroupedView) return new Map<string, MatchingProject[]>()
     const map = new Map<string, MatchingProject[]>()
     for (const project of projects) {
       for (const row of project.recruitRows) {
@@ -127,7 +133,7 @@ export function ProjectManagementPage() {
       }
     }
     return map
-  }, [isAdminScope, projects])
+  }, [useGroupedView, projects])
 
   const permissionProjectIds = useMemo(() => {
     const ids = new Set<number>()
@@ -201,7 +207,7 @@ export function ProjectManagementPage() {
             <p className="text-body-2-regular text-teal-gray-400 py-10 text-center">
               데이터를 불러오는 중...
             </p>
-          ) : isAdminScope ? (
+          ) : useGroupedView ? (
             partGroups.size > 0 ? (
               Array.from(partGroups.entries()).map(([part, partProjects]) => (
                 <div key={part} className="flex flex-col">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,6 +24,7 @@ const router = createRouter({
   routeTree,
   context: { queryClient },
   defaultPreload: "intent",
+  trailingSlash: "never",
 })
 
 declare module "@tanstack/react-router" {

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -454,6 +454,16 @@ function ProjectRegisterPage() {
     setShowSuccessModal(false)
     reset()
     queryClient.removeQueries({ queryKey: ["project", "managed"] })
+    if (isEditMode && editProjectId) {
+      queryClient.removeQueries({ queryKey: projectKeys.detail(editProjectId) })
+      queryClient.removeQueries({
+        queryKey: projectKeys.applicationForm(editProjectId),
+      })
+    } else if (gisuId) {
+      queryClient.removeQueries({
+        queryKey: projectKeys.draft(Number(gisuId)),
+      })
+    }
     await navigate({ to: "/matching/projects/management", replace: true })
   }
 

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -453,6 +453,7 @@ function ProjectRegisterPage() {
   const handleSuccessConfirm = async () => {
     setShowSuccessModal(false)
     reset()
+    queryClient.removeQueries({ queryKey: ["project", "managed"] })
     await navigate({ to: "/matching/projects/management", replace: true })
   }
 


### PR DESCRIPTION
## Summary

- 지부장(CHAPTER_PRESIDENT) 계정에서 지부 PM 등록 프로젝트가 관리 목록에 미노출되는 버그 수정
- 프로젝트 수정 완료 후 관리 목록 페이지로 돌아올 때 캐시가 즉시 갱신되지 않는 버그 수정

## 버그 1: 지부장 목록 미노출

**원인:** `isAdminScope(isAnyOperator)`를 렌더링 분기에 직접 사용하여 지부장도 FE 파트별 그룹 뷰로 진입. 해당 뷰는 Web/iOS/Android 파트만 필터링하므로 다른 파트 프로젝트는 보이지 않음.

**수정:** `useGroupedView = isCentralStaff || isSuperAdmin`으로 분리하여 지부장·학교 회장단은 단순 목록 뷰 적용.

## 버그 2: 수정 후 캐시 미갱신

**원인:** `invalidateQueries`만으로는 stale 데이터가 캐시에 잔존. 관리 페이지 마운트 시 old data를 먼저 렌더링 후 background refetch 발생.

**수정:** navigate 직전 `removeQueries`로 managed 캐시를 완전 제거하여 관리 페이지가 항상 fresh fetch로 시작.

## Test plan

- [ ] 지부장 계정 로그인 → 프로젝트 관리 페이지에서 지부 PM 등록 프로젝트 목록 확인
- [ ] 중앙 운영진 계정 로그인 → 기존 FE 파트별 그룹 뷰 정상 동작 확인
- [ ] 프로젝트 수정 완료 → 관리 목록 페이지에서 수정 내용 즉시 반영 확인

Closes #205