### PR TITLE
feat: 프로필 드롭다운에서 프로필 사진을 눌러도 계정 설정으로 이동

### DIFF
--- a/src/shared/ui/ProfileDropdown.tsx
+++ b/src/shared/ui/ProfileDropdown.tsx
@@ -91,7 +91,11 @@ export function ProfileDropdown({
             <button
               type="button"
               className="h-11.5 w-11.5 shrink-0 overflow-hidden rounded-full"
-              onClick={() => navigate({ to: "/settings" })}
+              aria-label="프로필 이미지"
+              onClick={() => {
+                navigate({ to: "/settings" })
+                handleOpenChange(false)
+              }}
             >
               {me?.profileImageLink ? (
                 <img

--- a/src/shared/ui/ProfileDropdown.tsx
+++ b/src/shared/ui/ProfileDropdown.tsx
@@ -88,7 +88,11 @@ export function ProfileDropdown({
           )}
         >
           <div className="flex flex-col gap-2.5 px-2.5">
-            <div className="h-11.5 w-11.5 shrink-0 overflow-hidden rounded-full">
+            <button
+              type="button"
+              className="h-11.5 w-11.5 shrink-0 overflow-hidden rounded-full"
+              onClick={() => navigate({ to: "/settings" })}
+            >
               {me?.profileImageLink ? (
                 <img
                   src={me.profileImageLink}
@@ -98,7 +102,7 @@ export function ProfileDropdown({
               ) : (
                 <ProfileIcon className="size-full" />
               )}
-            </div>
+            </button>
 
             <div className="flex flex-col gap-0.5">
               <div className="flex items-center justify-between gap-4">


### PR DESCRIPTION
## 📸 작업 내용

- 프로필 드롭다운에서 프로필 사진을 눌러도 계정 설정으로 이동

## 🎞️ 주요 코드 설명

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #277 
