### PR TITLE
🔒️ fix: 매칭 차수 설정 접근 권한을 운영 총괄 권한으로 제한

### DIFF
--- a/src/components/sidebar/MatchingSegmentRegion.tsx
+++ b/src/components/sidebar/MatchingSegmentRegion.tsx
@@ -3,9 +3,8 @@ import { useMemo } from "react"
 
 import {
   canAccessProjectSettings,
+  canManageMatchingRounds,
   canManageProjects,
-  isCurrentTermPm,
-  isOperator,
 } from "@/features/auth/model/identity"
 import { SIDEBAR_ITEMS } from "@/shared/config/navigation"
 import { resolveNavigationFromPathname } from "@/shared/config/navigationResolve"
@@ -26,16 +25,16 @@ export function MatchingSegmentRegion({
   const { viewMe } = useViewMe()
   const canAccessSettings = canAccessProjectSettings(viewMe)
   const canManage = canManageProjects(viewMe)
-  const canRecruit = isOperator(viewMe) || isCurrentTermPm(viewMe)
+  const canManageRounds = canManageMatchingRounds(viewMe)
 
   const visibleSections = useMemo(
     () =>
       filterSectionsByPermission(SIDEBAR_ITEMS, {
         canAccessProjectSettings: canAccessSettings,
         canManageProjects: canManage,
-        canManageRecruitment: canRecruit,
+        canManageMatchingRounds: canManageRounds,
       }),
-    [canAccessSettings, canManage, canRecruit],
+    [canAccessSettings, canManage, canManageRounds],
   )
 
   const resolved = resolveNavigationFromPathname(pathname, visibleSections)

--- a/src/components/sidebar/useVisibleSidebarSections.ts
+++ b/src/components/sidebar/useVisibleSidebarSections.ts
@@ -2,9 +2,8 @@ import { useMemo } from "react"
 
 import {
   canAccessProjectSettings,
+  canManageMatchingRounds,
   canManageProjects,
-  isCurrentTermPm,
-  isOperator,
 } from "@/features/auth/model/identity"
 import { SIDEBAR_ITEMS } from "@/shared/config/navigation"
 import { useViewMe } from "@/shared/view-mode/useViewMe"
@@ -15,16 +14,16 @@ export function useVisibleSidebarSections() {
   const { viewMe, isLoading } = useViewMe()
   const canAccessSettings = canAccessProjectSettings(viewMe)
   const canManage = canManageProjects(viewMe)
-  const canRecruit = isOperator(viewMe) || isCurrentTermPm(viewMe)
+  const canManageRounds = canManageMatchingRounds(viewMe)
 
   const visibleSections = useMemo(
     () =>
       filterSectionsByPermission(SIDEBAR_ITEMS, {
         canAccessProjectSettings: canAccessSettings,
         canManageProjects: canManage,
-        canManageRecruitment: canRecruit,
+        canManageMatchingRounds: canManageRounds,
       }),
-    [canAccessSettings, canManage, canRecruit],
+    [canAccessSettings, canManage, canManageRounds],
   )
 
   return { visibleSections, isLoading }

--- a/src/components/sidebar/utils.test.ts
+++ b/src/components/sidebar/utils.test.ts
@@ -7,7 +7,7 @@ import { filterSectionsByPermission } from "./utils"
 const ALL = {
   canAccessProjectSettings: true,
   canManageProjects: true,
-  canManageRecruitment: true,
+  canManageMatchingRounds: true,
 }
 
 function sectionIds(sections: ReturnType<typeof filterSectionsByPermission>) {
@@ -44,7 +44,7 @@ describe("filterSectionsByPermission", () => {
     const result = filterSectionsByPermission(SIDEBAR_ITEMS, {
       canAccessProjectSettings: false,
       canManageProjects: true,
-      canManageRecruitment: true,
+      canManageMatchingRounds: true,
     })
     expect(sectionIds(result)).not.toContain("project-settings")
   })
@@ -57,10 +57,10 @@ describe("filterSectionsByPermission", () => {
     expect(menuIds(result, "project-settings")).toEqual(["project-announce"])
   })
 
-  it("recruitment 불가면 매칭 차수 설정 항목 제거", () => {
+  it("매칭 차수 관리 불가면 매칭 차수 설정 항목 제거", () => {
     const result = filterSectionsByPermission(SIDEBAR_ITEMS, {
       ...ALL,
-      canManageRecruitment: false,
+      canManageMatchingRounds: false,
     })
     expect(menuIds(result, "team-matching")).not.toContain("matching-rounds")
   })
@@ -68,7 +68,7 @@ describe("filterSectionsByPermission", () => {
   it("관리 권한이 없어도 지원 현황 항목 노출", () => {
     const result = filterSectionsByPermission(SIDEBAR_ITEMS, {
       ...ALL,
-      canManageRecruitment: false,
+      canManageMatchingRounds: false,
     })
     expect(menuIds(result, "team-matching")).toContain("matching-applications")
   })

--- a/src/components/sidebar/utils.ts
+++ b/src/components/sidebar/utils.ts
@@ -3,7 +3,7 @@ import { SIDEBAR_ID, type SideBarSection } from "@/shared/config/navigation"
 export interface SidebarPermissions {
   canAccessProjectSettings: boolean
   canManageProjects: boolean
-  canManageRecruitment: boolean
+  canManageMatchingRounds: boolean
 }
 
 export function filterSectionsByPermission(
@@ -11,7 +11,7 @@ export function filterSectionsByPermission(
   {
     canAccessProjectSettings,
     canManageProjects,
-    canManageRecruitment,
+    canManageMatchingRounds,
   }: SidebarPermissions,
 ): SideBarSection[] {
   return sections
@@ -37,7 +37,7 @@ export function filterSectionsByPermission(
           ...section,
           menus: section.menus.filter((menu) => {
             if (menu.id === SIDEBAR_ID.item.matchingRounds)
-              return canManageRecruitment
+              return canManageMatchingRounds
             return true
           }),
         }

--- a/src/features/auth/model/identity.ts
+++ b/src/features/auth/model/identity.ts
@@ -82,6 +82,17 @@ export function canManageProjects(me: MemberInfoResponse | undefined): boolean {
   return isOperator(me) || isSchoolLeadership(me) || isCurrentTermPm(me)
 }
 
+export function canManageMatchingRounds(
+  me: MemberInfoResponse | undefined,
+): boolean {
+  return hasAnyRoleType(me, [
+    "SUPER_ADMIN",
+    "CENTRAL_PRESIDENT",
+    "CENTRAL_VICE_PRESIDENT",
+    "CHAPTER_PRESIDENT",
+  ])
+}
+
 export function getProjectPmSearchScope(me: MemberInfoResponse | undefined): {
   chapterId?: string
   schoolId?: string

--- a/src/features/auth/model/matchingRoundPermission.test.ts
+++ b/src/features/auth/model/matchingRoundPermission.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest"
+
+import { canManageMatchingRounds } from "./identity"
+
+import type { MemberInfoResponse } from "@/features/auth/api/me"
+import type {
+  ChallengerInfoResponse,
+  ChallengerRoleResponse,
+  Part,
+  RoleType,
+} from "@/features/challenger/model/types"
+
+function makeMe(
+  roleTypes: RoleType[],
+  records: Array<{ gisuId: string; part: Part }> = [],
+): MemberInfoResponse {
+  const roles: ChallengerRoleResponse[] = roleTypes.map((roleType) => ({
+    challengerRoleId: "0",
+    challengerId: "0",
+    roleType,
+    organizationType: "CENTRAL",
+    organizationId: "0",
+    gisuId: "10",
+    gisu: "10",
+  }))
+
+  const challengerRecords: ChallengerInfoResponse[] = records.map((record) => ({
+    challengerId: "0",
+    memberId: "0",
+    gisuId: record.gisuId,
+    gisu: record.gisuId,
+    chapterId: "0",
+    chapterName: "테스트 지부",
+    part: record.part,
+    challengerStatus: "ACTIVE",
+    name: "테스트",
+    nickname: "테스트",
+    email: null,
+    schoolId: "0",
+    schoolName: "테스트 학교",
+  }))
+
+  return {
+    id: "0",
+    name: "테스트",
+    nickname: "테스트",
+    email: "test@test.com",
+    schoolId: "0",
+    schoolName: "테스트 학교",
+    profileImageLink: null,
+    status: "ACTIVE",
+    hasLocalCredential: false,
+    roles,
+    challengerRecords,
+  }
+}
+
+describe("canManageMatchingRounds", () => {
+  it("슈퍼 관리자·중앙 총괄단·지부장은 true", () => {
+    expect(canManageMatchingRounds(makeMe(["SUPER_ADMIN"]))).toBe(true)
+    expect(canManageMatchingRounds(makeMe(["CENTRAL_PRESIDENT"]))).toBe(true)
+    expect(canManageMatchingRounds(makeMe(["CENTRAL_VICE_PRESIDENT"]))).toBe(
+      true,
+    )
+    expect(canManageMatchingRounds(makeMe(["CHAPTER_PRESIDENT"]))).toBe(true)
+  })
+
+  it("중앙 팀원·학교 운영진·PM·일반 챌린저는 false", () => {
+    expect(
+      canManageMatchingRounds(makeMe(["CENTRAL_OPERATING_TEAM_MEMBER"])),
+    ).toBe(false)
+    expect(
+      canManageMatchingRounds(makeMe(["CENTRAL_EDUCATION_TEAM_MEMBER"])),
+    ).toBe(false)
+    expect(canManageMatchingRounds(makeMe(["SCHOOL_PRESIDENT"]))).toBe(false)
+    expect(canManageMatchingRounds(makeMe(["SCHOOL_PART_LEADER"]))).toBe(false)
+    expect(
+      canManageMatchingRounds(
+        makeMe(["CHALLENGER"], [{ gisuId: "10", part: "PLAN" }]),
+      ),
+    ).toBe(false)
+    expect(
+      canManageMatchingRounds(
+        makeMe(["CHALLENGER"], [{ gisuId: "10", part: "WEB" }]),
+      ),
+    ).toBe(false)
+  })
+})

--- a/src/features/auth/model/matchingRoundPermission.test.ts
+++ b/src/features/auth/model/matchingRoundPermission.test.ts
@@ -85,4 +85,9 @@ describe("canManageMatchingRounds", () => {
       ),
     ).toBe(false)
   })
+
+  it("유저 정보가 없거나(undefined) 역할이 없는 경우 false", () => {
+    expect(canManageMatchingRounds(undefined)).toBe(false)
+    expect(canManageMatchingRounds(makeMe([]))).toBe(false)
+  })
 })

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -14,7 +14,10 @@ import { applicationKeys } from "@/features/application/api/applicationKeys"
 import { useChapters } from "@/features/application/hooks/useApplicationPageData"
 import { useMe } from "@/features/auth/hooks/useMe"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
-import { isChapterPresident, isOperator } from "@/features/auth/model/identity"
+import {
+  canManageMatchingRounds,
+  isChapterPresident,
+} from "@/features/auth/model/identity"
 import {
   type Branch,
   emptyRoundSchedules,
@@ -43,7 +46,7 @@ export const Route = createFileRoute("/matching/rounds")({
   beforeLoad: async ({ context }) => {
     const me = await ensureMe(context.queryClient)
     const viewMe = projectViewMe(me, useViewModeStore.getState().mode)
-    if (!isOperator(viewMe)) throw redirect({ to: "/" })
+    if (!canManageMatchingRounds(viewMe)) throw redirect({ to: "/" })
   },
   component: MatchingRoundsPage,
 })


### PR DESCRIPTION
## 📸 작업 내용

> 매칭 차수 설정 접근 권한을 단일 기준(`canManageMatchingRounds`)으로 통일해, 사이드바 노출과 페이지 접근 가드의 불일치를 해소했습니다.

- 매칭 차수 설정(매칭 차수 관리) 권한 판별을 `canManageMatchingRounds` 단일 함수로 통일
- 허용 역할: `SUPER_ADMIN`, `CENTRAL_PRESIDENT`, `CENTRAL_VICE_PRESIDENT`, `CHAPTER_PRESIDENT`
- 기존 불일치 해소: 사이드바는 `isOperator || isCurrentTermPm`, `/matching/rounds` 페이지는 `isOperator` 기준으로 서로 달랐음
- 사이드바 권한 키 `canManageRecruitment` → `canManageMatchingRounds`로 리네이밍하여 의미 명확화

## 🎞️ 주요 코드 설명

### 권한 판별 함수 추가 (`identity.ts`)

```TypeScript
export function canManageMatchingRounds(
  me: MemberInfoResponse | undefined,
): boolean {
  return hasAnyRoleType(me, [
    "SUPER_ADMIN",
    "CENTRAL_PRESIDENT",
    "CENTRAL_VICE_PRESIDENT",
    "CHAPTER_PRESIDENT",
  ])
}
```

- 매칭 차수 관리 권한을 역할 기반으로 명시. 사이드바와 페이지 가드가 이 함수를 공유합니다.

### 페이지 접근 가드 통일 (`routes/matching/rounds.tsx`)

```TypeScript
beforeLoad: async ({ context }) => {
  const me = await ensureMe(context.queryClient)
  const viewMe = projectViewMe(me, useViewModeStore.getState().mode)
  if (!canManageMatchingRounds(viewMe)) throw redirect({ to: "/" })
},
```

- 기존 `isOperator` 단독 체크를 새 권한 함수로 교체. 사이드바 노출 기준과 동일해집니다.

## 🖥️ 구현화면

> 권한 게이팅 로직 변경으로, 역할별 매칭 차수 설정 노출/접근 여부가 아래와 같이 정리됩니다.

| 역할 | 변경 전 | 변경 후 |
| :---: | :---: | :---: |
| 슈퍼 관리자 / 중앙 총괄단 / 지부장 | 노출 | 노출 |
| 학교 운영진 / 현재 기수 PM | 노출(불일치) | 비노출 |

## 🔗 연결된 이슈

- Connected: #260
