### PR TITLE
🐛 fix: 챌린저 지원서 제출 실패 수정 (SURVEY-0010/0011)

### DIFF
--- a/src/features/project/list/model/applyAnswerPayload.ts
+++ b/src/features/project/list/model/applyAnswerPayload.ts
@@ -56,7 +56,7 @@ function parseOptionId(value: string): number | null {
 function getValidOptionId(question: Question, value: string): number | null {
   const optionId = parseOptionId(value)
   if (optionId === null) return null
-  return question.options.some((option) => option.optionId === optionId)
+  return question.options.some((option) => Number(option.optionId) === optionId)
     ? optionId
     : null
 }

--- a/src/features/project/list/model/applyAnswerPayload.ts
+++ b/src/features/project/list/model/applyAnswerPayload.ts
@@ -80,7 +80,9 @@ export function buildAnswerPayload(
     const base = { questionId: Number(questionId) }
 
     if (question.fieldType === "text") {
-      return [{ ...base, textValue: typeof value === "string" ? value : "" }]
+      const text = typeof value === "string" ? value : ""
+      if (text.trim() === "") return []
+      return [{ ...base, textValue: text }]
     }
 
     if (question.fieldType === "radio") {
@@ -101,16 +103,16 @@ export function buildAnswerPayload(
     }
 
     if (question.fieldType === "file") {
-      if (!isUploadedFileValue(value)) return [base]
+      if (!isUploadedFileValue(value)) return []
       return [{ ...base, fileIds: [value.fileId] }]
     }
 
     if (question.fieldType === "portfolio") {
-      if (!isApplyPortfolioValue(value)) return [base]
+      if (!isApplyPortfolioValue(value)) return []
       if (value.kind === "link") return [{ ...base, textValue: value.url }]
       return [{ ...base, fileIds: [value.fileId] }]
     }
 
-    return [base]
+    return []
   })
 }

--- a/src/features/project/list/model/applyAnswerPayload.ts
+++ b/src/features/project/list/model/applyAnswerPayload.ts
@@ -73,46 +73,48 @@ export function buildAnswerPayload(
     s.questions.forEach((q) => questionMap.set(q.id, q))
   })
 
-  return Object.entries(formValues).flatMap(([questionId, value]) => {
-    const question = questionMap.get(questionId)
-    if (!question) return []
+  return Object.entries(formValues).flatMap(
+    ([questionId, value]): ApplicationAnswerItem[] => {
+      const question = questionMap.get(questionId)
+      if (!question) return []
 
-    const base = { questionId: Number(questionId) }
+      const base = { questionId: Number(questionId) }
 
-    if (question.fieldType === "text") {
-      const text = typeof value === "string" ? value : ""
-      if (text.trim() === "") return []
-      return [{ ...base, textValue: text }]
-    }
+      if (question.fieldType === "text") {
+        const text = typeof value === "string" ? value : ""
+        if (text.trim() === "") return []
+        return [{ ...base, textValue: text }]
+      }
 
-    if (question.fieldType === "radio") {
-      if (typeof value !== "string" || !value) return []
-      const optionId = getValidOptionId(question, value)
-      if (optionId === null) return []
-      return [{ ...base, selectedOptionIds: [optionId] }]
-    }
+      if (question.fieldType === "radio") {
+        if (typeof value !== "string" || !value) return []
+        const optionId = getValidOptionId(question, value)
+        if (optionId === null) return []
+        return [{ ...base, selectedOptionIds: [optionId] }]
+      }
 
-    if (question.fieldType === "checkbox") {
-      if (!Array.isArray(value) || value.length === 0) return []
-      const selectedIds = value.flatMap((optionValue) => {
-        const optionId = getValidOptionId(question, optionValue)
-        return optionId === null ? [] : [optionId]
-      })
-      if (selectedIds.length === 0) return []
-      return [{ ...base, selectedOptionIds: selectedIds }]
-    }
+      if (question.fieldType === "checkbox") {
+        if (!Array.isArray(value) || value.length === 0) return []
+        const selectedIds = value.flatMap((optionValue) => {
+          const optionId = getValidOptionId(question, optionValue)
+          return optionId === null ? [] : [optionId]
+        })
+        if (selectedIds.length === 0) return []
+        return [{ ...base, selectedOptionIds: selectedIds }]
+      }
 
-    if (question.fieldType === "file") {
-      if (!isUploadedFileValue(value)) return []
-      return [{ ...base, fileIds: [value.fileId] }]
-    }
+      if (question.fieldType === "file") {
+        if (!isUploadedFileValue(value)) return []
+        return [{ ...base, fileIds: [value.fileId] }]
+      }
 
-    if (question.fieldType === "portfolio") {
-      if (!isApplyPortfolioValue(value)) return []
-      if (value.kind === "link") return [{ ...base, textValue: value.url }]
-      return [{ ...base, fileIds: [value.fileId] }]
-    }
+      if (question.fieldType === "portfolio") {
+        if (!isApplyPortfolioValue(value)) return []
+        if (value.kind === "link") return [{ ...base, textValue: value.url }]
+        return [{ ...base, fileIds: [value.fileId] }]
+      }
 
-    return []
-  })
+      return []
+    },
+  )
 }

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.test.ts
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.test.ts
@@ -90,3 +90,84 @@ describe("buildAnswerPayload", () => {
     expect(payload).toEqual([])
   })
 })
+
+const valueSections: Section[] = [
+  {
+    id: "common",
+    name: "공통 문항",
+    isEnabled: true,
+    questions: [
+      {
+        id: "201",
+        title: "단답",
+        caption: "",
+        fieldType: "text",
+        required: false,
+        options: [],
+      },
+      {
+        id: "202",
+        title: "파일 첨부",
+        caption: "",
+        fieldType: "file",
+        required: false,
+        options: [],
+      },
+      {
+        id: "203",
+        title: "포트폴리오",
+        caption: "",
+        fieldType: "portfolio",
+        required: false,
+        options: [],
+      },
+    ],
+  },
+]
+
+describe("buildAnswerPayload - 값 없는 항목 제외", () => {
+  it("미작성 text/file/portfolio는 bare 항목으로 전송하지 않는다", () => {
+    const payload = buildAnswerPayload(
+      {
+        "201": "",
+        "202": null,
+        "203": null,
+      },
+      valueSections,
+    )
+
+    expect(payload).toEqual([])
+  })
+
+  it("공백만 입력한 text는 제외한다", () => {
+    const payload = buildAnswerPayload({ "201": "   " }, valueSections)
+
+    expect(payload).toEqual([])
+  })
+
+  it("값이 있는 text/file/portfolio는 정상 전송한다", () => {
+    const payload = buildAnswerPayload(
+      {
+        "201": "답변",
+        "202": { fileId: "file-1", fileName: "a.pdf" },
+        "203": { kind: "link", url: "https://example.com" },
+      },
+      valueSections,
+    )
+
+    expect(payload).toEqual([
+      { questionId: 201, textValue: "답변" },
+      { questionId: 202, fileIds: ["file-1"] },
+      { questionId: 203, textValue: "https://example.com" },
+    ])
+  })
+
+  it("포트폴리오 파일은 fileIds로 전송한다", () => {
+    const payload = buildAnswerPayload(
+      { "203": { kind: "file", fileId: "pf-1", fileName: "p.pdf" } },
+      valueSections,
+    )
+
+    expect(payload).toEqual([{ questionId: 203, fileIds: ["pf-1"] }])
+  })
+})

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.test.ts
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.test.ts
@@ -171,3 +171,52 @@ describe("buildAnswerPayload - 값 없는 항목 제외", () => {
     expect(payload).toEqual([{ questionId: 203, fileIds: ["pf-1"] }])
   })
 })
+
+const stringIdSections: Section[] = [
+  {
+    id: "common",
+    name: "공통 문항",
+    isEnabled: true,
+    questions: [
+      {
+        id: "301",
+        title: "단일 선택",
+        caption: "",
+        fieldType: "radio",
+        required: true,
+        options: [
+          { content: "11", optionId: "104" as unknown as number },
+          { content: "22", optionId: "105" as unknown as number },
+        ],
+      },
+      {
+        id: "302",
+        title: "복수 선택",
+        caption: "",
+        fieldType: "checkbox",
+        required: true,
+        options: [
+          { content: "1111", optionId: "107" as unknown as number },
+          { content: "2222", optionId: "108" as unknown as number },
+        ],
+      },
+    ],
+  },
+]
+
+describe("buildAnswerPayload - optionId 문자열 직렬화", () => {
+  it("백엔드가 optionId를 문자열로 내려줘도 selectedOptionIds로 매칭한다", () => {
+    const payload = buildAnswerPayload(
+      {
+        "301": "104",
+        "302": ["107", "108"],
+      },
+      stringIdSections,
+    )
+
+    expect(payload).toEqual([
+      { questionId: 301, selectedOptionIds: [104] },
+      { questionId: 302, selectedOptionIds: [107, 108] },
+    ])
+  })
+})


### PR DESCRIPTION
## 배경 (#256)
모든 챌린저의 지원서 제출이 실패하는 P0. 진단 PR #257로 실제 서버 에러를 노출해, 임시저장(`PUT /v1/projects/{id}/applications/me`)에서 두 종류의 payload 버그를 확인했습니다.

## 버그 1 — `SURVEY-0011` "응답 형식이 올바르지 않아요"
미작성 file/portfolio/빈 text 질문이 값 없는 bare 항목(`{questionId}`)으로 전송 → 서버가 형식 오류로 거부.
- 직전 커밋 `cc18dd2`가 radio/checkbox만 `[base]`→`[]`로 고치고 file/portfolio/빈 text/fallback은 누락한 회귀.
- 재현 payload: `[{questionId:111,textValue:"..."}, {questionId:114}, {questionId:115}]` (114/115가 bare)

**수정**: `buildAnswerPayload`에서 값 없는 답변은 omit (text 공백 포함 / file 미첨부 / portfolio 미작성 / fallback)

## 버그 2 — `SURVEY-0010` "필수 질문에 답변해주세요"
백엔드가 `optionId`를 **문자열**(`"104"`)로 직렬화하는데, `getValidOptionId`가 파싱된 **숫자**(`104`)와 엄격 비교(`===`)해서 `"104" === 104 → false`. 결과적으로 **모든 radio/checkbox 답변이 payload에서 누락** → 필수 선택형 질문 미답변으로 제출 실패.
- GET 응답 확인: `"options":[{"optionId":"104","content":"11",...}]` (int64가 문자열)
- 타입 정의는 `optionId?: number`지만 런타임 값은 문자열인 불일치.

**수정**: `Number(option.optionId) === optionId` 정규화 비교

## 테스트
`buildAnswerPayload` 단위 테스트 9건 (신규: 미작성 항목 제외 4건 + 문자열 optionId 매칭 1건). 전부 통과.

## 범위/안전성
- 변경은 `buildAnswerPayload`(submit payload 생성)에 한정. 선택형/미작성 처리만 영향.
- 필수 질문은 클라이언트 검증이 막으므로 항상 값 존재. PUT은 전체 상태 치환이라 미작성=omit이 올바름.

Closes #256