### PR TITLE
🐛 fix: 지원폼 수정 시 질문/선택지 서버 ID 보존

### DIFF
--- a/src/features/project/list/model/applicationQuestions.mock.ts
+++ b/src/features/project/list/model/applicationQuestions.mock.ts
@@ -68,7 +68,7 @@ const DEFAULT_SECTIONS: Section[] = [
         caption: "",
         fieldType: "checkbox",
         required: true,
-        options: ["Figma", "Illustration"],
+        options: [{ content: "Figma" }, { content: "Illustration" }],
       },
       {
         id: "q-d2",
@@ -92,7 +92,7 @@ const DEFAULT_SECTIONS: Section[] = [
         caption: "",
         fieldType: "checkbox",
         required: true,
-        options: ["Figma", "Github"],
+        options: [{ content: "Figma" }, { content: "Github" }],
       },
       {
         id: "q-f2",
@@ -116,7 +116,13 @@ const DEFAULT_SECTIONS: Section[] = [
         caption: "",
         fieldType: "radio",
         required: true,
-        options: ["Java", "Kotlin", "Python", "Node.js", "Go"],
+        options: [
+          { content: "Java" },
+          { content: "Kotlin" },
+          { content: "Python" },
+          { content: "Node.js" },
+          { content: "Go" },
+        ],
       },
       {
         id: "q-b2",
@@ -125,12 +131,12 @@ const DEFAULT_SECTIONS: Section[] = [
         fieldType: "checkbox",
         required: true,
         options: [
-          "Spring Boot",
-          "Django",
-          "FastAPI",
-          "NestJS",
-          "Docker",
-          "AWS",
+          { content: "Spring Boot" },
+          { content: "Django" },
+          { content: "FastAPI" },
+          { content: "NestJS" },
+          { content: "Docker" },
+          { content: "AWS" },
         ],
       },
       {

--- a/src/features/project/list/model/applicationQuestions.mock.ts
+++ b/src/features/project/list/model/applicationQuestions.mock.ts
@@ -92,7 +92,7 @@ const DEFAULT_SECTIONS: Section[] = [
         caption: "",
         fieldType: "checkbox",
         required: true,
-        options: [{ content: "Figma" }, { content: "Github" }],
+        options: [{ content: "Figma" }, { content: "GitHub" }],
       },
       {
         id: "q-f2",

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -106,8 +106,9 @@ function buildAnswerPayload(
 
     if (question.fieldType === "radio") {
       if (typeof value !== "string" || !value) return [base]
-      const idx = question.options.indexOf(value)
-      const optionId = idx !== -1 ? question.optionIds?.[idx] : undefined
+      const optionId = question.options.find(
+        (o) => o.content === value,
+      )?.optionId
       if (optionId == null) return [base]
       return [{ ...base, selectedOptionIds: [optionId] }]
     }
@@ -115,8 +116,9 @@ function buildAnswerPayload(
     if (question.fieldType === "checkbox") {
       if (!Array.isArray(value) || value.length === 0) return [base]
       const selectedIds = value.flatMap((content) => {
-        const idx = question.options.indexOf(content)
-        const optionId = idx !== -1 ? question.optionIds?.[idx] : undefined
+        const optionId = question.options.find(
+          (o) => o.content === content,
+        )?.optionId
         return optionId != null ? [optionId] : []
       })
       if (selectedIds.length === 0) return [base]
@@ -448,18 +450,18 @@ export function ProjectApplyModal({
             <div className={OPTION_LIST_CLASS}>
               {q.options.map((opt) => (
                 <CheckboxList
-                  key={opt}
-                  checked={Array.isArray(value) && value.includes(opt)}
+                  key={opt.optionId ?? opt.content}
+                  checked={Array.isArray(value) && value.includes(opt.content)}
                   onChange={(checked) => {
                     const current = Array.isArray(value) ? value : []
                     onChange(
                       checked
-                        ? [...current, opt]
-                        : current.filter((o) => o !== opt),
+                        ? [...current, opt.content]
+                        : current.filter((o) => o !== opt.content),
                     )
                   }}
                 >
-                  {opt}
+                  {opt.content}
                 </CheckboxList>
               ))}
             </div>
@@ -476,13 +478,13 @@ export function ProjectApplyModal({
             <div className={OPTION_LIST_CLASS}>
               {q.options.map((opt) => (
                 <RadioList
-                  key={opt}
-                  checked={value === opt}
+                  key={opt.optionId ?? opt.content}
+                  checked={value === opt.content}
                   onChange={(checked) => {
-                    if (checked) onChange(opt)
+                    if (checked) onChange(opt.content)
                   }}
                 >
-                  {opt}
+                  {opt.content}
                 </RadioList>
               ))}
             </div>

--- a/src/features/project/list/ui/apply-modal/RecruitQuestionsViewModal.tsx
+++ b/src/features/project/list/ui/apply-modal/RecruitQuestionsViewModal.tsx
@@ -144,8 +144,12 @@ function renderPreviewField(q: Question) {
       return (
         <div className={OPTION_LIST_CLASS}>
           {q.options.map((opt) => (
-            <CheckboxList key={opt} checked={false} onChange={() => {}}>
-              {opt}
+            <CheckboxList
+              key={opt.optionId ?? opt.content}
+              checked={false}
+              onChange={() => {}}
+            >
+              {opt.content}
             </CheckboxList>
           ))}
         </div>
@@ -154,8 +158,12 @@ function renderPreviewField(q: Question) {
       return (
         <div className={OPTION_LIST_CLASS}>
           {q.options.map((opt) => (
-            <RadioList key={opt} checked={false} onChange={() => {}}>
-              {opt}
+            <RadioList
+              key={opt.optionId ?? opt.content}
+              checked={false}
+              onChange={() => {}}
+            >
+              {opt.content}
             </RadioList>
           ))}
         </div>

--- a/src/features/project/new/api/adapters.test.ts
+++ b/src/features/project/new/api/adapters.test.ts
@@ -136,7 +136,7 @@ describe("buildUpsertApplicationFormBody", () => {
       ...commonQ,
       id: "q-r",
       fieldType: "radio" as const,
-      options: ["A", "B"],
+      options: [{ content: "A" }, { content: "B" }],
     }
     const result = buildUpsertApplicationFormBody([radioQ], [])
     expect(result.sections[0]!.questions[0]!.type).toBe("RADIO")
@@ -153,5 +153,41 @@ describe("buildUpsertApplicationFormBody", () => {
     const qs = result.sections[0]!.questions
     expect(qs[0]!.orderNo).toBe(0)
     expect(qs[1]!.orderNo).toBe(1)
+  })
+
+  it("기존 질문 수정 시 questionId를 payload에 포함", () => {
+    const editedQ = {
+      id: "q-1",
+      questionId: 42,
+      title: "수정된 질문",
+      caption: "",
+      fieldType: "text" as const,
+      required: true,
+      options: [],
+    }
+    const result = buildUpsertApplicationFormBody([editedQ], [])
+    expect(result.sections[0]!.questions[0]!.questionId).toBe(42)
+  })
+
+  it("신규 질문은 questionId 없이 전송 (생략)", () => {
+    const result = buildUpsertApplicationFormBody([commonQ], [])
+    expect(result.sections[0]!.questions[0]!.questionId).toBeUndefined()
+  })
+
+  it("옵션의 optionId를 보존하여 전송하고, 없는 옵션은 생략", () => {
+    const radioQ = {
+      id: "q-r",
+      questionId: 7,
+      title: "단일 선택",
+      caption: "",
+      fieldType: "radio" as const,
+      required: false,
+      options: [{ content: "A", optionId: 100 }, { content: "B" }],
+    }
+    const result = buildUpsertApplicationFormBody([radioQ], [])
+    const opts = result.sections[0]!.questions[0]!.options
+    expect(opts[0]).toMatchObject({ content: "A", orderNo: 0, optionId: 100 })
+    expect(opts[1]).toMatchObject({ content: "B", orderNo: 1 })
+    expect(opts[1]!.optionId).toBeUndefined()
   })
 })

--- a/src/features/project/new/api/adapters.ts
+++ b/src/features/project/new/api/adapters.ts
@@ -113,7 +113,7 @@ export function mapApplicationFormToSections(
             )
 
       const questions: Question[] = apiSection.questions
-        .slice()
+        .filter((apiQ) => apiQ.questionId != null)
         .sort((a, b) => (a.orderNo ?? 0) - (b.orderNo ?? 0))
         .map((apiQ) => {
           const sortedOptions = apiQ.options

--- a/src/features/project/new/api/adapters.ts
+++ b/src/features/project/new/api/adapters.ts
@@ -59,12 +59,17 @@ export function buildPartQuotasEntries(
 
 function toApiQuestion(q: Question, idx: number): ApplicationQuestionItem {
   return {
+    ...(q.questionId !== undefined && { questionId: q.questionId }),
     type: FIELD_TYPE_TO_API[q.fieldType],
     title: q.title,
     description: q.caption || undefined,
     isRequired: q.required,
     orderNo: idx,
-    options: q.options.map((content, i) => ({ content, orderNo: i })),
+    options: q.options.map((opt, i) => ({
+      content: opt.content,
+      orderNo: i,
+      ...(opt.optionId !== undefined && { optionId: opt.optionId }),
+    })),
   }
 }
 
@@ -116,14 +121,15 @@ export function mapApplicationFormToSections(
             .sort((a, b) => (a.orderNo ?? 0) - (b.orderNo ?? 0))
           return {
             id: String(apiQ.questionId),
+            questionId: apiQ.questionId ?? undefined,
             title: apiQ.title,
             caption: apiQ.description ?? "",
             fieldType: API_FIELD_TYPE_TO_UI[apiQ.type],
             required: apiQ.isRequired ?? false,
-            options: sortedOptions.map((o) => o.content),
-            optionIds: sortedOptions
-              .map((o) => o.optionId)
-              .filter((id): id is number => id != null),
+            options: sortedOptions.map((o) => ({
+              content: o.content,
+              optionId: o.optionId ?? undefined,
+            })),
           }
         })
 

--- a/src/features/project/new/model/applicationFormHydrator.ts
+++ b/src/features/project/new/model/applicationFormHydrator.ts
@@ -31,7 +31,7 @@ const ALLOWED_PARTS_TO_SECTION_ID: Record<string, string> = {
 }
 
 function toQuestion(apiQ: ApplicationQuestionItem): Question {
-  const sortedOptions = [...apiQ.options].sort(
+  const sortedOptions = [...(apiQ.options ?? [])].sort(
     (a, b) => (a.orderNo ?? 0) - (b.orderNo ?? 0),
   )
   return {

--- a/src/features/project/new/model/applicationFormHydrator.ts
+++ b/src/features/project/new/model/applicationFormHydrator.ts
@@ -31,13 +31,20 @@ const ALLOWED_PARTS_TO_SECTION_ID: Record<string, string> = {
 }
 
 function toQuestion(apiQ: ApplicationQuestionItem): Question {
+  const sortedOptions = [...apiQ.options].sort(
+    (a, b) => (a.orderNo ?? 0) - (b.orderNo ?? 0),
+  )
   return {
     id: genId(),
+    questionId: apiQ.questionId ?? undefined,
     title: apiQ.title,
     caption: apiQ.description ?? "",
     fieldType: API_TYPE_TO_FIELD[apiQ.type] ?? "text",
     required: apiQ.isRequired ?? false,
-    options: apiQ.options.map((o) => o.content),
+    options: sortedOptions.map((o) => ({
+      content: o.content,
+      optionId: o.optionId ?? undefined,
+    })),
   }
 }
 

--- a/src/features/project/new/model/applicationQuestion.ts
+++ b/src/features/project/new/model/applicationQuestion.ts
@@ -1,13 +1,18 @@
 export type FieldType = "text" | "radio" | "checkbox" | "file" | "portfolio"
 
+export interface QuestionOption {
+  content: string
+  optionId?: number
+}
+
 export interface Question {
   id: string
+  questionId?: number
   title: string
   caption: string
   fieldType: FieldType
   required: boolean
-  options: string[]
-  optionIds?: number[]
+  options: QuestionOption[]
 }
 
 export interface Section {
@@ -63,7 +68,7 @@ export function validateQuestion(
         questionId: question.id,
       }
     }
-    if (question.options.some((opt) => opt.trim() === "")) {
+    if (question.options.some((opt) => opt.content.trim() === "")) {
       return {
         message: `${locationLabel} ${questionNumber}번 질문에 비어있는 옵션이 있습니다.`,
         questionId: question.id,

--- a/src/features/project/new/ui/application/QuestionCard.tsx
+++ b/src/features/project/new/ui/application/QuestionCard.tsx
@@ -14,7 +14,7 @@ import type { Question } from "@/features/project/new/model/applicationQuestion"
 
 interface QuestionFieldRendererProps {
   question: Question
-  onOptionsChange: (opts: string[]) => void
+  onOptionsChange: (opts: Question["options"]) => void
 }
 
 function QuestionFieldRenderer({

--- a/src/routes/test/checkbox.tsx
+++ b/src/routes/test/checkbox.tsx
@@ -82,7 +82,10 @@ function CheckboxListRow({
 }
 
 function CheckboxFieldListSection() {
-  const [options, setOptions] = useState(["옵션 1", "옵션 2"])
+  const [options, setOptions] = useState([
+    { content: "옵션 1" },
+    { content: "옵션 2" },
+  ])
   return <CheckboxFieldList options={options} onOptionsChange={setOptions} />
 }
 

--- a/src/routes/test/question-form.tsx
+++ b/src/routes/test/question-form.tsx
@@ -66,7 +66,7 @@ function TextFormSection({
 function RadioFormSection() {
   const [title, setTitle] = useState("단일 선택 질문을 작성하세요")
   const [caption, setCaption] = useState("")
-  const [options, setOptions] = useState(["옵션 1"])
+  const [options, setOptions] = useState([{ content: "옵션 1" }])
   const [required, setRequired] = useState(false)
 
   return (
@@ -89,7 +89,7 @@ function RadioFormSection() {
 function CheckboxFormSection() {
   const [title, setTitle] = useState("복수 선택 질문을 작성하세요")
   const [caption, setCaption] = useState("")
-  const [options, setOptions] = useState(["옵션 1"])
+  const [options, setOptions] = useState([{ content: "옵션 1" }])
   const [required, setRequired] = useState(false)
 
   return (

--- a/src/shared/ui/question-field/CheckboxFieldList.tsx
+++ b/src/shared/ui/question-field/CheckboxFieldList.tsx
@@ -3,9 +3,14 @@ import { cn } from "@/shared/lib/utils"
 
 import { AddOptionButton } from "../input/checkbox/AddOptionButton"
 
+interface CheckboxFieldListOption {
+  content: string
+  optionId?: number
+}
+
 interface CheckboxFieldListProps {
-  options: string[]
-  onOptionsChange: (options: string[]) => void
+  options: CheckboxFieldListOption[]
+  onOptionsChange: (options: CheckboxFieldListOption[]) => void
   className?: string
 }
 
@@ -15,11 +20,13 @@ export function CheckboxFieldList({
   className,
 }: CheckboxFieldListProps) {
   function updateOption(index: number, value: string) {
-    onOptionsChange(options.map((opt, i) => (i === index ? value : opt)))
+    onOptionsChange(
+      options.map((opt, i) => (i === index ? { ...opt, content: value } : opt)),
+    )
   }
 
   function addOption() {
-    onOptionsChange([...options, ""])
+    onOptionsChange([...options, { content: "" }])
   }
 
   function removeOption(index: number) {
@@ -44,7 +51,7 @@ export function CheckboxFieldList({
           />
           <input
             type="text"
-            value={opt}
+            value={opt.content}
             onChange={(e) => updateOption(i, e.target.value)}
             placeholder={`옵션 ${i + 1}`}
             className="text-body-2-regular text-teal-gray-700 placeholder:text-teal-gray-400 flex-1 bg-transparent outline-none"

--- a/src/shared/ui/question-field/RadioFieldList.tsx
+++ b/src/shared/ui/question-field/RadioFieldList.tsx
@@ -3,9 +3,14 @@ import { cn } from "@/shared/lib/utils"
 
 import { AddRadioOptionButton } from "../input/radio/AddRadioOptionButton"
 
+interface RadioFieldListOption {
+  content: string
+  optionId?: number
+}
+
 interface RadioFieldListProps {
-  options: string[]
-  onOptionsChange: (options: string[]) => void
+  options: RadioFieldListOption[]
+  onOptionsChange: (options: RadioFieldListOption[]) => void
   className?: string
 }
 
@@ -15,11 +20,13 @@ export function RadioFieldList({
   className,
 }: RadioFieldListProps) {
   function updateOption(index: number, value: string) {
-    onOptionsChange(options.map((opt, i) => (i === index ? value : opt)))
+    onOptionsChange(
+      options.map((opt, i) => (i === index ? { ...opt, content: value } : opt)),
+    )
   }
 
   function addOption() {
-    onOptionsChange([...options, ""])
+    onOptionsChange([...options, { content: "" }])
   }
 
   function removeOption(index: number) {
@@ -44,7 +51,7 @@ export function RadioFieldList({
           />
           <input
             type="text"
-            value={opt}
+            value={opt.content}
             onChange={(e) => updateOption(i, e.target.value)}
             placeholder={`옵션 ${i + 1}`}
             className="text-body-2-regular text-teal-gray-700 placeholder:text-teal-gray-400 flex-1 bg-transparent outline-none"


### PR DESCRIPTION
## 개요

지원폼(application-form)을 수정 후 저장할 때 기존 질문/선택지의 서버 ID(`questionId`/`optionId`)가 누락되어, `PUT /v1/projects/:id/application-form`(upsert)이 항목을 삭제 후 재생성하던 문제를 수정합니다.

## 원인

- `applicationFormHydrator`가 폼을 불러올 때 서버 `questionId`를 버리고 `genId()`로 대체, `optionId` 미보존
- `adapters.toApiQuestion`이 저장 시 `questionId`/`optionId` 미전송
- `Question` 타입에 서버 ID 보존 필드 부재 (`sectionId`만 정상 왕복)

## 변경 사항

- 옵션을 `{ content, optionId }` 객체 배열로 통합 (`options`/`optionIds` 병렬 배열 제거 → 추가/삭제 시 인덱스 정합성 구조적 보장)
- `Question.questionId` 필드 추가
- hydrator/adapter 양방향으로 `questionId`/`optionId` 보존·전송
- 지원자 답변 흐름(`ProjectApplyModal`)을 content 기반 매칭으로 조정
- 옵션 ID 왕복 회귀 테스트 추가

## 검증

- 타입체크(`tsc -b`) 통과
- ESLint 통과
- adapters 테스트 21개 통과 (회귀 테스트 3개 포함)

Closes #231