### PR TITLE
🐛 fix: currentCount를 partGroups 멤버 수로 계산하여 수동 배정/해제 반영

### DIFF
--- a/src/features/matching/model/matchingStatusMapper.ts
+++ b/src/features/matching/model/matchingStatusMapper.ts
@@ -183,7 +183,10 @@ function toMatchingProject(
     : "springboot"
 
   const totalCount = designQuota + feQuota + beQuota
-  const currentCount = applicants.filter((a) => a.status === "APPROVED").length
+  // 실제 배정된 멤버 수 (수동 배정 포함, 매칭 해제 즉시 반영)
+  const currentCount = members
+    ? members.partGroups.reduce((sum, g) => sum + g.members.length, 0)
+    : applicants.filter((a) => a.status === "APPROVED").length
 
   return {
     projectId: project.id,


### PR DESCRIPTION
## 📸 작업 내용

- currentCount를 partGroups 멤버 수로 계산하여 수동 배정/해제 반영

## 🎞️ 주요 코드 설명

<!-- 코드 설명, 없다면 생략해도 됩니다! -->

> 설명이 필요한 코드 위주로 작성해주세요

### 주제1

```TypeScript
// 여기에 코드를 작성해주세요
```

- 대충 코드에 대한 내용

### 주제2

```TypeScript
// 여기에 코드를 작성해주세요
```

- 대충 코드에 대한 내용

## 🖥️ 구현화면

> localhost 캡쳐 사진을 첨부해 주세요.

|           A 기능            |           B 기능            |
| :-------------------------: | :-------------------------: |
| <img src = "" width ="250"> | <img src = "" width ="250"> |

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #이슈번호

## 📚 참고자료

<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

## 💬 기타 더 이야기해볼 점

<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
