### PR TITLE
[fix] 운영진 ADMIN record view 분류 제외

### DIFF
--- a/src/shared/view-mode/availableViewModes.test.ts
+++ b/src/shared/view-mode/availableViewModes.test.ts
@@ -59,6 +59,11 @@ describe("computeAvailableViewModes", () => {
     expect(computeAvailableViewModes(me)).toEqual(["admin"])
   })
 
+  it("운영진 + 현재 ADMIN record → [admin]", () => {
+    const me = makeMe(["SUPER_ADMIN"], ["ADMIN"])
+    expect(computeAvailableViewModes(me)).toEqual(["admin"])
+  })
+
   it("운영진 + 과거 비-PLAN 챌린저 → [admin]", () => {
     const me = makeMe(["CENTRAL_OPERATING_TEAM_MEMBER"], ["WEB"], null)
     expect(computeAvailableViewModes(me)).toEqual(["admin"])

--- a/src/shared/view-mode/availableViewModes.ts
+++ b/src/shared/view-mode/availableViewModes.ts
@@ -1,6 +1,7 @@
 import { isAnyOperator } from "@/features/auth/model/identity"
 
 import { getCurrentGisuChallengerRecords } from "./currentGisuRecords"
+import { isOtherChallengerPart, isPmPart } from "./viewModeParts"
 
 import type { MemberInfoResponse } from "@/features/auth/api/me"
 
@@ -13,7 +14,7 @@ export function computeAvailableViewModes(
   const modes: ViewMode[] = []
   if (isAnyOperator(me)) modes.push("admin")
   const records = getCurrentGisuChallengerRecords(me)
-  if (records.some((r) => r.part === "PLAN")) modes.push("pm")
-  if (records.some((r) => r.part !== "PLAN")) modes.push("others")
+  if (records.some((r) => isPmPart(r.part))) modes.push("pm")
+  if (records.some((r) => isOtherChallengerPart(r.part))) modes.push("others")
   return modes
 }

--- a/src/shared/view-mode/projectViewMe.test.ts
+++ b/src/shared/view-mode/projectViewMe.test.ts
@@ -70,6 +70,27 @@ describe("projectViewMe", () => {
     expect(v?.challengerRecords).toEqual([])
   })
 
+  it("ADMIN record는 others viewMe에서 제외한다", () => {
+    const me = {
+      ...baseMe,
+      currentGisuMemberInfo: {
+        gisuId: "10",
+        generation: "10",
+        challenger: {
+          challengerId: "1",
+          part: "ADMIN",
+          challengerStatus: "ACTIVE",
+        },
+        isAdmin: true,
+        roleTypes: ["SUPER_ADMIN"],
+      },
+      challengerRecords: [{ challengerId: "1", gisuId: "10", part: "ADMIN" }],
+    } as unknown as MemberInfoResponse
+    const v = projectViewMe(me, "others")
+    expect(v?.roles).toEqual([])
+    expect(v?.challengerRecords).toEqual([])
+  })
+
   it("me가 undefined면 undefined 반환", () => {
     expect(projectViewMe(undefined, "admin")).toBeUndefined()
   })

--- a/src/shared/view-mode/projectViewMe.ts
+++ b/src/shared/view-mode/projectViewMe.ts
@@ -1,4 +1,5 @@
 import { getCurrentGisuChallengerRecords } from "./currentGisuRecords"
+import { isOtherChallengerPart, isPmPart } from "./viewModeParts"
 
 import type { MemberInfoResponse } from "@/features/auth/api/me"
 
@@ -17,13 +18,13 @@ export function projectViewMe(
       return {
         ...me,
         roles: [],
-        challengerRecords: records.filter((r) => r.part === "PLAN"),
+        challengerRecords: records.filter((r) => isPmPart(r.part)),
       }
     case "others":
       return {
         ...me,
         roles: [],
-        challengerRecords: records.filter((r) => r.part !== "PLAN"),
+        challengerRecords: records.filter((r) => isOtherChallengerPart(r.part)),
       }
   }
 }

--- a/src/shared/view-mode/viewModeParts.ts
+++ b/src/shared/view-mode/viewModeParts.ts
@@ -1,0 +1,18 @@
+import type { Part } from "@/features/challenger/model/types"
+
+const OTHER_CHALLENGER_PARTS = new Set<Part>([
+  "DESIGN",
+  "WEB",
+  "ANDROID",
+  "IOS",
+  "NODEJS",
+  "SPRINGBOOT",
+])
+
+export function isPmPart(part: Part): boolean {
+  return part === "PLAN"
+}
+
+export function isOtherChallengerPart(part: Part): boolean {
+  return OTHER_CHALLENGER_PARTS.has(part)
+}


### PR DESCRIPTION
## 변경 사항

운영진 전용 ADMIN record가 Challenger-Others View로 분류되지 않도록 view mode 파트 분류 기준을 명확히 했습니다.

## 원인

이전 로직은 현재 기수 record만 보도록 좁혔지만, others view 조건이 PLAN이 아닌 모든 part를 허용하는 형태였습니다. 이 때문에 superadmin@university.neordinary.com처럼 현재 기수 ADMIN record만 가진 운영진 계정도 others view 후보가 생겨 dropdown이 노출될 수 있었습니다.

## 수정 내용

- Challenger-Plan View는 PLAN만 허용
- Challenger-Others View는 DESIGN, WEB, ANDROID, IOS, NODEJS, SPRINGBOOT만 허용
- ADMIN part는 Challenger view 후보에서 제외
- ADMIN record가 dropdown 후보와 others viewMe에 포함되지 않는 테스트 추가

## 검증

- pnpm exec vitest run src/shared/view-mode/availableViewModes.test.ts src/shared/view-mode/projectViewMe.test.ts
- pnpm exec tsc -b
- git diff --check