### PR TITLE
프로젝트 등록 단계 이동 및 초안 UX 개선

### DIFF
--- a/src/components/sidebar/MatchingSegmentRegion.tsx
+++ b/src/components/sidebar/MatchingSegmentRegion.tsx
@@ -48,5 +48,9 @@ export function MatchingSegmentRegion({
     to: m.to,
   }))
 
-  return <Segment title={section.title} items={items} value={menu.id} />
+  return (
+    <div id="matching-segment-region">
+      <Segment title={section.title} items={items} value={menu.id} />
+    </div>
+  )
 }

--- a/src/features/auth/model/identity.test.ts
+++ b/src/features/auth/model/identity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   canAccessProjectSettings,
+  canManageProjectRecruitInfo,
   canManageProjects,
   getProjectPmSearchScope,
   isAnyOperator,
@@ -168,6 +169,38 @@ describe("canManageProjects", () => {
   })
 })
 
+describe("canManageProjectRecruitInfo", () => {
+  it("슈퍼어드민·중앙 총괄단·지부장은 true", () => {
+    expect(canManageProjectRecruitInfo(makeMe(["SUPER_ADMIN"]))).toBe(true)
+    expect(canManageProjectRecruitInfo(makeMe(["CENTRAL_PRESIDENT"]))).toBe(
+      true,
+    )
+    expect(
+      canManageProjectRecruitInfo(makeMe(["CENTRAL_VICE_PRESIDENT"])),
+    ).toBe(true)
+    expect(canManageProjectRecruitInfo(makeMe(["CHAPTER_PRESIDENT"]))).toBe(
+      true,
+    )
+  })
+
+  it("중앙 일반 운영진·학교 회장단·PM은 false", () => {
+    expect(
+      canManageProjectRecruitInfo(makeMe(["CENTRAL_OPERATING_TEAM_MEMBER"])),
+    ).toBe(false)
+    expect(canManageProjectRecruitInfo(makeMe(["SCHOOL_PRESIDENT"]))).toBe(
+      false,
+    )
+    expect(canManageProjectRecruitInfo(makeMe(["SCHOOL_VICE_PRESIDENT"]))).toBe(
+      false,
+    )
+    expect(
+      canManageProjectRecruitInfo(
+        makeMe(["CHALLENGER"], [{ gisuId: "10", part: "PLAN" }]),
+      ),
+    ).toBe(false)
+  })
+})
+
 describe("getProjectPmSearchScope", () => {
   it("SUPER_ADMIN은 빈 객체 반환", () => {
     expect(getProjectPmSearchScope(makeMe(["SUPER_ADMIN"]))).toEqual({})
@@ -201,12 +234,12 @@ describe("getProjectPmSearchScope", () => {
     ).toEqual({ schoolId: "5" })
   })
 
-  it("순수 PM(현기수 PLAN, 운영 역할 없음)은 빈 객체 반환", () => {
+  it("순수 PM(현기수 PLAN, 운영 역할 없음)은 본인 지부 scope를 반환", () => {
     expect(
       getProjectPmSearchScope(
         makeMe(["CHALLENGER"], [{ gisuId: "10", part: "PLAN" }]),
       ),
-    ).toEqual({})
+    ).toEqual({ chapterId: "0" })
   })
 
   it("undefined는 빈 객체 반환", () => {

--- a/src/features/auth/model/identity.ts
+++ b/src/features/auth/model/identity.ts
@@ -11,6 +11,12 @@ const CENTRAL_ROLE_TYPES: RoleType[] = [
   "CENTRAL_EDUCATION_TEAM_MEMBER",
 ]
 
+const CENTRAL_CORE_ROLE_TYPES: RoleType[] = [
+  "SUPER_ADMIN",
+  "CENTRAL_PRESIDENT",
+  "CENTRAL_VICE_PRESIDENT",
+]
+
 const ADMIN_ROLE_TYPES: RoleType[] = [
   "SUPER_ADMIN",
   "CENTRAL_PRESIDENT",
@@ -80,6 +86,12 @@ export function canAccessProjectSettings(
 
 export function canManageProjects(me: MemberInfoResponse | undefined): boolean {
   return isOperator(me) || isSchoolLeadership(me) || isCurrentTermPm(me)
+}
+
+export function canManageProjectRecruitInfo(
+  me: MemberInfoResponse | undefined,
+): boolean {
+  return hasAnyRoleType(me, [...CENTRAL_CORE_ROLE_TYPES, "CHAPTER_PRESIDENT"])
 }
 
 export function canManageMatchingRounds(

--- a/src/features/challenger/api/member.ts
+++ b/src/features/challenger/api/member.ts
@@ -17,6 +17,39 @@ export async function searchMembers(
   return data.result
 }
 
+export async function searchAllMembers(
+  params: SearchMemberParams,
+): Promise<SearchMemberResponse> {
+  const firstPage = await searchMembers({ ...params, page: 0 })
+  const totalPages = firstPage.page.totalPages
+
+  if (totalPages <= 1) return firstPage
+
+  const restPages = await Promise.all(
+    Array.from({ length: totalPages - 1 }, (_, index) =>
+      searchMembers({ ...params, page: index + 1 }),
+    ),
+  )
+
+  const content = [
+    ...firstPage.page.content,
+    ...restPages.flatMap((response) => response.page.content),
+  ]
+
+  return {
+    totalCount: firstPage.totalCount,
+    page: {
+      ...firstPage.page,
+      content,
+      page: 0,
+      totalElements: firstPage.page.totalElements,
+      totalPages,
+      hasNext: false,
+      hasPrevious: false,
+    },
+  }
+}
+
 export async function getMemberProfile(
   memberId: string,
 ): Promise<MemberInfoResponse> {

--- a/src/features/project/new/model/useApplicationForm.ts
+++ b/src/features/project/new/model/useApplicationForm.ts
@@ -71,6 +71,7 @@ export function useApplicationForm() {
     setApplication({
       commonQuestions: insertAfter(commonQuestions, afterId, newQ),
     })
+    setFocusedId(newQ.id)
   }
 
   function updateSection(sectionId: string, patch: Partial<Section>) {
@@ -111,6 +112,7 @@ export function useApplicationForm() {
           : { ...s, questions: insertAfter(s.questions, afterId, newQ) },
       ),
     })
+    setFocusedId(newQ.id)
   }
 
   function appendSectionQuestion(sectionId: string) {

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -18,7 +18,7 @@ import {
   isCurrentTermPm,
   isSuperAdmin,
 } from "@/features/auth/model/identity"
-import { searchMembers } from "@/features/challenger/api/member"
+import { searchAllMembers } from "@/features/challenger/api/member"
 import { Dropdown } from "@/features/challenger/ui/shared/Dropdown"
 import {
   addProjectMember,
@@ -92,7 +92,7 @@ export const BasicInfoForm = forwardRef<
       { part: "PLAN", gisuId: activeGisuId, ...pmSearchScope },
     ],
     queryFn: () =>
-      searchMembers({
+      searchAllMembers({
         part: "PLAN",
         gisuId: activeGisuId != null ? String(activeGisuId) : undefined,
         size: 200,

--- a/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
+++ b/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
@@ -47,6 +47,7 @@ interface RecruitInfoFormProps {
   onNext: () => void
   readOnly?: boolean
   isHydrated?: boolean
+  canUpdatePartQuotasOverride?: boolean
 }
 
 function buildSummaryText(
@@ -67,7 +68,13 @@ export const RecruitInfoForm = forwardRef<
   RecruitInfoFormHandle,
   RecruitInfoFormProps
 >(function RecruitInfoForm(
-  { onPrev, onNext, readOnly = false, isHydrated = true },
+  {
+    onPrev,
+    onNext,
+    readOnly = false,
+    isHydrated = true,
+    canUpdatePartQuotasOverride,
+  },
   ref,
 ) {
   const addToast = useToastStore((s) => s.addToast)
@@ -77,12 +84,15 @@ export const RecruitInfoForm = forwardRef<
   const projectPermissionsQuery = useProjectPermissions(
     projectId ?? undefined,
     {
-      enabled: projectId !== null,
+      enabled: projectId !== null && canUpdatePartQuotasOverride !== true,
     },
   )
-  const canUpdatePartQuotas = projectPermissionsQuery.canManage
+  const canUpdatePartQuotas =
+    canUpdatePartQuotasOverride ?? projectPermissionsQuery.canManage
   const isPartQuotaPermissionLoading =
-    projectId !== null && projectPermissionsQuery.isPending
+    canUpdatePartQuotasOverride !== true &&
+    projectId !== null &&
+    projectPermissionsQuery.isPending
   const isReadOnly =
     readOnly || isPartQuotaPermissionLoading || !canUpdatePartQuotas
 

--- a/src/features/project/new/ui/stepper/StepperTab.tsx
+++ b/src/features/project/new/ui/stepper/StepperTab.tsx
@@ -83,6 +83,7 @@ export function StepperTab({
           side="bottom"
           hoverOnly
           open={tooltipOpenProp}
+          autoHideDuration={3000}
           triggerClassName="block w-full h-full"
         >
           {button}

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -303,6 +303,19 @@ function ProjectRegisterPage() {
     }
   }, [draftQuery.data, projectId])
 
+  useEffect(() => {
+    return () => {
+      const { gisuId: storedGisuId } = useProjectRegisterStore.getState()
+
+      reset()
+      if (storedGisuId) {
+        queryClient.removeQueries({
+          queryKey: projectKeys.draft(storedGisuId),
+        })
+      }
+    }
+  }, [queryClient, reset])
+
   const applicationFormQuery = useQuery({
     queryKey: projectKeys.applicationForm(projectId ?? 0),
     queryFn: () => getApplicationForm(projectId!),

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -17,9 +17,9 @@ import { useMe } from "@/features/auth/hooks/useMe"
 import { useResourcePermission } from "@/features/auth/hooks/useResourcePermission"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
 import {
+  canManageProjectRecruitInfo,
   canManageProjects,
   getLatestChallengerRecord,
-  isCurrentTermPm,
   isProjectRegistrationQuotaLimited,
 } from "@/features/auth/model/identity"
 import { hasGrantedPermission } from "@/features/auth/model/resourcePermission"
@@ -148,10 +148,10 @@ function ProjectRegisterPage() {
   const basicInfoRef = useRef<BasicInfoFormHandle>(null)
   const recruitInfoRef = useRef<RecruitInfoFormHandle>(null)
   const applicationFormRef = useRef<ApplicationFormHandle>(null)
+  const formTopRef = useRef<HTMLDivElement>(null)
 
   const queryClient = useQueryClient()
   const { data: me } = useMe()
-  const isPm = isCurrentTermPm(me)
   const myChapterId = getLatestChallengerRecord(me)?.chapterId
   const matchingRoundsQuery = useQuery({
     queryKey: applicationKeys.matchingRounds(
@@ -169,7 +169,6 @@ function ProjectRegisterPage() {
   )
   const projectId = useProjectRegisterStore((s) => s.projectId)
   const application = useProjectRegisterStore((s) => s.application)
-  const recruitInfo = useProjectRegisterStore((s) => s.recruitInfo)
   const pmInfo = useProjectRegisterStore((s) => s.pmInfo)
   const reset = useProjectRegisterStore((s) => s.reset)
   const setProjectId = useProjectRegisterStore((s) => s.setProjectId)
@@ -195,11 +194,16 @@ function ProjectRegisterPage() {
   const isCreatePermissionLoading =
     !isEditMode && projectWritePermissionQuery.isPending
   const canManageProject = projectPermissionsQuery.canManage
-  const canEditRecruitStep = projectId !== null ? canManageProject : !isPm
+  const canManageRecruitInfoByRole = canManageProjectRecruitInfo(me)
+  const canEditRecruitStep = isEditMode
+    ? canManageProject
+    : canManageRecruitInfoByRole
 
   const resolveCanEditRecruitStep = async (): Promise<boolean> => {
+    if (!isEditMode) return canManageRecruitInfoByRole
+
     const pid = useProjectRegisterStore.getState().projectId
-    if (pid === null) return !isPm
+    if (pid === null) return false
     try {
       const permission = await queryClient.ensureQueryData({
         queryKey: [
@@ -215,7 +219,7 @@ function ProjectRegisterPage() {
       })
       return hasGrantedPermission(permission, "MANAGE")
     } catch {
-      return !isPm
+      return false
     }
   }
 
@@ -388,52 +392,57 @@ function ProjectRegisterPage() {
     )
   }
 
+  const moveToStep = (targetStep: number) => {
+    setStep(targetStep)
+    requestAnimationFrame(() => {
+      const scrollTarget =
+        document.getElementById("matching-segment-region") ?? formTopRef.current
+
+      scrollTarget?.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      })
+    })
+  }
+
   const handleBasicInfoNext = async () => {
     const canEdit = await resolveCanEditRecruitStep()
-    setStep(canEdit ? 2 : 3)
+    moveToStep(canEdit ? 2 : 3)
   }
 
   const handleApplicationFormPrev = async () => {
     const canEdit = await resolveCanEditRecruitStep()
-    setStep(canEdit ? 2 : 1)
+    moveToStep(canEdit ? 2 : 1)
   }
 
-  const handleStepChange = async (idx: number) => {
-    if (isEditMode) return
-    if (!canEditRecruitStep && idx === 2) {
-      setStep(2)
-      triggerStepTooltip(2)
-      return
-    }
-    if (idx <= step) {
-      setStep(idx)
-      return
-    }
+  const guardForwardStepMove = async (targetStep: number) => {
+    if (targetStep < step) return true
+
     if (step === 1) {
       const ok = await basicInfoRef.current?.validate()
       if (!ok) {
-        triggerStepTooltip(idx)
-        return
+        triggerStepTooltip(targetStep)
+        return false
       }
-      const saved = await basicInfoRef.current?.save()
-      if (!saved) return
-    } else if (step === 2 && canEditRecruitStep) {
-      const total = Object.values(recruitInfo).reduce(
-        (sum, { count }) => sum + count,
-        0,
-      )
-      if (total === 0) {
-        addToast({
-          message: "모집 인원을 1명 이상 입력해 주세요.",
-          color: "red",
-          variant: "deep",
-          type: "default",
-          duration: 3000,
-        })
-        return
-      }
+      return (await basicInfoRef.current?.save()) ?? true
     }
-    setStep(idx)
+
+    if (step === 2) {
+      return (await recruitInfoRef.current?.save()) ?? true
+    }
+
+    return true
+  }
+
+  const handleStepChange = async (targetStep: number) => {
+    if (targetStep === step) return
+    if (!canEditRecruitStep && targetStep === 2) {
+      triggerStepTooltip(2)
+      return
+    }
+    const canMove = await guardForwardStepMove(targetStep)
+    if (!canMove) return
+    moveToStep(targetStep)
   }
 
   const isEditModeDirty = useCallback(
@@ -507,7 +516,7 @@ function ProjectRegisterPage() {
   return (
     <section className="flex w-full flex-col items-start justify-start">
       <div className="border-teal-gray-100 flex h-full w-242 flex-col gap-2.5 rounded-[12px] border bg-white px-8.5 pt-8 pb-10">
-        <div className="flex flex-col items-start gap-1.5">
+        <div ref={formTopRef} className="flex flex-col items-start gap-1.5">
           <span className="text-heading-6-semibold text-teal-gray-900">
             프로젝트 등록
           </span>
@@ -518,25 +527,17 @@ function ProjectRegisterPage() {
         <Stepper
           step={step}
           onStepChange={handleStepChange}
-          disabledSteps={
-            isEditMode
-              ? [1, 2, 3].filter((idx) => idx !== step)
-              : !canEditRecruitStep
-                ? [2]
-                : []
-          }
+          disabledSteps={!canEditRecruitStep ? [2] : []}
           disabledTooltips={
-            isEditMode
-              ? {}
-              : !canEditRecruitStep
-                ? {
-                    2: "기술 스택 및 파트별 TO는 운영진이 수기로 조정합니다.",
-                    3: "기본 정보를 입력한 뒤 작성할 수 있습니다.",
-                  }
-                : {
-                    2: "기본 정보를 입력한 뒤 작성할 수 있습니다.",
-                    3: "기본 정보를 입력한 뒤 작성할 수 있습니다.",
-                  }
+            !canEditRecruitStep
+              ? {
+                  2: "기술 스택 및 파트별 TO는 운영진이 수기로 조정합니다.",
+                  3: "기본 정보를 입력한 뒤 작성할 수 있습니다.",
+                }
+              : {
+                  2: "기본 정보를 입력한 뒤 작성할 수 있습니다.",
+                  3: "기본 정보를 입력한 뒤 작성할 수 있습니다.",
+                }
           }
           openTooltipStep={tooltipTriggerStep}
         />
@@ -552,9 +553,12 @@ function ProjectRegisterPage() {
           <RecruitInfoForm
             ref={recruitInfoRef}
             readOnly={!canEditRecruitStep}
+            canUpdatePartQuotasOverride={
+              isEditMode ? undefined : canManageRecruitInfoByRole
+            }
             isHydrated={isEditMode ? detailQuery.isSuccess : true}
-            onPrev={() => setStep(1)}
-            onNext={() => setStep(3)}
+            onPrev={() => moveToStep(1)}
+            onNext={() => moveToStep(3)}
           />
         )}
         {step === 3 && (

--- a/src/shared/ui/question-field/QuestionForm.tsx
+++ b/src/shared/ui/question-field/QuestionForm.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from "react"
+
 import DragAndDrop from "@/shared/assets/icon/drag-and-drop/DragAndDrop"
 import TrashCan from "@/shared/assets/icon/garbage/TrashCan"
 import { cn } from "@/shared/lib/utils"
@@ -49,6 +51,19 @@ export function QuestionForm({
   className,
   dragHandleProps,
 }: QuestionFormProps) {
+  const titleTextareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    if (!focused || readonlyTitle) return
+
+    const titleTextarea = titleTextareaRef.current
+    if (!titleTextarea) return
+
+    titleTextarea.focus()
+    const cursorPosition = titleTextarea.value.length
+    titleTextarea.setSelectionRange(cursorPosition, cursorPosition)
+  }, [focused, readonlyTitle])
+
   return (
     <article
       className={cn(
@@ -68,7 +83,7 @@ export function QuestionForm({
         />
       )}
 
-      {dragHandleProps && (
+      {focused && dragHandleProps && (
         <button
           type="button"
           className="mt-4 inline-flex cursor-grab items-center justify-center active:cursor-grabbing"
@@ -103,6 +118,7 @@ export function QuestionForm({
                 </div>
                 {!readonlyTitle && (
                   <textarea
+                    ref={titleTextareaRef}
                     rows={1}
                     value={title}
                     onChange={(e) => onTitleChange?.(e.target.value)}


### PR DESCRIPTION
## 변경 사항
- PM 선택 드롭다운에서 페이지네이션된 멤버 검색 결과를 끝까지 조회합니다.
- 프로젝트 등록 Stepper 이동 가드와 Step 2 권한 기반 비활성화 UX를 정리합니다.
- 지원 문항 추가 후 새 문항에 자동 포커스하고, 드래그 핸들은 포커스된 문항에만 표시합니다.
- 프로젝트 등록 페이지 이탈 시 등록 store와 draft query cache를 정리합니다.

## 이슈
Closes #271
Closes #272
Closes #273
Closes #274

## 검증
- pnpm exec tsc --noEmit
- pnpm exec eslint src/routes/matching/projects/new.tsx
- pnpm exec eslint src/features/challenger/api/member.ts src/features/project/new/ui/basic-info/BasicInfoForm.tsx src/routes/matching/projects/new.tsx src/components/sidebar/MatchingSegmentRegion.tsx src/features/auth/model/identity.ts src/features/auth/model/identity.test.ts src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx src/features/project/new/ui/stepper/StepperTab.tsx src/features/project/new/model/useApplicationForm.ts src/shared/ui/question-field/QuestionForm.tsx
- pnpm exec vitest run src/features/auth/model/identity.test.ts