### PR TITLE
fix: 지원현황·매칭현황·매칭차수 설정 페이지의 0613 1차 QA 피드백 반영

### DIFF
--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -32,7 +32,7 @@ import type {
 // 매칭 라운드 목록에서 현재 활성 차수 번호 계산
 // PM 결정 기간(endsAt ~ decisionDeadline)도 "활성"으로 판별
 function getCurrentRound(rounds: MatchingRoundResponse[]): {
-  currentRound: number
+  currentRound: number | undefined
   activeRound: number | undefined
 } {
   const now = Date.now()
@@ -46,12 +46,22 @@ function getCurrentRound(rounds: MatchingRoundResponse[]): {
       active.phase === "FIRST" ? 1 : active.phase === "SECOND" ? 2 : 3
     return { currentRound: round, activeRound: round }
   }
-  const sorted = [...rounds].sort(
-    (a, b) => new Date(b.endsAt).getTime() - new Date(a.endsAt).getTime(),
-  )
-  if (!sorted[0]) return { currentRound: 1, activeRound: undefined }
+  // 완료된 차수(decisionDeadline 지남) 중 가장 최근, 없으면 undefined
+  const completed = [...rounds]
+    .filter((r) => new Date(r.decisionDeadline).getTime() < now)
+    .sort(
+      (a, b) =>
+        new Date(b.decisionDeadline).getTime() -
+        new Date(a.decisionDeadline).getTime(),
+    )
   const fallback =
-    sorted[0].phase === "FIRST" ? 1 : sorted[0].phase === "SECOND" ? 2 : 3
+    completed.length > 0
+      ? completed[0]!.phase === "FIRST"
+        ? 1
+        : completed[0]!.phase === "SECOND"
+          ? 2
+          : 3
+      : undefined
   return { currentRound: fallback, activeRound: undefined }
 }
 

--- a/src/features/application/model/apiTypes.ts
+++ b/src/features/application/model/apiTypes.ts
@@ -13,6 +13,9 @@ export type ApplicationStatusEnum = "SUBMITTED" | "APPROVED" | "REJECTED"
 
 export type MatchingPhase = "FIRST" | "SECOND" | "THIRD"
 
+// 응답 전용 - 랜덤 매칭/강제 배정 케이스 포함 (APPLY-101/102 matchingRound.phase)
+export type MatchingRoundPhaseView = MatchingPhase | "RANDOM_MATCHING"
+
 export type MatchingType = "PLAN_DESIGN" | "PLAN_DEVELOPER"
 
 // GET /api/v1/projects/{projectId}/applications 응답 항목
@@ -28,7 +31,7 @@ export interface ProjectApplicantResponse {
   matchingRound: {
     id: string
     type: MatchingType
-    phase: MatchingPhase
+    phase: MatchingRoundPhaseView
   }
   status: ApplicationStatusEnum
   submittedAt: string

--- a/src/features/application/model/mappers.ts
+++ b/src/features/application/model/mappers.ts
@@ -15,7 +15,7 @@ import type {
   FormQuestion,
   FormResponseData,
   ManagedProjectSummaryResponse,
-  MatchingPhase,
+  MatchingRoundPhaseView,
   PartEnum,
   ProjectApplicantResponse,
 } from "./apiTypes"
@@ -75,14 +75,15 @@ export function toFrontRole(serverPart: PartEnum): Role {
   return PART_MAP[serverPart] ?? "plan"
 }
 
-// 서버 phase -> 프론트 라운드 번호
-const PHASE_MAP: Record<MatchingPhase, number> = {
+// 서버 phase -> 프론트 라운드 번호 (RANDOM_MATCHING은 0으로 처리 - 실제로 응답에 오지 않음)
+const PHASE_MAP: Record<MatchingRoundPhaseView, number> = {
   FIRST: 1,
   SECOND: 2,
   THIRD: 3,
+  RANDOM_MATCHING: 0,
 }
 
-export function toRoundNumber(phase: MatchingPhase): number {
+export function toRoundNumber(phase: MatchingRoundPhaseView): number {
   return PHASE_MAP[phase] ?? 1
 }
 

--- a/src/features/application/model/mappers.ts
+++ b/src/features/application/model/mappers.ts
@@ -172,14 +172,16 @@ export function toProjectApplication(
 export function summaryToStats(
   summary: ChapterStatisticsResponse["summary"],
   projectIdToName: Map<string, string>,
-  filterRound?: number, // 미지정 시 전 차수 합산
+  filterRound?: number, // 미지정 시 전 차수 합산, 0 = 완료된 차수 없음, N = N차까지 표시
 ): Omit<ApplicationStats, "universities"> {
-  // 차수별 지원 현황
-  const rounds = summary.roundApplicationStatistics.map((r) => ({
-    round: toRoundNumber(r.matchingRound.phase),
-    applied: Number(r.appliedMemberCount),
-    total: Number(r.availableMemberCount),
-  }))
+  // 차수별 지원 현황 (완료된 차수만)
+  const rounds = summary.roundApplicationStatistics
+    .map((r) => ({
+      round: toRoundNumber(r.matchingRound.phase),
+      applied: Number(r.appliedMemberCount),
+      total: Number(r.availableMemberCount),
+    }))
+    .filter((r) => filterRound === undefined || r.round <= filterRound)
 
   // 총원 / 매칭 완료 (schoolMatchingStatistics 합산)
   // 서버가 숫자 필드를 문자열로 내려주므로 Number() 변환 필요
@@ -195,48 +197,60 @@ export function summaryToStats(
   const completionRate =
     totalMembers > 0 ? Math.round((completedCount / totalMembers) * 100) : 0
 
-  // 프로젝트별 차수별 지원 현황
+  // 프로젝트별 차수별 지원 현황 (완료된 차수만)
   const projectRounds: ProjectRoundData[] = summary.projectRoundStatistics.map(
     (p) => ({
       name: projectIdToName.get(String(p.projectId)) ?? String(p.projectId),
       rounds: [
-        Number(
-          p.matchingRounds.find((r) => r.matchingRound.phase === "FIRST")
-            ?.appliedMemberCount ?? 0,
-        ),
-        Number(
-          p.matchingRounds.find((r) => r.matchingRound.phase === "SECOND")
-            ?.appliedMemberCount ?? 0,
-        ),
-        Number(
-          p.matchingRounds.find((r) => r.matchingRound.phase === "THIRD")
-            ?.appliedMemberCount ?? 0,
-        ),
+        filterRound === undefined || filterRound >= 1
+          ? Number(
+              p.matchingRounds.find((r) => r.matchingRound.phase === "FIRST")
+                ?.appliedMemberCount ?? 0,
+            )
+          : 0,
+        filterRound === undefined || filterRound >= 2
+          ? Number(
+              p.matchingRounds.find((r) => r.matchingRound.phase === "SECOND")
+                ?.appliedMemberCount ?? 0,
+            )
+          : 0,
+        filterRound === undefined || filterRound >= 3
+          ? Number(
+              p.matchingRounds.find((r) => r.matchingRound.phase === "THIRD")
+                ?.appliedMemberCount ?? 0,
+            )
+          : 0,
       ],
     }),
   )
 
-  // Top 4 프로젝트 (filterRound 지정 시 해당 차수, 미지정 시 전 차수 합산)
+  // Top 4 프로젝트 (filterRound 지정 시 해당 차수, 미지정 시 전 차수 합산, 0이면 전체 0)
   const phaseMap: Record<number, "FIRST" | "SECOND" | "THIRD"> = {
     1: "FIRST",
     2: "SECOND",
     3: "THIRD",
   }
-  const targetPhase = filterRound ? phaseMap[filterRound] : undefined
   const topProjects: TopProject[] = summary.projectRoundStatistics
-    .map((p) => ({
-      projectId: p.projectId,
-      name: projectIdToName.get(String(p.projectId)) ?? String(p.projectId),
-      count: targetPhase
-        ? Number(
-            p.matchingRounds.find((r) => r.matchingRound.phase === targetPhase)
-              ?.appliedMemberCount ?? 0,
-          )
-        : p.matchingRounds.reduce(
-            (s, r) => s + Number(r.appliedMemberCount),
-            0,
-          ),
-    }))
+    .map((p) => {
+      let count = 0
+      if (filterRound === undefined) {
+        count = p.matchingRounds.reduce(
+          (s, r) => s + Number(r.appliedMemberCount),
+          0,
+        )
+      } else if (filterRound > 0) {
+        const targetPhase = phaseMap[filterRound]
+        count = Number(
+          p.matchingRounds.find((r) => r.matchingRound.phase === targetPhase)
+            ?.appliedMemberCount ?? 0,
+        )
+      }
+      return {
+        projectId: p.projectId,
+        name: projectIdToName.get(String(p.projectId)) ?? String(p.projectId),
+        count,
+      }
+    })
     .sort(
       (a, b) => b.count - a.count || Number(a.projectId) - Number(b.projectId),
     )

--- a/src/features/application/ui/ApplicantTableHead.tsx
+++ b/src/features/application/ui/ApplicantTableHead.tsx
@@ -51,7 +51,7 @@ export function ApplicantTableHead({
         type="button"
         aria-label={hasExpanded ? "모두 접기" : "모두 펼치기"}
         onClick={onToggleAll}
-        className="shadow-inner-neutral-2 flex size-6.5 shrink-0 items-center justify-center rounded-lg bg-teal-200 transition-colors hover:bg-teal-300"
+        className="shadow-inner-neutral-2 flex size-6.5 shrink-0 items-center justify-center rounded-lg bg-teal-100 transition-colors hover:bg-teal-200"
       >
         {hasExpanded ? (
           <CollapseAllIcon width={24} height={24} className="text-teal-700" />

--- a/src/features/application/ui/ApplicationDetailModal.tsx
+++ b/src/features/application/ui/ApplicationDetailModal.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 
+import { useToastStore } from "@/components/toast/useToastStore"
 import { useResourcePermissionsBatch } from "@/features/auth/hooks/useResourcePermissionsBatch"
 import { Modal } from "@/shared/ui/Modal"
 
@@ -36,6 +37,8 @@ export function ApplicationDetailModal({
   onOpenChange,
   currentRound,
 }: ApplicationDetailModalProps) {
+  const addToast = useToastStore((s) => s.addToast)
+
   const [selectedApplicantId, setSelectedApplicantId] = useState<string | null>(
     null,
   )
@@ -44,6 +47,19 @@ export function ApplicationDetailModal({
   const [statusOverrides, setStatusOverrides] = useState<
     Record<string, StatusValue>
   >({})
+
+  // 지원자 없는 프로젝트 모달 오픈 시 토스트 노출
+  useEffect(() => {
+    if (open && project.applicants.length === 0) {
+      addToast({
+        message: "아직 지원자가 없습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    }
+  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const applicationIds = useMemo(() => {
     const ids = new Set<number>()
@@ -213,6 +229,7 @@ export function ApplicationDetailModal({
               currentRound={currentRound}
               canApproveApplicant={canApproveApplicant}
               approvePermissionLoading={isApprovePermissionLoading}
+              className="w-full"
             />
           </div>
 

--- a/src/features/application/ui/ApplicationStatsSection.tsx
+++ b/src/features/application/ui/ApplicationStatsSection.tsx
@@ -56,7 +56,7 @@ export function ApplicationStatsSection({
   stats,
   dataUpdatedAt,
   variant = "application",
-  currentRound = 1,
+  currentRound,
   activeRound,
   className,
 }: ApplicationStatsSectionProps) {
@@ -89,7 +89,7 @@ export function ApplicationStatsSection({
         <div className="shadow-drop-neutral-3 border-teal-gray-100 relative h-70 w-102 shrink-0 overflow-hidden rounded-lg border bg-white">
           <h3 className="text-heading-6-semibold absolute top-7 left-8 text-teal-700">
             {variant === "application"
-              ? `${currentRound}차 매칭 지원 현황`
+              ? `${currentRound ?? "N"}차 매칭 지원 현황`
               : "지부 프로젝트 매칭률"}
           </h3>
 
@@ -187,7 +187,7 @@ export function ApplicationStatsSection({
         {/* 1차 매칭 지원 Top 4 */}
         <div className="shadow-drop-neutral-3 border-teal-gray-100 flex w-100.5 shrink-0 flex-col rounded-xl border bg-white px-8 pt-7 pb-8">
           <h3 className="text-heading-6-semibold text-teal-700">
-            {stats.rounds.length > 0
+            {stats.rounds.length > 0 && currentRound
               ? `${currentRound}차 매칭 ${labels.roundSuffix} Top 4 `
               : `N차 매칭 완료 Top 4 `}
           </h3>

--- a/src/features/application/ui/ApplicationStatsSection.tsx
+++ b/src/features/application/ui/ApplicationStatsSection.tsx
@@ -32,12 +32,14 @@ const VARIANT_LABELS = {
     completedLabel: "지원 완료",
     pendingLabel: "지원 전",
     roundSuffix: "지원",
+    top4Suffix: "지원",
   },
   matching: {
     sectionTitle: "01 매칭 통계",
     completedLabel: "매칭 완료",
     pendingLabel: "매칭 전",
     roundSuffix: "매칭",
+    top4Suffix: "완료",
   },
 } as const
 
@@ -188,8 +190,8 @@ export function ApplicationStatsSection({
         <div className="shadow-drop-neutral-3 border-teal-gray-100 flex w-100.5 shrink-0 flex-col rounded-xl border bg-white px-8 pt-7 pb-8">
           <h3 className="text-heading-6-semibold text-teal-700">
             {stats.rounds.length > 0 && currentRound
-              ? `${currentRound}차 매칭 ${labels.roundSuffix} Top 4 `
-              : `N차 매칭 완료 Top 4 `}
+              ? `${currentRound}차 매칭 ${labels.top4Suffix} Top 4 `
+              : `N차 매칭 ${labels.top4Suffix} Top 4 `}
           </h3>
           {stats.topProjects.some((p) => p.count > 0) ? (
             <div className="mt-10 flex items-end gap-2.5 px-2.5">

--- a/src/features/application/ui/ApplicationTableSection.tsx
+++ b/src/features/application/ui/ApplicationTableSection.tsx
@@ -275,7 +275,7 @@ export function ApplicationTableSection({
         <ApplicantTableHead hasExpanded={hasExpanded} onToggleAll={toggleAll} />
 
         {pagedProjects.length === 0 && (
-          <div className="border-teal-gray-100 flex min-h-[72px] items-center justify-center rounded-b-[12px] border-r border-b border-l">
+          <div className="border-teal-gray-100 flex min-h-18 items-center justify-center rounded-b-[12px] border-r border-b border-l">
             <p className="text-body-2-medium text-teal-gray-300">
               등록된 프로젝트와 지원자가 없습니다
             </p>

--- a/src/features/application/ui/ApplicationTableSection.tsx
+++ b/src/features/application/ui/ApplicationTableSection.tsx
@@ -274,6 +274,14 @@ export function ApplicationTableSection({
       <div role="table" className="flex flex-col">
         <ApplicantTableHead hasExpanded={hasExpanded} onToggleAll={toggleAll} />
 
+        {pagedProjects.length === 0 && (
+          <div className="border-teal-gray-100 flex min-h-[72px] items-center justify-center rounded-b-[12px] border-r border-b border-l">
+            <p className="text-body-2-medium text-teal-gray-300">
+              등록된 프로젝트와 지원자가 없습니다
+            </p>
+          </div>
+        )}
+
         {pagedProjects.map((project) => {
           const isExpanded = expandedIds.has(project.id)
 

--- a/src/features/application/ui/detail-modal/ModalApplicantPanel.tsx
+++ b/src/features/application/ui/detail-modal/ModalApplicantPanel.tsx
@@ -17,6 +17,14 @@ import type {
   StatusValue,
 } from "../../model/types"
 
+// 파트별 할당 정원 추출 (지원자 없는 빈 상태에서 0/n 표시용)
+function getRoleTotalCount(role: Role, project: ProjectApplication): number {
+  if (role === "design") return project.designCount.total
+  if (role === "web") return project.feCount.total
+  if (role === "springboot" || role === "nodejs") return project.beCount.total
+  return 0
+}
+
 interface ModalApplicantPanelProps {
   project: ProjectApplication
   chapterName: string
@@ -174,16 +182,25 @@ export function ModalApplicantPanel({
             <OptionButtonGroup
               type="multiple"
               variant="segmented"
-              value={roundFilter}
-              onValueChange={onRoundFilterChange}
+              value={roundFilter.length === 0 ? ["all"] : roundFilter}
+              onValueChange={(newValues) => {
+                if (newValues.includes("all") && roundFilter.length > 0) {
+                  onRoundFilterChange([])
+                } else {
+                  onRoundFilterChange(newValues.filter((v) => v !== "all"))
+                }
+              }}
             >
-              <OptionButton value="1" className="h-7">
+              <OptionButton value="all" size="sm">
+                전체
+              </OptionButton>
+              <OptionButton value="1" size="sm">
                 1차
               </OptionButton>
-              <OptionButton value="2" className="h-7">
+              <OptionButton value="2" size="sm">
                 2차
               </OptionButton>
-              <OptionButton value="3" className="h-7">
+              <OptionButton value="3" size="sm">
                 3차
               </OptionButton>
             </OptionButtonGroup>
@@ -191,16 +208,25 @@ export function ModalApplicantPanel({
             <OptionButtonGroup
               type="multiple"
               variant="segmented"
-              value={statusFilter}
-              onValueChange={onStatusFilterChange}
+              value={statusFilter.length === 0 ? ["all"] : statusFilter}
+              onValueChange={(newValues) => {
+                if (newValues.includes("all") && statusFilter.length > 0) {
+                  onStatusFilterChange([])
+                } else {
+                  onStatusFilterChange(newValues.filter((v) => v !== "all"))
+                }
+              }}
             >
-              <OptionButton value="pass" className="h-7">
+              <OptionButton value="all" size="sm">
+                전체
+              </OptionButton>
+              <OptionButton value="pass" size="sm">
                 합격
               </OptionButton>
-              <OptionButton value="fail" className="h-7">
+              <OptionButton value="fail" size="sm">
                 불합격
               </OptionButton>
-              <OptionButton value="pending" className="h-7">
+              <OptionButton value="pending" size="sm">
                 대기
               </OptionButton>
             </OptionButtonGroup>
@@ -210,27 +236,47 @@ export function ModalApplicantPanel({
 
       {/* 스크롤 가능 리스트 */}
       <div className="scrollbar-none flex flex-1 flex-col gap-12.5 overflow-y-auto px-12.5 pt-4.5 pb-8.5">
-        {Array.from(grouped.entries()).map(([role, applicants]) => (
-          <ApplicantRoleSection
-            key={role}
-            role={role}
-            applicants={applicants}
-            totalCount={totalByRole.get(role) ?? 0}
-            selectedApplicantId={selectedApplicantId}
-            onApplicantClick={onApplicantClick}
-            onStatusChange={onStatusChange}
-            currentRound={currentRound}
-            canApproveApplicant={canApproveApplicant}
-            approvePermissionLoading={approvePermissionLoading}
-          />
-        ))}
+        {project.applicants.length === 0 ? (
+          // 지원자 없는 빈 상태: 파트별 헤더만 표시
+          project.parts.map((role) => (
+            <ApplicantRoleSection
+              key={role}
+              role={role}
+              applicants={[]}
+              totalCount={getRoleTotalCount(role, project)}
+              selectedApplicantId={selectedApplicantId}
+              onApplicantClick={onApplicantClick}
+              onStatusChange={onStatusChange}
+              currentRound={currentRound}
+              canApproveApplicant={canApproveApplicant}
+              approvePermissionLoading={approvePermissionLoading}
+            />
+          ))
+        ) : (
+          <>
+            {Array.from(grouped.entries()).map(([role, applicants]) => (
+              <ApplicantRoleSection
+                key={role}
+                role={role}
+                applicants={applicants}
+                totalCount={totalByRole.get(role) ?? 0}
+                selectedApplicantId={selectedApplicantId}
+                onApplicantClick={onApplicantClick}
+                onStatusChange={onStatusChange}
+                currentRound={currentRound}
+                canApproveApplicant={canApproveApplicant}
+                approvePermissionLoading={approvePermissionLoading}
+              />
+            ))}
 
-        {grouped.size === 0 && (
-          <div className="flex h-40 items-center justify-center">
-            <span className="text-body-2-regular text-teal-gray-400">
-              해당 조건의 지원자가 없습니다.
-            </span>
-          </div>
+            {grouped.size === 0 && (
+              <div className="flex h-40 items-center justify-center">
+                <span className="text-body-2-regular text-teal-gray-400">
+                  해당 조건의 지원자가 없습니다.
+                </span>
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/src/features/matching/hooks/useMatchingStatusData.ts
+++ b/src/features/matching/hooks/useMatchingStatusData.ts
@@ -246,10 +246,13 @@ export function useMatchingStatusData(chapterName?: string) {
         }
       : chapterStatsQuery.data.summary
 
+    // activeRound가 있으면 해당 차수는 진행 중 → 이전 차수까지만 표시
+    const completedRound =
+      activeRound !== undefined ? activeRound - 1 : undefined
     const partial = summaryToStats(
       filteredSummary,
       projectIdToName,
-      currentRound,
+      completedRound,
     )
     const universities: UniversityCount[] =
       filteredSummary.schoolMatchingStatistics
@@ -267,6 +270,7 @@ export function useMatchingStatusData(chapterName?: string) {
     chapterStatsQuery.data,
     projectIdToName,
     currentRound,
+    activeRound,
     schoolIdToName,
     chapterName,
     chapterSchoolIds,

--- a/src/features/matching/hooks/useMatchingStatusData.ts
+++ b/src/features/matching/hooks/useMatchingStatusData.ts
@@ -35,7 +35,7 @@ import type {
 // 매칭 라운드 목록에서 현재 활성 차수 번호 계산
 // PM 결정 기간(endsAt ~ decisionDeadline)도 "활성"으로 판별
 function getCurrentRound(rounds: MatchingRoundResponse[]): {
-  currentRound: number
+  currentRound: number | undefined
   activeRound: number | undefined
 } {
   const now = Date.now()
@@ -48,11 +48,16 @@ function getCurrentRound(rounds: MatchingRoundResponse[]): {
     const round = toRoundNumber(active.phase)
     return { currentRound: round, activeRound: round }
   }
-  // 없으면 가장 최근 라운드 (타이틀용), activeRound는 undefined
-  const sorted = [...rounds].sort(
-    (a, b) => new Date(b.endsAt).getTime() - new Date(a.endsAt).getTime(),
-  )
-  const fallback = sorted.length > 0 ? toRoundNumber(sorted[0]!.phase) : 1
+  // 완료된 차수(decisionDeadline 지남) 중 가장 최근, 없으면 1차 기본값
+  const completed = [...rounds]
+    .filter((r) => new Date(r.decisionDeadline).getTime() < now)
+    .sort(
+      (a, b) =>
+        new Date(b.decisionDeadline).getTime() -
+        new Date(a.decisionDeadline).getTime(),
+    )
+  const fallback =
+    completed.length > 0 ? toRoundNumber(completed[0]!.phase) : undefined
   return { currentRound: fallback, activeRound: undefined }
 }
 

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -312,7 +312,7 @@ function MatchingRoundsPage() {
           })
         }
         return createMatchingRound({
-          name: `${round.roundLabel} ${matchingType}`,
+          name: `${selectedBranch} ${round.roundLabel} Plan-Developer 매칭`,
           type: serverType,
           phase: round.phase,
           chapterId: chapterId!,

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -190,6 +190,22 @@ function MatchingRoundsPage() {
 
   // 지부 변경 시 dirty 초기화
   const handleBranchChange = (branch: Branch) => {
+    if (isChapterPresident(me)) {
+      const myChapterId = me?.roles?.find(
+        (r) => r.roleType === "CHAPTER_PRESIDENT",
+      )?.organizationId
+      const targetChapter = chapters.find((c) => c.name === branch)
+      if (!targetChapter || String(targetChapter.id) !== myChapterId) {
+        addToast({
+          message: "소속된 지부의 매칭 기간만 설정할 수 있습니다.",
+          color: "red",
+          variant: "deep",
+          type: "default",
+          duration: 3000,
+        })
+        return
+      }
+    }
     setSelectedBranch(branch)
     setIsDirty(false)
     setSaveState("idle")
@@ -342,7 +358,7 @@ function MatchingRoundsPage() {
       )?.organizationId
       if (!chapterId || String(chapterId) !== myChapterId) {
         addToast({
-          message: "다른 지부의 매칭 일정은 설정할 수 없습니다.",
+          message: "소속된 지부의 매칭 기간만 설정할 수 있습니다.",
           color: "red",
           variant: "deep",
           type: "default",
@@ -484,8 +500,13 @@ function MatchingRoundsPage() {
     saveMutation.mutate()
   }
 
+  const hasExistingRounds = rounds.some((r) => !!r.id)
   const saveButtonText =
-    saveState === "completed" ? "저장 완료" : isDirty ? "수정하기" : "저장하기"
+    saveState === "completed"
+      ? "저장 완료"
+      : isDirty && hasExistingRounds
+        ? "수정하기"
+        : "저장하기"
   const saveButtonDisabled =
     !isDirty || saveState === "completed" || isFirstRoundStarted
 

--- a/src/routes/matching/status.tsx
+++ b/src/routes/matching/status.tsx
@@ -68,7 +68,17 @@ function MatchingStatusPage() {
     isLoading,
   } = useMatchingStatusData(selectedChapter)
 
-  const displayParts = matchingParts
+  const DEFAULT_PARTS = ["Web", "iOS", "Android"]
+  const hasAnyMatch = matchingParts.some((part) =>
+    part.projects.some((project) =>
+      project.roleRows.some((row) =>
+        row.blocks.some((b) => b.type === "filled" || b.type === "round1"),
+      ),
+    ),
+  )
+  const displayParts = hasAnyMatch
+    ? matchingParts
+    : DEFAULT_PARTS.map((name) => ({ partName: name, projects: [] }))
   const displayStats = stats
 
   return (


### PR DESCRIPTION
## 📸 작업 내용

> 지원현황·매칭현황·매칭차수 설정 페이지의 QA 피드백 반영
  - **지원현황**: 지원 상세 모달 지원자 없는 빈 상태 디자인 추가 (파트별 헤더 + 0/n 카운트 + 토스트)
  - **지원현황**: 차수 시작 전 Top4·지원 현황 타이틀을 `N차`로 표시
  - **지원현황**: 지원 통계 현재 차수 계산 오류 수정 (`endsAt` 기준 → `decisionDeadline` 완료 차수 기준)
  - **매칭현황**: 매칭 결과 없을 때 기본 파트(Web/iOS/Android) 빈 상태 노출
  - **매칭현황**: 초기 진입 시 default 화면 설정
  - **매칭차수 설정**: 지부장이 타 지부 탭으로 전환 시 접근 차단 + 토스트 안내
  - **매칭차수 설정**: 차수 생성 name 형식 수정 (`${지부이름} N차 Plan-Developer 매칭`)
  - **공통**: '매칭' 글자 중복 수정
  - **타입**: 서버 PR#951 `MatchingRoundPhaseView` 응답 타입 반영 (`RANDOM_MATCHING` 추가)


## 🔗 연결된 이슈

- Closed #255 
