### PR TITLE
task: 프로젝트 관리 및 목록 페이지 qa 반영

### DIFF
--- a/src/features/project/list/model/matchingProjectList.ts
+++ b/src/features/project/list/model/matchingProjectList.ts
@@ -143,6 +143,7 @@ export function useMatchingProjectListFilters() {
         schoolIds: selectedSchool ? [Number(selectedSchool)] : undefined,
         parts: selectedParts.length > 0 ? selectedParts : undefined,
         partQuotaStatus: selectedRecruitStatus,
+        statuses: ["IN_PROGRESS"],
         page: page - 1,
         size: MATCHING_PROJECT_PAGE_SIZE,
       }),

--- a/src/features/project/management/ui/ProjectManagementCard.tsx
+++ b/src/features/project/management/ui/ProjectManagementCard.tsx
@@ -75,6 +75,7 @@ export function ProjectManagementCard({
                   projectName={data.title}
                   chapterName={data.branch}
                   status={data.status}
+                  recruitRows={data.recruitRows}
                   canDeleteProject={canDeleteProject}
                   canEditProject={canEditProject}
                   canPublishProject={canPublishProject}

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -13,11 +13,13 @@ import {
 } from "@/features/application/model/mappers"
 import { ApplicationDetailModal } from "@/features/application/ui/ApplicationDetailModal"
 import { getProjectDetail } from "@/features/project/list/api/matchingProject"
+import { TeamMemberModal } from "@/features/project/list/ui/team-member-modal/TeamMemberModal"
 import { deleteProject } from "@/features/project/management/api"
 import { invalidateProjectSummaryQueries } from "@/features/project/new/api"
 import { publishProject } from "@/features/project/new/api/projectPublish"
 import MoreVerticalIcon from "@/shared/assets/icon/more/MoreVerticalIcon"
 import { DropdownItem } from "@/shared/ui/dropdown/DropdownItem"
+import { Modal } from "@/shared/ui/Modal"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
 
 import type { PartEnum } from "@/features/application/model/apiTypes"
@@ -27,12 +29,14 @@ import type {
   Role,
 } from "@/features/application/model/types"
 import type { ProjectStatus } from "@/features/project/list/api/matchingProject"
+import type { ProjectRecruitRow } from "@/features/project/list/model/matchingProject"
 
 interface ProjectManagementMoreMenuProps {
   projectId: string
   projectName: string
   chapterName: string
   status?: ProjectStatus
+  recruitRows: ProjectRecruitRow[]
   canDeleteProject: boolean
   canEditProject: boolean
   canPublishProject: boolean
@@ -44,6 +48,7 @@ export function ProjectManagementMoreMenu({
   projectName,
   chapterName,
   status,
+  recruitRows,
   canDeleteProject,
   canEditProject,
   canPublishProject,
@@ -55,6 +60,7 @@ export function ProjectManagementMoreMenu({
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [publishOpen, setPublishOpen] = useState(false)
   const [applicationOpen, setApplicationOpen] = useState(false)
+  const [teamModalOpen, setTeamModalOpen] = useState(false)
   const addToast = useToastStore((s) => s.addToast)
 
   const numericProjectId = Number(projectId)
@@ -223,10 +229,15 @@ export function ProjectManagementMoreMenu({
     }
   }
 
+  const handleTeamViewClick = () => {
+    setPopoverOpen(false)
+    setTeamModalOpen(true)
+  }
+
   const menuItems = [
     { label: "지원 현황 확인하기", onClick: handleApplicationClick },
     { label: "기획 보기", onClick: () => void handlePlanViewClick() },
-    { label: "팀원 구성 보기", onClick: () => {} },
+    { label: "팀원 구성 보기", onClick: handleTeamViewClick },
   ]
 
   if (isPermissionLoading || canEditProject) {
@@ -288,6 +299,20 @@ export function ProjectManagementMoreMenu({
           </Popover.Content>
         </Popover.Portal>
       </Popover.Root>
+
+      <Modal.Root open={teamModalOpen} onOpenChange={setTeamModalOpen}>
+        <Modal.Portal>
+          <Modal.Overlay tone="light" />
+          <Modal.Content aria-describedby={undefined}>
+            <Modal.Title className="sr-only">팀원 구성</Modal.Title>
+            <TeamMemberModal
+              projectId={numericProjectId}
+              recruitRows={recruitRows}
+              onClose={() => setTeamModalOpen(false)}
+            />
+          </Modal.Content>
+        </Modal.Portal>
+      </Modal.Root>
 
       {projectApplication && (
         <ApplicationDetailModal

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -9,6 +9,7 @@ import {
   isCurrentTermPm,
   isSuperAdmin,
 } from "@/features/auth/model/identity"
+import { getChaptersWithSchools } from "@/features/challenger/api/organization"
 import { gisuKeys, projectKeys } from "@/features/project/new/api/queryKeys"
 import { getActiveGisu } from "@/shared/api/gisu"
 import { EmptyState } from "@/shared/ui/EmptyState"
@@ -126,15 +127,30 @@ export function ProjectManagementPage() {
     enabled: hasAccess && !!gisuId,
   })
 
+  const chaptersQuery = useQuery({
+    queryKey: ["chapters", "with-schools", gisuId],
+    queryFn: () => getChaptersWithSchools(String(gisuId!)),
+    enabled: useGroupedView && !!gisuId,
+  })
+
   const projects: MatchingProject[] = useMemo(
     () => (managedQuery.data ?? []).map(toMatchingProject),
     [managedQuery.data],
   )
 
+  const filteredProjects: MatchingProject[] = useMemo(() => {
+    if (!useGroupedView) return projects
+    const chapters = chaptersQuery.data?.chapters ?? []
+    const chapter = chapters.find((c) => c.chapterName === selectedChapter)
+    if (!chapter) return projects
+    const schoolNames = new Set(chapter.schools.map((s) => s.schoolName))
+    return projects.filter((p) => schoolNames.has(p.school))
+  }, [useGroupedView, projects, chaptersQuery.data, selectedChapter])
+
   const partGroups = useMemo(() => {
     if (!useGroupedView) return new Map<string, MatchingProject[]>()
     const map = new Map<string, MatchingProject[]>()
-    for (const project of projects) {
+    for (const project of filteredProjects) {
       for (const row of project.recruitRows) {
         if (!FE_PART_LABELS.has(row.part)) continue
         if (!map.has(row.part)) map.set(row.part, [])
@@ -142,7 +158,7 @@ export function ProjectManagementPage() {
       }
     }
     return map
-  }, [useGroupedView, projects])
+  }, [useGroupedView, filteredProjects])
 
   const permissionProjectIds = useMemo(() => {
     const ids = new Set<number>()
@@ -218,7 +234,7 @@ export function ProjectManagementPage() {
         </div>
 
         <div className="flex flex-col gap-10">
-          {isAdminScope && (
+          {useGroupedView && (
             <SegmentButton
               items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
               value={selectedChapter}


### PR DESCRIPTION
## 📸 작업 내용

> 프로젝트 관리 페이지 수정 

- 프로젝트 관리 카드 '팀원 구성 보기' 연결
- 진행 중인 프로젝트 조회 기능 추가
- 전체 프로젝트 관리 필터링 구현
- 어드민 이외 권한에서 매칭 시트 노출되도록 수정
- PM/Others 권한에서 매칭 결과 시트 미노출 버그 수정
- 지원하기 버튼 매칭 기간 로직 수정 (페이지 레벨에서 조회 후 prop 전달)

## 🎞️ 주요 코드 설명

> 설명이 필요한 코드 위주로 작성해주세요

### 매칭 기간 조회 로직 개선

```TypeScript
// MatchingProjectsListPage에서 activeMatchingRound 조회 후 ProjectDetailCard에 prop으로 전달
const { data: activeMatchingRound } = useQuery({
  queryKey: ["activeMatchingRound", myChapterId],
  queryFn: () => getActiveMatchingRound(myChapterId!),
  enabled: isChallengerView && myChapterId != null,
})

<ProjectDetailCard
  projectId={selectedProjectId}
  activeMatchingRound={activeMatchingRound}
/>
```

- 기존 ProjectDetailCard 내부에서 매칭 라운드를 조회해 타이밍 문제 발생하던 문제를
페이지 마운트 시 미리 조회 후 prop으로 전달하도록 변경
- 로딩 중 → 버튼 로딩 표시 / 라운드 없음 → 버튼 disabled / 라운드 있음 → 버튼 활성화


## 🖥️ 구현화면

> localhost 캡쳐 사진을 첨부해 주세요.


## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #221 