### PR TITLE
fix: 프로젝트 수정 후 목록 캐시 갱신

### DIFF
--- a/src/features/project/list/model/matchingProjectList.ts
+++ b/src/features/project/list/model/matchingProjectList.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { isOperator } from "@/features/auth/model/identity"
 import { getChaptersWithSchools } from "@/features/challenger/api/organization"
+import { projectKeys } from "@/features/project/new/api"
 import { getActiveGisu } from "@/shared/api/gisu"
 import { useViewMe } from "@/shared/view-mode/useViewMe"
 
@@ -125,16 +126,15 @@ export function useMatchingProjectListFilters() {
   )
 
   const { data, isLoading, isError } = useQuery({
-    queryKey: [
-      "matchingProjects",
-      effectiveGisuId,
+    queryKey: projectKeys.list({
+      gisuId: effectiveGisuId,
       page,
-      debouncedSearchQuery,
-      selectedBranch,
-      selectedSchool,
-      selectedParts,
-      selectedRecruitStatus,
-    ],
+      keyword: debouncedSearchQuery,
+      chapterId: selectedBranch,
+      schoolId: selectedSchool,
+      parts: selectedParts,
+      partQuotaStatus: selectedRecruitStatus,
+    }),
     queryFn: () =>
       getMatchingProjects({
         gisuId: effectiveGisuId!,

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -13,6 +13,7 @@ import {
 import { ApplicationDetailModal } from "@/features/application/ui/ApplicationDetailModal"
 import { getProjectDetail } from "@/features/project/list/api/matchingProject"
 import { deleteProject } from "@/features/project/management/api"
+import { invalidateProjectSummaryQueries } from "@/features/project/new/api"
 import MoreVerticalIcon from "@/shared/assets/icon/more/MoreVerticalIcon"
 import { DropdownItem } from "@/shared/ui/dropdown/DropdownItem"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
@@ -104,7 +105,7 @@ export function ProjectManagementMoreMenu({
     mutationFn: () => deleteProject(Number(projectId)),
     onSuccess: () => {
       setDeleteOpen(false)
-      void queryClient.invalidateQueries({ queryKey: ["project", "managed"] })
+      invalidateProjectSummaryQueries(queryClient, Number(projectId))
       void queryClient.invalidateQueries({
         queryKey: [...applicationKeys.all, "managed"],
       })

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -9,7 +9,7 @@ import {
   isCurrentTermPm,
   isSuperAdmin,
 } from "@/features/auth/model/identity"
-import { gisuKeys } from "@/features/project/new/api/queryKeys"
+import { gisuKeys, projectKeys } from "@/features/project/new/api/queryKeys"
 import { getActiveGisu } from "@/shared/api/gisu"
 import { EmptyState } from "@/shared/ui/EmptyState"
 import { SegmentButton } from "@/shared/ui/segment-button/SegmentButton"
@@ -117,7 +117,7 @@ export function ProjectManagementPage() {
     : undefined
 
   const managedQuery = useQuery({
-    queryKey: ["project", "managed", "me", gisuId],
+    queryKey: projectKeys.managedMe(gisuId),
     queryFn: () =>
       getManagedProjects(gisuId!, { size: MANAGED_PROJECTS_PAGE_SIZE }),
     enabled: hasAccess && !!gisuId,

--- a/src/features/project/new/api/index.ts
+++ b/src/features/project/new/api/index.ts
@@ -25,6 +25,7 @@ export {
 
 export { publishProject } from "./projectPublish"
 
+export { invalidateProjectSummaryQueries } from "./queryInvalidation"
 export { gisuKeys, memberKeys, projectKeys } from "./queryKeys"
 
 export {

--- a/src/features/project/new/api/queryInvalidation.ts
+++ b/src/features/project/new/api/queryInvalidation.ts
@@ -1,0 +1,19 @@
+import { projectKeys } from "./queryKeys"
+
+import type { QueryClient } from "@tanstack/react-query"
+
+export function invalidateProjectSummaryQueries(
+  queryClient: QueryClient,
+  projectId?: number,
+) {
+  void queryClient.invalidateQueries({ queryKey: projectKeys.lists() })
+  void queryClient.invalidateQueries({ queryKey: ["matchingProjects"] })
+  void queryClient.invalidateQueries({ queryKey: projectKeys.managed() })
+
+  if (projectId === undefined) return
+
+  void queryClient.invalidateQueries({
+    queryKey: projectKeys.detail(projectId),
+  })
+  void queryClient.invalidateQueries({ queryKey: ["projectDetail", projectId] })
+}

--- a/src/features/project/new/api/queryKeys.ts
+++ b/src/features/project/new/api/queryKeys.ts
@@ -1,5 +1,23 @@
+type ProjectListQueryParams = {
+  gisuId: number | undefined
+  page: number
+  keyword: string
+  chapterId: string | undefined
+  schoolId: string | undefined
+  parts: readonly string[]
+  partQuotaStatus: string | undefined
+}
+
 export const projectKeys = {
   all: ["project"] as const,
+  lists: () => [...projectKeys.all, "list"] as const,
+  list: (params: ProjectListQueryParams) =>
+    [...projectKeys.lists(), params] as const,
+  managed: () => [...projectKeys.all, "managed"] as const,
+  managedMe: (gisuId: number | undefined) =>
+    [...projectKeys.managed(), "me", gisuId] as const,
+  managedCheck: (gisuId: number | undefined) =>
+    [...projectKeys.managedMe(gisuId), "check"] as const,
   draft: (gisuId: number) =>
     [...projectKeys.all, "draft", "me", gisuId] as const,
   detail: (projectId: number) =>

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { isAxiosError } from "axios"
 import {
   forwardRef,
@@ -23,6 +23,7 @@ import { Dropdown } from "@/features/challenger/ui/shared/Dropdown"
 import {
   addProjectMember,
   createProjectDraft,
+  invalidateProjectSummaryQueries,
   removeProjectMember,
   updateProjectDraft,
   uploadFileFlow,
@@ -111,6 +112,7 @@ export const BasicInfoForm = forwardRef<
   const setBasicInfo = useProjectRegisterStore((s) => s.setBasicInfo)
   const basicDraftFields = useProjectRegisterStore((s) => s.basicDraftFields)
   const addToast = useToastStore((s) => s.addToast)
+  const queryClient = useQueryClient()
 
   const [isSaving, setIsSaving] = useState(false)
   const [hasSavedOnce, setHasSavedOnce] = useState(false)
@@ -382,6 +384,7 @@ export const BasicInfoForm = forwardRef<
       }
 
       setPmInfo({ isMultiPm, pm1: pm1Member, pm2: pm2Member })
+      invalidateProjectSummaryQueries(queryClient, resolvedProjectId)
       reset(values, { keepValues: true, keepDirty: false })
       setSavedSnapshot({ pm1: pm1Member, pm2: pm2Member, isMultiPm })
       setHasSavedOnce(true)

--- a/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
+++ b/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query"
 import {
   forwardRef,
   useEffect,
@@ -10,6 +11,7 @@ import { useToastStore } from "@/components/toast/useToastStore"
 import { useProjectPermissions } from "@/features/project/hooks/useProjectPermissions"
 import {
   buildPartQuotasEntries,
+  invalidateProjectSummaryQueries,
   updatePartQuotas,
 } from "@/features/project/new/api"
 import { Button } from "@/shared/ui/Button"
@@ -87,6 +89,7 @@ export const RecruitInfoForm = forwardRef<
   const [isSaving, setIsSaving] = useState(false)
   const [hasSavedOnce, setHasSavedOnce] = useState(false)
   const savedSnapshotRef = useRef(JSON.stringify(storeRecruitInfo))
+  const queryClient = useQueryClient()
 
   useEffect(() => {
     if (isHydrated) {
@@ -150,6 +153,7 @@ export const RecruitInfoForm = forwardRef<
         entries: buildPartQuotasEntries(roleStates),
       })
       setRecruitInfo(roleStates)
+      invalidateProjectSummaryQueries(queryClient, projectId)
       savedSnapshotRef.current = snapshotToSave
       setHasSavedOnce(true)
       if (!silent) {

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -34,6 +34,7 @@ import {
   getMyDraft,
   getProjectDetail,
   gisuKeys,
+  invalidateProjectSummaryQueries,
   projectKeys,
   submitProject,
   transferOwnership,
@@ -205,7 +206,7 @@ function ProjectRegisterPage() {
   }, [gisuId, setGisuId])
 
   const managedCheckQuery = useQuery({
-    queryKey: ["project", "managed", "me", gisuId, "check"],
+    queryKey: projectKeys.managedCheck(gisuId),
     queryFn: () => getManagedProjects(Number(gisuId)),
     enabled: isPm && !isEditMode && !!gisuId,
   })
@@ -316,7 +317,7 @@ function ProjectRegisterPage() {
     },
     onSuccess: () => {
       applicationFormRef.current?.resetDirty()
-      void queryClient.invalidateQueries({ queryKey: ["project", "managed"] })
+      invalidateProjectSummaryQueries(queryClient, projectId ?? undefined)
       setShowSuccessModal(true)
     },
     onError: (error) => {
@@ -456,7 +457,9 @@ function ProjectRegisterPage() {
   const handleSuccessConfirm = async () => {
     setShowSuccessModal(false)
     reset()
-    queryClient.removeQueries({ queryKey: ["project", "managed"] })
+    queryClient.removeQueries({ queryKey: projectKeys.managed() })
+    queryClient.removeQueries({ queryKey: projectKeys.lists() })
+    queryClient.removeQueries({ queryKey: ["matchingProjects"] })
     if (isEditMode && editProjectId) {
       queryClient.removeQueries({ queryKey: projectKeys.detail(editProjectId) })
       queryClient.removeQueries({


### PR DESCRIPTION
## 📸 작업 내용

> 작업한 내용을 두괄식으로 작성해주세요

- 프로젝트 수정 저장 후 `프로젝트 목록` 화면에서 오래된 프로젝트 정보가 유지되는 캐시 문제를 수정했습니다.
- 프로젝트 목록, 관리 목록, 상세 조회 캐시를 프로젝트 도메인 query key로 정리했습니다.
- 프로젝트 기본 정보 저장, 모집 정보 저장, 수정 완료, 삭제 성공 시 관련 프로젝트 캐시를 함께 무효화하도록 공통 helper를 추가했습니다.

## 🎞️ 주요 코드 설명

<!-- 코드 설명, 없다면 생략해도 됩니다! -->

> 설명이 필요한 코드 위주로 작성해주세요

### 프로젝트 목록 query key 정리

```TypeScript
queryKey: projectKeys.list({
  gisuId: effectiveGisuId,
  page,
  keyword: debouncedSearchQuery,
  chapterId: selectedBranch,
  schoolId: selectedSchool,
  parts: selectedParts,
  partQuotaStatus: selectedRecruitStatus,
})
```

- 기존 `["matchingProjects", ...]` 형태의 분산된 key를 `projectKeys.list()`로 이동했습니다.
- 프로젝트 관련 캐시를 `projectKeys` prefix 기준으로 무효화할 수 있게 했습니다.

### 프로젝트 요약 캐시 무효화 공통화

```TypeScript
invalidateProjectSummaryQueries(queryClient, projectId)
```

- 프로젝트 목록, 관리 목록, 상세 조회 캐시를 한 번에 갱신합니다.
- 기존 런타임에 남아 있을 수 있는 legacy `["matchingProjects"]` 캐시도 함께 무효화합니다.

## 🖥️ 구현화면

> localhost 캡쳐 사진을 첨부해 주세요.

캐시 무효화 로직 수정이라 별도 화면 캡쳐는 첨부하지 않았습니다.

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #226
- Closes #226
