### PR TITLE
fix: 공지사항 카드 뒤로 공지 내용이 비쳐 보임

### DIFF
--- a/src/features/notice/ui/NoticeCard.tsx
+++ b/src/features/notice/ui/NoticeCard.tsx
@@ -14,7 +14,7 @@ import { Button } from "@/shared/ui/Button"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
 
 const noticeCardVariants = cva(
-  "flex w-full scroll-mt-6 items-center justify-between gap-2.5 px-4 text-left",
+  "flex w-full scroll-mt-6 items-center justify-between gap-2.5 px-4 text-left bg-white",
   {
     variants: {
       hasChip: {

--- a/src/features/notice/ui/NoticeCard.tsx
+++ b/src/features/notice/ui/NoticeCard.tsx
@@ -152,8 +152,9 @@ export function NoticeCard({
           <motion.div
             initial={{ height: 0, opacity: 0 }}
             animate={{ height: "auto", opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
+            exit={{ height: 0, opacity: 1 }}
             transition={{ duration: 0.35, ease: "easeInOut" }}
+            className="overflow-hidden"
           >
             <div className="w-full overflow-hidden pb-4">
               <div


### PR DESCRIPTION
## 📸 작업 내용

- 공지사항 카드 배경색(흰색) 추가
- 공지사항 내용 투명도 수정

## 🎞️ 주요 코드 설명

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #279 
