### PR TITLE
fix: 0612 1차 QA

### DIFF
--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/shared/lib/utils"
 export const FADE_OUT_DURATION = 300
 
 const toastVariants = cva(
-  "w-100 h-12.5 px-4 py-1 gap-2.5 rounded-[12px] flex justify-between items-center text-label-1-medium shadow-drop-neutral-2 transition-opacity",
+  "w-fit min-w-60 h-12.5 px-4 py-1 gap-2.5 rounded-[12px] flex justify-between items-center text-label-1-medium shadow-drop-neutral-2 transition-opacity",
   {
     variants: {
       variant: {

--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -111,10 +111,7 @@ export function ToastProvider() {
       aria-live="polite"
       aria-label="알림 목록"
     >
-      <div
-        className="pointer-events-none relative"
-        style={{ height: "50px", width: "400px" }}
-      >
+      <div className="pointer-events-none relative" style={{ height: "50px" }}>
         {visible.map((toast, i) => {
           const fromFront = visible.length - 1 - i
           const translateY = -fromFront * STACK_OFFSET
@@ -127,7 +124,7 @@ export function ToastProvider() {
               key={toast.id}
               className="pointer-events-auto absolute bottom-0 left-0 origin-bottom transition-all duration-300"
               style={{
-                transform: `translateY(${translateY}px) scale(${scale})`,
+                transform: `translateX(-50%) translateY(${translateY}px) scale(${scale})`,
                 zIndex,
                 animation: isFront ? "toast-shake 0.4s ease-in-out" : undefined,
               }}

--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -4,9 +4,9 @@ import { useMemo } from "react"
 import {
   getAllChapters,
   getAllSchools,
+  getChaptersWithSchools,
 } from "@/features/challenger/api/organization"
 import { getActiveGisu } from "@/shared/api/gisu"
-import { SCHOOLS_BY_BRANCH } from "@/shared/config/schools"
 
 import {
   getAllProjects,
@@ -167,6 +167,21 @@ export function useAdminPageData(chapterName?: string) {
     [chaptersQuery.data],
   )
 
+  // 지부별 학교 ID 조회 (schoolMatchingStatistics 필터링용)
+  const chaptersWithSchoolsQuery = useQuery({
+    queryKey: ["chapters-with-schools", gisuId],
+    queryFn: () => getChaptersWithSchools(String(gisuId)),
+    enabled: gisuId > 0,
+  })
+  const chapterSchoolIds = useMemo(() => {
+    if (!chapterName || !chaptersWithSchoolsQuery.data) return null
+    const chapter = chaptersWithSchoolsQuery.data.chapters.find(
+      (c) => c.chapterName === chapterName,
+    )
+    if (!chapter) return null
+    return new Set(chapter.schools.map((s) => String(s.schoolId)))
+  }, [chapterName, chaptersWithSchoolsQuery.data])
+
   // 선택된 챕터 이름 -> chapterId 매핑
   const chapterId = useMemo(() => {
     if (!chapterName || chapters.length === 0) return undefined
@@ -268,25 +283,13 @@ export function useAdminPageData(chapterName?: string) {
       }
     }
 
-    const chapterSchools = chapterName
-      ? new Set<string>(
-          SCHOOLS_BY_BRANCH[chapterName as keyof typeof SCHOOLS_BY_BRANCH] ??
-            [],
-        )
-      : null
-
-    // 해당 챕터 소속 학교 + 프로젝트만 필터링 (서버가 챕터 필터링 없이 내려줌)
-    const filteredSummary = chapterSchools
+    // 해당 챕터 소속 학교 + 프로젝트만 필터링
+    const filteredSummary = chapterSchoolIds
       ? {
           ...chapterStatsQuery.data.summary,
           schoolMatchingStatistics:
             chapterStatsQuery.data.summary.schoolMatchingStatistics.filter(
-              (s) => {
-                const name = shortenSchoolName(
-                  schoolIdToName.get(String(s.schoolId)) ?? "",
-                )
-                return chapterSchools.has(name)
-              },
+              (s) => chapterSchoolIds.has(String(s.schoolId)),
             ),
           projectRoundStatistics:
             chapterStatsQuery.data.summary.projectRoundStatistics.filter((p) =>

--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -283,13 +283,13 @@ export function useAdminPageData(chapterName?: string) {
       }
     }
 
-    // 해당 챕터 소속 학교 + 프로젝트만 필터링
-    const filteredSummary = chapterSchoolIds
+    // 해당 챕터 소속 학교 + 프로젝트만 필터링 (로딩 중엔 빈 Set으로 필터링해 flicker 방지)
+    const filteredSummary = chapterName
       ? {
           ...chapterStatsQuery.data.summary,
           schoolMatchingStatistics:
             chapterStatsQuery.data.summary.schoolMatchingStatistics.filter(
-              (s) => chapterSchoolIds.has(String(s.schoolId)),
+              (s) => (chapterSchoolIds ?? new Set()).has(String(s.schoolId)),
             ),
           projectRoundStatistics:
             chapterStatsQuery.data.summary.projectRoundStatistics.filter((p) =>
@@ -311,7 +311,13 @@ export function useAdminPageData(chapterName?: string) {
         .sort((a, b) => b.applied - a.applied)
         .slice(0, 5)
     return { ...partial, universities }
-  }, [chapterStatsQuery.data, projectIdToName, schoolIdToName, chapterName])
+  }, [
+    chapterStatsQuery.data,
+    projectIdToName,
+    schoolIdToName,
+    chapterName,
+    chapterSchoolIds,
+  ])
 
   return {
     projects: transformed,

--- a/src/features/matching/hooks/useMatchingStatusData.ts
+++ b/src/features/matching/hooks/useMatchingStatusData.ts
@@ -17,9 +17,11 @@ import {
   summaryToStats,
   toRoundNumber,
 } from "@/features/application/model/mappers"
-import { getAllSchools } from "@/features/challenger/api/organization"
+import {
+  getAllSchools,
+  getChaptersWithSchools,
+} from "@/features/challenger/api/organization"
 import { getProjectMembers } from "@/features/project/list/api/matchingProject"
-import { SCHOOLS_BY_BRANCH } from "@/shared/config/schools"
 import { useViewModeStore } from "@/shared/view-mode"
 
 import { toMatchingPartDataList } from "../model/matchingStatusMapper"
@@ -128,6 +130,21 @@ export function useMatchingStatusData(chapterName?: string) {
     return map
   }, [schoolsQuery.data])
 
+  // 지부별 학교 ID 조회 (schoolMatchingStatistics 필터링용)
+  const chaptersWithSchoolsQuery = useQuery({
+    queryKey: ["chapters-with-schools", gisuId],
+    queryFn: () => getChaptersWithSchools(String(gisuId)),
+    enabled: gisuId > 0,
+  })
+  const chapterSchoolIds = useMemo(() => {
+    if (!chapterName || !chaptersWithSchoolsQuery.data) return null
+    const chapter = chaptersWithSchoolsQuery.data.chapters.find(
+      (c) => c.chapterName === chapterName,
+    )
+    if (!chapter) return null
+    return new Set(chapter.schools.map((s) => String(s.schoolId)))
+  }, [chapterName, chaptersWithSchoolsQuery.data])
+
   // 지부 통계 조회 (rounds, totalMembers, projectRounds, topProjects)
   const chapterStatsQuery = useQuery({
     queryKey: applicationKeys.chapterStatistics(chapterId ?? 0),
@@ -214,25 +231,13 @@ export function useMatchingStatusData(chapterName?: string) {
       }
     }
 
-    const chapterSchools = chapterName
-      ? new Set<string>(
-          SCHOOLS_BY_BRANCH[chapterName as keyof typeof SCHOOLS_BY_BRANCH] ??
-            [],
-        )
-      : null
-
-    // 해당 챕터 소속 학교 + 프로젝트만 필터링 (서버가 챕터 필터링 없이 내려줌)
-    const filteredSummary = chapterSchools
+    // 해당 챕터 소속 학교 + 프로젝트만 필터링
+    const filteredSummary = chapterSchoolIds
       ? {
           ...chapterStatsQuery.data.summary,
           schoolMatchingStatistics:
             chapterStatsQuery.data.summary.schoolMatchingStatistics.filter(
-              (s) => {
-                const name = shortenSchoolName(
-                  schoolIdToName.get(String(s.schoolId)) ?? "",
-                )
-                return chapterSchools.has(name)
-              },
+              (s) => chapterSchoolIds.has(String(s.schoolId)),
             ),
           projectRoundStatistics:
             chapterStatsQuery.data.summary.projectRoundStatistics.filter((p) =>

--- a/src/features/matching/hooks/useMatchingStatusData.ts
+++ b/src/features/matching/hooks/useMatchingStatusData.ts
@@ -231,13 +231,13 @@ export function useMatchingStatusData(chapterName?: string) {
       }
     }
 
-    // 해당 챕터 소속 학교 + 프로젝트만 필터링
-    const filteredSummary = chapterSchoolIds
+    // 해당 챕터 소속 학교 + 프로젝트만 필터링 (로딩 중엔 빈 Set으로 필터링해 flicker 방지)
+    const filteredSummary = chapterName
       ? {
           ...chapterStatsQuery.data.summary,
           schoolMatchingStatistics:
             chapterStatsQuery.data.summary.schoolMatchingStatistics.filter(
-              (s) => chapterSchoolIds.has(String(s.schoolId)),
+              (s) => (chapterSchoolIds ?? new Set()).has(String(s.schoolId)),
             ),
           projectRoundStatistics:
             chapterStatsQuery.data.summary.projectRoundStatistics.filter((p) =>
@@ -269,6 +269,7 @@ export function useMatchingStatusData(chapterName?: string) {
     currentRound,
     schoolIdToName,
     chapterName,
+    chapterSchoolIds,
   ])
 
   return {

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -642,7 +642,7 @@ function MatchingRoundsPage() {
                 variant="weak"
                 color="neutral"
                 size="lg"
-                onClick={() => window.history.back()}
+                onClick={() => setIsDirty(false)}
               >
                 취소하기
               </Button>

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -6,6 +6,7 @@ import { useToastStore } from "@/components/toast/useToastStore"
 import { Tooltip } from "@/components/tooltip/Tooltip"
 import {
   createMatchingRound,
+  deleteMatchingRound,
   getMatchingRounds,
   updateMatchingRound,
 } from "@/features/application/api/applicationApi"
@@ -263,7 +264,9 @@ function MatchingRoundsPage() {
 
       const promises = rounds.map((round, idx) => {
         const data = filledData[idx]
-        if (!data) return Promise.resolve()
+        // 기존 저장된 차수의 날짜를 비운 경우 삭제
+        if (!data)
+          return round.id ? deleteMatchingRound(round.id) : Promise.resolve()
 
         const { startsAt, endsAt } = data
 
@@ -347,21 +350,6 @@ function MatchingRoundsPage() {
     }
 
     const filledRounds = rounds.filter((r) => r.startDate || r.endDate)
-
-    // 기존 저장 차수의 날짜를 비워서 저장 시 서버-클라이언트 desync 방지
-    const hasClearedExisting = rounds.some(
-      (r) => r.id !== undefined && (!r.startDate || !r.endDate),
-    )
-    if (hasClearedExisting) {
-      addToast({
-        message: "기존에 저장된 일정은 빈 값으로 수정할 수 없습니다.",
-        color: "red",
-        variant: "deep",
-        type: "default",
-        duration: 3000,
-      })
-      return
-    }
 
     // 날짜/시간 포맷 불완전 시 toISODatetime 크래시 방지
     const datePattern = /^\d{4}-\d{2}-\d{2}$/


### PR DESCRIPTION
## 📸 작업 내용
- 매칭 차수 설정 취소하기 버튼 window.history.back() 으로 인해 페이지를 이탈하던 문제 수정 → 폼 내용만 서버 데이터 기준으로 리셋되도록 변경
- 매칭 차수 날짜 초기화 후 저장 기존에는 에러 토스트만 표시하던 동작을 deleteMatchingRound API 호출로 교체, 빈 값 저장 시 해당 차수 삭제 처리
- 에러 토스트 너비 고정 w-100 에서 w-fit 으로 변경해 메시지 길이에 따라 동적 조절
- 통계 학교 필터링 하드코딩된 SCHOOLS_BY_BRANCH 제거 → /api/v1/chapters/with-schools API 기반 schoolId 직접 비교로 교체