### PR TITLE
🐛 fix: 머지 충돌로 깨진 publishMutation 선언 복구 (develop 빌드 실패 hotfix)

### DIFF
--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -136,7 +136,7 @@ export function ProjectManagementMoreMenu({
     },
   })
 
-    mutationFn: () => publishProject(numericProjectId),
+  const publishMutation = useMutation({
     mutationFn: () => publishProject(Number(projectId)),
     onSuccess: () => {
       setPublishOpen(false)

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -137,10 +137,10 @@ export function ProjectManagementMoreMenu({
   })
 
   const publishMutation = useMutation({
-    mutationFn: () => publishProject(Number(projectId)),
+    mutationFn: () => publishProject(numericProjectId),
     onSuccess: () => {
       setPublishOpen(false)
-      invalidateProjectSummaryQueries(queryClient, Number(projectId))
+      invalidateProjectSummaryQueries(queryClient, numericProjectId)
       addToast({
         message: "프로젝트가 공개되었습니다.",
         color: "primary",


### PR DESCRIPTION
## 📸 작업 내용

> develop 빌드 실패(Amplify 배포 #89 실패)를 복구합니다.

PR #229를 develop에 머지하는 과정에서 충돌 해결이 잘못되어, `ProjectManagementMoreMenu.tsx`의 `const publishMutation = useMutation({` 선언이 누락되고 `mutationFn`이 중복되었습니다. 이로 인해 `tsc` 빌드가 실패했습니다.

```
ProjectManagementMoreMenu.tsx(140,15): error TS1005: ';' expected.
ProjectManagementMoreMenu.tsx(141,14): error TS1005: ';' expected.
ELIFECYCLE  Command failed with exit code 2
!!! Build failed
```

- 깨진 `publishMutation` 선언부를 복구
- `pnpm install --frozen-lockfile` + `pnpm run build` 로컬 검증 통과 (Amplify와 동일 조건)

## 🔗 연결된 이슈

- 관련: #229 (머지 후 빌드 깨짐 hotfix)
