### PR TITLE
🐛 fix: 매칭 기간 아닐 때 지원하기 버튼 비활성화

### DIFF
--- a/src/features/project/list/model/projectDetailCta.test.ts
+++ b/src/features/project/list/model/projectDetailCta.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+
+import { isApplyButtonDisabled } from "./projectDetailCta"
+
+const applicable = {
+  isPmReadonly: false,
+  isDetailLoading: false,
+  hasApplicationForm: true,
+  isWritePermissionLoading: false,
+  canWriteApplication: true,
+  hasActiveRound: true,
+}
+
+describe("isApplyButtonDisabled", () => {
+  it("모든 조건을 충족하면 지원 버튼을 활성화한다", () => {
+    expect(isApplyButtonDisabled(applicable)).toBe(false)
+  })
+
+  it("활성 매칭 라운드가 없으면 지원 버튼을 비활성화한다", () => {
+    expect(
+      isApplyButtonDisabled({ ...applicable, hasActiveRound: false }),
+    ).toBe(true)
+  })
+
+  it("지원 양식이 없으면 비활성화한다", () => {
+    expect(
+      isApplyButtonDisabled({ ...applicable, hasApplicationForm: false }),
+    ).toBe(true)
+  })
+
+  it("지원 작성 권한이 없으면 비활성화한다", () => {
+    expect(
+      isApplyButtonDisabled({ ...applicable, canWriteApplication: false }),
+    ).toBe(true)
+  })
+
+  it("권한 조회 중에는 비활성화한다", () => {
+    expect(
+      isApplyButtonDisabled({ ...applicable, isWritePermissionLoading: true }),
+    ).toBe(true)
+  })
+
+  it("PM 읽기 전용 컨텍스트에서는 라운드가 없어도 비활성화하지 않는다", () => {
+    expect(
+      isApplyButtonDisabled({
+        ...applicable,
+        isPmReadonly: true,
+        hasActiveRound: false,
+        hasApplicationForm: false,
+        canWriteApplication: false,
+      }),
+    ).toBe(false)
+  })
+
+  it("상세 로딩 중에는 양식 미확인을 이유로 비활성화하지 않는다", () => {
+    expect(
+      isApplyButtonDisabled({
+        ...applicable,
+        isDetailLoading: true,
+        hasApplicationForm: false,
+      }),
+    ).toBe(false)
+  })
+})

--- a/src/features/project/list/model/projectDetailCta.ts
+++ b/src/features/project/list/model/projectDetailCta.ts
@@ -31,3 +31,29 @@ export function resolveProjectDetailCtaMode({
   if (hasOtherActiveApplication) return "apply-blocked-other"
   return "apply"
 }
+
+interface ApplyButtonDisabledParams {
+  isPmReadonly: boolean
+  isDetailLoading: boolean
+  hasApplicationForm: boolean
+  isWritePermissionLoading: boolean
+  canWriteApplication: boolean
+  hasActiveRound: boolean
+}
+
+export function isApplyButtonDisabled({
+  isPmReadonly,
+  isDetailLoading,
+  hasApplicationForm,
+  isWritePermissionLoading,
+  canWriteApplication,
+  hasActiveRound,
+}: ApplyButtonDisabledParams): boolean {
+  if (isPmReadonly) return false
+  return (
+    (!isDetailLoading && !hasApplicationForm) ||
+    isWritePermissionLoading ||
+    !canWriteApplication ||
+    !hasActiveRound
+  )
+}

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -34,7 +34,10 @@ import {
 import { filterApplicationSectionsByPart } from "../model/applicationSectionFilter"
 import { isRecruitDone } from "../model/matchingProject"
 import { DEFAULT_MATCHING_PROJECT_MOCK } from "../model/matchingProject.mock"
-import { resolveProjectDetailCtaMode } from "../model/projectDetailCta"
+import {
+  isApplyButtonDisabled,
+  resolveProjectDetailCtaMode,
+} from "../model/projectDetailCta"
 import { ApplyFormSkeleton } from "./apply-modal/ApplyFormSkeleton"
 import { MyApplicationModal } from "./apply-modal/MyApplicationModal"
 import { ProjectApplyModal } from "./apply-modal/ProjectApplyModal"
@@ -528,12 +531,15 @@ export function ProjectDetailCard({
                         !(viewOnly && userIsPm) &&
                         (isDetailLoading || isApplicationWritePermissionLoading)
                       }
-                      disabled={
-                        !(viewOnly && userIsPm) &&
-                        ((!isDetailLoading && !detail?.applicationFormId) ||
-                          isApplicationWritePermissionLoading ||
-                          !canWriteProjectApplication)
-                      }
+                      disabled={isApplyButtonDisabled({
+                        isPmReadonly: viewOnly && userIsPm,
+                        isDetailLoading,
+                        hasApplicationForm: !!detail?.applicationFormId,
+                        isWritePermissionLoading:
+                          isApplicationWritePermissionLoading,
+                        canWriteApplication: canWriteProjectApplication,
+                        hasActiveRound: activeMatchingRound != null,
+                      })}
                       onClick={() => {
                         if (viewOnly && userIsPm) {
                           // PM 읽기 전용: 모집 문항 보기 모달로 열기


### PR DESCRIPTION
## 개요
QA #3에서 발견한 버그 수정. 활성 매칭 라운드가 없을 때(매칭 기간 아님)에도 `지원하기` 버튼이 활성화되던 문제를 비활성화하도록 수정합니다.

## 변경 사항
- `projectDetailCta.ts`: 비활성 판정을 순수 함수 `isApplyButtonDisabled`로 추출(기존 PM 읽기전용/양식/권한/로딩 로직 보존) + **활성 매칭 라운드 게이트(`!hasActiveRound`) 추가**
- `ProjectDetailCard.tsx`: 인라인 `disabled` 식을 헬퍼 호출로 교체(`hasActiveRound: activeMatchingRound != null`)
- `projectDetailCta.test.ts`: 단위 테스트 추가

## 검증
- 신규 단위 테스트 7개 통과, `project/list` 전체 통과
- `tsc -b` / `eslint` clean
- 라이브 E2E는 별도 환경 필요로 미실행(단위 테스트 + 확인된 데이터 상태로 로직 검증)

## 참고
- 타 지부 프로젝트(plan-only)·권한 없는 프로젝트는 기존대로 정상 비노출/비활성 → 변경 없음

Closes #249