### PR TITLE
[fix] 지원서 선택형 답변 payload 수정

### DIFF
--- a/src/features/project/list/model/applyAnswerPayload.ts
+++ b/src/features/project/list/model/applyAnswerPayload.ts
@@ -64,9 +64,14 @@ function getValidOptionId(question: Question, value: string): number | null {
 export function buildAnswerPayload(
   formValues: Record<string, ApplyAnswerValue>,
   sections: Section[],
+  sectionEnabled: Record<string, boolean> = {},
 ): ApplicationAnswerItem[] {
   const questionMap = new Map<string, Question>()
-  sections.forEach((s) => s.questions.forEach((q) => questionMap.set(q.id, q)))
+  sections.forEach((s) => {
+    const enabled = sectionEnabled[s.id] ?? s.isEnabled
+    if (!enabled) return
+    s.questions.forEach((q) => questionMap.set(q.id, q))
+  })
 
   return Object.entries(formValues).flatMap(([questionId, value]) => {
     const question = questionMap.get(questionId)
@@ -79,19 +84,19 @@ export function buildAnswerPayload(
     }
 
     if (question.fieldType === "radio") {
-      if (typeof value !== "string" || !value) return [base]
+      if (typeof value !== "string" || !value) return []
       const optionId = getValidOptionId(question, value)
-      if (optionId === null) return [base]
+      if (optionId === null) return []
       return [{ ...base, selectedOptionIds: [optionId] }]
     }
 
     if (question.fieldType === "checkbox") {
-      if (!Array.isArray(value) || value.length === 0) return [base]
+      if (!Array.isArray(value) || value.length === 0) return []
       const selectedIds = value.flatMap((optionValue) => {
         const optionId = getValidOptionId(question, optionValue)
         return optionId === null ? [] : [optionId]
       })
-      if (selectedIds.length === 0) return [base]
+      if (selectedIds.length === 0) return []
       return [{ ...base, selectedOptionIds: selectedIds }]
     }
 

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.test.ts
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.test.ts
@@ -53,7 +53,7 @@ describe("buildAnswerPayload", () => {
     ])
   })
 
-  it("선택형 문항 값이 content이면 selectedOptionIds에 포함하지 않는다", () => {
+  it("선택형 문항 값이 content이면 답변 payload에서 제외한다", () => {
     const payload = buildAnswerPayload(
       {
         "101": "두 번째",
@@ -62,10 +62,10 @@ describe("buildAnswerPayload", () => {
       sections,
     )
 
-    expect(payload).toEqual([{ questionId: 101 }, { questionId: 102 }])
+    expect(payload).toEqual([])
   })
 
-  it("현재 옵션에 없는 option id는 selectedOptionIds에 포함하지 않는다", () => {
+  it("현재 옵션에 없는 option id는 답변 payload에서 제외한다", () => {
     const payload = buildAnswerPayload(
       {
         "101": "9999",
@@ -74,9 +74,19 @@ describe("buildAnswerPayload", () => {
       sections,
     )
 
-    expect(payload).toEqual([
-      { questionId: 101 },
-      { questionId: 102, selectedOptionIds: [2001] },
-    ])
+    expect(payload).toEqual([{ questionId: 102, selectedOptionIds: [2001] }])
+  })
+
+  it("비활성 섹션의 답변은 전송하지 않는다", () => {
+    const payload = buildAnswerPayload(
+      {
+        "101": "1001",
+        "102": ["2001"],
+      },
+      sections,
+      { common: false },
+    )
+
+    expect(payload).toEqual([])
   })
 })

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -302,7 +302,7 @@ export function ProjectApplyModal({
     setIsSubmitting(true)
     try {
       if (!isDevMatchingRound) {
-        const answers = buildAnswerPayload(formValues, sections)
+        const answers = buildAnswerPayload(formValues, sections, sectionEnabled)
         await saveApplicationDraft(projectId, answers)
         await submitApplication(projectId)
       }


### PR DESCRIPTION
## 변경 사항

지원서 제출 전 임시 저장 payload를 생성할 때 선택형 문항의 유효하지 않은 답변을 제외하도록 수정했습니다.

## 원인

radio/checkbox 문항에서 선택값이 없거나 현재 옵션에 없는 값이어도 { questionId } 형태의 답변이 전송될 수 있었습니다. 서버는 선택형 문항에 유효한 selectedOptionIds가 없는 답변을 잘못된 투표 선택으로 판단해 SURVEY-0023을 반환할 수 있습니다.

## 수정 내용

- radio/checkbox 답변에 유효한 option id가 없으면 payload에서 제외
- 비활성 섹션의 답변을 payload에서 제외
- 선택형 invalid/disabled 케이스 테스트 갱신 및 추가

## 검증

- pnpm exec vitest run src/features/project/list/ui/apply-modal/ProjectApplyModal.test.ts
- pnpm exec tsc --noEmit
- pnpm exec eslint src/features/project/list/model/applyAnswerPayload.ts src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx src/features/project/list/ui/apply-modal/ProjectApplyModal.test.ts
- git diff --check