### PR TITLE
🐛 fix: 등록 모드 지원 문항 작성 데이터 유실 방지

### DIFF
--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -302,10 +302,11 @@ function ProjectRegisterPage() {
   const applicationFormQuery = useQuery({
     queryKey: projectKeys.applicationForm(projectId ?? 0),
     queryFn: () => getApplicationForm(projectId!),
-    enabled: !!projectId,
+    enabled: isEditMode && !!projectId,
   })
 
   useEffect(() => {
+    if (!isEditMode) return
     if (applicationFormQuery.data) {
       hydrateApplicationFormIntoStore(applicationFormQuery.data)
       setApplicationFormHydrated(true)
@@ -317,7 +318,7 @@ function ProjectRegisterPage() {
       })
       setApplicationFormHydrated(true)
     }
-  }, [applicationFormQuery.data, setApplication])
+  }, [isEditMode, applicationFormQuery.data, setApplication])
 
   const submitMutation = useMutation({
     mutationFn: async () => {


### PR DESCRIPTION
## 배경 (#265, related #115)
프로젝트 등록(생성) 중 step3 지원 문항을 작성하는 동안 `applicationForm` GET이 resolve되거나 스텝을 이동하면 작성 중인 문항이 사라지는 문제. (#115의 재발 — 다른 근본 원인)

## 근본 원인
- `applicationFormQuery`가 `enabled: !!projectId`라 **등록 모드(draft 생성 후)에서도 실행**됨
- 등록 중 프로젝트는 submit 전까지 서버에 폼이 없어 `getApplicationForm`이 **항상 `null`** 반환
- hydrate effect의 `data === null` 분기가 `setApplication({ commonQuestions: [], sections: [] })`로 **store를 비움**
- `useApplicationForm`은 작성 내용을 store에 즉시 기록하므로(로컬 상태 아님), 이 null-clear가 작성 중 데이터를 덮어씀

## 변경
`applicationForm` GET + hydrate effect를 **편집 모드 전용**으로 게이팅:
```diff
- enabled: !!projectId,
+ enabled: isEditMode && !!projectId,

  useEffect(() => {
+   if (!isEditMode) return
    ...
- }, [applicationFormQuery.data, setApplication])
+ }, [isEditMode, applicationFormQuery.data, setApplication])
```
등록 모드에선 store가 단일 소스이므로 GET이 store를 건드리지 않습니다. 편집 모드 동작(서버 폼 hydrate)은 그대로.

## 범위/안전성
- 변경은 등록 페이지의 applicationForm 쿼리/effect 게이팅 3줄
- 등록 모드: GET 미실행 → store clobber 차단. `isHydrated`는 등록 모드에서 이미 `true`라 영향 없음
- tsc/eslint 통과
- 이탈 경고 모달(#112)·필수값 토스트(#106)는 이미 구현/해결됨 (이 PR 범위 아님)

## 참고
- 지원 폼 수정 시 커서 점프(#266, P5)는 별도 추적 — 라이브 재현 필요

Closes #265