### PR TITLE
[FIX] 프로젝트 관리 카드 클릭 시 목록 빈 화면 버그 및 Dialog 경고 수정

### DIFF
--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -45,7 +45,7 @@ function getCurrentRound(rounds: MatchingRoundResponse[]): number {
 // 활성 기수 ID 조회
 export function useActiveGisuId() {
   return useQuery({
-    queryKey: ["gisu", "active"],
+    queryKey: ["gisu"],
     queryFn: getActiveGisu,
     staleTime: 5 * 60 * 1000,
     select: (data) => (data?.gisuId != null ? Number(data.gisuId) : null),

--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -3,9 +3,9 @@ import { useMemo } from "react"
 
 import {
   getAllChapters,
-  getAllGisu,
   getAllSchools,
 } from "@/features/challenger/api/organization"
+import { getActiveGisu } from "@/shared/api/gisu"
 
 import {
   getAllProjects,
@@ -46,11 +46,9 @@ function getCurrentRound(rounds: MatchingRoundResponse[]): number {
 export function useActiveGisuId() {
   return useQuery({
     queryKey: ["gisu", "active"],
-    queryFn: async () => {
-      const res = await getAllGisu()
-      const active = res.gisuList.find((g) => g.isActive)
-      return active ? Number(active.gisuId) : null
-    },
+    queryFn: getActiveGisu,
+    staleTime: 5 * 60 * 1000,
+    select: (data) => (data?.gisuId != null ? Number(data.gisuId) : null),
   })
 }
 

--- a/src/features/application/ui/ApplicationDetailModal.tsx
+++ b/src/features/application/ui/ApplicationDetailModal.tsx
@@ -176,6 +176,7 @@ export function ApplicationDetailModal({
         <Modal.Overlay tone="deep" />
         <Modal.Content
           className="flex max-h-[calc(100vh-60px)] items-start gap-4"
+          aria-describedby={undefined}
           onOpenAutoFocus={(e) => e.preventDefault()}
           onEscapeKeyDown={(e) => {
             // 우측 패널 열려있으면 패널만 닫고, 없으면 전체 닫기

--- a/src/features/auth/hooks/useMe.ts
+++ b/src/features/auth/hooks/useMe.ts
@@ -6,7 +6,7 @@ import { useAuthStore } from "../store/authStore"
 export function useMe() {
   const isAuthed = useAuthStore((s) => s.isAuthed)
   return useQuery({
-    queryKey: ["auth", "me"],
+    queryKey: ["auth"],
     queryFn: getMyInfo,
     staleTime: 1000 * 60 * 5,
     enabled: isAuthed,

--- a/src/features/matching/ui/AssignmentModal.tsx
+++ b/src/features/matching/ui/AssignmentModal.tsx
@@ -125,6 +125,7 @@ export function AssignmentModal({
         <Modal.Overlay tone="deep" />
         <Modal.Content
           className="flex h-157.5 w-185 max-w-[calc(100vw-32px)] flex-col rounded-xl bg-white px-12.5 pt-14 pb-10 shadow-lg focus:outline-none"
+          aria-describedby={undefined}
           onOpenAutoFocus={(e) => e.preventDefault()}
         >
           <Modal.Title className="sr-only">팀원 수동 배정</Modal.Title>

--- a/src/features/matching/ui/MatchingDetailModal.tsx
+++ b/src/features/matching/ui/MatchingDetailModal.tsx
@@ -80,7 +80,10 @@ export function MatchingDetailModal({
     <Modal.Root open={open} onOpenChange={(next) => !next && handleClose()}>
       <Modal.Portal>
         <Modal.Overlay tone="deep" />
-        <Modal.Content className="flex max-h-[calc(100vh-60px)] items-start">
+        <Modal.Content
+          className="flex max-h-[calc(100vh-60px)] items-start"
+          aria-describedby={undefined}
+        >
           <Modal.Title className="sr-only">
             {applicant.name} 지원서 상세
           </Modal.Title>

--- a/src/features/matching/ui/MatchingResultRow.tsx
+++ b/src/features/matching/ui/MatchingResultRow.tsx
@@ -295,7 +295,10 @@ export function MatchingResultRow({
       >
         <Modal.Portal>
           <Modal.Overlay tone="deep" />
-          <Modal.Content className="shadow-drop-neutral-3 rounded-2xl">
+          <Modal.Content
+            className="shadow-drop-neutral-3 rounded-2xl"
+            aria-describedby={undefined}
+          >
             {projectId && (
               <ProjectDetailCard
                 projectId={projectId}

--- a/src/features/project/list/model/matchingProjectList.ts
+++ b/src/features/project/list/model/matchingProjectList.ts
@@ -79,7 +79,7 @@ export function useMatchingProjectListFilters() {
   const userIsOperator = isOperator(me)
 
   const { data: gisuData } = useQuery({
-    queryKey: ["gisu", "active"],
+    queryKey: ["gisu"],
     queryFn: getActiveGisu,
   })
 

--- a/src/features/project/list/ui/MatchingProjectsListPage.tsx
+++ b/src/features/project/list/ui/MatchingProjectsListPage.tsx
@@ -158,7 +158,10 @@ export function MatchingProjectsListPage() {
       >
         <Modal.Portal>
           <Modal.Overlay tone="deep" />
-          <Modal.Content className="shadow-drop-neutral-3 rounded-2xl">
+          <Modal.Content
+            className="shadow-drop-neutral-3 rounded-2xl"
+            aria-describedby={undefined}
+          >
             <Modal.Title className="sr-only">프로젝트 상세</Modal.Title>
             {selectedProjectId !== null && (
               <ProjectDetailCard projectId={selectedProjectId} />

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -614,7 +614,7 @@ export function ProjectDetailCard({
       <Modal.Root open={isTeamModalOpen} onOpenChange={setIsTeamModalOpen}>
         <Modal.Portal>
           <Modal.Overlay tone="light" />
-          <Modal.Content>
+          <Modal.Content aria-describedby={undefined}>
             <Modal.Title className="sr-only">팀원 구성</Modal.Title>
             <TeamMemberModal
               projectId={projectId}
@@ -631,7 +631,7 @@ export function ProjectDetailCard({
       >
         <Modal.Portal>
           <Modal.Overlay tone="deep" />
-          <Modal.Content>
+          <Modal.Content aria-describedby={undefined}>
             {showFormSkeleton ? (
               <ApplyFormSkeleton />
             ) : applicationForm == null ? (
@@ -651,6 +651,7 @@ export function ProjectDetailCard({
         <Modal.Portal>
           <Modal.Overlay tone="deep" />
           <Modal.Content
+            aria-describedby={undefined}
             onInteractOutside={(e) => e.preventDefault()}
             onEscapeKeyDown={(e) => e.preventDefault()}
           >
@@ -688,7 +689,7 @@ export function ProjectDetailCard({
       >
         <Modal.Portal>
           <Modal.Overlay tone="deep" />
-          <Modal.Content>
+          <Modal.Content aria-describedby={undefined}>
             {myApplicationForProject ? (
               <MyApplicationModal
                 data={data}

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -180,13 +180,11 @@ export function ProjectDetailCard({
     staleTime: 5 * 60 * 1000,
   })
 
-  const { data: activeGisuId } = useQuery({
+  const { data: activeGisuData } = useQuery({
     queryKey: ["gisu", "active"],
-    queryFn: async () => {
-      const res = await getActiveGisu()
-      return res.gisuId ?? null
-    },
+    queryFn: getActiveGisu,
   })
+  const activeGisuId = activeGisuData?.gisuId ?? null
 
   const { data: myApplications } = useQuery({
     queryKey: ["myApplications", activeGisuId],

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -181,7 +181,7 @@ export function ProjectDetailCard({
   })
 
   const { data: activeGisuData } = useQuery({
-    queryKey: ["gisu", "active"],
+    queryKey: ["gisu"],
     queryFn: getActiveGisu,
     staleTime: 5 * 60 * 1000,
   })

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -183,6 +183,7 @@ export function ProjectDetailCard({
   const { data: activeGisuData } = useQuery({
     queryKey: ["gisu", "active"],
     queryFn: getActiveGisu,
+    staleTime: 5 * 60 * 1000,
   })
   const activeGisuId = activeGisuData?.gisuId ?? null
 

--- a/src/features/project/management/ui/ProjectManagementCard.tsx
+++ b/src/features/project/management/ui/ProjectManagementCard.tsx
@@ -114,7 +114,10 @@ export function ProjectManagementCard({
       <Modal.Root open={open} onOpenChange={setOpen}>
         <Modal.Portal>
           <Modal.Overlay tone="deep" />
-          <Modal.Content className="shadow-drop-neutral-3 rounded-2xl">
+          <Modal.Content
+            className="shadow-drop-neutral-3 rounded-2xl"
+            aria-describedby={undefined}
+          >
             <Modal.Title className="sr-only">{data.title}</Modal.Title>
             <ProjectDetailCard
               projectId={Number(data.id)}

--- a/src/features/project/new/api/queryKeys.ts
+++ b/src/features/project/new/api/queryKeys.ts
@@ -13,7 +13,7 @@ export const projectKeys = {
 } as const
 
 export const gisuKeys = {
-  active: ["gisu", "active"] as const,
+  active: ["gisu"] as const,
 } as const
 
 export const memberKeys = {

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -76,7 +76,7 @@ export const BasicInfoForm = forwardRef<
   const { data: meData } = useMe()
   const isPm = isCurrentTermPm(meData)
   const activeGisuQuery = useQuery({
-    queryKey: ["gisu", "active"],
+    queryKey: ["gisu"],
     queryFn: getActiveGisu,
     staleTime: 5 * 60 * 1000,
   })

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,6 +17,7 @@ const queryClient = new QueryClient({
     queries: {
       staleTime: 0,
       retry: 1,
+      refetchOnMount: "always",
     },
   },
 })

--- a/src/shared/ui/Pagination.tsx
+++ b/src/shared/ui/Pagination.tsx
@@ -34,7 +34,7 @@ export function Pagination({
       {showPrev ? (
         <button
           type="button"
-          className="text-teal-gray-400 hover:text-teal-gray-700 hover:bg-teal-gray-50 hover:shadow-pagination-num-hover flex h-[1.875rem] w-[1.875rem] shrink-0 items-center justify-center gap-1 rounded-xl border-0 bg-transparent transition-colors transition-shadow focus-visible:ring-2 focus-visible:ring-teal-500/40 focus-visible:outline-none disabled:pointer-events-none"
+          className="text-teal-gray-400 hover:text-teal-gray-700 hover:bg-teal-gray-50 hover:shadow-pagination-num-hover flex h-7.5 w-7.5 shrink-0 items-center justify-center gap-1 rounded-xl border-0 bg-transparent transition-colors focus-visible:ring-2 focus-visible:ring-teal-500/40 focus-visible:outline-none disabled:pointer-events-none"
           aria-label="이전 페이지"
           onClick={() => onPageChange(safePage - 1)}
         >
@@ -52,7 +52,7 @@ export function Pagination({
               aria-label={`${page}페이지`}
               aria-current={isActive ? "page" : undefined}
               className={cn(
-                "text-subtitle-4-semibold text-teal-gray-900 flex h-[1.875rem] min-w-[1.875rem] shrink-0 items-center justify-center gap-1 rounded-xl border-0 px-1 transition-colors transition-shadow focus-visible:ring-2 focus-visible:ring-teal-500/40 focus-visible:outline-none disabled:pointer-events-none",
+                "text-subtitle-4-semibold text-teal-gray-900 flex h-7.5 min-w-7.5 shrink-0 items-center justify-center gap-1 rounded-xl border-0 px-1 transition-shadow focus-visible:ring-2 focus-visible:ring-teal-500/40 focus-visible:outline-none disabled:pointer-events-none",
                 isActive
                   ? "bg-teal-gray-100 hover:bg-teal-gray-100"
                   : "hover:bg-teal-gray-50 hover:shadow-pagination-num-hover bg-transparent",
@@ -68,7 +68,7 @@ export function Pagination({
       {showNext ? (
         <button
           type="button"
-          className="text-teal-gray-400 hover:text-teal-gray-700 hover:bg-teal-gray-50 hover:shadow-pagination-num-hover flex h-[1.875rem] w-[1.875rem] shrink-0 items-center justify-center gap-1 rounded-xl border-0 bg-transparent transition-colors transition-shadow focus-visible:ring-2 focus-visible:ring-teal-500/40 focus-visible:outline-none disabled:pointer-events-none"
+          className="text-teal-gray-100 hover:text-teal-gray-700 hover:bg-teal-gray-50 hover:shadow-pagination-num-hover flex h-7.5 w-7.5 shrink-0 items-center justify-center gap-1 rounded-xl border-0 bg-transparent transition-colors focus-visible:ring-2 focus-visible:ring-teal-500/40 focus-visible:outline-none disabled:pointer-events-none"
           aria-label="다음 페이지"
           onClick={() => onPageChange(safePage + 1)}
         >


### PR DESCRIPTION
## 📸 작업 내용

- 프로젝트 관리 페이지에서 카드 클릭 시 목록이 빈 화면으로 변하는 버그 수정
- 프로젝트 수정 페이지로 이동하지 못하던 문제 해결
- 프로젝트 전반 `Modal.Content` Radix Dialog 콘솔 경고 일괄 해소

## 🎞️ 주요 코드 설명

### ProjectDetailCard — gisu queryFn 통일

```typescript
// 수정 전: 서로 다른 queryFn이 같은 queryKey를 사용
// ProjectManagementPage
queryFn: getActiveGisu  // ActiveGisuResponse 객체 반환

// ProjectDetailCard (문제)
queryFn: async () => {
  const res = await getActiveGisu()
  return res.gisuId ?? null  // 숫자만 반환 → 캐시 오염
}

// 수정 후: queryFn 통일
const { data: activeGisuData } = useQuery({
  queryKey: ["gisu", "active"],
  queryFn: getActiveGisu,
})
const activeGisuId = activeGisuData?.gisuId ?? null
```

- `staleTime: 0` 환경에서 동일 queryKey에 다른 queryFn이 등록될 경우 캐시를 덮어써 상위 컴포넌트의 데이터를 오염시키는 문제
- `gisuId` 숫자가 `ActiveGisuResponse` 자리에 들어가 `data?.gisuId = undefined` → managed query 비활성화 → 빈 목록

### Modal.Content aria-describedby 일괄 처리

```tsx
// 수정 전
<Modal.Content className="...">

// 수정 후
<Modal.Content className="..." aria-describedby={undefined}>
```

- `Modal.Description`이 없는 모든 `Modal.Content`에 적용 (7개 파일)

## 🖥️ 구현화면

> 테스트 후 스크린샷 첨부 예정

## 🔗 연결된 이슈

- Connected: #211