### PR TITLE
Feat/계정 설정 api 연결 완료

### DIFF
--- a/src/features/auth/api/me.ts
+++ b/src/features/auth/api/me.ts
@@ -15,13 +15,14 @@ export interface MemberInfoResponse {
   schoolName: string
   profileImageLink: string
   status: "ACTIVE" | "INACTIVE" | "WITHDRAWN"
+  hasLocalCredential: boolean
   roles: ChallengerRoleResponse[]
   challengerRecords?: ChallengerInfoResponse[]
 }
 
 export async function getMyInfo(): Promise<MemberInfoResponse> {
   const { data } =
-    await api.get<ApiResponse<MemberInfoResponse>>("/v1/member/me")
+    await api.get<ApiResponse<MemberInfoResponse>>("/v2/member/me")
   return data.result
 }
 

--- a/src/features/auth/api/me.ts
+++ b/src/features/auth/api/me.ts
@@ -2,28 +2,110 @@ import { api } from "@/shared/lib/axios"
 
 import type {
   ChallengerInfoResponse,
+  ChallengerPointInfo,
   ChallengerRoleResponse,
 } from "@/features/challenger/model/types"
 import type { ApiResponse } from "@/shared/lib/apiResponse"
 
+export interface MemberProfileInfo {
+  id: string | null
+  linkedIn: string | null
+  instagram: string | null
+  github: string | null
+  blog: string | null
+  personal: string | null
+}
+
 export interface MemberInfoResponse {
-  id: number
+  id: string
   name: string
   nickname: string
   email: string
-  schoolId: number
+  schoolId: string
   schoolName: string
-  profileImageLink: string
+  profileImageLink: string | null
   status: "ACTIVE" | "INACTIVE" | "WITHDRAWN"
   hasLocalCredential: boolean
+  profile?: MemberProfileInfo | null
+  totalActivityDays?: string
   roles: ChallengerRoleResponse[]
   challengerRecords?: ChallengerInfoResponse[]
 }
 
+interface V2HistoryItem {
+  challengerId: string
+  gisuId: string
+  generation: string
+  chapterId: string
+  chapterName: string
+  part: string
+  challengerStatus: string
+  points?: ChallengerPointInfo[]
+  totalPoints?: string
+  roleTypes?: string[]
+  [key: string]: unknown
+}
+
+interface MemberInfoV2Raw {
+  hasLocalCredential?: boolean
+  profile?: MemberProfileInfo | null
+  totalActivityDays?: string
+  challengerHistory?: V2HistoryItem[]
+  currentGisuMemberInfo?: {
+    gisuId: string
+    generation: string
+    challenger?: {
+      challengerId: string
+      part: string
+      challengerStatus: string
+    } | null
+    isAdmin?: boolean
+    roleTypes?: string[]
+  } | null
+  [key: string]: unknown
+}
+
 export async function getMyInfo(): Promise<MemberInfoResponse> {
-  const { data } =
-    await api.get<ApiResponse<MemberInfoResponse>>("/v2/member/me")
-  return data.result
+  const { data } = await api.get<ApiResponse<MemberInfoV2Raw>>("/v2/member/me")
+  const raw = data.result
+  const history = raw.challengerHistory ?? []
+  const currentGisu = raw.currentGisuMemberInfo
+
+  // 현재 기수 history 항목 → CHAPTER_PRESIDENT의 organizationId(chapterId) 추출용
+  const currentHistory = history.find((h) => h.gisuId === currentGisu?.gisuId)
+
+  const challengerRecords: ChallengerInfoResponse[] = history.map((h) => ({
+    ...(h as unknown as ChallengerInfoResponse),
+    challengerId: String(h.challengerId),
+    gisuId: String(h.gisuId),
+    gisu: String(h.generation), // generation(기수 번호) → gisu(표시용)
+    chapterId: String(h.chapterId),
+    memberId: "",
+    name: "",
+    nickname: "",
+    email: null,
+    schoolId: "",
+    schoolName: "",
+  }))
+
+  // 현재 기수 roleTypes 기준, chapterId를 organizationId로 사용
+  const roles: ChallengerRoleResponse[] = (currentGisu?.roleTypes ?? []).map(
+    (rt) => ({
+      roleType: rt as ChallengerRoleResponse["roleType"],
+      organizationId: String(currentHistory?.chapterId ?? ""),
+      challengerRoleId: "",
+      challengerId: String(currentHistory?.challengerId ?? ""),
+      organizationType: "CHAPTER" as ChallengerRoleResponse["organizationType"],
+      gisuId: String(currentGisu?.gisuId ?? ""),
+      gisu: String(currentGisu?.generation ?? ""),
+    }),
+  )
+
+  return {
+    ...(raw as unknown as MemberInfoResponse),
+    challengerRecords,
+    roles,
+  }
 }
 
 export async function updateMemberInfo(body: {

--- a/src/features/auth/api/me.ts
+++ b/src/features/auth/api/me.ts
@@ -24,3 +24,28 @@ export async function getMyInfo(): Promise<MemberInfoResponse> {
     await api.get<ApiResponse<MemberInfoResponse>>("/v1/member/me")
   return data.result
 }
+
+export async function updateMemberInfo(body: {
+  profileImageId?: string
+}): Promise<MemberInfoResponse> {
+  const { data } = await api.patch<ApiResponse<MemberInfoResponse>>(
+    "/v1/member",
+    body,
+  )
+  return data.result
+}
+
+export interface DeleteMemberRequest {
+  googleAccessToken?: string
+  kakaoAccessToken?: string
+}
+
+export async function deleteMember(
+  body: DeleteMemberRequest = {},
+): Promise<MemberInfoResponse> {
+  const { data } = await api.delete<ApiResponse<MemberInfoResponse>>(
+    "/v1/member",
+    { data: body },
+  )
+  return data.result
+}

--- a/src/features/auth/api/memberOauth.ts
+++ b/src/features/auth/api/memberOauth.ts
@@ -1,0 +1,37 @@
+import { api } from "@/shared/lib/axios"
+
+import type { MemberOAuthItem } from "@/features/auth/model/types"
+import type { ApiResponse } from "@/shared/lib/apiResponse"
+
+export interface UnlinkOAuthRequest {
+  googleAccessToken?: string
+  kakaoAccessToken?: string
+}
+
+export async function getMemberOAuthList(): Promise<MemberOAuthItem[]> {
+  const { data } = await api.get<ApiResponse<MemberOAuthItem[]>>(
+    "/v1/member-oauth/me",
+  )
+  return data.result
+}
+
+export async function addMemberOAuth(body: {
+  oAuthVerificationToken: string
+}): Promise<MemberOAuthItem[]> {
+  const { data } = await api.post<ApiResponse<MemberOAuthItem[]>>(
+    "/v1/member-oauth",
+    body,
+  )
+  return data.result
+}
+
+export async function removeMemberOAuth(
+  memberOAuthId: number,
+  body?: UnlinkOAuthRequest,
+): Promise<MemberOAuthItem[]> {
+  const { data } = await api.delete<ApiResponse<MemberOAuthItem[]>>(
+    `/v1/member-oauth/${memberOAuthId}`,
+    { data: body },
+  )
+  return data.result
+}

--- a/src/features/auth/hooks/useMe.ts
+++ b/src/features/auth/hooks/useMe.ts
@@ -6,7 +6,7 @@ import { useAuthStore } from "../store/authStore"
 export function useMe() {
   const isAuthed = useAuthStore((s) => s.isAuthed)
   return useQuery({
-    queryKey: ["auth"],
+    queryKey: ["auth", "me"],
     queryFn: getMyInfo,
     staleTime: 1000 * 60 * 5,
     enabled: isAuthed,

--- a/src/features/auth/hooks/useMemberOAuthList.ts
+++ b/src/features/auth/hooks/useMemberOAuthList.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { getMemberOAuthList } from "../api/memberOauth"
+import { useAuthStore } from "../store/authStore"
+
+export const MEMBER_OAUTH_QUERY_KEY = ["auth", "member-oauth"] as const
+
+export function useMemberOAuthList() {
+  const isAuthed = useAuthStore((s) => s.isAuthed)
+  return useQuery({
+    queryKey: MEMBER_OAUTH_QUERY_KEY,
+    queryFn: getMemberOAuthList,
+    staleTime: 1000 * 60 * 5,
+    enabled: isAuthed,
+  })
+}

--- a/src/features/auth/hooks/useOAuthLinking.ts
+++ b/src/features/auth/hooks/useOAuthLinking.ts
@@ -1,5 +1,4 @@
 import { useQueryClient } from "@tanstack/react-query"
-import axios from "axios"
 import { useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
@@ -26,40 +25,10 @@ import {
 
 import { MEMBER_OAUTH_QUERY_KEY } from "./useMemberOAuthList"
 
-function getBeErrorCode(error: unknown): string | null {
-  if (axios.isAxiosError(error)) {
-    const data = error.response?.data as { code?: string } | undefined
-    return data?.code ?? null
-  }
-  return null
-}
-
-interface UnlinkTarget {
-  memberOAuthId: number
-}
-
 export function useOAuthLinking() {
   const addToast = useToastStore((s) => s.addToast)
   const queryClient = useQueryClient()
   const [isLinking, setIsLinking] = useState(false)
-  const [unlinkTarget, setUnlinkTarget] = useState<UnlinkTarget | null>(null)
-
-  const handleLinkError = (error: unknown, provider: string) => {
-    const code = getBeErrorCode(error)
-    let message = `${provider} 연동에 실패했습니다. 다시 시도해주세요.`
-    if (code === "AUTHENTICATION-0012") {
-      message = `이미 다른 계정에 연결된 ${provider} 계정입니다.`
-    } else if (code === "AUTHENTICATION-0013") {
-      message = `이미 연동되어 있는 ${provider} 계정입니다.`
-    }
-    addToast({
-      message,
-      color: "red",
-      variant: "deep",
-      type: "default",
-      duration: 3000,
-    })
-  }
 
   const handleGoogleLink = async () => {
     if (isLinking) return
@@ -92,7 +61,13 @@ export function useOAuthLinking() {
       })
     } catch (err) {
       if (isGooglePopupCancelled(err)) return
-      handleLinkError(err, "Google")
+      addToast({
+        message: "Google 연동에 실패했습니다. 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
     } finally {
       setIsLinking(false)
     }
@@ -129,7 +104,13 @@ export function useOAuthLinking() {
       })
     } catch (err) {
       if (isApplePopupCancelled(err)) return
-      handleLinkError(err, "Apple")
+      addToast({
+        message: "Apple 연동에 실패했습니다. 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
     } finally {
       setIsLinking(false)
     }
@@ -140,10 +121,9 @@ export function useOAuthLinking() {
     startKakaoSignIn()
   }
 
-  const handleUnlink = async () => {
-    if (!unlinkTarget) return
+  const handleUnlink = async (memberOAuthId: number) => {
     try {
-      await removeMemberOAuth(unlinkTarget.memberOAuthId)
+      await removeMemberOAuth(memberOAuthId)
       await queryClient.invalidateQueries({ queryKey: MEMBER_OAUTH_QUERY_KEY })
       addToast({
         message: "소셜 연동이 해제되었습니다.",
@@ -152,27 +132,18 @@ export function useOAuthLinking() {
         type: "default",
         duration: 3000,
       })
-    } catch (err) {
-      const code = getBeErrorCode(err)
-      const message =
-        code === "AUTHENTICATION-0016"
-          ? "마지막 소셜 연동은 해제할 수 없습니다. 비밀번호를 먼저 설정해주세요."
-          : "연동 해제에 실패했습니다. 다시 시도해주세요."
+    } catch {
       addToast({
-        message,
+        message: "연동 해제에 실패했습니다. 다시 시도해주세요.",
         color: "red",
         variant: "deep",
         type: "default",
         duration: 3000,
       })
-    } finally {
-      setUnlinkTarget(null)
     }
   }
 
   return {
-    unlinkTarget,
-    setUnlinkTarget,
     handleGoogleLink,
     handleAppleLink,
     handleKakaoLink,

--- a/src/features/auth/hooks/useOAuthLinking.ts
+++ b/src/features/auth/hooks/useOAuthLinking.ts
@@ -1,0 +1,181 @@
+import { useQueryClient } from "@tanstack/react-query"
+import axios from "axios"
+import { useState } from "react"
+
+import { useToastStore } from "@/components/toast/useToastStore"
+import {
+  addMemberOAuth,
+  removeMemberOAuth,
+} from "@/features/auth/api/memberOauth"
+import {
+  loginWithApple,
+  loginWithGoogle,
+} from "@/features/auth/api/socialLogin"
+import {
+  isApplePopupCancelled,
+  signInWithApple,
+} from "@/features/auth/lib/appleSignIn"
+import {
+  isGooglePopupCancelled,
+  signInWithGoogle,
+} from "@/features/auth/lib/googleSignIn"
+import {
+  setKakaoLinkIntent,
+  startKakaoSignIn,
+} from "@/features/auth/lib/kakaoSignIn"
+
+import { MEMBER_OAUTH_QUERY_KEY } from "./useMemberOAuthList"
+
+function getBeErrorCode(error: unknown): string | null {
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data as { code?: string } | undefined
+    return data?.code ?? null
+  }
+  return null
+}
+
+interface UnlinkTarget {
+  memberOAuthId: number
+}
+
+export function useOAuthLinking() {
+  const addToast = useToastStore((s) => s.addToast)
+  const queryClient = useQueryClient()
+  const [isLinking, setIsLinking] = useState(false)
+  const [unlinkTarget, setUnlinkTarget] = useState<UnlinkTarget | null>(null)
+
+  const handleLinkError = (error: unknown, provider: string) => {
+    const code = getBeErrorCode(error)
+    let message = `${provider} 연동에 실패했습니다. 다시 시도해주세요.`
+    if (code === "AUTHENTICATION-0012") {
+      message = `이미 다른 계정에 연결된 ${provider} 계정입니다.`
+    } else if (code === "AUTHENTICATION-0013") {
+      message = `이미 연동되어 있는 ${provider} 계정입니다.`
+    }
+    addToast({
+      message,
+      color: "red",
+      variant: "deep",
+      type: "default",
+      duration: 3000,
+    })
+  }
+
+  const handleGoogleLink = async () => {
+    if (isLinking) return
+    setIsLinking(true)
+    try {
+      const { accessToken } = await signInWithGoogle()
+      const res = await loginWithGoogle({ accessToken })
+      if (res.code === "LOGIN_SUCCESS") {
+        addToast({
+          message: "이미 다른 계정에 연결된 Google 계정입니다.",
+          color: "red",
+          variant: "deep",
+          type: "default",
+          duration: 3000,
+        })
+        return
+      }
+      if (!res.oAuthVerificationToken)
+        throw new Error("oAuthVerificationToken 없음")
+      await addMemberOAuth({
+        oAuthVerificationToken: res.oAuthVerificationToken,
+      })
+      await queryClient.invalidateQueries({ queryKey: MEMBER_OAUTH_QUERY_KEY })
+      addToast({
+        message: "Google 계정이 연동되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } catch (err) {
+      if (isGooglePopupCancelled(err)) return
+      handleLinkError(err, "Google")
+    } finally {
+      setIsLinking(false)
+    }
+  }
+
+  const handleAppleLink = async () => {
+    if (isLinking) return
+    setIsLinking(true)
+    try {
+      const { authorizationCode } = await signInWithApple()
+      const res = await loginWithApple({ authorizationCode })
+      if (res.code === "LOGIN_SUCCESS") {
+        addToast({
+          message: "이미 다른 계정에 연결된 Apple 계정입니다.",
+          color: "red",
+          variant: "deep",
+          type: "default",
+          duration: 3000,
+        })
+        return
+      }
+      if (!res.oAuthVerificationToken)
+        throw new Error("oAuthVerificationToken 없음")
+      await addMemberOAuth({
+        oAuthVerificationToken: res.oAuthVerificationToken,
+      })
+      await queryClient.invalidateQueries({ queryKey: MEMBER_OAUTH_QUERY_KEY })
+      addToast({
+        message: "Apple 계정이 연동되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } catch (err) {
+      if (isApplePopupCancelled(err)) return
+      handleLinkError(err, "Apple")
+    } finally {
+      setIsLinking(false)
+    }
+  }
+
+  const handleKakaoLink = () => {
+    setKakaoLinkIntent()
+    startKakaoSignIn()
+  }
+
+  const handleUnlink = async () => {
+    if (!unlinkTarget) return
+    try {
+      await removeMemberOAuth(unlinkTarget.memberOAuthId)
+      await queryClient.invalidateQueries({ queryKey: MEMBER_OAUTH_QUERY_KEY })
+      addToast({
+        message: "소셜 연동이 해제되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } catch (err) {
+      const code = getBeErrorCode(err)
+      const message =
+        code === "AUTHENTICATION-0016"
+          ? "마지막 소셜 연동은 해제할 수 없습니다. 비밀번호를 먼저 설정해주세요."
+          : "연동 해제에 실패했습니다. 다시 시도해주세요."
+      addToast({
+        message,
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } finally {
+      setUnlinkTarget(null)
+    }
+  }
+
+  return {
+    unlinkTarget,
+    setUnlinkTarget,
+    handleGoogleLink,
+    handleAppleLink,
+    handleKakaoLink,
+    handleUnlink,
+  }
+}

--- a/src/features/auth/lib/kakaoSignIn.ts
+++ b/src/features/auth/lib/kakaoSignIn.ts
@@ -1,5 +1,6 @@
 const KAKAO_REDIRECT_PATH = "/oauth/kakao/callback"
 const KAKAO_STATE_STORAGE_KEY = "kakao_oauth_state"
+const KAKAO_LINK_INTENT_KEY = "kakao_link_intent"
 
 function generateSecureState(): string {
   if (typeof crypto?.randomUUID === "function") {
@@ -21,6 +22,16 @@ export function consumeKakaoState(received: string | null): boolean {
   const saved = sessionStorage.getItem(KAKAO_STATE_STORAGE_KEY)
   sessionStorage.removeItem(KAKAO_STATE_STORAGE_KEY)
   return Boolean(saved) && saved === received
+}
+
+export function setKakaoLinkIntent(): void {
+  sessionStorage.setItem(KAKAO_LINK_INTENT_KEY, "link")
+}
+
+export function consumeKakaoLinkIntent(): boolean {
+  const intent = sessionStorage.getItem(KAKAO_LINK_INTENT_KEY)
+  sessionStorage.removeItem(KAKAO_LINK_INTENT_KEY)
+  return intent === "link"
 }
 
 export function startKakaoSignIn(): void {

--- a/src/features/auth/model/identity.test.ts
+++ b/src/features/auth/model/identity.test.ts
@@ -54,14 +54,15 @@ function makeMe(
   }))
 
   return {
-    id: 0,
+    id: "0",
     name: "테스트",
     nickname: "테스트",
     email: "test@test.com",
-    schoolId: 0,
+    schoolId: "0",
     schoolName: "테스트 학교",
-    profileImageLink: "",
+    profileImageLink: null,
     status: "ACTIVE",
+    hasLocalCredential: false,
     roles,
     challengerRecords,
     ...overrides,
@@ -186,7 +187,7 @@ describe("getProjectPmSearchScope", () => {
   it("SCHOOL_PRESIDENT는 schoolId를 문자열로 반환", () => {
     expect(
       getProjectPmSearchScope(
-        makeMe(["SCHOOL_PRESIDENT"], [], { schoolId: 12 }),
+        makeMe(["SCHOOL_PRESIDENT"], [], { schoolId: "12" }),
       ),
     ).toEqual({ schoolId: "12" })
   })
@@ -194,7 +195,7 @@ describe("getProjectPmSearchScope", () => {
   it("SCHOOL_VICE_PRESIDENT도 schoolId를 문자열로 반환", () => {
     expect(
       getProjectPmSearchScope(
-        makeMe(["SCHOOL_VICE_PRESIDENT"], [], { schoolId: 5 }),
+        makeMe(["SCHOOL_VICE_PRESIDENT"], [], { schoolId: "5" }),
       ),
     ).toEqual({ schoolId: "5" })
   })

--- a/src/features/auth/model/types.ts
+++ b/src/features/auth/model/types.ts
@@ -154,3 +154,9 @@ export interface EmailRegisterMemberRequest {
   schoolId: number
   termsAgreements: TermConsentStatus[]
 }
+
+export interface MemberOAuthItem {
+  memberId: number
+  memberOAuthId: number
+  provider: OAuthProvider
+}

--- a/src/features/auth/store/selectedChallengerStore.ts
+++ b/src/features/auth/store/selectedChallengerStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand"
+
+interface SelectedChallengerState {
+  selectedGisuId: string | null
+  setSelectedGisuId: (gisuId: string) => void
+}
+
+export const useSelectedChallengerStore = create<SelectedChallengerState>(
+  (set) => ({
+    selectedGisuId: null,
+    setSelectedGisuId: (gisuId) => set({ selectedGisuId: gisuId }),
+  }),
+)

--- a/src/features/project/list/model/matchingProjectList.ts
+++ b/src/features/project/list/model/matchingProjectList.ts
@@ -116,12 +116,12 @@ export function useMatchingProjectListFilters() {
     () =>
       selectedBranch
         ? (
-            chaptersData?.chapters.find((ch) => ch.chapterId === selectedBranch)
-              ?.schools ?? []
-          ).map((s) => ({ value: s.schoolId, label: s.schoolName }))
+          chaptersData?.chapters.find((ch) => ch.chapterId === selectedBranch)
+            ?.schools ?? []
+        ).map((s) => ({ value: s.schoolId, label: s.schoolName }))
         : (chaptersData?.chapters ?? []).flatMap((ch) =>
-            ch.schools.map((s) => ({ value: s.schoolId, label: s.schoolName })),
-          ),
+          ch.schools.map((s) => ({ value: s.schoolId, label: s.schoolName })),
+        ),
     [chaptersData, selectedBranch],
   )
 

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -406,7 +406,7 @@ export function ProjectDetailCard({
               <div className="flex w-full items-center justify-between gap-4">
                 {showLogo ? (
                   <div className="flex min-w-0 items-center gap-2">
-                    <ProjectLogo />
+                    <ProjectLogo src={detail?.logoImageUrl ?? undefined} />
                     <h2 className="text-heading-6-semibold text-teal-gray-900 line-clamp-1 w-60 min-w-0">
                       {data.title}
                     </h2>

--- a/src/features/settings/ui/AccountSettingsPage.tsx
+++ b/src/features/settings/ui/AccountSettingsPage.tsx
@@ -1,12 +1,19 @@
+import { useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
-import { useState } from "react"
+import { useRef, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
+import { deleteMember, updateMemberInfo } from "@/features/auth/api/me"
 import { useMe } from "@/features/auth/hooks/useMe"
-import { signInWithApple } from "@/features/auth/lib/appleSignIn"
-import { signInWithGoogle } from "@/features/auth/lib/googleSignIn"
-import { startKakaoSignIn } from "@/features/auth/lib/kakaoSignIn"
+import { useMemberOAuthList } from "@/features/auth/hooks/useMemberOAuthList"
+import { useOAuthLinking } from "@/features/auth/hooks/useOAuthLinking"
+import {
+  isGooglePopupCancelled,
+  signInWithGoogle,
+} from "@/features/auth/lib/googleSignIn"
 import { toRoleTag } from "@/features/auth/model/mappers"
+import { useAuthStore } from "@/features/auth/store/authStore"
+import { uploadFileFlow } from "@/features/project/new/api/storage"
 import EditIcon from "@/shared/assets/icon/edit/EditIcon"
 import ProfileIcon from "@/shared/assets/icon/people/ProfileIcon"
 import { Button } from "@/shared/ui/Button"
@@ -17,21 +24,130 @@ import { CtaModal } from "@/shared/ui/modal/CtaModal"
 import { ChangePasswordForm } from "./ChangePasswordForm"
 import { SocialButton } from "./SocialButton"
 
-// TODO: GET /v1/member-oauth/me 및 로컬 계정 여부 조회 API 연결 후 동적 처리
-export type UserLoginType = "social" | "local" | "local-linked"
-const MOCK_LOGIN_TYPE: UserLoginType = "local"
+import type { OAuthProvider } from "@/features/auth/model/types"
+
+import type { Social } from "./SocialButton"
+
+const PROVIDER_TO_SOCIAL: Record<OAuthProvider, Social> = {
+  GOOGLE: "google",
+  KAKAO: "kakao",
+  APPLE: "apple",
+}
 
 export function AccountSettingsPage() {
   const { data: me } = useMe()
+  const { data: oauths = [] } = useMemberOAuthList()
   const role = me?.roles?.[0] ? toRoleTag(me.roles[0].roleType) : "challenger"
   const [showPasswordChange, setShowPasswordChange] = useState(false)
   const [showDeleteModal, setShowDeleteModal] = useState(false)
+  const [isUploadingImage, setIsUploadingImage] = useState(false)
   const navigate = useNavigate()
   const addToast = useToastStore((s) => s.addToast)
+  const queryClient = useQueryClient()
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
-  // TODO: API 연결 후 실제 값으로 교체
-  const loginType: UserLoginType = MOCK_LOGIN_TYPE
-  const isSocialOnly = loginType === "social"
+  const {
+    unlinkTarget,
+    setUnlinkTarget,
+    handleGoogleLink,
+    handleAppleLink,
+    handleKakaoLink,
+    handleUnlink,
+  } = useOAuthLinking()
+
+  const linkedMap = new Map(
+    oauths.map((o) => [PROVIDER_TO_SOCIAL[o.provider], o.memberOAuthId]),
+  )
+
+  const handleProfileImageChange = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setIsUploadingImage(true)
+    try {
+      const { fileId } = await uploadFileFlow(file, "PROFILE_IMAGE")
+      await updateMemberInfo({ profileImageId: fileId })
+      await queryClient.invalidateQueries({ queryKey: ["auth", "me"] })
+      addToast({
+        message: "프로필 이미지가 변경되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } catch {
+      addToast({
+        message: "이미지 업로드에 실패했습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } finally {
+      setIsUploadingImage(false)
+      e.target.value = ""
+    }
+  }
+
+  const handleDeleteAccount = async () => {
+    let googleAccessToken: string | undefined
+    if (linkedMap.has("google")) {
+      try {
+        const result = await signInWithGoogle()
+        googleAccessToken = result.accessToken
+      } catch (err) {
+        if (!isGooglePopupCancelled(err)) {
+          addToast({
+            message: "Google 인증에 실패했습니다. 다시 시도해주세요.",
+            color: "red",
+            variant: "deep",
+            type: "default",
+            duration: 3000,
+          })
+          return
+        }
+      }
+    }
+    try {
+      await deleteMember({ googleAccessToken })
+      useAuthStore.getState().clear()
+      addToast({
+        message: "계정이 삭제되어 로그아웃되었습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      void navigate({ to: "/login" })
+    } catch {
+      addToast({
+        message: "계정 삭제에 실패했습니다. 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      setShowDeleteModal(false)
+    }
+  }
+
+  const getSocialProps = (social: Social) => {
+    const memberOAuthId = linkedMap.get(social)
+    const linked = memberOAuthId !== undefined
+    const onLink =
+      social === "kakao"
+        ? handleKakaoLink
+        : social === "google"
+          ? handleGoogleLink
+          : handleAppleLink
+    const onUnlink = () => setUnlinkTarget({ memberOAuthId: memberOAuthId! })
+    return { linked, onClick: linked ? onUnlink : onLink }
+  }
+
+  // TODO: 로컬 계정 여부 조회 API 연결 후 동적 처리
+  const isSocialOnly = false
+
   const emailInputClass = isSocialOnly
     ? "!text-teal-gray-700"
     : "!text-teal-600"
@@ -58,10 +174,19 @@ export function AccountSettingsPage() {
                   <ProfileIcon className="text-teal-gray-300 size-full" />
                 )}
               </div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleProfileImageChange}
+              />
               <button
                 type="button"
                 aria-label="프로필 사진 변경"
-                className="border-teal-gray-100 absolute right-0 bottom-0 flex h-7 w-7 items-center justify-center rounded-[0.875rem] border bg-white"
+                disabled={isUploadingImage}
+                className="border-teal-gray-100 absolute right-0 bottom-0 flex h-7 w-7 items-center justify-center rounded-[0.875rem] border bg-white disabled:opacity-50"
+                onClick={() => fileInputRef.current?.click()}
               >
                 <EditIcon className="text-teal-gray-500" />
               </button>
@@ -94,22 +219,18 @@ export function AccountSettingsPage() {
                     <span className="text-heading-7-semibold text-teal-gray-900">
                       계정 연동
                     </span>
-                    {/* TODO: API 연결 후 linked 값 동적으로 처리 */}
                     <div className="flex items-center gap-8">
                       <SocialButton
                         social="kakao"
-                        linked={true}
-                        onClick={startKakaoSignIn}
+                        {...getSocialProps("kakao")}
                       />
                       <SocialButton
                         social="apple"
-                        linked={false}
-                        onClick={() => void signInWithApple()}
+                        {...getSocialProps("apple")}
                       />
                       <SocialButton
                         social="google"
-                        linked={false}
-                        onClick={() => void signInWithGoogle()}
+                        {...getSocialProps("google")}
                       />
                     </div>
                   </div>
@@ -169,6 +290,22 @@ export function AccountSettingsPage() {
           </div>
         </div>
       </div>
+
+      {/* 연동 해제 확인 모달 */}
+      <CtaModal
+        open={unlinkTarget !== null}
+        variant="error"
+        title="연동을 해제하시겠습니까?"
+        content="해제하면 해당 소셜 계정으로 로그인할 수 없게 됩니다."
+        cancelText="돌아가기"
+        confirmText="연동 해제"
+        onOpenChange={(open) => {
+          if (!open) setUnlinkTarget(null)
+        }}
+        onCancel={() => setUnlinkTarget(null)}
+        onConfirm={() => void handleUnlink()}
+      />
+
       <CtaModal
         open={showDeleteModal}
         variant="error"
@@ -185,16 +322,8 @@ export function AccountSettingsPage() {
         onOpenChange={setShowDeleteModal}
         onCancel={() => setShowDeleteModal(false)}
         onConfirm={() => {
-          // TODO: 계정 삭제 API 연결
           setShowDeleteModal(false)
-          addToast({
-            message: "계정이 삭제되어 로그아웃되었습니다.",
-            color: "red",
-            variant: "deep",
-            type: "default",
-            duration: 3000,
-          })
-          void navigate({ to: "/login" })
+          void handleDeleteAccount()
         }}
       />
     </div>

--- a/src/features/settings/ui/AccountSettingsPage.tsx
+++ b/src/features/settings/ui/AccountSettingsPage.tsx
@@ -201,11 +201,22 @@ export function AccountSettingsPage() {
           </div>
 
           {/* 설정 카드 */}
-          <div className="border-teal-gray-100 mt-8 flex w-full items-start gap-2.5 rounded-xl border bg-white py-9 pl-11">
+          <div className="border-teal-gray-100 relative mt-8 flex w-full items-start gap-2.5 rounded-xl border bg-white py-9 pl-11">
             {showPasswordChange ? (
-              <ChangePasswordForm
-                onSuccess={() => setShowPasswordChange(false)}
-              />
+              <>
+                <ChangePasswordForm
+                  onSuccess={() => setShowPasswordChange(false)}
+                />
+                <Button
+                  variant="weak"
+                  color="neutral"
+                  size="s"
+                  className="absolute right-11 bottom-10 h-11"
+                  onClick={() => setShowPasswordChange(false)}
+                >
+                  이전
+                </Button>
+              </>
             ) : (
               <div className="flex w-full max-w-100 flex-col items-start gap-20">
                 <div className="flex w-full flex-col items-start gap-14">

--- a/src/features/settings/ui/AccountSettingsPage.tsx
+++ b/src/features/settings/ui/AccountSettingsPage.tsx
@@ -140,8 +140,7 @@ export function AccountSettingsPage() {
     return { linked, onClick: linked ? onUnlink : onLink }
   }
 
-  // TODO: 로컬 계정 여부 조회 API 연결 후 동적 처리
-  const isSocialOnly = false
+  const isSocialOnly = me?.hasLocalCredential === false
 
   const emailInputClass = isSocialOnly
     ? "!text-teal-gray-700"

--- a/src/features/settings/ui/AccountSettingsPage.tsx
+++ b/src/features/settings/ui/AccountSettingsPage.tsx
@@ -41,19 +41,14 @@ export function AccountSettingsPage() {
   const [showPasswordChange, setShowPasswordChange] = useState(false)
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const [isUploadingImage, setIsUploadingImage] = useState(false)
+  const [unlinkTarget, setUnlinkTarget] = useState<number | null>(null)
   const navigate = useNavigate()
   const addToast = useToastStore((s) => s.addToast)
   const queryClient = useQueryClient()
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-  const {
-    unlinkTarget,
-    setUnlinkTarget,
-    handleGoogleLink,
-    handleAppleLink,
-    handleKakaoLink,
-    handleUnlink,
-  } = useOAuthLinking()
+  const { handleGoogleLink, handleAppleLink, handleKakaoLink, handleUnlink } =
+    useOAuthLinking()
 
   const linkedMap = new Map(
     oauths.map((o) => [PROVIDER_TO_SOCIAL[o.provider], o.memberOAuthId]),
@@ -141,7 +136,7 @@ export function AccountSettingsPage() {
         : social === "google"
           ? handleGoogleLink
           : handleAppleLink
-    const onUnlink = () => setUnlinkTarget({ memberOAuthId: memberOAuthId! })
+    const onUnlink = () => setUnlinkTarget(memberOAuthId!)
     return { linked, onClick: linked ? onUnlink : onLink }
   }
 
@@ -303,7 +298,9 @@ export function AccountSettingsPage() {
           if (!open) setUnlinkTarget(null)
         }}
         onCancel={() => setUnlinkTarget(null)}
-        onConfirm={() => void handleUnlink()}
+        onConfirm={() =>
+          unlinkTarget !== null && void handleUnlink(unlinkTarget)
+        }
       />
 
       <CtaModal

--- a/src/features/settings/ui/AccountSettingsPage.tsx
+++ b/src/features/settings/ui/AccountSettingsPage.tsx
@@ -100,8 +100,8 @@ export function AccountSettingsPage() {
             type: "default",
             duration: 3000,
           })
-          return
         }
+        return
       }
     }
     try {

--- a/src/features/settings/ui/ChangePasswordForm.tsx
+++ b/src/features/settings/ui/ChangePasswordForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
+import { changePassword } from "@/features/auth/api/credentials"
 import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
 import { Button } from "@/shared/ui/Button"
 import { InputBox } from "@/shared/ui/input/InputBox"
@@ -26,16 +27,31 @@ export function ChangePasswordForm({ onSuccess }: ChangePasswordFormProps) {
   const isNextValid = isValidPassword(next)
   const isConfirmMatch = confirm.length > 0 && next === confirm
 
-  const handleSubmit = () => {
-    // TODO: API 연결 후 실제 비밀번호 변경 요청으로 교체
-    addToast({
-      message: "비밀번호가 변경되었습니다.",
-      color: "primary",
-      variant: "deep",
-      type: "default",
-      duration: 3000,
-    })
-    onSuccess()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const handleSubmit = async () => {
+    setIsSubmitting(true)
+    try {
+      await changePassword({ currentPassword: current, newPassword: next })
+      addToast({
+        message: "비밀번호가 변경되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      onSuccess()
+    } catch {
+      addToast({
+        message: "비밀번호 변경에 실패했습니다. 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
   }
 
   return (
@@ -141,8 +157,9 @@ export function ChangePasswordForm({ onSuccess }: ChangePasswordFormProps) {
         variant="fill"
         color="primary"
         size="s"
-        disabled={!current || !isNextValid || !isConfirmMatch}
-        onClick={handleSubmit}
+        disabled={!current || !isNextValid || !isConfirmMatch || isSubmitting}
+        isLoading={isSubmitting}
+        onClick={() => void handleSubmit()}
         className="h-11 w-full bg-teal-300 disabled:bg-teal-200"
       >
         변경하기

--- a/src/routes/oauth/kakao/callback.tsx
+++ b/src/routes/oauth/kakao/callback.tsx
@@ -1,10 +1,14 @@
+import { useQueryClient } from "@tanstack/react-query"
 import { createFileRoute, useNavigate } from "@tanstack/react-router"
 import { useEffect, useRef } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
+import { addMemberOAuth } from "@/features/auth/api/memberOauth"
 import { loginWithKakao } from "@/features/auth/api/socialLogin"
+import { MEMBER_OAUTH_QUERY_KEY } from "@/features/auth/hooks/useMemberOAuthList"
 import { handleLoginResponse } from "@/features/auth/lib/handleLoginResponse"
 import {
+  consumeKakaoLinkIntent,
   consumeKakaoState,
   getKakaoRedirectUri,
 } from "@/features/auth/lib/kakaoSignIn"
@@ -16,6 +20,7 @@ export const Route = createFileRoute("/oauth/kakao/callback")({
 function KakaoCallbackPage() {
   const navigate = useNavigate()
   const addToast = useToastStore((s) => s.addToast)
+  const queryClient = useQueryClient()
   const didRun = useRef(false)
   const isActiveRef = useRef(true)
 
@@ -41,7 +46,8 @@ function KakaoCallbackPage() {
       const description = params.get("error_description") ?? error
       console.error("[Kakao Callback]", error, description)
       if (error === "access_denied") {
-        void navigate({ to: "/login" })
+        const isLinkAttempt = consumeKakaoLinkIntent()
+        void navigate({ to: isLinkAttempt ? "/settings" : "/login" })
         return
       }
       showError("Kakao 로그인에 실패했습니다. 다시 시도해주세요.")
@@ -60,6 +66,8 @@ function KakaoCallbackPage() {
       return
     }
 
+    const isLinkAttempt = consumeKakaoLinkIntent()
+
     void (async () => {
       try {
         const keepLoggedInStr = sessionStorage.getItem("kakao_keep_logged_in")
@@ -72,6 +80,50 @@ function KakaoCallbackPage() {
           redirectUri: getKakaoRedirectUri(),
         })
         if (!isActiveRef.current) return
+
+        if (isLinkAttempt) {
+          if (res.code === "LOGIN_SUCCESS") {
+            addToast({
+              message: "이미 다른 계정에 연결된 카카오 계정입니다.",
+              color: "red",
+              variant: "deep",
+              type: "default",
+              duration: 3000,
+            })
+            void navigate({ to: "/settings" })
+            return
+          }
+
+          if (!res.oAuthVerificationToken) {
+            addToast({
+              message: "카카오 연동에 실패했습니다. 다시 시도해주세요.",
+              color: "red",
+              variant: "deep",
+              type: "default",
+              duration: 3000,
+            })
+            void navigate({ to: "/settings" })
+            return
+          }
+
+          await addMemberOAuth({
+            oAuthVerificationToken: res.oAuthVerificationToken,
+          })
+          await queryClient.invalidateQueries({
+            queryKey: MEMBER_OAUTH_QUERY_KEY,
+          })
+          addToast({
+            message: "카카오 계정이 연동되었습니다.",
+            color: "primary",
+            variant: "deep",
+            type: "default",
+            duration: 3000,
+          })
+          void navigate({ to: "/settings" })
+          return
+        }
+
+        // 일반 로그인 플로우
         const result = handleLoginResponse(res, keepLoggedIn)
         if (result === "LOGIN_SUCCESS") {
           void navigate({ to: "/" })
@@ -80,7 +132,20 @@ function KakaoCallbackPage() {
         }
       } catch (err) {
         if (!isActiveRef.current) return
-        console.error("[Kakao Callback] login failed", err)
+        console.error("[Kakao Callback] failed", err)
+
+        if (isLinkAttempt) {
+          addToast({
+            message: "카카오 연동에 실패했습니다. 다시 시도해주세요.",
+            color: "red",
+            variant: "deep",
+            type: "default",
+            duration: 3000,
+          })
+          void navigate({ to: "/settings" })
+          return
+        }
+
         showError("Kakao 로그인에 실패했습니다. 다시 시도해주세요.")
       }
     })()
@@ -88,7 +153,7 @@ function KakaoCallbackPage() {
     return () => {
       isActiveRef.current = false
     }
-  }, [navigate, addToast])
+  }, [navigate, addToast, queryClient])
 
   return (
     <main className="flex min-h-[80vh] items-center justify-center">

--- a/src/routes/test/header.tsx
+++ b/src/routes/test/header.tsx
@@ -47,13 +47,14 @@ function HeaderTestPage() {
 }
 
 export const HEADER_PREVIEW_USER: MemberInfoResponse = {
-  id: 1,
+  id: "1",
   name: "김운영",
   nickname: "운영자",
   email: "operator@example.com",
-  schoolId: 1,
+  hasLocalCredential: false,
+  schoolId: "1",
   schoolName: "UMC 대학교",
-  profileImageLink: "",
+  profileImageLink: null,
   status: "ACTIVE",
   roles: [
     {
@@ -93,7 +94,7 @@ export function useHeaderPreviewUser() {
 
   useEffect(() => {
     const previousAuthState = useAuthStore.getState()
-    const previousAuthQuery = queryClient.getQueryData(["auth"])
+    const previousAuthQuery = queryClient.getQueryData(["auth", "me"])
 
     useAuthStore.setState({
       accessToken: null,
@@ -101,7 +102,7 @@ export function useHeaderPreviewUser() {
       memberId: null,
       isAuthed: false,
     })
-    queryClient.setQueryData(["auth"], HEADER_PREVIEW_USER)
+    queryClient.setQueryData(["auth", "me"], HEADER_PREVIEW_USER)
     setIsReady(true)
 
     return () => {
@@ -111,7 +112,7 @@ export function useHeaderPreviewUser() {
         memberId: previousAuthState.memberId,
         isAuthed: previousAuthState.isAuthed,
       })
-      queryClient.setQueryData(["auth"], previousAuthQuery)
+      queryClient.setQueryData(["auth", "me"], previousAuthQuery)
     }
   }, [queryClient])
 

--- a/src/shared/ui/ProfileDropdown.tsx
+++ b/src/shared/ui/ProfileDropdown.tsx
@@ -6,6 +6,7 @@ import { useMe } from "@/features/auth/hooks/useMe"
 import { logout } from "@/features/auth/lib/logout"
 import { isCentralStaff, isSuperAdmin } from "@/features/auth/model/identity"
 import { toRoleTag } from "@/features/auth/model/mappers"
+import { useSelectedChallengerStore } from "@/features/auth/store/selectedChallengerStore"
 import { cn } from "@/shared/lib/utils"
 
 import ProfileIcon from "../assets/icon/people/ProfileIcon"
@@ -33,6 +34,17 @@ export function ProfileDropdown({
 
   const { data: me } = useMe()
   const canManageMembers = isSuperAdmin(me) || isCentralStaff(me)
+
+  const { selectedGisuId, setSelectedGisuId } = useSelectedChallengerStore()
+
+  // TODO: GET /api/v2/member/me 연동 후 challengerRecords → challengerHistory, record.gisu → record.generation 으로 교체
+  useEffect(() => {
+    if (selectedGisuId || !me?.challengerRecords?.length) return
+    const latest = [...me.challengerRecords].sort(
+      (a, b) => Number(b.gisuId) - Number(a.gisuId),
+    )[0]
+    if (latest) setSelectedGisuId(latest.gisuId)
+  }, [me, selectedGisuId, setSelectedGisuId])
 
   useEffect(() => {
     if (!isOpen) return
@@ -116,16 +128,19 @@ export function ProfileDropdown({
               </span>
 
               <div className="border-teal-gray-100 flex w-full flex-col gap-0.5 rounded-[10px] border px-0.5 py-0.5">
-                {/* TODO: 기수 선택 시 글로벌 상태 변경 */}
                 {me?.challengerRecords && me.challengerRecords.length > 0 ? (
-                  me.challengerRecords.map((record, index) => (
-                    <GenerationListItem
-                      key={record.challengerId}
-                      generation={Number(record.gisu)}
-                      active={index === 0} // 현재는 첫 번째 항목을 활성 상태로 표시
-                      className="w-full"
-                    />
-                  ))
+                  me.challengerRecords
+                    .slice()
+                    .sort((a, b) => Number(b.gisuId) - Number(a.gisuId))
+                    .map((record) => (
+                      <GenerationListItem
+                        key={record.challengerId}
+                        generation={Number(record.gisu)}
+                        active={record.gisuId === selectedGisuId}
+                        onClick={() => setSelectedGisuId(record.gisuId)}
+                        className="w-full"
+                      />
+                    ))
                 ) : (
                   <div className="text-caption-3-medium text-teal-gray-400 py-2 text-center">
                     참여 기록이 없습니다.


### PR DESCRIPTION
## 📸 작업 내용

> 계정 설정 페이지의 OAuth(Google·Kakao·Apple) 연동/해제, 회원 탈퇴 API를 연결하고, /v1/member/me → /v2/member/me 전환에 따른 응답 매핑 및 타입 정비를 완료했습니다.

- 계정 설정 - Google·Kakao·Apple 소셜 계정 연동 및 해제
- 계정 설정 - 회원 탈퇴 API 연결 (소셜 계정 token 전달 처리 포함)
- 계정 설정 - hasLocalCredential 기반 비밀번호 변경 버튼 노출 조건 처리
- 카카오 콜백에 링크 의도 분기 추가 (로그인 vs 연동 플로우 구분)
- /v2/member/me 응답 구조(challengerHistory, currentGisuMemberInfo)를 프론트 타입 (challengerRecords, roles)으로 매핑
- 프로필 드롭다운 기수 선택 기능 및 프로젝트 목록 페이지 유저 기수 반영


## 🎞️ 주요 코드 설명

> 설명이 필요한 코드 위주로 작성해주세요

### v2/member/me 응답 매핑

```TypeScript
// src/features/auth/api/me.ts
export async function getMyInfo(): Promise<MemberInfoResponse> {
  const { data } = await api.get<ApiResponse<MemberInfoV2Raw>>("/v2/member/me")
  const raw = data.result
  const history = raw.challengerHistory ?? []
  const currentGisu = raw.currentGisuMemberInfo

  const currentHistory = history.find((h) => h.gisuId === currentGisu?.gisuId)

  const challengerRecords = history.map((h) => ({
    ...(h as unknown as ChallengerInfoResponse),
    gisu: String(h.generation), // generation → gisu 변환
    ...
  }))

  const roles = (currentGisu?.roleTypes ?? []).map((rt) => ({
    roleType: rt,
    organizationId: currentHistory?.chapterId ?? "",
    ...
  }))

  return { ...(raw as unknown as MemberInfoResponse), challengerRecords, roles }
}
```

- v2는 challengerRecords 대신 challengerHistory, roles 대신 currentGisuMemberInfo.roleTypes로 내려줌
- 소비자 코드(identity.ts, ProfileDropdown 등) 변경 없이 기존 MemberInfoResponse 형태로 매핑해서 반환

### 카카오 링크 의도 분기

```TypeScript
// src/features/auth/lib/kakaoSignIn.ts
export function setKakaoLinkIntent(): void {
  sessionStorage.setItem("kakao_link_intent", "link")
}
export function consumeKakaoLinkIntent(): boolean {
  const intent = sessionStorage.getItem("kakao_link_intent")
  sessionStorage.removeItem("kakao_link_intent")
  return intent === "link"
}
```

- 카카오는 팝업이 없고 리다이렉트 방식이라, 같은 콜백 URL을 로그인/연동 두 목적으로 공용
- 연동 버튼 클릭 시 sessionStorage에 플래그를 저장하고 콜백 진입 시 소비해서 분기 처리

### useMe queryKey 통일
```TypeScript
// 변경 전: queryKey: ["auth"]
// 변경 후: queryKey: ["auth", "me"]
}
```
- 기존 useMe의 ["auth"]와 ensureMe / invalidateQueries / removeQueries의 ["auth", "me"]가 불일치해 프리페치 캐시 미활용 및 invalidation 미동작 버그 수정


## 🖥️ 구현화면

> localhost 캡쳐 사진을 첨부해 주세요.



## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #184 