### PR TITLE
🐛 fix: 0612 QA - 중복 등록·매칭 중 수정 차단 + 토스트/헤더 개선

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from "@tanstack/react-router"
 import { useEffect, useMemo, useState } from "react"
 
 import { MobileSidebarDrawerContent } from "@/components/sidebar/MobileSidebarDrawerContent"
+import { useToastStore } from "@/components/toast/useToastStore"
 import { isOperator, isSchoolStaff } from "@/features/auth/model/identity"
 import CloseIcon from "@/shared/assets/icon/close/CloseIcon"
 import HamburgerIcon from "@/shared/assets/icon/hamburger/HamburgerIcon"
@@ -45,6 +46,7 @@ interface HeaderProps {
 export default function Header({ activePathname }: HeaderProps = {}) {
   const location = useLocation()
   const { viewMe } = useViewMe()
+  const addToast = useToastStore((s) => s.addToast)
   const pathname = activePathname ?? location.pathname
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false)
 
@@ -53,6 +55,16 @@ export default function Header({ activePathname }: HeaderProps = {}) {
     if (isSchoolStaff(viewMe)) return [...BASE_NAV, MANAGE_NAV]
     return BASE_NAV
   }, [viewMe])
+
+  const handleDisabledClick = (label: string) => {
+    addToast({
+      message: `${label} 서비스는 준비 중입니다. 더 나은 UMC 웹사이트로 찾아뵙겠습니다!`,
+      color: "primary",
+      variant: "deep",
+      type: "notice",
+      duration: 3000,
+    })
+  }
 
   useEffect(() => {
     setIsMobileMenuOpen(false)
@@ -77,6 +89,11 @@ export default function Header({ activePathname }: HeaderProps = {}) {
               to={item.to}
               selected={pathname.startsWith(item.to)}
               disabled={item.disabled}
+              onClick={
+                item.disabled
+                  ? () => handleDisabledClick(item.label)
+                  : undefined
+              }
               className="min-w-0 px-3 xl:min-w-18 xl:px-4.5"
             />
           ))}
@@ -132,7 +149,10 @@ export default function Header({ activePathname }: HeaderProps = {}) {
                 selected={selected}
                 disabled={item.disabled}
                 className="text-body-1-medium h-11 w-full min-w-0 justify-center px-4"
-                onClick={() => setIsMobileMenuOpen(false)}
+                onClick={() => {
+                  if (item.disabled) handleDisabledClick(item.label)
+                  setIsMobileMenuOpen(false)
+                }}
               />
             )
           })}

--- a/src/components/header/NavigationButton.tsx
+++ b/src/components/header/NavigationButton.tsx
@@ -19,23 +19,27 @@ export default function NavigationButton({
   className,
   onClick,
 }: NavigationButtonProps) {
+  const sharedClassName = cn(
+    "flex h-9 min-w-18 items-center justify-center rounded-full px-4.5 py-1.5 whitespace-nowrap transition-colors",
+    selected
+      ? "text-subtitle-3-semibold bg-teal-100 text-teal-600"
+      : "text-body-1-medium text-teal-gray-600",
+    !disabled &&
+      !selected &&
+      "hover:bg-teal-gray-100 hover:shadow-inner-neutral-3",
+    className,
+  )
+
+  if (disabled) {
+    return (
+      <button type="button" onClick={onClick} className={sharedClassName}>
+        {label}
+      </button>
+    )
+  }
+
   return (
-    <Link
-      to={to}
-      disabled={disabled}
-      onClick={onClick}
-      className={cn(
-        "flex h-9 min-w-18 items-center justify-center rounded-full px-4.5 py-1.5 whitespace-nowrap transition-colors",
-        selected
-          ? "text-subtitle-3-semibold bg-teal-100 text-teal-600"
-          : "text-body-1-medium text-teal-gray-600",
-        !disabled &&
-          !selected &&
-          "hover:bg-teal-gray-100 hover:shadow-inner-neutral-3",
-        disabled && "pointer-events-none",
-        className,
-      )}
-    >
+    <Link to={to} onClick={onClick} className={sharedClassName}>
       {label}
     </Link>
   )

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/shared/lib/utils"
 export const FADE_OUT_DURATION = 300
 
 const toastVariants = cva(
-  "w-fit min-w-[min(400px,90vw)] max-w-[min(90vw,600px)] min-h-12.5 px-4 py-1 gap-2.5 rounded-[12px] flex items-center text-label-1-medium transition-opacity",
+  "w-max min-w-[min(400px,90vw)] max-w-[min(90vw,600px)] min-h-12.5 px-4 py-1 gap-2.5 rounded-[12px] flex items-center text-label-1-medium transition-opacity",
   {
     variants: {
       variant: {

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -2,12 +2,13 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 import SvgCircleCheckIcon from "@/shared/assets/icon/check/CircleCheckIcon"
 import SvgCloseIcon from "@/shared/assets/icon/close/CloseIcon"
+import errorCone from "@/shared/assets/icon/error/error-cone.svg"
 import { cn } from "@/shared/lib/utils"
 
 export const FADE_OUT_DURATION = 300
 
 const toastVariants = cva(
-  "w-fit min-w-60 h-12.5 px-4 py-1 gap-2.5 rounded-[12px] flex justify-between items-center text-label-1-medium shadow-drop-neutral-2 transition-opacity",
+  "w-fit min-w-[min(400px,90vw)] max-w-[min(90vw,600px)] min-h-12.5 px-4 py-1 gap-2.5 rounded-[12px] flex items-center text-label-1-medium transition-opacity",
   {
     variants: {
       variant: {
@@ -17,6 +18,11 @@ const toastVariants = cva(
       color: {
         primary: "",
         red: "",
+      },
+      type: {
+        default: "justify-between shadow-drop-neutral-2",
+        time: "justify-between shadow-drop-neutral-2",
+        notice: "justify-center shadow-drop-neutral-1",
       },
     },
     compoundVariants: [
@@ -28,6 +34,7 @@ const toastVariants = cva(
     defaultVariants: {
       variant: "deep",
       color: "primary",
+      type: "default",
     },
   },
 )
@@ -49,7 +56,6 @@ const countdownColorMap = {
 
 interface ToastProps extends VariantProps<typeof toastVariants> {
   message: string
-  type?: "default" | "time"
   remaining: number
   isDismissing: boolean
   onDismiss: () => void
@@ -71,38 +77,71 @@ export function Toast({
       role={resolvedColor === "red" ? "alert" : "status"}
       aria-atomic="true"
       className={cn(
-        toastVariants({ variant, color }),
+        toastVariants({ variant, color, type }),
         isDismissing && "opacity-0",
       )}
       style={{ transitionDuration: `${FADE_OUT_DURATION}ms` }}
     >
-      <div className="flex items-center gap-2.5">
-        <SvgCircleCheckIcon
-          aria-hidden="true"
-          width={20}
-          height={20}
-          className={iconColorMap[resolvedColor]}
-        />
-        <span className={textColorMap[resolvedColor]}>{message}</span>
-      </div>
-      {type === "time" ? (
-        <span
-          className={cn(
-            "text-label-1-medium",
-            countdownColorMap[resolvedColor],
-          )}
-        >
-          {Math.ceil(remaining / 1000)}s
-        </span>
+      {type === "notice" ? (
+        <>
+          <img
+            src={errorCone}
+            alt=""
+            width={24}
+            height={24}
+            className="shrink-0"
+          />
+          <span
+            className={cn(
+              "text-center wrap-break-word",
+              textColorMap[resolvedColor],
+            )}
+          >
+            {message}
+          </span>
+          <img
+            src={errorCone}
+            alt=""
+            width={24}
+            height={24}
+            className="shrink-0"
+          />
+        </>
       ) : (
-        <button
-          type="button"
-          onClick={onDismiss}
-          className="text-teal-gray-400 flex items-center justify-center"
-          aria-label="토스트 닫기"
-        >
-          <SvgCloseIcon width={20} height={20} />
-        </button>
+        <>
+          <div className="flex min-w-0 items-center gap-2.5">
+            <SvgCircleCheckIcon
+              aria-hidden="true"
+              width={20}
+              height={20}
+              className={cn("shrink-0", iconColorMap[resolvedColor])}
+            />
+            <span
+              className={cn("wrap-break-word", textColorMap[resolvedColor])}
+            >
+              {message}
+            </span>
+          </div>
+          {type === "time" ? (
+            <span
+              className={cn(
+                "text-label-1-medium",
+                countdownColorMap[resolvedColor],
+              )}
+            >
+              {Math.ceil(remaining / 1000)}s
+            </span>
+          ) : (
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="text-teal-gray-400 flex items-center justify-center"
+              aria-label="토스트 닫기"
+            >
+              <SvgCloseIcon width={20} height={20} />
+            </button>
+          )}
+        </>
       )}
     </div>
   )

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -2,7 +2,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 
 import SvgCircleCheckIcon from "@/shared/assets/icon/check/CircleCheckIcon"
 import SvgCloseIcon from "@/shared/assets/icon/close/CloseIcon"
-import errorCone from "@/shared/assets/icon/error/error-cone.svg"
+import RubberConeIcon from "@/shared/assets/icon/RubberConeIcon"
 import { cn } from "@/shared/lib/utils"
 
 export const FADE_OUT_DURATION = 300
@@ -84,9 +84,8 @@ export function Toast({
     >
       {type === "notice" ? (
         <>
-          <img
-            src={errorCone}
-            alt=""
+          <RubberConeIcon
+            aria-hidden="true"
             width={24}
             height={24}
             className="shrink-0"
@@ -99,9 +98,8 @@ export function Toast({
           >
             {message}
           </span>
-          <img
-            src={errorCone}
-            alt=""
+          <RubberConeIcon
+            aria-hidden="true"
             width={24}
             height={24}
             className="shrink-0"

--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -122,22 +122,28 @@ export function ToastProvider() {
           return (
             <div
               key={toast.id}
-              className="pointer-events-auto absolute bottom-0 left-0 origin-bottom transition-all duration-300"
-              style={{
-                transform: `translateX(-50%) translateY(${translateY}px) scale(${scale})`,
-                zIndex,
-                animation: isFront ? "toast-shake 0.4s ease-in-out" : undefined,
-              }}
+              className="pointer-events-auto absolute bottom-0 left-1/2 -translate-x-1/2"
+              style={{ zIndex }}
             >
-              <Toast
-                message={toast.message}
-                color={toast.color}
-                variant={toast.variant}
-                type={toast.type}
-                remaining={remainingMap.get(toast.id) ?? toast.duration}
-                isDismissing={dismissingIds.has(toast.id)}
-                onDismiss={() => dismiss(toast.id)}
-              />
+              <div
+                className="origin-bottom transition-all duration-300"
+                style={{
+                  transform: `translateY(${translateY}px) scale(${scale})`,
+                  animation: isFront
+                    ? "toast-shake 0.4s ease-in-out"
+                    : undefined,
+                }}
+              >
+                <Toast
+                  message={toast.message}
+                  color={toast.color}
+                  variant={toast.variant}
+                  type={toast.type}
+                  remaining={remainingMap.get(toast.id) ?? toast.duration}
+                  isDismissing={dismissingIds.has(toast.id)}
+                  onDismiss={() => dismiss(toast.id)}
+                />
+              </div>
             </div>
           )
         })}

--- a/src/components/toast/useToastStore.ts
+++ b/src/components/toast/useToastStore.ts
@@ -5,7 +5,7 @@ export interface ToastItem {
   message: string
   color: "primary" | "red"
   variant: "deep" | "weak"
-  type: "default" | "time"
+  type: "default" | "time" | "notice"
   duration: number
 }
 

--- a/src/features/auth/model/identity.test.ts
+++ b/src/features/auth/model/identity.test.ts
@@ -5,6 +5,7 @@ import {
   canManageProjects,
   getProjectPmSearchScope,
   isAnyOperator,
+  isProjectRegistrationQuotaLimited,
   isSchoolLeadership,
 } from "./identity"
 
@@ -209,5 +210,73 @@ describe("getProjectPmSearchScope", () => {
 
   it("undefined는 빈 객체 반환", () => {
     expect(getProjectPmSearchScope(undefined)).toEqual({})
+  })
+})
+
+describe("isProjectRegistrationQuotaLimited", () => {
+  it("순수 PM(현기수 PLAN, 운영 역할 없음)은 1개 제한 대상 true", () => {
+    expect(
+      isProjectRegistrationQuotaLimited(
+        makeMe(["CHALLENGER"], [{ gisuId: "10", part: "PLAN" }]),
+      ),
+    ).toBe(true)
+  })
+  it("Plan + 지부장은 운영 권한 우선으로 제한 제외 false", () => {
+    expect(
+      isProjectRegistrationQuotaLimited(
+        makeMe(["CHAPTER_PRESIDENT"], [{ gisuId: "10", part: "PLAN" }]),
+      ),
+    ).toBe(false)
+  })
+  it("Plan + 최고관리자도 제한 제외 false", () => {
+    expect(
+      isProjectRegistrationQuotaLimited(
+        makeMe(["SUPER_ADMIN"], [{ gisuId: "10", part: "PLAN" }]),
+      ),
+    ).toBe(false)
+  })
+  it("Plan + 학교 회장도 제한 제외 false", () => {
+    expect(
+      isProjectRegistrationQuotaLimited(
+        makeMe(["SCHOOL_PRESIDENT"], [{ gisuId: "10", part: "PLAN" }]),
+      ),
+    ).toBe(false)
+  })
+  it("Plan + 학교 기타운영진도 제한 제외 false", () => {
+    expect(
+      isProjectRegistrationQuotaLimited(
+        makeMe(["SCHOOL_ETC_ADMIN"], [{ gisuId: "10", part: "PLAN" }]),
+      ),
+    ).toBe(false)
+  })
+  it("운영진이지만 현기수 비PM(비PLAN)이면 false", () => {
+    expect(
+      isProjectRegistrationQuotaLimited(
+        makeMe(["SUPER_ADMIN"], [{ gisuId: "10", part: "IOS" }]),
+      ),
+    ).toBe(false)
+  })
+  it("비PM 일반 챌린저는 false", () => {
+    expect(
+      isProjectRegistrationQuotaLimited(
+        makeMe(["CHALLENGER"], [{ gisuId: "10", part: "IOS" }]),
+      ),
+    ).toBe(false)
+  })
+  it("최신 기수가 PLAN이 아니면(이전 기수 PLAN 무시) false", () => {
+    expect(
+      isProjectRegistrationQuotaLimited(
+        makeMe(
+          ["CHALLENGER"],
+          [
+            { gisuId: "9", part: "PLAN" },
+            { gisuId: "10", part: "IOS" },
+          ],
+        ),
+      ),
+    ).toBe(false)
+  })
+  it("undefined는 false", () => {
+    expect(isProjectRegistrationQuotaLimited(undefined)).toBe(false)
   })
 })

--- a/src/features/auth/model/identity.ts
+++ b/src/features/auth/model/identity.ts
@@ -105,6 +105,13 @@ export function isCurrentTermPm(me: MemberInfoResponse | undefined): boolean {
   return latest?.part === "PLAN"
 }
 
+export function isProjectRegistrationQuotaLimited(
+  me: MemberInfoResponse | undefined,
+): boolean {
+  if (isAnyOperator(me)) return false
+  return isCurrentTermPm(me)
+}
+
 export function getViewerBranch(
   me: MemberInfoResponse | undefined,
 ): string | undefined {

--- a/src/features/project/new/model/matchingPeriod.test.ts
+++ b/src/features/project/new/model/matchingPeriod.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest"
+
+import { isWithinMatchingPeriod } from "./matchingPeriod"
+
+import type { MatchingRoundResponse } from "@/features/application/model/apiTypes"
+
+function makeRound(startsAt: string, endsAt: string): MatchingRoundResponse {
+  return {
+    id: "1",
+    name: "1차 매칭",
+    description: "",
+    type: "PLAN_DESIGN",
+    phase: "FIRST",
+    chapterId: "28",
+    startsAt,
+    endsAt,
+    decisionDeadline: endsAt,
+    autoDecisionExecutedAt: null,
+    autoDecisionExecutedMemberId: null,
+    createdAt: "",
+    updatedAt: "",
+  }
+}
+
+describe("isWithinMatchingPeriod", () => {
+  const now = new Date("2026-06-13T12:00:00Z")
+
+  it("현재 시각이 차수 기간 내면 true (매칭 중)", () => {
+    expect(
+      isWithinMatchingPeriod(
+        [makeRound("2026-06-13T00:00:00Z", "2026-06-14T00:00:00Z")],
+        now,
+      ),
+    ).toBe(true)
+  })
+
+  it("매칭 기간 전이면 false", () => {
+    expect(
+      isWithinMatchingPeriod(
+        [makeRound("2026-06-14T00:00:00Z", "2026-06-15T00:00:00Z")],
+        now,
+      ),
+    ).toBe(false)
+  })
+
+  it("매칭 기간 후면 false", () => {
+    expect(
+      isWithinMatchingPeriod(
+        [makeRound("2026-06-10T00:00:00Z", "2026-06-11T00:00:00Z")],
+        now,
+      ),
+    ).toBe(false)
+  })
+
+  it("여러 차수 중 하나라도 기간 내면 true", () => {
+    expect(
+      isWithinMatchingPeriod(
+        [
+          makeRound("2026-06-10T00:00:00Z", "2026-06-11T00:00:00Z"),
+          makeRound("2026-06-13T00:00:00Z", "2026-06-14T00:00:00Z"),
+        ],
+        now,
+      ),
+    ).toBe(true)
+  })
+
+  it("차수 사이(어느 기간에도 들지 않음)면 false", () => {
+    expect(
+      isWithinMatchingPeriod(
+        [
+          makeRound("2026-06-10T00:00:00Z", "2026-06-11T00:00:00Z"),
+          makeRound("2026-06-15T00:00:00Z", "2026-06-16T00:00:00Z"),
+        ],
+        now,
+      ),
+    ).toBe(false)
+  })
+
+  it("시작 경계 시각은 포함하여 true", () => {
+    expect(
+      isWithinMatchingPeriod(
+        [makeRound("2026-06-13T12:00:00Z", "2026-06-14T00:00:00Z")],
+        now,
+      ),
+    ).toBe(true)
+  })
+
+  it("종료 경계 시각은 포함하여 true", () => {
+    expect(
+      isWithinMatchingPeriod(
+        [makeRound("2026-06-12T00:00:00Z", "2026-06-13T12:00:00Z")],
+        now,
+      ),
+    ).toBe(true)
+  })
+
+  it("빈 배열/undefined는 false", () => {
+    expect(isWithinMatchingPeriod([], now)).toBe(false)
+    expect(isWithinMatchingPeriod(undefined, now)).toBe(false)
+  })
+})

--- a/src/features/project/new/model/matchingPeriod.ts
+++ b/src/features/project/new/model/matchingPeriod.ts
@@ -1,0 +1,17 @@
+import dayjs from "dayjs"
+
+import type { MatchingRoundResponse } from "@/features/application/model/apiTypes"
+
+export function isWithinMatchingPeriod(
+  rounds: MatchingRoundResponse[] | undefined,
+  now: Date,
+): boolean {
+  if (!rounds?.length) return false
+  const current = dayjs(now)
+  return rounds.some((round) => {
+    if (!round.startsAt || !round.endsAt) return false
+    const start = dayjs(round.startsAt)
+    const end = dayjs(round.endsAt)
+    return !current.isBefore(start) && !current.isAfter(end)
+  })
+}

--- a/src/features/project/new/ui/application/ApplicationForm.tsx
+++ b/src/features/project/new/ui/application/ApplicationForm.tsx
@@ -38,6 +38,7 @@ interface ApplicationFormProps {
   onPrev?: () => void
   onNext?: () => void
   isEditMode?: boolean
+  readOnly?: boolean
   isHydrated?: boolean
   isSubmitting?: boolean
   canCreateProject?: boolean
@@ -52,6 +53,7 @@ export const ApplicationForm = forwardRef<
     onPrev,
     onNext,
     isEditMode = false,
+    readOnly = false,
     isHydrated = true,
     isSubmitting = false,
     canCreateProject = true,
@@ -214,7 +216,17 @@ export const ApplicationForm = forwardRef<
 
   return (
     <div className={cn("flex flex-col gap-4 py-4")}>
-      <div className="mx-auto flex w-full max-w-225 flex-col gap-6">
+      {readOnly && (
+        <div className="text-body-2-medium mx-auto w-full max-w-225 rounded-[8px] border border-yellow-300 bg-yellow-50 px-4 py-3 text-yellow-700">
+          매칭 기간 중에는 지원 폼을 수정할 수 없습니다.
+        </div>
+      )}
+      <div
+        className={cn(
+          "mx-auto flex w-full max-w-225 flex-col gap-6",
+          readOnly && "pointer-events-none opacity-60 select-none",
+        )}
+      >
         <div className="flex flex-col">
           <FormHeader variant="common" />
           <QuestionListContainer
@@ -338,15 +350,17 @@ export const ApplicationForm = forwardRef<
       </div>
 
       <div className="flex justify-between">
-        <Button
-          type="button"
-          variant="weak"
-          color="primary"
-          disabled={!canTempSave}
-          onClick={handleTempSave}
-        >
-          {tempSaveLabel}
-        </Button>
+        {!readOnly && (
+          <Button
+            type="button"
+            variant="weak"
+            color="primary"
+            disabled={!canTempSave}
+            onClick={handleTempSave}
+          >
+            {tempSaveLabel}
+          </Button>
+        )}
         <div className="flex items-center gap-4">
           <Button
             type="button"
@@ -356,16 +370,18 @@ export const ApplicationForm = forwardRef<
           >
             이전
           </Button>
-          <Button
-            type="button"
-            variant="fill"
-            color="primary"
-            isLoading={isSubmitting}
-            disabled={isSubmitting}
-            onClick={handleNext}
-          >
-            {isEditMode ? "수정 완료" : "등록하기"}
-          </Button>
+          {!readOnly && (
+            <Button
+              type="button"
+              variant="fill"
+              color="primary"
+              isLoading={isSubmitting}
+              disabled={isSubmitting}
+              onClick={handleNext}
+            >
+              {isEditMode ? "수정 완료" : "등록하기"}
+            </Button>
+          )}
         </div>
       </div>
     </div>

--- a/src/routes/matching/projects/management.tsx
+++ b/src/routes/matching/projects/management.tsx
@@ -1,5 +1,7 @@
-import { createFileRoute, redirect } from "@tanstack/react-router"
+import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router"
+import { useEffect } from "react"
 
+import { useToastStore } from "@/components/toast/useToastStore"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
 import { canManageProjects } from "@/features/auth/model/identity"
 import { ProjectManagementPage } from "@/features/project/management"
@@ -7,10 +9,34 @@ import { useViewModeStore } from "@/shared/view-mode"
 import { projectViewMe } from "@/shared/view-mode/projectViewMe"
 
 export const Route = createFileRoute("/matching/projects/management")({
+  validateSearch: (
+    search: Record<string, unknown>,
+  ): { notice?: "duplicate" } =>
+    search.notice === "duplicate" ? { notice: "duplicate" } : {},
   beforeLoad: async ({ context }) => {
     const me = await ensureMe(context.queryClient)
     const viewMe = projectViewMe(me, useViewModeStore.getState().mode)
     if (!canManageProjects(viewMe)) throw redirect({ to: "/matching/projects" })
   },
-  component: ProjectManagementPage,
+  component: ProjectManagementRoute,
 })
+
+function ProjectManagementRoute() {
+  const { notice } = Route.useSearch()
+  const navigate = useNavigate()
+  const addToast = useToastStore((s) => s.addToast)
+
+  useEffect(() => {
+    if (notice !== "duplicate") return
+    addToast({
+      message: "등록된 프로젝트가 이미 존재 합니다.",
+      color: "red",
+      variant: "deep",
+      type: "default",
+      duration: 3000,
+    })
+    void navigate({ to: "/matching/projects/management", replace: true })
+  }, [notice, navigate, addToast])
+
+  return <ProjectManagementPage />
+}

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -7,15 +7,18 @@ import {
   useNavigate,
 } from "@tanstack/react-router"
 import { isAxiosError } from "axios"
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
+import { getMatchingRounds } from "@/features/application/api/applicationApi"
+import { applicationKeys } from "@/features/application/api/applicationKeys"
 import { getResourcePermission } from "@/features/auth/api/permissions"
 import { useMe } from "@/features/auth/hooks/useMe"
 import { useResourcePermission } from "@/features/auth/hooks/useResourcePermission"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
 import {
   canManageProjects,
+  getLatestChallengerRecord,
   isCurrentTermPm,
   isProjectRegistrationQuotaLimited,
 } from "@/features/auth/model/identity"
@@ -44,6 +47,7 @@ import {
 } from "@/features/project/new/api"
 import { hydrateApplicationFormIntoStore } from "@/features/project/new/model/applicationFormHydrator"
 import { hydrateDraftIntoStore } from "@/features/project/new/model/draftHydrator"
+import { isWithinMatchingPeriod } from "@/features/project/new/model/matchingPeriod"
 import { hydrateProjectDetailIntoStore } from "@/features/project/new/model/projectDetailHydrator"
 import { useProjectRegisterStore } from "@/features/project/new/model/useProjectRegisterStore"
 import { getActiveGisu } from "@/shared/api/gisu"
@@ -148,6 +152,21 @@ function ProjectRegisterPage() {
   const queryClient = useQueryClient()
   const { data: me } = useMe()
   const isPm = isCurrentTermPm(me)
+  const myChapterId = getLatestChallengerRecord(me)?.chapterId
+  const matchingRoundsQuery = useQuery({
+    queryKey: applicationKeys.matchingRounds(
+      myChapterId ? Number(myChapterId) : undefined,
+    ),
+    queryFn: () =>
+      getMatchingRounds(myChapterId ? Number(myChapterId) : undefined),
+    enabled: isEditMode && myChapterId !== undefined,
+  })
+  const isApplicationReadOnly = useMemo(
+    () =>
+      isEditMode &&
+      isWithinMatchingPeriod(matchingRoundsQuery.data, new Date()),
+    [isEditMode, matchingRoundsQuery.data],
+  )
   const projectId = useProjectRegisterStore((s) => s.projectId)
   const application = useProjectRegisterStore((s) => s.application)
   const recruitInfo = useProjectRegisterStore((s) => s.recruitInfo)
@@ -330,14 +349,19 @@ function ProjectRegisterPage() {
     },
     onError: (error) => {
       const status = isAxiosError(error) ? error.response?.status : undefined
+      const code = isAxiosError(error)
+        ? (error.response?.data as { code?: string } | undefined)?.code
+        : undefined
       const message =
-        status === 403
-          ? isEditMode
-            ? "프로젝트를 수정할 권한이 없습니다."
-            : "프로젝트를 등록할 권한이 없습니다."
-          : isEditMode
-            ? "프로젝트 수정에 실패했습니다. 다시 시도해주세요."
-            : "프로젝트 등록에 실패했습니다. 다시 시도해주세요."
+        code === "PROJECT-0009"
+          ? "매칭 기간 중에는 지원 폼을 수정할 수 없습니다."
+          : status === 403
+            ? isEditMode
+              ? "프로젝트를 수정할 권한이 없습니다."
+              : "프로젝트를 등록할 권한이 없습니다."
+            : isEditMode
+              ? "프로젝트 수정에 실패했습니다. 다시 시도해주세요."
+              : "프로젝트 등록에 실패했습니다. 다시 시도해주세요."
       addToast({
         message,
         color: "red",
@@ -536,6 +560,7 @@ function ProjectRegisterPage() {
           <ApplicationForm
             ref={applicationFormRef}
             isEditMode={isEditMode}
+            readOnly={isApplicationReadOnly}
             isHydrated={isEditMode ? applicationFormHydrated : true}
             isSubmitting={submitMutation.isPending || isCreatePermissionLoading}
             canCreateProject={canCreateProject}

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import {
   createFileRoute,
+  isRedirect,
   redirect,
   useBlocker,
   useNavigate,
@@ -16,6 +17,7 @@ import { ensureMe } from "@/features/auth/lib/ensureMe"
 import {
   canManageProjects,
   isCurrentTermPm,
+  isProjectRegistrationQuotaLimited,
 } from "@/features/auth/model/identity"
 import { hasGrantedPermission } from "@/features/auth/model/resourcePermission"
 import { useProjectPermissions } from "@/features/project/hooks/useProjectPermissions"
@@ -65,6 +67,7 @@ export const Route = createFileRoute("/matching/projects/new")({
       return
     }
 
+    let hasWritePermission = false
     try {
       const permission = await context.queryClient.ensureQueryData({
         queryKey: [
@@ -81,13 +84,38 @@ export const Route = createFileRoute("/matching/projects/new")({
           }),
         staleTime: 0,
       })
-
-      if (hasGrantedPermission(permission, "WRITE")) return
+      hasWritePermission = hasGrantedPermission(permission, "WRITE")
     } catch {
       throw redirect({ to: "/matching/projects" })
     }
 
-    throw redirect({ to: "/matching/projects" })
+    if (!hasWritePermission) {
+      throw redirect({ to: "/matching/projects" })
+    }
+
+    if (isProjectRegistrationQuotaLimited(viewMe)) {
+      try {
+        const gisu = await context.queryClient.ensureQueryData({
+          queryKey: gisuKeys.active,
+          queryFn: getActiveGisu,
+        })
+        const gisuId = gisu?.gisuId ? Number(gisu.gisuId) : undefined
+        if (gisuId) {
+          const managed = await context.queryClient.ensureQueryData({
+            queryKey: projectKeys.managedCheck(gisuId),
+            queryFn: () => getManagedProjects(gisuId),
+          })
+          if (managed.length > 0) {
+            throw redirect({
+              to: "/matching/projects/management",
+              search: { notice: "duplicate" },
+            })
+          }
+        }
+      } catch (error) {
+        if (isRedirect(error)) throw error
+      }
+    }
   },
   validateSearch: (search: Record<string, unknown>) => ({
     projectId:
@@ -204,26 +232,6 @@ function ProjectRegisterPage() {
   useEffect(() => {
     if (gisuId) setGisuId(Number(gisuId))
   }, [gisuId, setGisuId])
-
-  const managedCheckQuery = useQuery({
-    queryKey: projectKeys.managedCheck(gisuId),
-    queryFn: () => getManagedProjects(Number(gisuId)),
-    enabled: isPm && !isEditMode && !!gisuId,
-  })
-
-  useEffect(() => {
-    if (!isPm || isEditMode) return
-    if (managedCheckQuery.data && managedCheckQuery.data.length > 0) {
-      addToast({
-        message: "등록된 프로젝트가 이미 존재 합니다.",
-        color: "red",
-        variant: "deep",
-        type: "default",
-        duration: 3000,
-      })
-      navigate({ to: "/matching/projects/management", replace: true })
-    }
-  }, [isPm, isEditMode, managedCheckQuery.data, addToast, navigate])
 
   useEffect(() => {
     if (isEditMode && editProjectId && projectId !== editProjectId) {
@@ -428,8 +436,6 @@ function ProjectRegisterPage() {
   })
 
   const isLeaveModalOpen = leaveBlockStatus === "blocked"
-
-  if (isPm && !isEditMode && managedCheckQuery.isPending) return null
 
   const handleRegister = () => {
     submitMutation.mutate()

--- a/src/routes/test/toast.tsx
+++ b/src/routes/test/toast.tsx
@@ -41,6 +41,38 @@ function ToastTestPage() {
             color:{color} / variant:{variant} / type:{type}
           </button>
         ))}
+        <button
+          type="button"
+          onClick={() =>
+            addToast({
+              message:
+                "매우 긴 에러 메시지입니다. 너비가 400px를 넘으면 콘텐츠에 맞춰 늘어나고, 90vw 상한에 도달하면 줄바꿈되며 토스트 높이가 늘어나는지 확인합니다.",
+              color: "red",
+              variant: "deep",
+              type: "default",
+              duration: 5000,
+            })
+          }
+          className="bg-error-100 text-error-700 text-label-1-medium w-fit rounded-[8px] px-4 py-2"
+        >
+          긴 메시지 테스트 (red/deep)
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            addToast({
+              message:
+                "리크루팅 서비스는 준비 중입니다. 더 나은 UMC 웹사이트로 찾아뵙겠습니다!",
+              color: "primary",
+              variant: "deep",
+              type: "notice",
+              duration: 3000,
+            })
+          }
+          className="text-label-1-medium w-fit rounded-[8px] bg-teal-100 px-4 py-2 text-teal-700"
+        >
+          notice (서비스 공지)
+        </button>
       </div>
     </main>
   )

--- a/src/shared/assets/icon/RubberConeIcon.tsx
+++ b/src/shared/assets/icon/RubberConeIcon.tsx
@@ -1,0 +1,27 @@
+import type { SVGProps } from "react"
+const RubberConeIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    {...props}
+  >
+    <path
+      fill="#E5F5F2"
+      d="M11.236 2.375 3.676 20.05H20.21l-7.56-17.675a.77.77 0 0 0-1.415 0"
+    />
+    <rect
+      width={23.04}
+      height={2.288}
+      x={0.48}
+      y={20.032}
+      fill="#0E8179"
+      rx={1.144}
+    />
+    <path
+      fill="#0E8179"
+      d="M20.21 20.05H3.677l1.087-2.541h14.361zm-2.642-6.178H6.318l1.726-4.035h7.799zM11.235 2.375a.77.77 0 0 1 1.416 0L14.287 6.2H9.6z"
+    />
+  </svg>
+)
+export default RubberConeIcon


### PR DESCRIPTION
## 개요

0612 데모데이 매칭 시스템 QA 검증 중 발견한 버그 2건과, 디자인 반영 UI/UX 개선을 포함합니다.

1. **프로젝트 중복 등록 차단** (QA #1) — Close #245
2. **매칭 기간 중 지원 폼 수정 차단** (QA #3) — Close #247
3. **토스트/헤더 개선** (디자인 반영)

---

## QA #1: 프로젝트 중복 등록 차단 (#245)

콜드 로드(URL 직접/새로고침)에서 차단 안내 토스트가 안 뜨고, 차단 판단이 운영진을 구분하지 못하던 문제.

### ♻️ 판단 순수 함수 분리 (`f846457`)
- `isProjectRegistrationQuotaLimited(me)` — 운영진 권한(`isAnyOperator`)이면 제외, 순수 PM만 제한 대상 / 유닛 테스트 9개

### 🐛 차단 로직 beforeLoad 이동 (`e9d5ae7`)
- 컴포넌트 `useEffect` → 라우터 `beforeLoad`로 이동(렌더 전 차단, 콜드/SPA 일관)
- 안내 토스트는 도착 화면에서 `notice=duplicate`로 표시(콜드 로드 경합 해소), 운영진 제외

---

## QA #3: 매칭 기간 중 지원 폼 수정 차단 (#247)

매칭 중에도 지원 폼 편집 UI가 열리고, 저장 시점에야 `PROJECT-0009`로 막히던 문제.

### ✨ 매칭 기간 판단 순수 함수 (`379cf7a`)
- `isWithinMatchingPeriod(rounds, now)` + 유닛 테스트 8개

### 🐛 매칭 중 수정 차단 (`e5a8843`)
- owner 지부의 `matching-rounds` 조회 → 매칭 중이면 `ApplicationForm` 읽기 전용 + 안내
- `PROJECT-0009` 응답을 매칭 기간 안내로 표시

---

## 추가 개선: 토스트 / 헤더

### 🐛 토스트 등장 시 가운데 정렬 어긋남 수정 (`d2aa012`)
- `shake` 애니메이션의 transform이 가로 정렬(`translateX(-50%)`)을 덮어써 토스트가 한쪽에서 흔들리다 가운데로 이동하던 버그. 가로 정렬을 외부 래퍼로 분리해 해결.

### ✨ 토스트 너비 동적 대응 + Service Notice 케이스 (`5e4f455`)
- 너비를 `min(400px,90vw)` ~ `min(90vw,600px)`로 동적 처리, 줄바꿈 허용
- 양옆 라바콘(`errorCone`) 아이콘 + 가운데 메시지의 **Service Notice**(준비 중 안내) 케이스 추가

### ✨ 헤더 미연결 메뉴 안내 (`512c1e7`)
- 소개/모집 안내/프로젝트/리크루팅/시스템 관리 등 미연결 메뉴 클릭 시 Service Notice 토스트로 준비 중 안내

---

## 검증

- eslint / `tsc -b` / vitest(추가 유닛 17개) / 프로덕션 빌드 전부 통과

## 관련 이슈

Close #245
Close #247