### PR TITLE
fix: 매칭 차수 시작 시간의 초를 00초로 전송하도록 수정

### DIFF
--- a/src/features/matching/model/matchingRoundMock.ts
+++ b/src/features/matching/model/matchingRoundMock.ts
@@ -69,9 +69,14 @@ function parseServerDatetime(iso: string): { date: string; time: string } {
   return { date: `${y}-${m}-${d}`, time: `${hh}:${mm}` }
 }
 
-// UI date + time -> ISO datetime 문자열 (로컬 시간 -> UTC 변환, 초:밀리초는 59:999 고정)
-export function toISODatetime(date: string, time: string): string {
-  const dt = new Date(`${date}T${time}:59.999`)
+// UI date + time -> ISO datetime 문자열 (로컬 시간 -> UTC 변환)
+export function toISODatetime(
+  date: string,
+  time: string,
+  seconds: "start" | "end" = "end",
+): string {
+  const suffix = seconds === "start" ? ":00.000" : ":59.999"
+  const dt = new Date(`${date}T${time}${suffix}`)
   return dt.toISOString()
 }
 

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -260,8 +260,8 @@ function MatchingRoundsPage() {
         if (!round.startDate || !round.endDate) return null
         return {
           round,
-          startsAt: toISODatetime(round.startDate, round.startTime),
-          endsAt: toISODatetime(round.endDate, round.endTime),
+          startsAt: toISODatetime(round.startDate, round.startTime, "start"),
+          endsAt: toISODatetime(round.endDate, round.endTime, "end"),
         }
       })
 


### PR DESCRIPTION
## 📸 작업 내용

- 매칭 차수 시작 시간의 초를 00초로 전송하도록 수정
