### PR TITLE
✨ feat: 프로젝트 공개(publish) 운영진 화면 연동

### DIFF
--- a/src/features/project/list/model/matchingProject.ts
+++ b/src/features/project/list/model/matchingProject.ts
@@ -1,3 +1,5 @@
+import type { ProjectStatus } from "../api/matchingProject"
+
 export type ProjectRecruitRow = {
   part: string
   current: number
@@ -28,4 +30,5 @@ export type MatchingProject = {
   partQuotaStatus?: PartQuotaStatus
   isApplied?: boolean
   externalLink?: string | null
+  status?: ProjectStatus
 }

--- a/src/features/project/management/ui/ProjectManagementCard.tsx
+++ b/src/features/project/management/ui/ProjectManagementCard.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 
 import { ProjectDetailCard } from "@/features/project/list/ui/ProjectDetailCard"
 import { ProjectLogo } from "@/shared/assets/icon/logo/ProjectLogo"
+import { ProjectStatusChip } from "@/shared/ui/chip/ProjectStatusChip"
 import { RecruitStatusChip } from "@/shared/ui/chip/RecruitStatusChip"
 import MemberCount from "@/shared/ui/MemberCount"
 import { Modal } from "@/shared/ui/Modal"
@@ -15,6 +16,7 @@ interface ProjectManagementCardProps {
   data: MatchingProject
   canDeleteProject: boolean
   canEditProject: boolean
+  canPublishProject: boolean
   isPermissionLoading: boolean
 }
 
@@ -22,6 +24,7 @@ export function ProjectManagementCard({
   data,
   canDeleteProject,
   canEditProject,
+  canPublishProject,
   isPermissionLoading,
 }: ProjectManagementCardProps) {
   const cover = data.coverImage
@@ -64,14 +67,17 @@ export function ProjectManagementCard({
                 <span className="text-heading-7-semibold text-teal-gray-900">
                   {data.title}
                 </span>
+                <ProjectStatusChip status={data.status} />
               </div>
               <div onClick={(e) => e.stopPropagation()}>
                 <ProjectManagementMoreMenu
                   projectId={data.id}
                   projectName={data.title}
                   chapterName={data.branch}
+                  status={data.status}
                   canDeleteProject={canDeleteProject}
                   canEditProject={canEditProject}
+                  canPublishProject={canPublishProject}
                   isPermissionLoading={isPermissionLoading}
                 />
               </div>

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -136,7 +136,7 @@ export function ProjectManagementMoreMenu({
     },
   })
 
-  const publishMutation = useMutation({
+    mutationFn: () => publishProject(numericProjectId),
     mutationFn: () => publishProject(Number(projectId)),
     onSuccess: () => {
       setPublishOpen(false)

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
+import { isAxiosError } from "axios"
 import { Popover } from "radix-ui"
 import { useMemo, useState } from "react"
 
@@ -13,6 +14,7 @@ import {
 import { ApplicationDetailModal } from "@/features/application/ui/ApplicationDetailModal"
 import { getProjectDetail } from "@/features/project/list/api/matchingProject"
 import { deleteProject } from "@/features/project/management/api"
+import { publishProject } from "@/features/project/new/api/projectPublish"
 import MoreVerticalIcon from "@/shared/assets/icon/more/MoreVerticalIcon"
 import { DropdownItem } from "@/shared/ui/dropdown/DropdownItem"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
@@ -23,13 +25,16 @@ import type {
   ProjectApplication,
   Role,
 } from "@/features/application/model/types"
+import type { ProjectStatus } from "@/features/project/list/api/matchingProject"
 
 interface ProjectManagementMoreMenuProps {
   projectId: string
   projectName: string
   chapterName: string
+  status?: ProjectStatus
   canDeleteProject: boolean
   canEditProject: boolean
+  canPublishProject: boolean
   isPermissionLoading: boolean
 }
 
@@ -37,14 +42,17 @@ export function ProjectManagementMoreMenu({
   projectId,
   projectName,
   chapterName,
+  status,
   canDeleteProject,
   canEditProject,
+  canPublishProject,
   isPermissionLoading,
 }: ProjectManagementMoreMenuProps) {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [popoverOpen, setPopoverOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
+  const [publishOpen, setPublishOpen] = useState(false)
   const [applicationOpen, setApplicationOpen] = useState(false)
   const addToast = useToastStore((s) => s.addToast)
 
@@ -127,10 +135,45 @@ export function ProjectManagementMoreMenu({
     },
   })
 
+  const publishMutation = useMutation({
+    mutationFn: () => publishProject(Number(projectId)),
+    onSuccess: () => {
+      setPublishOpen(false)
+      void queryClient.invalidateQueries({ queryKey: ["project", "managed"] })
+      void queryClient.invalidateQueries({ queryKey: ["project"] })
+      addToast({
+        message: "프로젝트가 공개되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    },
+    onError: (error) => {
+      const serverMessage = isAxiosError(error)
+        ? (error.response?.data as { message?: string } | undefined)?.message
+        : undefined
+      addToast({
+        message:
+          serverMessage ?? "프로젝트 공개에 실패했습니다. 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    },
+  })
+
   const handleDeleteClick = () => {
     if (!canDeleteProject || isPermissionLoading) return
     setPopoverOpen(false)
     setDeleteOpen(true)
+  }
+
+  const handlePublishClick = () => {
+    if (!canPublishProject || isPermissionLoading) return
+    setPopoverOpen(false)
+    setPublishOpen(true)
   }
 
   const handleApplicationClick = () => {
@@ -224,6 +267,15 @@ export function ProjectManagementMoreMenu({
                   onClick={onClick}
                 />
               ))}
+              {status === "PENDING_REVIEW" &&
+                (isPermissionLoading || canPublishProject) && (
+                  <DropdownItem
+                    label="공개하기"
+                    disabled={isPermissionLoading}
+                    onClick={handlePublishClick}
+                    className="text-teal-500"
+                  />
+                )}
               {(isPermissionLoading || canDeleteProject) && (
                 <DropdownItem
                   label="삭제"
@@ -262,6 +314,23 @@ export function ProjectManagementMoreMenu({
         onOpenChange={setDeleteOpen}
         onCancel={() => setDeleteOpen(false)}
         onConfirm={() => deleteMutation.mutate()}
+      />
+
+      <CtaModal
+        open={publishOpen}
+        title="프로젝트 공개"
+        content={
+          <>
+            공개하면 챌린저들이 지원할 수 있습니다. <br /> '{projectName}'을
+            공개하시겠습니까?
+          </>
+        }
+        cancelText="돌아가기"
+        confirmText="공개하기"
+        confirmLoading={publishMutation.isPending}
+        onOpenChange={setPublishOpen}
+        onCancel={() => setPublishOpen(false)}
+        onConfirm={() => publishMutation.mutate()}
       />
     </>
   )

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -14,8 +14,8 @@ import {
 import { ApplicationDetailModal } from "@/features/application/ui/ApplicationDetailModal"
 import { getProjectDetail } from "@/features/project/list/api/matchingProject"
 import { deleteProject } from "@/features/project/management/api"
-import { publishProject } from "@/features/project/new/api/projectPublish"
 import { invalidateProjectSummaryQueries } from "@/features/project/new/api"
+import { publishProject } from "@/features/project/new/api/projectPublish"
 import MoreVerticalIcon from "@/shared/assets/icon/more/MoreVerticalIcon"
 import { DropdownItem } from "@/shared/ui/dropdown/DropdownItem"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
@@ -140,8 +140,7 @@ export function ProjectManagementMoreMenu({
     mutationFn: () => publishProject(Number(projectId)),
     onSuccess: () => {
       setPublishOpen(false)
-      void queryClient.invalidateQueries({ queryKey: ["project", "managed"] })
-      void queryClient.invalidateQueries({ queryKey: ["project"] })
+      invalidateProjectSummaryQueries(queryClient, Number(projectId))
       addToast({
         message: "프로젝트가 공개되었습니다.",
         color: "primary",

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -21,6 +21,7 @@ import { ProjectManagementCard } from "./ProjectManagementCard"
 import { ProjectManagementSubTitle } from "./ProjectManagementSubTitle"
 
 import type { ResourcePermissionQuery } from "@/features/auth/api/permissions"
+import type { ProjectStatus } from "@/features/project/list/api/matchingProject"
 import type { MatchingProject } from "@/features/project/list/model/matchingProject"
 
 const FE_PART_LABELS = new Set(["Web", "iOS", "Android"])
@@ -44,6 +45,7 @@ type ProjectSummaryInput = {
   name?: string | null
   description?: string | null
   thumbnailImageUrl?: string | null
+  status?: ProjectStatus | null
   productOwner?: {
     nickname?: string | null
     name?: string | null
@@ -76,6 +78,7 @@ function toMatchingProject(item: ProjectSummaryInput): MatchingProject {
     title: item.name ?? "",
     description: item.description ?? "",
     authorSchoolLine: ownerLine,
+    status: item.status ?? undefined,
     coverImage: item.thumbnailImageUrl ? { src: item.thumbnailImageUrl } : null,
     recruitRows: (item.partQuotas ?? [])
       .slice()
@@ -175,6 +178,7 @@ export function ProjectManagementPage() {
       return {
         canDeleteProject: false,
         canEditProject: false,
+        canPublishProject: false,
       }
     }
 
@@ -188,6 +192,11 @@ export function ProjectManagementPage() {
         resourceType: "PROJECT",
         resourceId: projectId,
         permissionType: "EDIT",
+      }),
+      canPublishProject: projectPermissionsQuery.hasPermission({
+        resourceType: "PROJECT",
+        resourceId: projectId,
+        permissionType: "MANAGE",
       }),
     }
   }

--- a/src/shared/ui/chip/ProjectStatusChip.tsx
+++ b/src/shared/ui/chip/ProjectStatusChip.tsx
@@ -1,0 +1,40 @@
+import { cva } from "class-variance-authority"
+
+import { cn } from "@/shared/lib/utils"
+
+import type { ProjectStatus } from "@/features/project/list/api/matchingProject"
+
+const projectStatusChipVariants = cva(
+  "inline-flex items-center justify-center rounded-md px-2 py-0.5 text-center text-body-3-medium",
+)
+
+const STATUS_CHIP: Partial<
+  Record<ProjectStatus, { label: string; className: string }>
+> = {
+  IN_PROGRESS: { label: "공개됨", className: "bg-teal-100 text-teal-600" },
+  PENDING_REVIEW: {
+    label: "검토 대기",
+    className: "bg-error-100 text-error-500",
+  },
+}
+
+interface ProjectStatusChipProps {
+  status?: ProjectStatus
+  className?: string
+}
+
+export function ProjectStatusChip({
+  status,
+  className,
+}: ProjectStatusChipProps) {
+  const chip = status ? STATUS_CHIP[status] : undefined
+  if (!chip) return null
+
+  return (
+    <span
+      className={cn(projectStatusChipVariants(), chip.className, className)}
+    >
+      {chip.label}
+    </span>
+  )
+}


### PR DESCRIPTION
## 📸 작업 내용

> 운영진 관리 화면에서 검토 대기(PENDING_REVIEW) 프로젝트를 공개(publish)할 수 있도록 연동했습니다.

`POST /api/v1/projects/{projectId}/publish` 는 API 함수만 존재하고 어디서도 호출되지 않는 데드 코드였습니다. PM이 제출(submit)한 `PENDING_REVIEW` 프로젝트를 운영진이 검토 후 공개하는 단계가 프론트에 없어, 이를 운영진 관리 화면에 연동했습니다.

- 관리 카드 더보기 메뉴에 **공개하기** 액션 추가
  - `MANAGE` 권한 + `PENDING_REVIEW` 상태일 때만 노출 (PM에게는 미노출, API도 PM 차단)
- 공개 확인 모달 + publish mutation
  - 성공 시 관리/목록 캐시 무효화 + 성공 토스트
  - 실패 시 **서버 응답 메시지**를 토스트로 표시
- 관리 카드에 프로젝트 상태 칩(**공개됨 / 검토 대기**) 표시
- `MatchingProject` 타입에 `status` 전달

## 🎞️ 주요 코드 설명

### publish mutation — 실패 시 서버 메시지 노출

```TypeScript
const publishMutation = useMutation({
  mutationFn: () => publishProject(Number(projectId)),
  onSuccess: () => {
    setPublishOpen(false)
    void queryClient.invalidateQueries({ queryKey: ["project", "managed"] })
    void queryClient.invalidateQueries({ queryKey: ["project"] })
    addToast({ message: "프로젝트가 공개되었습니다.", /* ... */ })
  },
  onError: (error) => {
    const serverMessage = isAxiosError(error)
      ? (error.response?.data as { message?: string } | undefined)?.message
      : undefined
    addToast({
      message: serverMessage ?? "프로젝트 공개에 실패했습니다. 다시 시도해주세요.",
      /* ... */
    })
  },
})
```

### 노출 조건 — PENDING_REVIEW + MANAGE 권한일 때만

```TypeScript
{status === "PENDING_REVIEW" &&
  (isPermissionLoading || canPublishProject) && (
    <DropdownItem label="공개하기" onClick={handlePublishClick} className="text-teal-500" />
  )}
```

## 🖥️ 구현화면

> 로컬(5173) 운영진(superadmin) 계정으로 검증 완료

- PENDING_REVIEW 카드 더보기에 "공개하기" 노출 / IN_PROGRESS 카드엔 미노출
- 상태 칩: PENDING_REVIEW → "검토 대기", IN_PROGRESS → "공개됨"
- 정원 미설정 프로젝트 공개 시도 → 서버 메시지 토스트 노출: "공개하려면 파트별 정원이 1개 이상 등록되어 있어야 합니다."

|        공개하기 노출/미노출        |        상태 칩 / 실패 토스트         |
| :-------------------------: | :-------------------------: |
| <img src = "" width ="250"> | <img src = "" width ="250"> |

## 🔗 연결된 이슈

- Connected: #228
