### PR TITLE
[fix] 사이드바 view dropdown 권한 기준 수정

### DIFF
--- a/src/features/auth/api/me.ts
+++ b/src/features/auth/api/me.ts
@@ -4,6 +4,7 @@ import type {
   ChallengerInfoResponse,
   ChallengerPointInfo,
   ChallengerRoleResponse,
+  Part,
 } from "@/features/challenger/model/types"
 import type { ApiResponse } from "@/shared/lib/apiResponse"
 
@@ -14,6 +15,18 @@ export interface MemberProfileInfo {
   github: string | null
   blog: string | null
   personal: string | null
+}
+
+export interface CurrentGisuMemberInfo {
+  gisuId: string
+  generation: string
+  challenger?: {
+    challengerId: string
+    part: Part
+    challengerStatus: string
+  } | null
+  isAdmin?: boolean
+  roleTypes?: string[]
 }
 
 export interface MemberInfoResponse {
@@ -28,6 +41,7 @@ export interface MemberInfoResponse {
   hasLocalCredential: boolean
   profile?: MemberProfileInfo | null
   totalActivityDays?: string
+  currentGisuMemberInfo?: CurrentGisuMemberInfo | null
   roles: ChallengerRoleResponse[]
   challengerRecords?: ChallengerInfoResponse[]
 }
@@ -56,7 +70,7 @@ interface MemberInfoV2Raw {
     generation: string
     challenger?: {
       challengerId: string
-      part: string
+      part: Part
       challengerStatus: string
     } | null
     isAdmin?: boolean
@@ -103,6 +117,20 @@ export async function getMyInfo(): Promise<MemberInfoResponse> {
 
   return {
     ...(raw as unknown as MemberInfoResponse),
+    currentGisuMemberInfo: currentGisu
+      ? {
+          ...currentGisu,
+          gisuId: String(currentGisu.gisuId),
+          generation: String(currentGisu.generation),
+          challenger: currentGisu.challenger
+            ? {
+                ...currentGisu.challenger,
+                challengerId: String(currentGisu.challenger.challengerId),
+                part: currentGisu.challenger.part,
+              }
+            : null,
+        }
+      : null,
     challengerRecords,
     roles,
   }

--- a/src/shared/view-mode/availableViewModes.test.ts
+++ b/src/shared/view-mode/availableViewModes.test.ts
@@ -4,7 +4,11 @@ import { computeAvailableViewModes } from "./availableViewModes"
 
 import type { MemberInfoResponse } from "@/features/auth/api/me"
 
-function makeMe(roleTypes: string[], parts: string[]): MemberInfoResponse {
+function makeMe(
+  roleTypes: string[],
+  parts: string[],
+  currentIndex: number | null = parts.length > 0 ? 0 : null,
+): MemberInfoResponse {
   return {
     roles: roleTypes.map((roleType) => ({ roleType })),
     challengerRecords: parts.map((part, i) => ({
@@ -12,6 +16,20 @@ function makeMe(roleTypes: string[], parts: string[]): MemberInfoResponse {
       gisuId: String(10 - i),
       part,
     })),
+    currentGisuMemberInfo:
+      currentIndex === null
+        ? null
+        : {
+            gisuId: String(10 - currentIndex),
+            generation: String(10 - currentIndex),
+            challenger: {
+              challengerId: String(currentIndex),
+              part: parts[currentIndex],
+              challengerStatus: "ACTIVE",
+            },
+            isAdmin: roleTypes.length > 0,
+            roleTypes,
+          },
   } as unknown as MemberInfoResponse
 }
 
@@ -26,9 +44,9 @@ describe("computeAvailableViewModes", () => {
     expect(computeAvailableViewModes(me)).toEqual(["admin", "pm"])
   })
 
-  it("PLAN + 비-PLAN만 → [pm, others]", () => {
+  it("현재 PLAN + 과거 비-PLAN 챌린저 → [pm]", () => {
     const me = makeMe([], ["PLAN", "WEB"])
-    expect(computeAvailableViewModes(me)).toEqual(["pm", "others"])
+    expect(computeAvailableViewModes(me)).toEqual(["pm"])
   })
 
   it("비-PLAN 챌린저만 → [others]", () => {
@@ -38,6 +56,11 @@ describe("computeAvailableViewModes", () => {
 
   it("학교 운영진 단일 → [admin]", () => {
     const me = makeMe(["SCHOOL_PRESIDENT"], [])
+    expect(computeAvailableViewModes(me)).toEqual(["admin"])
+  })
+
+  it("운영진 + 과거 비-PLAN 챌린저 → [admin]", () => {
+    const me = makeMe(["CENTRAL_OPERATING_TEAM_MEMBER"], ["WEB"], null)
     expect(computeAvailableViewModes(me)).toEqual(["admin"])
   })
 

--- a/src/shared/view-mode/availableViewModes.ts
+++ b/src/shared/view-mode/availableViewModes.ts
@@ -1,5 +1,7 @@
 import { isAnyOperator } from "@/features/auth/model/identity"
 
+import { getCurrentGisuChallengerRecords } from "./currentGisuRecords"
+
 import type { MemberInfoResponse } from "@/features/auth/api/me"
 
 import type { ViewMode } from "."
@@ -10,7 +12,7 @@ export function computeAvailableViewModes(
   if (!me) return []
   const modes: ViewMode[] = []
   if (isAnyOperator(me)) modes.push("admin")
-  const records = me.challengerRecords ?? []
+  const records = getCurrentGisuChallengerRecords(me)
   if (records.some((r) => r.part === "PLAN")) modes.push("pm")
   if (records.some((r) => r.part !== "PLAN")) modes.push("others")
   return modes

--- a/src/shared/view-mode/currentGisuRecords.ts
+++ b/src/shared/view-mode/currentGisuRecords.ts
@@ -1,0 +1,18 @@
+import type { MemberInfoResponse } from "@/features/auth/api/me"
+import type { ChallengerInfoResponse } from "@/features/challenger/model/types"
+
+export function getCurrentGisuChallengerRecords(
+  me: MemberInfoResponse | undefined,
+): ChallengerInfoResponse[] {
+  const current = me?.currentGisuMemberInfo
+  const currentChallenger = current?.challenger
+  if (!current?.gisuId || !currentChallenger?.challengerId) return []
+
+  const currentGisuId = String(current.gisuId)
+  const currentChallengerId = String(currentChallenger.challengerId)
+  return (me?.challengerRecords ?? []).filter(
+    (record) =>
+      String(record.gisuId) === currentGisuId &&
+      String(record.challengerId) === currentChallengerId,
+  )
+}

--- a/src/shared/view-mode/projectViewMe.test.ts
+++ b/src/shared/view-mode/projectViewMe.test.ts
@@ -14,6 +14,17 @@ const baseMe = {
   profileImageLink: "",
   status: "ACTIVE",
   roles: [{ roleType: "CENTRAL_OPERATING_TEAM_MEMBER" }],
+  currentGisuMemberInfo: {
+    gisuId: "10",
+    generation: "10",
+    challenger: {
+      challengerId: "1",
+      part: "PLAN",
+      challengerStatus: "ACTIVE",
+    },
+    isAdmin: true,
+    roleTypes: ["CENTRAL_OPERATING_TEAM_MEMBER"],
+  },
   challengerRecords: [
     { challengerId: "1", gisuId: "10", part: "PLAN" },
     { challengerId: "2", gisuId: "9", part: "WEB" },
@@ -34,9 +45,29 @@ describe("projectViewMe", () => {
   })
 
   it("others: roles를 비우고 비-PLAN 기록만 남긴다", () => {
-    const v = projectViewMe(baseMe, "others")
+    const me = {
+      ...baseMe,
+      currentGisuMemberInfo: {
+        gisuId: "9",
+        generation: "9",
+        challenger: {
+          challengerId: "2",
+          part: "WEB",
+          challengerStatus: "ACTIVE",
+        },
+        isAdmin: true,
+        roleTypes: ["CENTRAL_OPERATING_TEAM_MEMBER"],
+      },
+    } as unknown as MemberInfoResponse
+    const v = projectViewMe(me, "others")
     expect(v?.roles).toEqual([])
     expect(v?.challengerRecords?.map((r) => r.part)).toEqual(["WEB"])
+  })
+
+  it("현재 기수가 아닌 기록은 viewMe에서 제외한다", () => {
+    const v = projectViewMe(baseMe, "others")
+    expect(v?.roles).toEqual([])
+    expect(v?.challengerRecords).toEqual([])
   })
 
   it("me가 undefined면 undefined 반환", () => {

--- a/src/shared/view-mode/projectViewMe.ts
+++ b/src/shared/view-mode/projectViewMe.ts
@@ -1,3 +1,5 @@
+import { getCurrentGisuChallengerRecords } from "./currentGisuRecords"
+
 import type { MemberInfoResponse } from "@/features/auth/api/me"
 
 import type { ViewMode } from "."
@@ -7,7 +9,7 @@ export function projectViewMe(
   mode: ViewMode,
 ): MemberInfoResponse | undefined {
   if (!me) return me
-  const records = me.challengerRecords ?? []
+  const records = getCurrentGisuChallengerRecords(me)
   switch (mode) {
     case "admin":
       return { ...me, challengerRecords: [] }


### PR DESCRIPTION
## 변경 사항

Closes #252

사이드바 view dropdown 후보를 전체 챌린저 이력이 아니라 현재 기수/현재 권한 기준으로 계산하도록 수정했습니다.

## 원인

/v2/member/me의 challengerRecords는 모든 기수 이력을 포함합니다. 기존 view mode 계산은 이 전체 이력을 그대로 사용해서, 현재 기수에서는 운영진 권한만 있는 사용자도 과거 PLAN 또는 비-PLAN 이력 때문에 Challenger view 후보가 노출될 수 있었습니다.

## 수정 내용

- currentGisuMemberInfo를 MemberInfoResponse에 명시하고 문자열 ID로 정규화
- 현재 기수 challenger와 일치하는 record만 추출하는 getCurrentGisuChallengerRecords 추가
- computeAvailableViewModes와 projectViewMe가 현재 기수 record만 사용하도록 변경
- 과거 이력으로 dropdown 후보가 생기지 않는 테스트 추가

## 검증

- pnpm exec vitest run src/shared/view-mode/availableViewModes.test.ts src/shared/view-mode/projectViewMe.test.ts
- pnpm exec tsc --noEmit
- pnpm exec eslint --fix src/features/auth/api/me.ts src/shared/view-mode/availableViewModes.ts src/shared/view-mode/availableViewModes.test.ts src/shared/view-mode/currentGisuRecords.ts src/shared/view-mode/projectViewMe.ts src/shared/view-mode/projectViewMe.test.ts
- git diff --check