### PR TITLE
🔊 fix: 지원서 제출 실패 시 실제 서버 에러 노출

### DIFF
--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -324,8 +324,7 @@ export function ProjectApplyModal({
         message: serverData?.message,
         error: err,
       })
-      const serverMessage =
-        serverData?.message ?? (err instanceof Error ? err.message : undefined)
+      const serverMessage = serverData?.message
       addToast({
         message:
           serverMessage ?? "지원서 제출에 실패했습니다. 다시 시도해 주세요.",

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -307,9 +307,28 @@ export function ProjectApplyModal({
         await submitApplication(projectId)
       }
       setIsCompleteModalOpen(true)
-    } catch {
+    } catch (err) {
+      const status =
+        err instanceof AxiosError ? err.response?.status : undefined
+      const failedUrl = err instanceof AxiosError ? err.config?.url : undefined
+      const serverData =
+        err instanceof AxiosError
+          ? (err.response?.data as
+              | { code?: string; message?: string }
+              | undefined)
+          : undefined
+      console.error("[apply submit] 지원서 제출 실패", {
+        status,
+        url: failedUrl,
+        code: serverData?.code,
+        message: serverData?.message,
+        error: err,
+      })
+      const serverMessage =
+        serverData?.message ?? (err instanceof Error ? err.message : undefined)
       addToast({
-        message: "지원서 제출에 실패했습니다. 다시 시도해 주세요.",
+        message:
+          serverMessage ?? "지원서 제출에 실패했습니다. 다시 시도해 주세요.",
         color: "red",
         variant: "deep",
         type: "default",


### PR DESCRIPTION
## 배경
챌린저 지원서 제출이 모든 사용자에게서 실패하는 **P0**(#256). 조사 결과 엔드포인트/요청 형식은 라이브 스펙과 완전히 일치했으나, `handleSubmitConfirm`의 `catch {}`가 실제 에러를 **에러 인자 없이 통째로 삼켜** 항상 동일한 generic 토스트만 표시 → 네트워크 접근 없이는 근본 원인 진단이 불가능했음.

## 변경
- `catch {}` → `catch (err)` 로 변경
- 실패한 요청의 `status` / `url` / 서버 `code` / `message`를 `console.error`로 로깅
- 서버가 내려준 `message`가 있으면 토스트에 그대로 노출 (없으면 기존 generic 문구로 fallback)

## 효과
- 성공 시 동작 **변화 없음**, 실패 시 메시지만 구체화 → 회귀 위험 거의 없음
- 배포 후 챌린저/QA가 1회 재현하면 실제 `code`/`message`로 원인을 즉시 특정 가능
  - `필수 답변 누락` → optionId 누락으로 인한 답변 drop 후보
  - `404`/`DRAFT 없음` → applicationId race 후보
  - `상태 전이 불가` → CANCELLED/SUBMITTED 상태 후보

## 참고
- 이 PR은 **진단용 선행 변경**이며 P0를 직접 해결하지 않음. 실제 원인 확정·수정은 #256 에서 이어서 진행. (그래서 `Closes`가 아닌 연결만)
- Refs #256