### PR TITLE
[FIX] 지원서 제출·PM 드롭다운 버그 수정 및 쿼리 캐시 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@commitlint/config-conventional": "^20.2.0",
     "@eslint/js": "^9.39.2",
     "@tailwindcss/vite": "^4.0.0",
+    "@tanstack/react-query-devtools": "^5.101.0",
     "@tanstack/router-plugin": "^1.159.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.0.0
         version: 4.2.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@tanstack/react-query-devtools':
+        specifier: ^5.101.0
+        version: 5.101.0(@tanstack/react-query@5.96.1(react@19.2.4))(react@19.2.4)
       '@tanstack/router-plugin':
         specifier: ^1.159.0
         version: 1.167.12(@tanstack/react-router@1.168.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
@@ -1817,6 +1820,15 @@ packages:
 
   '@tanstack/query-core@5.96.1':
     resolution: {integrity: sha512-u1yBgtavSy+N8wgtW3PiER6UpxcplMje65yXnnVgiHTqiMwLlxiw4WvQDrXyn+UD6lnn8kHaxmerJUzQcV/MMg==}
+
+  '@tanstack/query-devtools@5.101.0':
+    resolution: {integrity: sha512-MVqw17k08RQtGGLEL654+dX/btbX9p/8WjkznO//zusLTMaObxi3Q+MoFwGVkC9K3tqjn8qrrNhJevXx4fJTeQ==}
+
+  '@tanstack/react-query-devtools@5.101.0':
+    resolution: {integrity: sha512-cpZA0+WqKXwrwMfiWZEGGF6QrIWVQFbhBtxqDF5sQsAfrFf47HIE6fiPbQU3wyAUEN2+7UNqLCQe7oG6m3f93w==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.101.0
+      react: ^18 || ^19
 
   '@tanstack/react-query@5.96.1':
     resolution: {integrity: sha512-2X7KYK5KKWUKGeWCVcqxXAkYefJtrKB7tSKWgeG++b0H6BRHxQaLSSi8AxcgjmUnnosHuh9WsFZqvE16P1WCzA==}
@@ -6122,6 +6134,14 @@ snapshots:
   '@tanstack/history@1.161.6': {}
 
   '@tanstack/query-core@5.96.1': {}
+
+  '@tanstack/query-devtools@5.101.0': {}
+
+  '@tanstack/react-query-devtools@5.101.0(@tanstack/react-query@5.96.1(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-devtools': 5.101.0
+      '@tanstack/react-query': 5.96.1(react@19.2.4)
+      react: 19.2.4
 
   '@tanstack/react-query@5.96.1(react@19.2.4)':
     dependencies:

--- a/src/features/auth/model/identity.ts
+++ b/src/features/auth/model/identity.ts
@@ -96,7 +96,9 @@ export function getProjectPmSearchScope(me: MemberInfoResponse | undefined): {
   if (isSchoolLeadership(me)) {
     return me?.schoolId != null ? { schoolId: String(me.schoolId) } : {}
   }
-  return {}
+  if (!me?.challengerRecords?.length) return {}
+  const latest = latestRecord(me.challengerRecords)
+  return latest?.chapterId ? { chapterId: latest.chapterId } : {}
 }
 
 export function isCurrentTermPm(me: MemberInfoResponse | undefined): boolean {

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -272,8 +272,6 @@ export function ProjectApplyModal({
     applicationId !== null &&
     !isDevMatchingRound &&
     applicationEditPermissionQuery.isPending
-  const canEditApplication =
-    isDevMatchingRound || applicationEditPermissionQuery.hasPermission("EDIT")
 
   useEffect(() => {
     if (draftInitializedRef.current) return
@@ -377,16 +375,6 @@ export function ProjectApplyModal({
     setIsSubmitting(true)
     try {
       if (!isDevMatchingRound) {
-        if (!applicationId || !canEditApplication) {
-          addToast({
-            message: "지원서 제출에 실패했습니다. 다시 시도해 주세요.",
-            color: "red",
-            variant: "deep",
-            type: "default",
-            duration: 3000,
-          })
-          return
-        }
         const answers = buildAnswerPayload(formValues, sections)
         await saveApplicationDraft(projectId, answers)
         await submitApplication(projectId)

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -15,7 +15,9 @@ import { useToastStore } from "@/components/toast/useToastStore"
 import { useMe } from "@/features/auth/hooks/useMe"
 import {
   getProjectPmSearchScope,
+  isCentralStaff,
   isCurrentTermPm,
+  isSuperAdmin,
 } from "@/features/auth/model/identity"
 import { searchMembers } from "@/features/challenger/api/member"
 import { Dropdown } from "@/features/challenger/ui/shared/Dropdown"
@@ -124,35 +126,34 @@ export const BasicInfoForm = forwardRef<
   const [pm2Member, setPm2Member] = useState<MemberItem | null>(storePmInfo.pm2)
   const [pm2Error, setPm2Error] = useState(false)
 
-  const allPmMembers = useMemo(
-    () => (pmListQuery.data?.page.content ?? []).map(toMemberItem),
-    [pmListQuery.data],
+  const isCentral = isCentralStaff(meData) || isSuperAdmin(meData)
+
+  const allPmMembers = useMemo(() => {
+    const members = (pmListQuery.data?.page.content ?? []).map(toMemberItem)
+    if (isCentral) {
+      return members.sort((a, b) => a.nickname.localeCompare(b.nickname, "ko"))
+    }
+    return members
+  }, [pmListQuery.data, isCentral])
+
+  const pm1Options = useMemo(
+    () =>
+      allPmMembers.map((m) => ({
+        value: m.id,
+        label: `${m.nickname}/${m.name} · ${m.university}`,
+      })),
+    [allPmMembers],
   )
 
-  const pm1Options = useMemo(() => {
-    const filtered =
-      isPm && meData
-        ? allPmMembers.filter((m) => m.id === String(meData.id))
-        : allPmMembers
-    return filtered.map((m) => ({
-      value: m.id,
-      label: `${m.nickname}/${m.name} · ${m.university}`,
-    }))
-  }, [allPmMembers, isPm, meData])
-
   const pm2Options = useMemo(() => {
-    const excludeIds = new Set(
-      [pm1Member?.id, isPm && meData ? String(meData.id) : undefined].filter(
-        Boolean,
-      ),
-    )
+    const excludeId = pm1Member?.id
     return allPmMembers
-      .filter((m) => !excludeIds.has(m.id))
+      .filter((m) => m.id !== excludeId)
       .map((m) => ({
         value: m.id,
         label: `${m.nickname}/${m.name} · ${m.university}`,
       }))
-  }, [allPmMembers, pm1Member, isPm, meData])
+  }, [allPmMembers, pm1Member])
 
   const thumbnailRef = useRef<HTMLButtonElement>(null)
   const logoRef = useRef<HTMLButtonElement>(null)
@@ -280,6 +281,16 @@ export const BasicInfoForm = forwardRef<
       isMultiPm: storePmInfo.isMultiPm,
     })
   }, [storePmInfo])
+
+  useEffect(() => {
+    if (!isPm || !meData || pm1Member !== null || allPmMembers.length === 0)
+      return
+    const self = allPmMembers.find((m) => m.id === String(meData.id))
+    if (self) {
+      setPm1Member(self)
+      setPm1Error(false)
+    }
+  }, [isPm, meData, allPmMembers, pm1Member])
 
   const isPmChanged = savedSnapshot
     ? pm1Member !== savedSnapshot.pm1 ||

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import "./app.css"
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import { createRouter, RouterProvider } from "@tanstack/react-router"
 import { StrictMode } from "react"
 import ReactDOM from "react-dom/client"
@@ -14,7 +15,7 @@ const isMaintenance = import.meta.env.VITE_MAINTENANCE === "true"
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 1000 * 60 * 5,
+      staleTime: 0,
       retry: 1,
     },
   },
@@ -44,6 +45,7 @@ if (!rootElement.innerHTML) {
       ) : (
         <QueryClientProvider client={queryClient}>
           <RouterProvider router={router} />
+          <ReactQueryDevtools initialIsOpen={false} />
         </QueryClientProvider>
       )}
     </StrictMode>,


### PR DESCRIPTION
## 작업 내용

- ReactQueryDevtools 추가 및 전역 staleTime 0으로 변경 (서버 변경사항 즉시 반영)
- 지원서 제출 시 canEditApplication 프론트 가드 제거 → 실제 API 호출로 권한 검증
- PM 프로젝트 생성 step1 PM 선택 드롭다운 오작동 3종 수정

## 주요 코드 설명

### 1. 전역 staleTime 0

```typescript
// src/main.tsx
const queryClient = new QueryClient({
  defaultOptions: {
    queries: {
      staleTime: 0, // 5분 → 0: 마운트 시마다 서버에서 fresh fetch
    },
  },
})
```

- 서버에서 데이터 변경 시 프로젝트 목록·관리 페이지에 즉시 반영되지 않던 문제 해결

### 2. canEditApplication 가드 제거

```typescript
// 기존: 프론트에서 PROJECT_APPLICATION EDIT 권한 조회 → false면 토스트 후 return
// 수정: 가드 제거, saveApplicationDraft + submitApplication 직접 호출
if (!isDevMatchingRound) {
  const answers = buildAnswerPayload(formValues, sections)
  await saveApplicationDraft(projectId, answers)
  await submitApplication(projectId)
}
```

- 권한 API가 false를 반환해 제출 버튼이 클릭돼도 "제출 실패" 토스트만 뜨던 문제 해결
- 실제 권한 검증은 `/me` 백엔드 엔드포인트에서 처리

### 3. PM 드롭다운 스코프 수정

```typescript
// identity.ts - 일반 PM도 지부 스코프 반환
export function getProjectPmSearchScope(me) {
  // ...기존 분기들...
  // 추가: 일반 PM/챌린저
  const latest = latestRecord(me.challengerRecords)
  return latest?.chapterId ? { chapterId: latest.chapterId } : {}
}
```

- `getProjectPmSearchScope`가 일반 PM에게 `{}` 반환 → 전체 PM 조회되던 문제 해결
- pm1 자동 선택: isPm이면 데이터 로드 후 본인 자동 선택 effect 추가
- 중앙 운영진: `localeCompare('ko')` 기반 가나다순 정렬 적용

## 구현화면

> 테스트 후 스크린샷 첨부 예정

## 연결된 이슈

- Connected: #205
- Connected: #208

## 💬 기타 더 이야기해볼 점

전역 staleTime 0 설정은 API 호출 횟수가 증가할 수 있습니다. 이후 DevTools로 실제 쿼리 상태를 모니터링한 뒤, 자주 변경되지 않는 마스터 데이터(기수·지부 목록 등)는 개별 쿼리에 staleTime을 다시 명시하는 방향으로 조정 예정입니다.