### PR TITLE
fix: 프로젝트 관리 반응형과 로고 표시 개선

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from "@tanstack/react-router"
 import { useEffect, useMemo, useState } from "react"
 
 import { MobileSidebarDrawerContent } from "@/components/sidebar/MobileSidebarDrawerContent"
+import { SideBarViewSwitcher } from "@/components/sidebar/SideBarViewSwitcher"
 import { isOperator, isSchoolStaff } from "@/features/auth/model/identity"
 import CloseIcon from "@/shared/assets/icon/close/CloseIcon"
 import HamburgerIcon from "@/shared/assets/icon/hamburger/HamburgerIcon"
@@ -58,6 +59,19 @@ export default function Header({ activePathname }: HeaderProps = {}) {
     setIsMobileMenuOpen(false)
   }, [pathname])
 
+  useEffect(() => {
+    if (!isMobileMenuOpen) return
+
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setIsMobileMenuOpen(false)
+      }
+    }
+
+    window.addEventListener("keydown", handleEscape)
+    return () => window.removeEventListener("keydown", handleEscape)
+  }, [isMobileMenuOpen])
+
   return (
     <header className="bg-teal-gray-50 shadow-drop-neutral-3 relative z-50 flex min-h-16 w-full flex-col overflow-visible min-[960px]:h-20 min-[960px]:min-h-20 min-[960px]:flex-row min-[960px]:items-center min-[960px]:justify-between">
       <div className="flex h-16 w-full items-center justify-between min-[960px]:h-20">
@@ -87,7 +101,12 @@ export default function Header({ activePathname }: HeaderProps = {}) {
           <Profile />
         </div>
 
-        <div className="flex items-center gap-2 pr-5 min-[960px]:hidden">
+        <div className="flex min-w-0 items-center gap-2 pr-5 min-[960px]:hidden">
+          <SideBarViewSwitcher
+            className="relative z-[70] min-w-0"
+            dropdownClassName="w-28 bp1:w-43"
+            menuClassName="shadow-drop-neutral-2 absolute top-full right-0 z-[80] mt-1 w-full rounded-[8px]"
+          />
           <button
             type="button"
             aria-label={isMobileMenuOpen ? "메뉴 닫기" : "메뉴 열기"}
@@ -104,6 +123,15 @@ export default function Header({ activePathname }: HeaderProps = {}) {
           </button>
         </div>
       </div>
+
+      {isMobileMenuOpen && (
+        <button
+          type="button"
+          aria-label="모바일 메뉴 닫기"
+          className="fixed inset-x-0 top-16 bottom-0 z-40 bg-neutral-900/40 min-[960px]:hidden"
+          onClick={() => setIsMobileMenuOpen(false)}
+        />
+      )}
 
       <nav
         id="mobile-header-navigation"

--- a/src/components/sidebar/MobileSidebarDrawerContent.tsx
+++ b/src/components/sidebar/MobileSidebarDrawerContent.tsx
@@ -3,7 +3,6 @@ import { Link } from "@tanstack/react-router"
 import { resolveNavigationFromPathname } from "@/shared/config/navigationResolve"
 import { cn } from "@/shared/lib/utils"
 
-import { SideBarViewSwitcher } from "./SideBarViewSwitcher"
 import { useVisibleSidebarSections } from "./useVisibleSidebarSections"
 
 interface MobileSidebarDrawerContentProps {
@@ -25,22 +24,21 @@ export function MobileSidebarDrawerContent({
 
   return (
     <section className="border-teal-gray-100 flex flex-col gap-3 border-t pt-4">
-      <SideBarViewSwitcher className="px-0 pt-0" onSelect={onNavigate} />
-      <span className="text-caption-2-medium text-teal-gray-400 px-1">
+      <span className="text-caption-2-medium text-teal-gray-400 px-1 text-center">
         Demo Day
       </span>
 
-      <div className="flex flex-col gap-4">
+      <div className="bp1:grid-cols-2 grid grid-cols-1 gap-4">
         {visibleSections.map(({ id, title, icon: Icon, menus }) => (
           <div key={id} className="flex flex-col gap-1.5">
-            <div className="flex h-8 items-center gap-2 px-1">
+            <div className="flex h-8 items-center justify-center gap-2 px-1">
               <Icon className="text-teal-gray-500 size-4" />
-              <span className="text-body-2-medium text-teal-gray-600">
+              <span className="text-subtitle-4-semibold text-teal-gray-600">
                 {title}
               </span>
             </div>
 
-            <div className="grid grid-cols-2 gap-1">
+            <div className="grid grid-cols-1 gap-1">
               {menus.map((menu) => {
                 const isSelected = resolved?.menu.id === menu.id
                 return (

--- a/src/components/sidebar/SideBarViewSwitcher.tsx
+++ b/src/components/sidebar/SideBarViewSwitcher.tsx
@@ -10,11 +10,15 @@ import { SideBarDropDown } from "./dropdown/SideBarDropDown"
 interface SideBarViewSwitcherProps {
   onSelect?: (mode: ViewMode) => void
   className?: string
+  dropdownClassName?: string
+  menuClassName?: string
 }
 
 export function SideBarViewSwitcher({
   onSelect,
   className,
+  dropdownClassName,
+  menuClassName,
 }: SideBarViewSwitcherProps) {
   const { availableModes } = useAvailableViewModes()
   const mode = useViewModeStore((s) => s.mode)
@@ -35,6 +39,8 @@ export function SideBarViewSwitcher({
       <SideBarDropDown
         options={options}
         selectedIdx={selectedIdx}
+        className={dropdownClassName}
+        menuClassName={menuClassName}
         onSelect={(idx) => {
           const next = options[idx]?.mode
           if (!next || next === mode) return

--- a/src/components/sidebar/dropdown/SideBarDropDown.tsx
+++ b/src/components/sidebar/dropdown/SideBarDropDown.tsx
@@ -12,12 +12,16 @@ interface SideBarDropDownProps {
   options: ReadonlyArray<{ mode: ViewMode; label: string }>
   selectedIdx: number
   onSelect: (idx: number) => void
+  className?: string
+  menuClassName?: string
 }
 
 export function SideBarDropDown({
   options,
   selectedIdx,
   onSelect,
+  className,
+  menuClassName,
 }: SideBarDropDownProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false)
   const containerRef = useRef<HTMLDivElement>(null)
@@ -37,17 +41,17 @@ export function SideBarDropDown({
   }, [])
 
   return (
-    <div ref={containerRef}>
+    <div ref={containerRef} className={cn("relative w-43", className)}>
       <button
         onClick={() => setIsOpen(!isOpen)}
         aria-expanded={isOpen}
         aria-haspopup="menu"
         className={cn(
-          "flex h-6.5 w-43 justify-between rounded-[8px] py-1 pr-2 pl-3",
+          "flex h-6.5 w-full min-w-0 justify-between rounded-[8px] py-1 pr-2 pl-3",
           isOpen ? "bg-teal-gray-200" : "bg-teal-gray-150",
         )}
       >
-        <span className="text-teal-gray-600 text-body-3-regular">
+        <span className="text-body-3-regular text-teal-gray-600 min-w-0 truncate">
           {selectedLabel}
         </span>
         <DownChevronIcon
@@ -64,7 +68,7 @@ export function SideBarDropDown({
             animate={{ height: "auto", opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
             transition={{ duration: 0.35, ease: "easeInOut" }}
-            className="overflow-hidden"
+            className={cn("overflow-hidden", menuClassName)}
           >
             <SideBarDropDownMenu
               items={options.map((item) => item.label)}

--- a/src/components/sidebar/dropdown/SideBarDropDownMenuItem.tsx
+++ b/src/components/sidebar/dropdown/SideBarDropDownMenuItem.tsx
@@ -16,11 +16,11 @@ export function SideBarDropDownMenuItem({
     <button
       onClick={onClick}
       className={cn(
-        "text-body-3-regular flex h-6.5 w-42 items-center justify-between rounded-[8px] py-1 pr-2 pl-3 text-left",
+        "text-body-3-regular flex h-6.5 w-full items-center justify-between rounded-[8px] py-1 pr-2 pl-3 text-left",
         isSelected ? "bg-teal-50 text-teal-600" : "text-teal-gray-600",
       )}
     >
-      <span>{label}</span>
+      <span className="min-w-0 truncate">{label}</span>
       {isSelected && <CheckIcon className="h-4 w-4" />}
     </button>
   )

--- a/src/features/notice/ui/NoticeCard.tsx
+++ b/src/features/notice/ui/NoticeCard.tsx
@@ -14,7 +14,7 @@ import { Button } from "@/shared/ui/Button"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
 
 const noticeCardVariants = cva(
-  "flex w-full items-center justify-between gap-2.5 px-4 text-left",
+  "flex w-full scroll-mt-6 items-center justify-between gap-2.5 px-4 text-left",
   {
     variants: {
       hasChip: {

--- a/src/features/notice/ui/NoticeCardList.tsx
+++ b/src/features/notice/ui/NoticeCardList.tsx
@@ -66,7 +66,7 @@ export function NoticeCardList({
     if (!targetButton) return
 
     targetButton.focus()
-    targetButton.scrollIntoView({ block: "center", behavior: "smooth" })
+    targetButton.scrollIntoView({ block: "start", behavior: "smooth" })
   }, [expandedIndex, focusedNoticeId, notices])
 
   if (isLoading) {

--- a/src/features/notice/ui/NoticeCardList.tsx
+++ b/src/features/notice/ui/NoticeCardList.tsx
@@ -105,6 +105,15 @@ export function NoticeCardList({
               data-notice-id={notice.id}
               onExpandedChange={(nextExpanded) => {
                 setExpandedIndex(nextExpanded ? index : null)
+                if (!nextExpanded) return
+                const targetId = notice.id
+                requestAnimationFrame(() => {
+                  document
+                    .querySelector<HTMLElement>(
+                      `[data-notice-id="${targetId}"]`,
+                    )
+                    ?.scrollIntoView({ block: "start", behavior: "smooth" })
+                })
               }}
               onEdit={() => {
                 onEditNotice?.(notice.id)

--- a/src/features/project/list/model/matchingProject.ts
+++ b/src/features/project/list/model/matchingProject.ts
@@ -25,6 +25,7 @@ export type MatchingProject = {
   title: string
   description: string
   authorSchoolLine: string
+  logoImage?: ProjectCoverImage | null
   coverImage?: ProjectCoverImage | null
   recruitRows: ProjectRecruitRow[]
   partQuotaStatus?: PartQuotaStatus

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -19,6 +19,7 @@ import {
 import { getActiveGisu } from "@/shared/api/gisu"
 import { ProjectLogo } from "@/shared/assets/icon/logo/ProjectLogo"
 import { formatSchoolName } from "@/shared/lib/formatSchoolName"
+import { withImageCacheKey } from "@/shared/lib/withImageCacheKey"
 import { Button } from "@/shared/ui/Button"
 import { TeamMemberButton } from "@/shared/ui/button/TeamMemberButton"
 import { RecruitStatusChip } from "@/shared/ui/chip/RecruitStatusChip"
@@ -42,10 +43,7 @@ import { RecruitQuestionsViewModal } from "./apply-modal/RecruitQuestionsViewMod
 import { TeamMemberModal } from "./team-member-modal/TeamMemberModal"
 
 import type { ActiveMatchingRound, ProjectDetail } from "../api/matchingProject"
-import type {
-  MatchingProject,
-  ProjectCoverImage,
-} from "../model/matchingProject"
+import type { MatchingProject } from "../model/matchingProject"
 
 type ProjectDetailCardLogo = "on" | "off"
 
@@ -110,20 +108,6 @@ const PART_LABEL: Record<string, string> = {
 }
 const PART_ORDER = Object.keys(PART_LABEL)
 
-function withImageCacheKey(
-  src: string | null | undefined,
-  cacheKey: number,
-): string | null {
-  if (!src) return null
-
-  const hashIndex = src.indexOf("#")
-  const baseUrl = hashIndex >= 0 ? src.slice(0, hashIndex) : src
-  const hash = hashIndex >= 0 ? src.slice(hashIndex + 1) : ""
-  const separator = baseUrl.includes("?") ? "&" : "?"
-  const versionedUrl = `${baseUrl}${separator}v=${cacheKey}`
-  return hash ? `${versionedUrl}#${hash}` : versionedUrl
-}
-
 function toMatchingProject(
   detail: ProjectDetail,
   imageCacheKey: number,
@@ -147,13 +131,17 @@ function toMatchingProject(
     authorSchoolLine,
     logoImage: detail.logoImageUrl
       ? {
-          src: withImageCacheKey(detail.logoImageUrl, imageCacheKey)!,
+          src:
+            withImageCacheKey(detail.logoImageUrl, imageCacheKey) ??
+            detail.logoImageUrl,
           alt: `${detail.name} 로고`,
         }
       : null,
     coverImage: detail.thumbnailImageUrl
       ? {
-          src: withImageCacheKey(detail.thumbnailImageUrl, imageCacheKey)!,
+          src:
+            withImageCacheKey(detail.thumbnailImageUrl, imageCacheKey) ??
+            detail.thumbnailImageUrl,
           alt: `${detail.name} 대표 이미지`,
         }
       : null,
@@ -398,9 +386,7 @@ export function ProjectDetailCard({
           isAlreadyApproved,
         })
 
-  const cover: ProjectCoverImage | null = detail?.thumbnailImageUrl
-    ? { src: detail.thumbnailImageUrl }
-    : null
+  const cover = data.coverImage
   const showLogo = logo === "on"
   const shouldShowEditCta =
     showEditCta && (resolvedEditPermissionLoading || resolvedCanEditProject)

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -65,13 +65,13 @@ interface ProjectDetailCardProps {
 
 function ProjectDetailCardSkeleton() {
   return (
-    <div className="flex w-135 flex-col items-start overflow-hidden rounded-2xl bg-white">
-      <div className="bg-teal-gray-200 h-71.5 w-135 animate-pulse" />
-      <div className="flex w-full flex-col items-start p-5">
+    <div className="flex max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-135 min-w-0 flex-col items-start overflow-x-hidden overflow-y-auto rounded-2xl bg-white">
+      <div className="bg-teal-gray-200 aspect-[540/286] w-full shrink-0 animate-pulse" />
+      <div className="bp1:p-5 flex w-full flex-col items-start p-4">
         <div className="flex w-full flex-col items-start gap-6">
           <div className="flex w-full flex-col items-start gap-2.5">
-            <div className="flex w-full items-center justify-between gap-4">
-              <div className="bg-teal-gray-150 h-6 w-52 animate-pulse rounded-md" />
+            <div className="bp1:flex-row bp1:items-center bp1:justify-between bp1:gap-4 flex w-full flex-col items-start gap-2.5">
+              <div className="bg-teal-gray-150 h-6 w-full max-w-52 animate-pulse rounded-md" />
               <div className="bg-teal-gray-150 h-4 w-32 animate-pulse rounded-md" />
             </div>
             <div className="flex w-full flex-col gap-1.5">
@@ -89,8 +89,8 @@ function ProjectDetailCardSkeleton() {
             ))}
           </div>
         </div>
-        <div className="mt-8.5 flex w-full items-start gap-2.5">
-          <div className="bg-teal-gray-150 h-11 w-11 animate-pulse rounded-xl" />
+        <div className="bp1:mt-8.5 bp1:flex-row bp1:items-start mt-6 flex w-full flex-col items-stretch gap-2.5">
+          <div className="bg-teal-gray-150 bp1:w-11 h-11 w-full animate-pulse rounded-xl" />
           <div className="bg-teal-gray-150 h-11 flex-1 animate-pulse rounded-xl" />
           <div className="bg-teal-gray-150 h-11 flex-1 animate-pulse rounded-xl" />
         </div>
@@ -110,7 +110,24 @@ const PART_LABEL: Record<string, string> = {
 }
 const PART_ORDER = Object.keys(PART_LABEL)
 
-function toMatchingProject(detail: ProjectDetail): MatchingProject {
+function withImageCacheKey(
+  src: string | null | undefined,
+  cacheKey: number,
+): string | null {
+  if (!src) return null
+
+  const hashIndex = src.indexOf("#")
+  const baseUrl = hashIndex >= 0 ? src.slice(0, hashIndex) : src
+  const hash = hashIndex >= 0 ? src.slice(hashIndex + 1) : ""
+  const separator = baseUrl.includes("?") ? "&" : "?"
+  const versionedUrl = `${baseUrl}${separator}v=${cacheKey}`
+  return hash ? `${versionedUrl}#${hash}` : versionedUrl
+}
+
+function toMatchingProject(
+  detail: ProjectDetail,
+  imageCacheKey: number,
+): MatchingProject {
   const owner = detail.productOwner
   const authorSchoolLine = [
     owner.nickname && owner.name
@@ -128,8 +145,17 @@ function toMatchingProject(detail: ProjectDetail): MatchingProject {
     title: detail.name,
     description: detail.description,
     authorSchoolLine,
+    logoImage: detail.logoImageUrl
+      ? {
+          src: withImageCacheKey(detail.logoImageUrl, imageCacheKey)!,
+          alt: `${detail.name} 로고`,
+        }
+      : null,
     coverImage: detail.thumbnailImageUrl
-      ? { src: detail.thumbnailImageUrl }
+      ? {
+          src: withImageCacheKey(detail.thumbnailImageUrl, imageCacheKey)!,
+          alt: `${detail.name} 대표 이미지`,
+        }
       : null,
     recruitRows: [...detail.partQuotas]
       .sort((a, b) => {
@@ -199,7 +225,11 @@ export function ProjectDetailCard({
     useState(false)
   const [isRecruitQuestionsModalOpen, setIsRecruitQuestionsModalOpen] =
     useState(false)
-  const { data: detail, isLoading: isDetailLoading } = useQuery({
+  const {
+    data: detail,
+    dataUpdatedAt: detailDataUpdatedAt,
+    isLoading: isDetailLoading,
+  } = useQuery({
     queryKey: ["projectDetail", projectId],
     queryFn: () => getProjectDetail(projectId),
     staleTime: 5 * 60 * 1000,
@@ -235,7 +265,7 @@ export function ProjectDetailCard({
     myApplications?.some((a) => a.status === "APPROVED") ?? false
 
   const data = detail
-    ? toMatchingProject(detail)
+    ? toMatchingProject(detail, detailDataUpdatedAt)
     : DEFAULT_MATCHING_PROJECT_MOCK
 
   const isShowingFormModal = isApplyModalOpen || isRecruitQuestionsModalOpen
@@ -381,8 +411,8 @@ export function ProjectDetailCard({
 
   return (
     <>
-      <div className="flex w-135 flex-col items-start overflow-hidden rounded-2xl bg-white">
-        <div className="bg-teal-gray-200 flex h-71.5 w-135 items-center justify-center overflow-hidden">
+      <div className="flex max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-135 min-w-0 flex-col items-start overflow-x-hidden overflow-y-auto rounded-2xl bg-white">
+        <div className="bg-teal-gray-200 flex aspect-[540/286] w-full shrink-0 items-center justify-center overflow-hidden">
           {cover?.src ? (
             <img
               src={cover.src}
@@ -400,24 +430,24 @@ export function ProjectDetailCard({
           )}
         </div>
 
-        <div className="flex w-full flex-col items-start p-5">
+        <div className="bp1:p-5 flex w-full flex-col items-start p-4">
           <div className="flex w-full flex-col items-start gap-6">
             <div className="flex w-full flex-col items-start gap-2.5">
-              <div className="flex w-full items-center justify-between gap-4">
+              <div className="bp1:flex-row bp1:items-center bp1:justify-between bp1:gap-4 flex w-full min-w-0 flex-col items-start gap-2.5">
                 {showLogo ? (
-                  <div className="flex min-w-0 items-center gap-2">
-                    <ProjectLogo />
-                    <h2 className="text-heading-6-semibold text-teal-gray-900 line-clamp-1 w-60 min-w-0">
+                  <div className="bp1:w-auto flex w-full min-w-0 items-center gap-2">
+                    <ProjectLogo src={data.logoImage?.src} />
+                    <h2 className="text-heading-6-semibold text-teal-gray-900 bp1:line-clamp-1 bp1:w-60 line-clamp-2 w-full min-w-0">
                       {data.title}
                     </h2>
                   </div>
                 ) : (
-                  <h2 className="text-heading-6-semibold text-teal-gray-900 w-60 min-w-0">
+                  <h2 className="text-heading-6-semibold text-teal-gray-900 bp1:line-clamp-1 bp1:w-60 line-clamp-2 w-full min-w-0">
                     {data.title}
                   </h2>
                 )}
 
-                <p className="text-body-2-regular text-teal-gray-500 shrink-0 text-right">
+                <p className="text-body-2-regular text-teal-gray-500 bp1:w-auto bp1:shrink-0 bp1:text-right line-clamp-1 w-full text-left">
                   {data.authorSchoolLine}
                 </p>
               </div>
@@ -433,10 +463,10 @@ export function ProjectDetailCard({
                 return (
                   <div
                     key={row.part}
-                    className="flex w-full items-center justify-between"
+                    className="flex w-full min-w-0 items-center justify-between gap-3"
                   >
-                    <div className="flex w-30.5 items-center justify-between">
-                      <span className="text-body-2-medium text-teal-gray-700">
+                    <div className="flex w-30.5 min-w-0 shrink-0 items-center justify-between gap-2">
+                      <span className="text-body-2-medium text-teal-gray-700 truncate">
                         {row.part}
                       </span>
                       <MemberCount
@@ -452,9 +482,10 @@ export function ProjectDetailCard({
             </div>
           </div>
 
-          <div className="mt-8.5 flex w-full items-start gap-2.5">
+          <div className="bp1:mt-8.5 bp1:flex-row bp1:items-start mt-6 flex w-full flex-col items-stretch gap-2.5">
             <TeamMemberButton
               variant="weak"
+              className="bp1:w-auto w-full"
               onClick={() => setIsTeamModalOpen(true)}
             />
             <Button
@@ -629,7 +660,7 @@ export function ProjectDetailCard({
             {showFormSkeleton ? (
               <ApplyFormSkeleton />
             ) : applicationForm == null ? (
-              <div className="shadow-drop-neutral-3 flex h-40 w-232 items-center justify-center rounded-2xl bg-white">
+              <div className="shadow-drop-neutral-3 flex h-40 w-[calc(100vw-2rem)] max-w-232 items-center justify-center rounded-2xl bg-white">
                 <span className="text-body-2-regular text-teal-gray-500">
                   등록된 모집 문항이 없습니다.
                 </span>
@@ -655,7 +686,7 @@ export function ProjectDetailCard({
             {showFormSkeleton ? (
               <ApplyFormSkeleton />
             ) : applicationForm == null ? (
-              <div className="shadow-drop-neutral-3 flex h-40 w-232 items-center justify-center rounded-2xl bg-white">
+              <div className="shadow-drop-neutral-3 flex h-40 w-[calc(100vw-2rem)] max-w-232 items-center justify-center rounded-2xl bg-white">
                 <span className="text-body-2-regular text-teal-gray-500">
                   등록된 지원 양식이 없습니다.
                 </span>
@@ -706,7 +737,7 @@ export function ProjectDetailCard({
                 }}
               />
             ) : (
-              <div className="shadow-drop-neutral-3 flex h-40 w-232 items-center justify-center rounded-2xl bg-white">
+              <div className="shadow-drop-neutral-3 flex h-40 w-[calc(100vw-2rem)] max-w-232 items-center justify-center rounded-2xl bg-white">
                 <span className="text-body-2-regular text-teal-gray-500">
                   지원 내역을 찾을 수 없습니다.
                 </span>

--- a/src/features/project/management/ui/ProjectManagementCard.tsx
+++ b/src/features/project/management/ui/ProjectManagementCard.tsx
@@ -1,7 +1,5 @@
-import { useQuery } from "@tanstack/react-query"
 import { useState } from "react"
 
-import { getProjectDetail } from "@/features/project/list/api/matchingProject"
 import { ProjectDetailCard } from "@/features/project/list/ui/ProjectDetailCard"
 import { ProjectLogo } from "@/shared/assets/icon/logo/ProjectLogo"
 import { ProjectStatusChip } from "@/shared/ui/chip/ProjectStatusChip"
@@ -22,20 +20,6 @@ interface ProjectManagementCardProps {
   isPermissionLoading: boolean
 }
 
-function withImageCacheKey(
-  src: string | null | undefined,
-  cacheKey: number,
-): string | null {
-  if (!src) return null
-
-  const hashIndex = src.indexOf("#")
-  const baseUrl = hashIndex >= 0 ? src.slice(0, hashIndex) : src
-  const hash = hashIndex >= 0 ? src.slice(hashIndex + 1) : ""
-  const separator = baseUrl.includes("?") ? "&" : "?"
-  const versionedUrl = `${baseUrl}${separator}v=${cacheKey}`
-  return hash ? `${versionedUrl}#${hash}` : versionedUrl
-}
-
 export function ProjectManagementCard({
   data,
   canDeleteProject,
@@ -46,17 +30,11 @@ export function ProjectManagementCard({
   const cover = data.coverImage
   const [open, setOpen] = useState(false)
   const projectId = Number(data.id)
-  const shouldFetchLogo = !data.logoImage?.src && Number.isFinite(projectId)
-  const { data: projectDetail, dataUpdatedAt: projectDetailDataUpdatedAt } =
-    useQuery({
-      queryKey: ["projectDetail", projectId],
-      queryFn: () => getProjectDetail(projectId),
-      enabled: shouldFetchLogo,
-      staleTime: 5 * 60 * 1000,
-    })
-  const logoSrc =
-    data.logoImage?.src ??
-    withImageCacheKey(projectDetail?.logoImageUrl, projectDetailDataUpdatedAt)
+  const hasValidProjectId = Number.isFinite(projectId) && projectId > 0
+  const openDetailModal = () => {
+    if (!hasValidProjectId) return
+    setOpen(true)
+  }
 
   return (
     <>
@@ -64,9 +42,9 @@ export function ProjectManagementCard({
         className="border-teal-gray-100 [&:hover:not(:has(button:hover))]:bg-teal-gray-100 shadow-drop-neutral-2 bp1:p-4 flex w-full max-w-[56.25rem] min-w-0 cursor-pointer flex-col gap-4 rounded-2xl border bg-white p-3 transition-colors min-[960px]:flex-row min-[960px]:items-center min-[960px]:gap-7 min-[960px]:py-2.5 min-[960px]:pr-5 min-[960px]:pl-2.5"
         role="button"
         tabIndex={0}
-        onClick={() => setOpen(true)}
+        onClick={openDetailModal}
         onKeyDown={(e) => {
-          if (e.key === "Enter" || e.key === " ") setOpen(true)
+          if (e.key === "Enter" || e.key === " ") openDetailModal()
         }}
       >
         <div className="bg-teal-gray-200 flex aspect-[320/169] w-full shrink-0 overflow-hidden rounded-[0.625rem] min-[960px]:h-[10.5625rem] min-[960px]:w-[clamp(13rem,28vw,20rem)]">
@@ -92,7 +70,7 @@ export function ProjectManagementCard({
             <div className="flex min-w-0 items-start justify-between gap-3 self-stretch">
               <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
                 <div className="shrink-0">
-                  <ProjectLogo src={logoSrc ?? undefined} size={30} />
+                  <ProjectLogo src={data.logoImage?.src} size={30} />
                 </div>
                 <span className="text-heading-7-semibold text-teal-gray-900 bp1:line-clamp-1 line-clamp-2 min-w-0">
                   {data.title}
@@ -156,12 +134,14 @@ export function ProjectManagementCard({
             aria-describedby={undefined}
           >
             <Modal.Title className="sr-only">{data.title}</Modal.Title>
-            <ProjectDetailCard
-              projectId={projectId}
-              showEditCta
-              canEditProject={canEditProject}
-              editPermissionLoading={isPermissionLoading}
-            />
+            {hasValidProjectId && (
+              <ProjectDetailCard
+                projectId={projectId}
+                showEditCta
+                canEditProject={canEditProject}
+                editPermissionLoading={isPermissionLoading}
+              />
+            )}
           </Modal.Content>
         </Modal.Portal>
       </Modal.Root>

--- a/src/features/project/management/ui/ProjectManagementCard.tsx
+++ b/src/features/project/management/ui/ProjectManagementCard.tsx
@@ -1,7 +1,10 @@
+import { useQuery } from "@tanstack/react-query"
 import { useState } from "react"
 
+import { getProjectDetail } from "@/features/project/list/api/matchingProject"
 import { ProjectDetailCard } from "@/features/project/list/ui/ProjectDetailCard"
 import { ProjectLogo } from "@/shared/assets/icon/logo/ProjectLogo"
+import { withImageCacheKey } from "@/shared/lib/withImageCacheKey"
 import { ProjectStatusChip } from "@/shared/ui/chip/ProjectStatusChip"
 import { RecruitStatusChip } from "@/shared/ui/chip/RecruitStatusChip"
 import MemberCount from "@/shared/ui/MemberCount"
@@ -31,6 +34,17 @@ export function ProjectManagementCard({
   const [open, setOpen] = useState(false)
   const projectId = Number(data.id)
   const hasValidProjectId = Number.isFinite(projectId) && projectId > 0
+  const shouldFetchLogo = hasValidProjectId && !data.logoImage?.src
+  const { data: projectDetail, dataUpdatedAt: projectDetailDataUpdatedAt } =
+    useQuery({
+      queryKey: ["projectDetail", projectId],
+      queryFn: () => getProjectDetail(projectId),
+      enabled: shouldFetchLogo,
+      staleTime: 5 * 60 * 1000,
+    })
+  const logoSrc =
+    data.logoImage?.src ??
+    withImageCacheKey(projectDetail?.logoImageUrl, projectDetailDataUpdatedAt)
   const openDetailModal = () => {
     if (!hasValidProjectId) return
     setOpen(true)
@@ -70,7 +84,7 @@ export function ProjectManagementCard({
             <div className="flex min-w-0 items-start justify-between gap-3 self-stretch">
               <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
                 <div className="shrink-0">
-                  <ProjectLogo src={data.logoImage?.src} size={30} />
+                  <ProjectLogo src={logoSrc ?? undefined} size={30} />
                 </div>
                 <span className="text-heading-7-semibold text-teal-gray-900 bp1:line-clamp-1 line-clamp-2 min-w-0">
                   {data.title}

--- a/src/features/project/management/ui/ProjectManagementCard.tsx
+++ b/src/features/project/management/ui/ProjectManagementCard.tsx
@@ -1,5 +1,7 @@
+import { useQuery } from "@tanstack/react-query"
 import { useState } from "react"
 
+import { getProjectDetail } from "@/features/project/list/api/matchingProject"
 import { ProjectDetailCard } from "@/features/project/list/ui/ProjectDetailCard"
 import { ProjectLogo } from "@/shared/assets/icon/logo/ProjectLogo"
 import { ProjectStatusChip } from "@/shared/ui/chip/ProjectStatusChip"
@@ -20,6 +22,20 @@ interface ProjectManagementCardProps {
   isPermissionLoading: boolean
 }
 
+function withImageCacheKey(
+  src: string | null | undefined,
+  cacheKey: number,
+): string | null {
+  if (!src) return null
+
+  const hashIndex = src.indexOf("#")
+  const baseUrl = hashIndex >= 0 ? src.slice(0, hashIndex) : src
+  const hash = hashIndex >= 0 ? src.slice(hashIndex + 1) : ""
+  const separator = baseUrl.includes("?") ? "&" : "?"
+  const versionedUrl = `${baseUrl}${separator}v=${cacheKey}`
+  return hash ? `${versionedUrl}#${hash}` : versionedUrl
+}
+
 export function ProjectManagementCard({
   data,
   canDeleteProject,
@@ -29,11 +45,23 @@ export function ProjectManagementCard({
 }: ProjectManagementCardProps) {
   const cover = data.coverImage
   const [open, setOpen] = useState(false)
+  const projectId = Number(data.id)
+  const shouldFetchLogo = !data.logoImage?.src && Number.isFinite(projectId)
+  const { data: projectDetail, dataUpdatedAt: projectDetailDataUpdatedAt } =
+    useQuery({
+      queryKey: ["projectDetail", projectId],
+      queryFn: () => getProjectDetail(projectId),
+      enabled: shouldFetchLogo,
+      staleTime: 5 * 60 * 1000,
+    })
+  const logoSrc =
+    data.logoImage?.src ??
+    withImageCacheKey(projectDetail?.logoImageUrl, projectDetailDataUpdatedAt)
 
   return (
     <>
       <div
-        className="border-teal-gray-100 [&:hover:not(:has(button:hover))]:bg-teal-gray-100 shadow-drop-neutral-2 flex w-[56.25rem] cursor-pointer items-center gap-7 rounded-2xl border bg-white py-2.5 pr-5 pl-2.5 transition-colors"
+        className="border-teal-gray-100 [&:hover:not(:has(button:hover))]:bg-teal-gray-100 shadow-drop-neutral-2 bp1:p-4 flex w-full max-w-[56.25rem] min-w-0 cursor-pointer flex-col gap-4 rounded-2xl border bg-white p-3 transition-colors min-[960px]:flex-row min-[960px]:items-center min-[960px]:gap-7 min-[960px]:py-2.5 min-[960px]:pr-5 min-[960px]:pl-2.5"
         role="button"
         tabIndex={0}
         onClick={() => setOpen(true)}
@@ -41,7 +69,7 @@ export function ProjectManagementCard({
           if (e.key === "Enter" || e.key === " ") setOpen(true)
         }}
       >
-        <div className="bg-teal-gray-200 flex h-[10.5625rem] w-80 shrink-0 overflow-hidden rounded-[0.625rem]">
+        <div className="bg-teal-gray-200 flex aspect-[320/169] w-full shrink-0 overflow-hidden rounded-[0.625rem] min-[960px]:h-[10.5625rem] min-[960px]:w-[clamp(13rem,28vw,20rem)]">
           {cover?.src ? (
             <img
               src={cover.src}
@@ -59,17 +87,19 @@ export function ProjectManagementCard({
           )}
         </div>
 
-        <div className="flex flex-1 flex-col items-end gap-4">
-          <div className="flex flex-col items-start gap-2 self-stretch">
-            <div className="flex items-center justify-between self-stretch">
-              <div className="flex items-center gap-2">
-                <ProjectLogo size={30} />
-                <span className="text-heading-7-semibold text-teal-gray-900">
+        <div className="flex min-w-0 flex-1 flex-col items-stretch gap-4 min-[960px]:items-end">
+          <div className="flex min-w-0 flex-col items-start gap-2 self-stretch">
+            <div className="flex min-w-0 items-start justify-between gap-3 self-stretch">
+              <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+                <div className="shrink-0">
+                  <ProjectLogo src={logoSrc ?? undefined} size={30} />
+                </div>
+                <span className="text-heading-7-semibold text-teal-gray-900 bp1:line-clamp-1 line-clamp-2 min-w-0">
                   {data.title}
                 </span>
-                <ProjectStatusChip status={data.status} />
+                <ProjectStatusChip status={data.status} className="shrink-0" />
               </div>
-              <div onClick={(e) => e.stopPropagation()}>
+              <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
                 <ProjectManagementMoreMenu
                   projectId={data.id}
                   projectName={data.title}
@@ -84,21 +114,21 @@ export function ProjectManagementCard({
               </div>
             </div>
 
-            <p className="text-body-2-medium text-teal-gray-500">
+            <p className="text-body-2-medium text-teal-gray-500 line-clamp-1 w-full min-w-0">
               {data.authorSchoolLine}
             </p>
           </div>
 
-          <div className="flex flex-col items-start gap-1.25 self-stretch">
+          <div className="flex min-w-0 flex-col items-start gap-1.25 self-stretch">
             {data.recruitRows.map((row) => {
               const done = isRecruitDone(row)
               return (
                 <div
                   key={row.part}
-                  className="flex items-center justify-between self-stretch"
+                  className="flex min-w-0 items-center justify-between gap-2 self-stretch min-[960px]:gap-3"
                 >
-                  <div className="flex w-[7.3125rem] items-center justify-between">
-                    <span className="text-body-2-medium text-teal-gray-700">
+                  <div className="flex min-w-0 flex-1 items-center justify-between gap-2 min-[960px]:w-[7.3125rem] min-[960px]:flex-none min-[960px]:shrink-0">
+                    <span className="text-body-2-medium text-teal-gray-700 truncate">
                       {row.part}
                     </span>
                     <MemberCount
@@ -109,7 +139,7 @@ export function ProjectManagementCard({
                   </div>
                   <RecruitStatusChip
                     done={done}
-                    className="w-[3.875rem] text-xs leading-[150%] font-medium shadow-none"
+                    className="w-[3.875rem] shrink-0 text-xs leading-[150%] font-medium shadow-none"
                   />
                 </div>
               )
@@ -127,7 +157,7 @@ export function ProjectManagementCard({
           >
             <Modal.Title className="sr-only">{data.title}</Modal.Title>
             <ProjectDetailCard
-              projectId={Number(data.id)}
+              projectId={projectId}
               showEditCta
               canEditProject={canEditProject}
               editPermissionLoading={isPermissionLoading}

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -250,20 +250,21 @@ export function ProjectManagementPage() {
             프로젝트 관리
           </span>
           <span className="text-body-2-regular text-teal-gray-600">
-            모든 프로젝트의 상세 정보를 확인하고 수정할 수 있습니다. 단, 매칭
-            중에는 일부 수정이 제한됩니다.
+            모든 프로젝트의 상세 정보를 확인하고 수정할 수 있습니다.
+            <br className="bp1:hidden block" /> 단, 매칭 중에는 일부 수정이
+            제한됩니다.
           </span>
         </div>
 
         <div className="bp1:gap-8 flex min-w-0 flex-col gap-6 min-[960px]:gap-10">
           {useGroupedView && (
-            <div className="scrollbar-none bp1:-mx-6 bp1:px-6 -mx-4 overflow-x-auto px-4 min-[960px]:mx-0 min-[960px]:px-0">
+            <div className="min-w-0">
               <SegmentButton
                 items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
                 value={selectedChapter}
                 onValueChange={setSelectedChapter}
-                className="min-w-max min-[960px]:w-full min-[960px]:min-w-0"
-                itemClassName="min-[960px]:flex-1"
+                className="w-full min-w-0 [&>button>span:last-child]:min-w-0 [&>button>span:last-child]:truncate"
+                itemClassName="min-w-0 flex-1 basis-0 shrink px-2"
               />
             </div>
           )}

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -46,6 +46,7 @@ type ProjectSummaryInput = {
   name?: string | null
   description?: string | null
   thumbnailImageUrl?: string | null
+  logoImageUrl?: string | null
   status?: ProjectStatus | null
   productOwner?: {
     nickname?: string | null
@@ -61,7 +62,24 @@ type ProjectSummaryInput = {
     | null
 }
 
-function toMatchingProject(item: ProjectSummaryInput): MatchingProject {
+function withImageCacheKey(
+  src: string | null | undefined,
+  cacheKey: number,
+): string | null {
+  if (!src) return null
+
+  const hashIndex = src.indexOf("#")
+  const baseUrl = hashIndex >= 0 ? src.slice(0, hashIndex) : src
+  const hash = hashIndex >= 0 ? src.slice(hashIndex + 1) : ""
+  const separator = baseUrl.includes("?") ? "&" : "?"
+  const versionedUrl = `${baseUrl}${separator}v=${cacheKey}`
+  return hash ? `${versionedUrl}#${hash}` : versionedUrl
+}
+
+function toMatchingProject(
+  item: ProjectSummaryInput,
+  imageCacheKey: number,
+): MatchingProject {
   const owner = item.productOwner
   const ownerLine = [
     owner?.nickname && owner?.name
@@ -80,7 +98,18 @@ function toMatchingProject(item: ProjectSummaryInput): MatchingProject {
     description: item.description ?? "",
     authorSchoolLine: ownerLine,
     status: item.status ?? undefined,
-    coverImage: item.thumbnailImageUrl ? { src: item.thumbnailImageUrl } : null,
+    logoImage: item.logoImageUrl
+      ? {
+          src: withImageCacheKey(item.logoImageUrl, imageCacheKey)!,
+          alt: `${item.name ?? "프로젝트"} 로고`,
+        }
+      : null,
+    coverImage: item.thumbnailImageUrl
+      ? {
+          src: withImageCacheKey(item.thumbnailImageUrl, imageCacheKey)!,
+          alt: `${item.name ?? "프로젝트"} 대표 이미지`,
+        }
+      : null,
     recruitRows: (item.partQuotas ?? [])
       .slice()
       .sort((a, b) => {
@@ -134,8 +163,11 @@ export function ProjectManagementPage() {
   })
 
   const projects: MatchingProject[] = useMemo(
-    () => (managedQuery.data ?? []).map(toMatchingProject),
-    [managedQuery.data],
+    () =>
+      (managedQuery.data ?? []).map((project) =>
+        toMatchingProject(project, managedQuery.dataUpdatedAt),
+      ),
+    [managedQuery.data, managedQuery.dataUpdatedAt],
   )
 
   const filteredProjects: MatchingProject[] = useMemo(() => {
@@ -220,27 +252,29 @@ export function ProjectManagementPage() {
   if (!hasAccess) return null
 
   return (
-    <section className="relative isolate flex w-full flex-col items-start justify-start">
-      <div className="border-teal-gray-100 relative z-30 flex h-full min-w-242 flex-col gap-6 rounded-[12px] border bg-white px-8.5 pt-8 pb-10">
+    <section className="relative isolate flex w-full min-w-0 flex-col items-stretch justify-start">
+      <div className="border-teal-gray-100 bp1:gap-6 bp1:px-6 bp1:pt-6 bp1:pb-8 relative z-30 flex h-full w-full max-w-242 min-w-0 flex-col gap-5 rounded-[12px] border bg-white px-4 pt-5 pb-6 min-[960px]:px-8.5 min-[960px]:pt-8 min-[960px]:pb-10">
         <div className="flex flex-col items-start gap-1.5">
           <span className="text-heading-6-semibold text-teal-gray-900">
             프로젝트 관리
           </span>
           <span className="text-body-2-regular text-teal-gray-600">
-            모든 프로젝트의 상세 정보를 확인하고 수정할 수 있습니다.
-            <br />
-            단, 매칭 중에는 일부 수정이 제한됩니다.
+            모든 프로젝트의 상세 정보를 확인하고 수정할 수 있습니다. 단, 매칭
+            중에는 일부 수정이 제한됩니다.
           </span>
         </div>
 
-        <div className="flex flex-col gap-10">
+        <div className="bp1:gap-8 flex min-w-0 flex-col gap-6 min-[960px]:gap-10">
           {useGroupedView && (
-            <SegmentButton
-              items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
-              value={selectedChapter}
-              onValueChange={setSelectedChapter}
-              itemClassName="flex-1"
-            />
+            <div className="scrollbar-none bp1:-mx-6 bp1:px-6 -mx-4 overflow-x-auto px-4 min-[960px]:mx-0 min-[960px]:px-0">
+              <SegmentButton
+                items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
+                value={selectedChapter}
+                onValueChange={setSelectedChapter}
+                className="min-w-max min-[960px]:w-full min-[960px]:min-w-0"
+                itemClassName="min-[960px]:flex-1"
+              />
+            </div>
           )}
           {managedQuery.isLoading ? (
             <p className="text-body-2-regular text-teal-gray-400 py-10 text-center">
@@ -249,9 +283,9 @@ export function ProjectManagementPage() {
           ) : isAdminScope ? (
             useGroupedView && partGroups.size > 0 ? (
               Array.from(partGroups.entries()).map(([part, partProjects]) => (
-                <div key={part} className="flex flex-col">
+                <div key={part} className="flex min-w-0 flex-col">
                   <ProjectManagementSubTitle title={part} className="pb-2" />
-                  <div className="flex flex-col gap-4">
+                  <div className="grid min-w-0 grid-cols-1 gap-3 min-[700px]:grid-cols-2 min-[960px]:grid-cols-1 min-[960px]:gap-4">
                     {partProjects.map((project) => {
                       const permissions = getProjectActionPermissions(project)
                       return (
@@ -267,7 +301,7 @@ export function ProjectManagementPage() {
                 </div>
               ))
             ) : !useGroupedView && projects.length > 0 ? (
-              <div className="flex flex-col gap-3">
+              <div className="grid min-w-0 grid-cols-1 gap-3 min-[700px]:grid-cols-2 min-[960px]:grid-cols-1">
                 {projects.map((project) => {
                   const permissions = getProjectActionPermissions(project)
                   return (
@@ -287,7 +321,7 @@ export function ProjectManagementPage() {
               />
             )
           ) : projects.length > 0 ? (
-            <div className="flex flex-col gap-3">
+            <div className="grid min-w-0 grid-cols-1 gap-3 min-[700px]:grid-cols-2 min-[960px]:grid-cols-1">
               {projects.map((project) => {
                 const permissions = getProjectActionPermissions(project)
                 return (

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -12,6 +12,7 @@ import {
 import { getChaptersWithSchools } from "@/features/challenger/api/organization"
 import { gisuKeys, projectKeys } from "@/features/project/new/api/queryKeys"
 import { getActiveGisu } from "@/shared/api/gisu"
+import { withImageCacheKey } from "@/shared/lib/withImageCacheKey"
 import { EmptyState } from "@/shared/ui/EmptyState"
 import { SegmentButton } from "@/shared/ui/segment-button/SegmentButton"
 import { CHAPTERS } from "@/shared/ui/segment/ChapterSelector"
@@ -62,20 +63,6 @@ type ProjectSummaryInput = {
     | null
 }
 
-function withImageCacheKey(
-  src: string | null | undefined,
-  cacheKey: number,
-): string | null {
-  if (!src) return null
-
-  const hashIndex = src.indexOf("#")
-  const baseUrl = hashIndex >= 0 ? src.slice(0, hashIndex) : src
-  const hash = hashIndex >= 0 ? src.slice(hashIndex + 1) : ""
-  const separator = baseUrl.includes("?") ? "&" : "?"
-  const versionedUrl = `${baseUrl}${separator}v=${cacheKey}`
-  return hash ? `${versionedUrl}#${hash}` : versionedUrl
-}
-
 function toMatchingProject(
   item: ProjectSummaryInput,
   imageCacheKey: number,
@@ -100,13 +87,17 @@ function toMatchingProject(
     status: item.status ?? undefined,
     logoImage: item.logoImageUrl
       ? {
-          src: withImageCacheKey(item.logoImageUrl, imageCacheKey)!,
+          src:
+            withImageCacheKey(item.logoImageUrl, imageCacheKey) ??
+            item.logoImageUrl,
           alt: `${item.name ?? "프로젝트"} 로고`,
         }
       : null,
     coverImage: item.thumbnailImageUrl
       ? {
-          src: withImageCacheKey(item.thumbnailImageUrl, imageCacheKey)!,
+          src:
+            withImageCacheKey(item.thumbnailImageUrl, imageCacheKey) ??
+            item.thumbnailImageUrl,
           alt: `${item.name ?? "프로젝트"} 대표 이미지`,
         }
       : null,

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -106,7 +106,8 @@ function MatchingApplicationsPage() {
                 items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
                 value={selectedChapter}
                 onValueChange={(v) => setSelectedChapter(v)}
-                itemClassName="flex-1"
+                className="w-full min-w-0 [&>button>span:last-child]:min-w-0 [&>button>span:last-child]:truncate"
+                itemClassName="min-w-0 flex-1 basis-0 shrink px-2"
               />
               {admin.isLoading ? (
                 <div className="flex items-center justify-center py-20">

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -109,6 +109,12 @@ function readPendingNotice() {
   }
 }
 
+function readHashNoticeId() {
+  if (typeof window === "undefined") return null
+  const id = window.location.hash.match(/^#notice-(.+)$/)?.[1]
+  return id ? decodeURIComponent(id) : null
+}
+
 /** 팀 매칭 공지 페이지 (/matching) */
 export const Route = createFileRoute("/matching/")({
   validateSearch: (search: Record<string, unknown>): AnnounceSearch => {
@@ -139,6 +145,7 @@ function TeamMatchingAnnouncePage() {
   const navigate = useNavigate({ from: Route.fullPath })
   const addToast = useToastStore((state) => state.addToast)
   const [pendingNotice] = useState(readPendingNotice)
+  const [hashNoticeId] = useState(readHashNoticeId)
 
   const { data: me } = useMe()
   const { viewMe } = useViewMe()
@@ -227,7 +234,7 @@ function TeamMatchingAnnouncePage() {
 
   const totalPages = noticesData?.totalPages || 1
   const safePage = Math.min(Math.max(1, page), totalPages)
-  const focusedNoticeId = pendingNotice?.id ?? null
+  const focusedNoticeId = pendingNotice?.id ?? hashNoticeId ?? null
 
   const queryClient = useQueryClient()
 

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -21,7 +21,6 @@ import {
 import {
   type Chapter,
   CHAPTERS,
-  ChapterSelector,
   NoticeCardList,
   NoticeDetailContent,
   type NoticeItem,
@@ -30,6 +29,7 @@ import { deleteNotice, getNotices } from "@/features/notice/api/noticeApi"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import { Button } from "@/shared/ui/Button"
 import { Pagination } from "@/shared/ui/Pagination"
+import { SegmentButton } from "@/shared/ui/segment-button/SegmentButton"
 import { useViewModeStore } from "@/shared/view-mode"
 import { projectViewMe } from "@/shared/view-mode/projectViewMe"
 import { useViewMe } from "@/shared/view-mode/useViewMe"
@@ -311,7 +311,7 @@ function TeamMatchingAnnouncePage() {
 
   return (
     <section className="w-full">
-      <div className="border-teal-gray-100 flex min-h-213 w-full max-w-242 flex-col items-center justify-between rounded-[12px] border bg-white px-8.5 pt-8 pb-10">
+      <div className="border-teal-gray-100 bp1:min-h-213 bp1:px-6 bp1:pt-6 bp1:pb-8 flex w-full max-w-242 min-w-0 flex-col items-center justify-between rounded-[12px] border bg-white px-4 pt-5 pb-6 min-[960px]:px-8.5 min-[960px]:pt-8 min-[960px]:pb-10">
         <div className="flex w-full flex-col gap-6 pb-10">
           <div className="flex w-full flex-col items-start gap-1.5">
             <span className="text-heading-6-semibold text-teal-gray-900">
@@ -327,10 +327,13 @@ function TeamMatchingAnnouncePage() {
           </div>
 
           <div className="flex w-full flex-col items-center gap-2.5">
-            <div className="flex w-full items-center gap-2.5">
-              <ChapterSelector
-                selectedChapter={chapter}
-                onChapterChange={handleChapterChange}
+            <div className="bp1:flex-row bp1:items-center flex w-full flex-col gap-2.5">
+              <SegmentButton
+                items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
+                value={chapter}
+                onValueChange={(v) => handleChapterChange(v as Chapter)}
+                className="w-full min-w-0 [&>button>span:last-child]:min-w-0 [&>button>span:last-child]:truncate"
+                itemClassName="min-w-0 flex-1 basis-0 shrink px-2"
               />
 
               {canWrite ? (
@@ -340,7 +343,7 @@ function TeamMatchingAnnouncePage() {
                   color="primary"
                   size="m"
                   onClick={handleNoticePublishClick}
-                  className="w-26.5 items-center gap-1 py-3 pr-4 pl-3"
+                  className="bp1:w-26.5 w-full items-center justify-center gap-1 py-3 pr-4 pl-3"
                 >
                   <PlusIcon className="h-4 w-4" />
                   <span className="text-label-1-medium text-white">

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -108,6 +108,12 @@ function readPendingNotice() {
   }
 }
 
+function readHashNoticeId() {
+  if (typeof window === "undefined") return null
+  const id = window.location.hash.match(/^#notice-(.+)$/)?.[1]
+  return id ? decodeURIComponent(id) : null
+}
+
 /** 프로젝트 설정 공지 페이지 (/matching/projects/announce) */
 export const Route = createFileRoute("/matching/projects/announce/")({
   validateSearch: (search: Record<string, unknown>): AnnounceSearch => {
@@ -138,6 +144,7 @@ function ProjectSettingsAnnouncePage() {
   const navigate = useNavigate({ from: Route.fullPath })
   const addToast = useToastStore((state) => state.addToast)
   const [pendingNotice] = useState(readPendingNotice)
+  const [hashNoticeId] = useState(readHashNoticeId)
 
   const { data: me } = useMe()
   const { viewMe } = useViewMe()
@@ -226,7 +233,7 @@ function ProjectSettingsAnnouncePage() {
 
   const totalPages = noticesData?.totalPages || 1
   const safePage = Math.min(Math.max(1, page), totalPages)
-  const focusedNoticeId = pendingNotice?.id ?? null
+  const focusedNoticeId = pendingNotice?.id ?? hashNoticeId ?? null
 
   const queryClient = useQueryClient()
 

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -20,7 +20,6 @@ import {
 import {
   type Chapter,
   CHAPTERS,
-  ChapterSelector,
   NoticeCardList,
   NoticeDetailContent,
   type NoticeItem,
@@ -29,6 +28,7 @@ import { deleteNotice, getNotices } from "@/features/notice/api/noticeApi"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import { Button } from "@/shared/ui/Button"
 import { Pagination } from "@/shared/ui/Pagination"
+import { SegmentButton } from "@/shared/ui/segment-button/SegmentButton"
 import { useViewModeStore } from "@/shared/view-mode"
 import { projectViewMe } from "@/shared/view-mode/projectViewMe"
 import { useViewMe } from "@/shared/view-mode/useViewMe"
@@ -310,7 +310,7 @@ function ProjectSettingsAnnouncePage() {
 
   return (
     <section className="w-full">
-      <div className="border-teal-gray-100 flex min-h-213 w-full max-w-242 flex-col items-center justify-between rounded-[12px] border bg-white px-8.5 pt-8 pb-10">
+      <div className="border-teal-gray-100 bp1:min-h-213 bp1:px-6 bp1:pt-6 bp1:pb-8 flex w-full max-w-242 min-w-0 flex-col items-center justify-between rounded-[12px] border bg-white px-4 pt-5 pb-6 min-[960px]:px-8.5 min-[960px]:pt-8 min-[960px]:pb-10">
         <div className="flex w-full flex-col gap-6 pb-10">
           <div className="flex w-full flex-col items-start gap-1.5">
             <span className="text-heading-6-semibold text-teal-gray-900">
@@ -324,10 +324,13 @@ function ProjectSettingsAnnouncePage() {
           </div>
 
           <div className="flex w-full flex-col items-center gap-2.5">
-            <div className="flex w-full items-center gap-2.5">
-              <ChapterSelector
-                selectedChapter={chapter}
-                onChapterChange={handleChapterChange}
+            <div className="bp1:flex-row bp1:items-center flex w-full flex-col gap-2.5">
+              <SegmentButton
+                items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
+                value={chapter}
+                onValueChange={(v) => handleChapterChange(v as Chapter)}
+                className="w-full min-w-0 [&>button>span:last-child]:min-w-0 [&>button>span:last-child]:truncate"
+                itemClassName="min-w-0 flex-1 basis-0 shrink px-2"
               />
 
               {canWrite ? (
@@ -337,7 +340,7 @@ function ProjectSettingsAnnouncePage() {
                   color="primary"
                   size="m"
                   onClick={handleNoticePublishClick}
-                  className="w-26.5 items-center gap-1 py-3 pr-4 pl-3"
+                  className="bp1:w-26.5 w-full items-center justify-center gap-1 py-3 pr-4 pl-3"
                 >
                   <PlusIcon className="h-4 w-4" />
                   <span className="text-label-1-medium text-white">

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -514,8 +514,8 @@ function MatchingRoundsPage() {
             }))}
             value={matchingType}
             onValueChange={(v) => handleMatchingTypeChange(v as MatchingType)}
-            className="w-183.5"
-            itemClassName="flex-1"
+            className="w-full max-w-183.5 min-w-0 [&>button>span:last-child]:min-w-0 [&>button>span:last-child]:truncate"
+            itemClassName="min-w-0 flex-1 basis-0 shrink px-2"
           />
 
           {/* 01 매칭 기간 설정 */}

--- a/src/routes/matching/status.tsx
+++ b/src/routes/matching/status.tsx
@@ -90,7 +90,8 @@ function MatchingStatusPage() {
             items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
             value={selectedChapter}
             onValueChange={(v) => setSelectedChapter(v as Chapter)}
-            itemClassName="flex-1"
+            className="w-full min-w-0 [&>button>span:last-child]:min-w-0 [&>button>span:last-child]:truncate"
+            itemClassName="min-w-0 flex-1 basis-0 shrink px-2"
           />
 
           {isLoading ? (

--- a/src/shared/lib/withImageCacheKey.ts
+++ b/src/shared/lib/withImageCacheKey.ts
@@ -1,0 +1,13 @@
+export function withImageCacheKey(
+  src: string | null | undefined,
+  cacheKey: number,
+): string | null {
+  if (!src) return null
+
+  const hashIndex = src.indexOf("#")
+  const baseUrl = hashIndex >= 0 ? src.slice(0, hashIndex) : src
+  const hash = hashIndex >= 0 ? src.slice(hashIndex + 1) : ""
+  const separator = baseUrl.includes("?") ? "&" : "?"
+  const versionedUrl = `${baseUrl}${separator}v=${cacheKey}`
+  return hash ? `${versionedUrl}#${hash}` : versionedUrl
+}


### PR DESCRIPTION
## Summary
- `/matching/projects/management` 본문, 목록 카드, 상세 모달 반응형 적용
- 관리 목록/상세 카드의 썸네일 및 로고 이미지 URL에 조회 갱신 시점 기반 cache key 적용
- 상세 모달과 관리 목록 카드에서 프로젝트 로고 이미지를 표시하도록 연결
- 관리 목록 응답에 로고 URL이 없을 때 상세 API 캐시를 보조 조회해 개별 카드 로고 표시

## Test
- `pnpm lint`
- `pnpm build`
- `curl -I --max-time 5 http://localhost:5173/matching/projects/management`

## Note
- 현재 `/v1/projects/me/managed` 응답 스키마에는 `logoImageUrl`이 없어 카드별 상세 API 보조 조회가 발생할 수 있습니다.
- 추후 관리 목록 API 응답에 `logoImageUrl`이 포함되면 보조 조회를 제거할 수 있습니다.

Closes #243