### PR TITLE
💄 style: 프로젝트 등록 플로우 반응형 레이아웃 적용

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -53,6 +53,7 @@
   --radius-4xl: calc(var(--radius) * 2.6);
 
   --breakpoint-bp1: 480px;
+  --breakpoint-bp2: 960px;
 
   --color-white: var(--color-white);
   --color-teal-gray-50: var(--color-teal-gray-50);

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -36,14 +36,14 @@ export default function Footer() {
     <footer className="bg-teal-gray-100 max-bp1:px-9 max-bp1:py-10 flex flex-col items-center gap-2.5 self-stretch py-16 pr-14 pl-15">
       <div className="flex flex-col items-start gap-6 self-stretch">
         <div className="flex w-full justify-between gap-4 max-[930px]:flex-col">
-          <div className="flex items-center gap-4">
+          <div className="flex min-w-0 items-center gap-4">
             <UmcLogoFilled className="text-teal-gray-300 h-5.5 w-auto shrink-0" />
-            <span className="text-heading-7-semibold text-teal-gray-400 shrink-0">
+            <span className="text-heading-7-semibold text-teal-gray-400">
               University Make us Challenge
             </span>
           </div>
           <div className="text-teal-gray-400 flex flex-col items-center justify-center gap-2 pt-1 whitespace-nowrap max-[930px]:items-start">
-            <div className="flex items-center gap-6">
+            <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
               <nav
                 aria-label="약관 및 정책"
                 className="flex items-center gap-6"
@@ -94,21 +94,21 @@ export default function Footer() {
                   </span>
                 </dt>
                 <dd className="flex gap-2.25 max-[930px]:flex-col max-[930px]:gap-1">
-                  <div className="text-body-3-regular flex shrink-0 gap-2.5 tracking-[-0.02em]">
+                  <div className="text-body-3-regular flex shrink-0 flex-wrap gap-x-2.5 gap-y-0.5 tracking-[-0.02em]">
                     {members.group_1.map((item) => (
                       <span key={item}>{item}</span>
                     ))}
                   </div>
                   <div className="max-bp1:flex-col flex gap-1.5">
                     {members.group_2 && (
-                      <div className="text-body-3-regular flex shrink-0 gap-2.5 tracking-[-0.02em]">
+                      <div className="text-body-3-regular flex shrink-0 flex-wrap gap-x-2.5 gap-y-0.5 tracking-[-0.02em]">
                         {members.group_2.map((item) => (
                           <span key={item}>{item}</span>
                         ))}
                       </div>
                     )}
                     {members.group_3 && (
-                      <div className="text-body-3-regular flex shrink-0 gap-2.5 tracking-[-0.02em]">
+                      <div className="text-body-3-regular flex shrink-0 flex-wrap gap-x-2.5 gap-y-0.5 tracking-[-0.02em]">
                         {members.group_3.map((item) => (
                           <span key={item}>{item}</span>
                         ))}

--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -94,18 +94,24 @@ export default function Footer() {
                   </span>
                 </dt>
                 <dd className="flex gap-2.25 max-[930px]:flex-col max-[930px]:gap-1">
-                  <div className="text-body-3-regular shrink-0 tracking-[-0.02em]">
-                    {members.group_1.join("   ")}
+                  <div className="text-body-3-regular flex shrink-0 gap-2.5 tracking-[-0.02em]">
+                    {members.group_1.map((item) => (
+                      <span key={item}>{item}</span>
+                    ))}
                   </div>
                   <div className="max-bp1:flex-col flex gap-1.5">
                     {members.group_2 && (
-                      <div className="text-body-3-regular shrink-0 tracking-[-0.02em]">
-                        {members.group_2.join("   ")}
+                      <div className="text-body-3-regular flex shrink-0 gap-2.5 tracking-[-0.02em]">
+                        {members.group_2.map((item) => (
+                          <span key={item}>{item}</span>
+                        ))}
                       </div>
                     )}
                     {members.group_3 && (
-                      <div className="text-body-3-regular shrink-0 tracking-[-0.02em]">
-                        {members.group_3.join("   ")}
+                      <div className="text-body-3-regular flex shrink-0 gap-2.5 tracking-[-0.02em]">
+                        {members.group_3.map((item) => (
+                          <span key={item}>{item}</span>
+                        ))}
                       </div>
                     )}
                   </div>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -63,17 +63,17 @@ export default function Header({ activePathname }: HeaderProps = {}) {
   }, [isMobileMenuOpen])
 
   return (
-    <header className="bg-teal-gray-50 shadow-drop-neutral-3 relative z-50 flex min-h-16 w-full flex-col overflow-visible min-[960px]:h-20 min-[960px]:min-h-20 min-[960px]:flex-row min-[960px]:items-center min-[960px]:justify-between">
-      <div className="flex h-16 w-full items-center justify-between min-[960px]:h-20">
+    <header className="bg-teal-gray-50 shadow-drop-neutral-3 bp2:h-20 bp2:min-h-20 bp2:flex-row bp2:items-center bp2:justify-between relative z-50 flex min-h-16 w-full flex-col overflow-visible">
+      <div className="bp2:h-20 flex h-16 w-full items-center justify-between">
         <Link
           to="/"
-          className="flex w-36 items-center pl-10 xl:w-55"
+          className="flex w-55 items-center pl-10"
           onClick={() => setIsMobileMenuOpen(false)}
         >
           <UmcLogo className="text-teal-gray-700 h-5.5 w-17.5" />
         </Link>
 
-        <nav className="bg-teal-gray-50 border-teal-gray-100 hidden shrink-0 items-center gap-1 rounded-full border p-1 drop-shadow-[0_0_8px_rgba(10,86,80,0.04)] min-[960px]:flex xl:gap-1.5 xl:p-1.5">
+        <nav className="bg-teal-gray-50 border-teal-gray-100 bp2:flex hidden shrink-0 items-center gap-1.5 rounded-full border p-1.5 drop-shadow-[0_0_8px_rgba(10,86,80,0.04)]">
           {navItems.map((item) => (
             <NavigationButton
               key={item.to}
@@ -86,19 +86,19 @@ export default function Header({ activePathname }: HeaderProps = {}) {
                   ? () => handleDisabledClick(item.label)
                   : undefined
               }
-              className="min-w-0 px-3 xl:min-w-18 xl:px-4.5"
+              className="min-w-18 px-4.5"
             />
           ))}
         </nav>
 
-        <div className="hidden items-center justify-end gap-2 pr-6 min-[960px]:flex min-[960px]:w-40 xl:w-55 xl:gap-4 xl:pr-8.5">
+        <div className="bp2:flex bp2:w-40 hidden w-55 items-center justify-end gap-4 pr-8.5">
           <HeaderButton label="문의사항" type="trailing-icon" />
           <Profile />
         </div>
 
-        <div className="flex min-w-0 items-center gap-2 pr-5 min-[960px]:hidden">
+        <div className="bp2:hidden flex min-w-0 items-center gap-2 pr-5">
           <SideBarViewSwitcher
-            className="relative z-[70] min-w-0"
+            className="relative z-70 min-w-0"
             dropdownClassName="w-28 bp1:w-43"
             menuClassName="shadow-drop-neutral-2 absolute top-full right-0 z-[80] mt-1 w-full rounded-[8px]"
           />
@@ -123,7 +123,7 @@ export default function Header({ activePathname }: HeaderProps = {}) {
         <button
           type="button"
           aria-label="모바일 메뉴 닫기"
-          className="fixed inset-x-0 top-16 bottom-0 z-40 bg-neutral-900/40 min-[960px]:hidden"
+          className="bp2:hidden fixed inset-x-0 top-16 bottom-0 z-40 bg-neutral-900/40"
           onClick={() => setIsMobileMenuOpen(false)}
         />
       )}
@@ -131,7 +131,7 @@ export default function Header({ activePathname }: HeaderProps = {}) {
       <nav
         id="mobile-header-navigation"
         className={cn(
-          "border-teal-gray-100 bg-teal-gray-50 shadow-drop-neutral-3 absolute top-16 right-0 left-0 z-50 flex max-h-[calc(100dvh-64px)] w-full flex-col gap-4 overflow-y-auto border-t px-6 py-4 min-[960px]:hidden",
+          "border-teal-gray-100 bg-teal-gray-50 shadow-drop-neutral-3 bp2:hidden absolute top-16 right-0 left-0 z-50 flex max-h-[calc(100dvh-64px)] w-full flex-col gap-4 overflow-y-auto border-t px-6 py-4",
           !isMobileMenuOpen && "hidden",
         )}
       >

--- a/src/components/sidebar/SideBar.tsx
+++ b/src/components/sidebar/SideBar.tsx
@@ -55,7 +55,7 @@ export default function SideBar({ className, activePathname }: SideBarProps) {
     <nav
       aria-label="사이드 메뉴"
       className={cn(
-        "border-teal-gray-200 hidden w-55 shrink-0 flex-col items-center justify-start border-r pt-4 min-[960px]:flex",
+        "border-teal-gray-200 bp2:flex hidden w-55 shrink-0 flex-col items-center justify-start border-r pt-4",
         className,
       )}
     >

--- a/src/features/project/management/ui/ProjectManagementCard.tsx
+++ b/src/features/project/management/ui/ProjectManagementCard.tsx
@@ -53,7 +53,7 @@ export function ProjectManagementCard({
   return (
     <>
       <div
-        className="border-teal-gray-100 [&:hover:not(:has(button:hover))]:bg-teal-gray-100 shadow-drop-neutral-2 bp1:p-4 flex w-full max-w-[56.25rem] min-w-0 cursor-pointer flex-col gap-4 rounded-2xl border bg-white p-3 transition-colors min-[960px]:flex-row min-[960px]:items-center min-[960px]:gap-7 min-[960px]:py-2.5 min-[960px]:pr-5 min-[960px]:pl-2.5"
+        className="border-teal-gray-100 [&:hover:not(:has(button:hover))]:bg-teal-gray-100 shadow-drop-neutral-2 bp1:p-4 bp2:flex-row bp2:items-center bp2:gap-7 bp2:py-2.5 bp2:pr-5 bp2:pl-2.5 flex w-full max-w-[56.25rem] min-w-0 cursor-pointer flex-col gap-4 rounded-2xl border bg-white p-3 transition-colors"
         role="button"
         tabIndex={0}
         onClick={openDetailModal}
@@ -61,7 +61,7 @@ export function ProjectManagementCard({
           if (e.key === "Enter" || e.key === " ") openDetailModal()
         }}
       >
-        <div className="bg-teal-gray-200 flex aspect-[320/169] w-full shrink-0 overflow-hidden rounded-[0.625rem] min-[960px]:h-[10.5625rem] min-[960px]:w-[clamp(13rem,28vw,20rem)]">
+        <div className="bg-teal-gray-200 bp2:h-[10.5625rem] bp2:w-[clamp(13rem,28vw,20rem)] flex aspect-[320/169] w-full shrink-0 overflow-hidden rounded-[0.625rem]">
           {cover?.src ? (
             <img
               src={cover.src}
@@ -79,7 +79,7 @@ export function ProjectManagementCard({
           )}
         </div>
 
-        <div className="flex min-w-0 flex-1 flex-col items-stretch gap-4 min-[960px]:items-end">
+        <div className="bp2:items-end flex min-w-0 flex-1 flex-col items-stretch gap-4">
           <div className="flex min-w-0 flex-col items-start gap-2 self-stretch">
             <div className="flex min-w-0 items-start justify-between gap-3 self-stretch">
               <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
@@ -117,9 +117,9 @@ export function ProjectManagementCard({
               return (
                 <div
                   key={row.part}
-                  className="flex min-w-0 items-center justify-between gap-2 self-stretch min-[960px]:gap-3"
+                  className="bp2:gap-3 flex min-w-0 items-center justify-between gap-2 self-stretch"
                 >
-                  <div className="flex min-w-0 flex-1 items-center justify-between gap-2 min-[960px]:w-[7.3125rem] min-[960px]:flex-none min-[960px]:shrink-0">
+                  <div className="bp2:w-[7.3125rem] bp2:flex-none bp2:shrink-0 flex min-w-0 flex-1 items-center justify-between gap-2">
                     <span className="text-body-2-medium text-teal-gray-700 truncate">
                       {row.part}
                     </span>

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -244,7 +244,7 @@ export function ProjectManagementPage() {
 
   return (
     <section className="relative isolate flex w-full min-w-0 flex-col items-stretch justify-start">
-      <div className="border-teal-gray-100 bp1:gap-6 bp1:px-6 bp1:pt-6 bp1:pb-8 relative z-30 flex h-full w-full max-w-242 min-w-0 flex-col gap-5 rounded-[12px] border bg-white px-4 pt-5 pb-6 min-[960px]:px-8.5 min-[960px]:pt-8 min-[960px]:pb-10">
+      <div className="border-teal-gray-100 bp1:gap-6 bp1:px-6 bp1:pt-6 bp1:pb-8 bp2:px-8.5 bp2:pt-8 bp2:pb-10 relative z-30 flex h-full w-full max-w-242 min-w-0 flex-col gap-5 rounded-[12px] border bg-white px-4 pt-5 pb-6">
         <div className="flex flex-col items-start gap-1.5">
           <span className="text-heading-6-semibold text-teal-gray-900">
             프로젝트 관리
@@ -256,7 +256,7 @@ export function ProjectManagementPage() {
           </span>
         </div>
 
-        <div className="bp1:gap-8 flex min-w-0 flex-col gap-6 min-[960px]:gap-10">
+        <div className="bp1:gap-8 bp2:gap-10 flex min-w-0 flex-col gap-6">
           {useGroupedView && (
             <div className="min-w-0">
               <SegmentButton
@@ -277,7 +277,7 @@ export function ProjectManagementPage() {
               Array.from(partGroups.entries()).map(([part, partProjects]) => (
                 <div key={part} className="flex min-w-0 flex-col">
                   <ProjectManagementSubTitle title={part} className="pb-2" />
-                  <div className="grid min-w-0 grid-cols-1 gap-3 min-[700px]:grid-cols-2 min-[960px]:grid-cols-1 min-[960px]:gap-4">
+                  <div className="bp2:grid-cols-1 bp2:gap-4 grid min-w-0 grid-cols-1 gap-3 min-[700px]:grid-cols-2">
                     {partProjects.map((project) => {
                       const permissions = getProjectActionPermissions(project)
                       return (
@@ -293,7 +293,7 @@ export function ProjectManagementPage() {
                 </div>
               ))
             ) : !useGroupedView && projects.length > 0 ? (
-              <div className="grid min-w-0 grid-cols-1 gap-3 min-[700px]:grid-cols-2 min-[960px]:grid-cols-1">
+              <div className="bp2:grid-cols-1 grid min-w-0 grid-cols-1 gap-3 min-[700px]:grid-cols-2">
                 {projects.map((project) => {
                   const permissions = getProjectActionPermissions(project)
                   return (
@@ -313,7 +313,7 @@ export function ProjectManagementPage() {
               />
             )
           ) : projects.length > 0 ? (
-            <div className="grid min-w-0 grid-cols-1 gap-3 min-[700px]:grid-cols-2 min-[960px]:grid-cols-1">
+            <div className="bp2:grid-cols-1 grid min-w-0 grid-cols-1 gap-3 min-[700px]:grid-cols-2">
               {projects.map((project) => {
                 const permissions = getProjectActionPermissions(project)
                 return (

--- a/src/features/project/new/ui/application/ApplicationForm.tsx
+++ b/src/features/project/new/ui/application/ApplicationForm.tsx
@@ -342,14 +342,14 @@ export const ApplicationForm = forwardRef<
           </div>
         ))}
 
-        <div className="mb-21 flex flex-col gap-1">
-          <p className="text-body-2-regular text-teal-gray-500 whitespace-pre">
+        <div className="bp1:mb-21 mb-14 flex flex-col gap-1">
+          <p className="text-body-2-regular text-teal-gray-500 whitespace-pre-wrap">
             {`* 지원자의 파트에 따라 해당하는 섹션의 질문만 노출됩니다.\n* 개발(FE/BE) 섹션의 문항은 추후 기획-개발자 매칭 전 수정이 가능합니다.`}
           </p>
         </div>
       </div>
 
-      <div className="flex justify-between">
+      <div className="bp1:flex-row bp1:justify-between flex flex-col-reverse gap-3">
         {!readOnly && (
           <Button
             type="button"
@@ -361,7 +361,7 @@ export const ApplicationForm = forwardRef<
             {tempSaveLabel}
           </Button>
         )}
-        <div className="flex items-center gap-4">
+        <div className="flex items-center justify-end gap-4">
           <Button
             type="button"
             variant="weak"

--- a/src/features/project/new/ui/application/ApplicationForm.tsx
+++ b/src/features/project/new/ui/application/ApplicationForm.tsx
@@ -349,7 +349,7 @@ export const ApplicationForm = forwardRef<
         </div>
       </div>
 
-      <div className="bp1:flex-row bp1:justify-between flex flex-col-reverse gap-3">
+      <div className="flex items-center justify-between gap-3">
         {!readOnly && (
           <Button
             type="button"

--- a/src/features/project/new/ui/application/QuestionTypeToolbar.tsx
+++ b/src/features/project/new/ui/application/QuestionTypeToolbar.tsx
@@ -29,10 +29,11 @@ export function QuestionTypeToolbar({
   onAddAfter,
 }: QuestionTypeToolbarProps) {
   return (
-    <div className="flex items-center justify-center gap-3 py-4">
+    <div className="flex flex-wrap items-center justify-center gap-3 py-4">
       <FieldTypeButtonGroup
         options={FIELD_TYPE_OPTIONS}
         selected={selected}
+        className="max-w-full flex-wrap justify-center"
         onChange={(key) => onChange(key as FieldType)}
       />
       <FloatingActionButton aria-label="질문 추가" onClick={onAddAfter} />

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -447,11 +447,11 @@ export const BasicInfoForm = forwardRef<
     <form
       noValidate
       onSubmit={handleFormSubmit}
-      className="flex flex-col justify-start gap-14 px-4 pt-4"
+      className="bp1:px-4 bp2:gap-14 flex flex-col justify-start gap-10 px-0 pt-4"
     >
       <div className="flex flex-col gap-4">
         <SectionHeader index={1} title="프로젝트 카드" />
-        <div className="flex items-start gap-6">
+        <div className="flex min-w-0 flex-col items-start gap-6 xl:flex-row xl:items-start">
           <ProjectCardForm
             nickname={displayNickname}
             name={displayName}
@@ -467,7 +467,7 @@ export const BasicInfoForm = forwardRef<
             thumbnailUrl={uploaded.thumbnailUrl ?? undefined}
             logoUrl={uploaded.logoUrl ?? undefined}
           />
-          <div className="flex w-78 shrink-0 flex-col gap-2">
+          <div className="flex w-4/5 max-w-full min-w-0 flex-col gap-2 xl:w-78 xl:shrink-0">
             <Dropdown<string>
               id="pm1-select"
               value={pm1Member?.id}
@@ -564,7 +564,7 @@ export const BasicInfoForm = forwardRef<
           className="w-full"
         />
       </div>
-      <div className="flex justify-between">
+      <div className="bp1:flex-row bp1:justify-between flex flex-col-reverse gap-3">
         <Button
           type="button"
           variant="weak"

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -564,7 +564,7 @@ export const BasicInfoForm = forwardRef<
           className="w-full"
         />
       </div>
-      <div className="bp1:flex-row bp1:justify-between flex flex-col-reverse gap-3">
+      <div className="flex items-center justify-between gap-3">
         <Button
           type="button"
           variant="weak"

--- a/src/features/project/new/ui/basic-info/ProjectCardForm.tsx
+++ b/src/features/project/new/ui/basic-info/ProjectCardForm.tsx
@@ -64,7 +64,7 @@ export function ProjectCardForm({
   }, [logo])
 
   return (
-    <div className="border-teal-gray-100 shadow-drop-neutral-2 flex h-fit w-135 flex-col rounded-[12px] border bg-white">
+    <div className="border-teal-gray-100 shadow-drop-neutral-2 flex h-fit w-full max-w-135 min-w-0 flex-col rounded-[12px] border bg-white xl:max-w-none xl:flex-1">
       <ImageUploader
         ref={thumbnailRef}
         focusTarget="thumbnail"
@@ -80,7 +80,7 @@ export function ProjectCardForm({
         }}
       />
       <div className="h-fit w-full rounded-[12px] p-5">
-        <div className="mb-2.5 flex items-center justify-between">
+        <div className="bp1:items-center mb-2.5 flex flex-wrap items-start gap-2">
           <label htmlFor="service-title" className="sr-only">
             서비스 제목
           </label>
@@ -100,10 +100,10 @@ export function ProjectCardForm({
             aria-invalid={!!errors.title}
             {...register("title")}
             maxLength={16}
-            className="text-heading-6-semibold text-teal-gray-900 placeholder:text-teal-gray-400 aria-invalid:focus:ring-error-500 w-4/7 bg-transparent px-1 outline-none aria-invalid:focus:rounded-sm aria-invalid:focus:ring-2"
+            className="text-heading-6-semibold text-teal-gray-900 placeholder:text-teal-gray-400 aria-invalid:focus:ring-error-500 min-w-0 flex-1 bg-transparent px-1 outline-none aria-invalid:focus:rounded-sm aria-invalid:focus:ring-2"
           />
-          <div className="text-body-2-regular text-teal-gray-500 flex flex-col items-end gap-0.5">
-            <div className="flex w-fit items-center gap-2 whitespace-nowrap">
+          <div className="text-body-2-regular text-teal-gray-500 bp1:w-auto bp1:items-end flex w-full min-w-0 flex-col items-start gap-0.5">
+            <div className="flex max-w-full flex-wrap items-center gap-x-2 gap-y-0.5">
               <span>
                 {nickname}/{name}
               </span>
@@ -111,7 +111,7 @@ export function ProjectCardForm({
               <span>{university}</span>
             </div>
             {subPm && (
-              <div className="flex w-fit items-center gap-2 whitespace-nowrap">
+              <div className="flex max-w-full flex-wrap items-center gap-x-2 gap-y-0.5">
                 <span>
                   {subPm.nickname}/{subPm.name}
                 </span>

--- a/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
+++ b/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
@@ -252,9 +252,12 @@ export const RecruitInfoForm = forwardRef<
     <div className="flex flex-col gap-6 pt-4">
       <div className="px-4">
         <SectionHeader index={2} title="모집 인원 및 스택" />
-        <div className="border-teal-gray-200 mx-8.5 flex w-full flex-col gap-11.5 border-b pt-6 pb-11">
+        <div className="border-teal-gray-200 bp1:mx-8.5 bp2:gap-11.5 bp2:pb-11 mx-0 flex flex-col gap-8 border-b pt-6 pb-10">
           {ROLES.map(({ key, label, stacks }) => (
-            <div key={key} className="flex items-center gap-6">
+            <div
+              key={key}
+              className="bp1:flex-row bp1:flex-wrap bp1:items-center bp1:gap-6 flex min-w-0 flex-col items-start gap-3"
+            >
               <span className="text-body-1-regular text-teal-gray-700 w-16 shrink-0">
                 {label}
               </span>
@@ -269,6 +272,7 @@ export const RecruitInfoForm = forwardRef<
                   variant="segmented"
                   allowDeselect
                   value={roleStates[key].stack}
+                  className="max-w-full flex-wrap"
                   onValueChange={(v) =>
                     isReadOnly
                       ? undefined
@@ -289,18 +293,18 @@ export const RecruitInfoForm = forwardRef<
             </div>
           ))}
         </div>
-        <div className="bg-teal-gray-100 mt-4 mb-21 flex w-full items-center rounded-[8px] px-7 py-2.5">
-          <div className="text-subtitle-3-semibold border-teal-gray-200 flex border-r pr-7.5 text-teal-600">
-            <span className="mr-17">총 모집 인원</span>
+        <div className="bg-teal-gray-100 bp1:mb-21 bp1:flex-row bp1:items-center bp1:px-7 bp1:py-2.5 mt-4 mb-14 flex w-full flex-col gap-2 rounded-[8px] px-4 py-3">
+          <div className="text-subtitle-3-semibold border-teal-gray-200 bp1:border-r bp1:pr-7.5 flex text-teal-600">
+            <span className="bp1:mr-17 mr-6">총 모집 인원</span>
             <span className="mr-1">{totalCount}</span>
             <span>명</span>
           </div>
-          <span className="text-teal-gray-700 text-body-1-regular ml-7.5">
+          <span className="text-teal-gray-700 text-body-1-regular bp1:ml-7.5">
             {summaryText || "직군별 인원을 선택해 주세요"}
           </span>
         </div>
       </div>
-      <div className="flex justify-between">
+      <div className="bp1:flex-row bp1:justify-between flex flex-col-reverse gap-3">
         {!readOnly ? (
           <Button
             type="button"
@@ -315,7 +319,7 @@ export const RecruitInfoForm = forwardRef<
         ) : (
           <span />
         )}
-        <div className="flex items-center gap-4">
+        <div className="flex items-center justify-end gap-4">
           <Button type="button" variant="weak" color="neutral" onClick={onPrev}>
             이전
           </Button>

--- a/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
+++ b/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
@@ -252,21 +252,23 @@ export const RecruitInfoForm = forwardRef<
     <div className="flex flex-col gap-6 pt-4">
       <div className="px-4">
         <SectionHeader index={2} title="모집 인원 및 스택" />
-        <div className="border-teal-gray-200 bp1:mx-8.5 bp2:gap-11.5 bp2:pb-11 mx-0 flex flex-col gap-8 border-b pt-6 pb-10">
+        <div className="border-teal-gray-200 bp2:gap-11.5 bp2:pb-11 mx-8.5 flex flex-col gap-8 border-b pt-6 pb-10">
           {ROLES.map(({ key, label, stacks }) => (
             <div
               key={key}
               className="bp1:flex-row bp1:flex-wrap bp1:items-center bp1:gap-6 flex min-w-0 flex-col items-start gap-3"
             >
-              <span className="text-body-1-regular text-teal-gray-700 w-16 shrink-0">
-                {label}
-              </span>
-              <Counter
-                value={roleStates[key].count}
-                onChange={(v) => updateCount(key, v)}
-                disabled={isReadOnly}
-                aria-label={`${label} 인원`}
-              />
+              <div className="bp1:gap-6 flex items-center gap-3">
+                <span className="text-body-1-regular text-teal-gray-700 w-16 shrink-0">
+                  {label}
+                </span>
+                <Counter
+                  value={roleStates[key].count}
+                  onChange={(v) => updateCount(key, v)}
+                  disabled={isReadOnly}
+                  aria-label={`${label} 인원`}
+                />
+              </div>
               {stacks.length > 0 && (
                 <OptionButtonGroup
                   variant="segmented"
@@ -294,8 +296,8 @@ export const RecruitInfoForm = forwardRef<
           ))}
         </div>
         <div className="bg-teal-gray-100 bp1:mb-21 bp1:flex-row bp1:items-center bp1:px-7 bp1:py-2.5 mt-4 mb-14 flex w-full flex-col gap-2 rounded-[8px] px-4 py-3">
-          <div className="text-subtitle-3-semibold border-teal-gray-200 bp1:border-r bp1:pr-7.5 flex text-teal-600">
-            <span className="bp1:mr-17 mr-6">총 모집 인원</span>
+          <div className="text-subtitle-3-semibold border-teal-gray-200 bp1:border-r bp1:pr-7.5 flex shrink-0 whitespace-nowrap text-teal-600">
+            <span className="bp2:mr-17 mr-6">총 모집 인원</span>
             <span className="mr-1">{totalCount}</span>
             <span>명</span>
           </div>
@@ -304,7 +306,7 @@ export const RecruitInfoForm = forwardRef<
           </span>
         </div>
       </div>
-      <div className="bp1:flex-row bp1:justify-between flex flex-col-reverse gap-3">
+      <div className="flex items-center justify-between gap-3">
         {!readOnly ? (
           <Button
             type="button"

--- a/src/features/project/new/ui/stepper/Stepper.tsx
+++ b/src/features/project/new/ui/stepper/Stepper.tsx
@@ -25,7 +25,7 @@ export function Stepper({
     <section
       role="tablist"
       aria-label="등록 단계"
-      className="bg-teal-gray-100 flex h-11.5 min-w-225 items-center gap-2 rounded-[14px] p-1"
+      className="bg-teal-gray-100 bp1:gap-2 flex h-11.5 w-full min-w-0 items-center gap-1 rounded-[14px] p-1"
     >
       {ITEMS.map((item) => (
         <StepperTab

--- a/src/features/project/new/ui/stepper/StepperTab.tsx
+++ b/src/features/project/new/ui/stepper/StepperTab.tsx
@@ -31,7 +31,7 @@ export function StepperTab({
       tabIndex={isSelected ? 0 : -1}
       onClick={onClick}
       className={cn(
-        "relative flex h-full w-full items-center gap-2 rounded-[12px] py-1 pr-5 pl-3",
+        "bp1:justify-start bp1:gap-2 bp1:pr-5 bp1:pl-3 relative flex h-full w-full items-center justify-center gap-1.5 rounded-[12px] px-2 py-1",
         disabled ? "cursor-not-allowed opacity-40" : "cursor-pointer",
       )}
     >
@@ -49,7 +49,7 @@ export function StepperTab({
       <div
         aria-hidden="true"
         className={cn(
-          "text-label-3-semibold text-teal-gray-600 relative flex h-5 w-5 items-center justify-center rounded-full",
+          "text-label-3-semibold text-teal-gray-600 relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full",
           isSelected ? "bg-teal-gray-150" : "bg-teal-gray-200",
         )}
       >
@@ -57,7 +57,7 @@ export function StepperTab({
       </div>
       <span
         className={cn(
-          "text-label-1-semibold relative",
+          "text-label-1-semibold relative truncate",
           isSelected ? "text-teal-gray-800" : "text-teal-600",
         )}
       >

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -318,7 +318,7 @@ function TeamMatchingAnnouncePage() {
 
   return (
     <section className="w-full">
-      <div className="border-teal-gray-100 bp1:min-h-213 bp1:px-6 bp1:pt-6 bp1:pb-8 flex w-full max-w-242 min-w-0 flex-col items-center justify-between rounded-[12px] border bg-white px-4 pt-5 pb-6 min-[960px]:px-8.5 min-[960px]:pt-8 min-[960px]:pb-10">
+      <div className="border-teal-gray-100 bp1:min-h-213 bp1:px-6 bp1:pt-6 bp1:pb-8 bp2:px-8.5 bp2:pt-8 bp2:pb-10 flex w-full max-w-242 min-w-0 flex-col items-center justify-between rounded-[12px] border bg-white px-4 pt-5 pb-6">
         <div className="flex w-full flex-col gap-6 pb-10">
           <div className="flex w-full flex-col items-start gap-1.5">
             <span className="text-heading-6-semibold text-teal-gray-900">

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -317,7 +317,7 @@ function ProjectSettingsAnnouncePage() {
 
   return (
     <section className="w-full">
-      <div className="border-teal-gray-100 bp1:min-h-213 bp1:px-6 bp1:pt-6 bp1:pb-8 flex w-full max-w-242 min-w-0 flex-col items-center justify-between rounded-[12px] border bg-white px-4 pt-5 pb-6 min-[960px]:px-8.5 min-[960px]:pt-8 min-[960px]:pb-10">
+      <div className="border-teal-gray-100 bp1:min-h-213 bp1:px-6 bp1:pt-6 bp1:pb-8 bp2:px-8.5 bp2:pt-8 bp2:pb-10 flex w-full max-w-242 min-w-0 flex-col items-center justify-between rounded-[12px] border bg-white px-4 pt-5 pb-6">
         <div className="flex w-full flex-col gap-6 pb-10">
           <div className="flex w-full flex-col items-start gap-1.5">
             <span className="text-heading-6-semibold text-teal-gray-900">

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -527,8 +527,8 @@ function ProjectRegisterPage() {
   }
 
   return (
-    <section className="flex w-full flex-col items-start justify-start">
-      <div className="border-teal-gray-100 flex h-full w-242 flex-col gap-2.5 rounded-[12px] border bg-white px-8.5 pt-8 pb-10">
+    <section className="flex w-full min-w-0 flex-col items-start justify-start">
+      <div className="border-teal-gray-100 bp1:px-6 bp2:px-8.5 bp2:pt-8 bp2:pb-10 flex h-full w-full max-w-242 min-w-0 flex-col gap-2.5 rounded-[12px] border bg-white px-4 pt-6 pb-8">
         <div ref={formTopRef} className="flex flex-col items-start gap-1.5">
           <span className="text-heading-6-semibold text-teal-gray-900">
             프로젝트 등록

--- a/src/routes/matching/route.tsx
+++ b/src/routes/matching/route.tsx
@@ -25,12 +25,12 @@ function MatchingLayout() {
         <div className="flex min-w-0 flex-1 flex-col">
           <div
             className={cn(
-              "px-4 pt-6 min-[960px]:pt-12",
-              isProjectsIndex ? "min-[960px]:px-9.5" : "min-[960px]:px-11",
+              "bp2:pt-12 px-4 pt-6",
+              isProjectsIndex ? "bp2:px-9.5" : "bp2:px-11",
             )}
           >
             <MatchingSegmentRegion />
-            <div className="flex min-w-0 flex-1 flex-col pt-6 pb-20 min-[960px]:pt-8">
+            <div className="bp2:pt-8 flex min-w-0 flex-1 flex-col pt-6 pb-20">
               <Outlet />
             </div>
           </div>

--- a/src/routes/test/header.tsx
+++ b/src/routes/test/header.tsx
@@ -26,10 +26,10 @@ function HeaderTestPage() {
       <div className="flex w-full">
         <SideBar activePathname={HEADER_PREVIEW_PATHNAME} />
         <div className="flex min-w-0 flex-1 flex-col">
-          <div className="px-4 pt-6 min-[960px]:px-8.5 min-[960px]:pt-14.5">
+          <div className="bp2:px-8.5 bp2:pt-14.5 px-4 pt-6">
             <MatchingSegmentRegion activePathname={HEADER_PREVIEW_PATHNAME} />
           </div>
-          <div className="flex min-h-screen min-w-0 flex-1 flex-col px-4 pt-6 min-[960px]:px-8.5 min-[960px]:pt-8">
+          <div className="bp2:px-8.5 bp2:pt-8 flex min-h-screen min-w-0 flex-1 flex-col px-4 pt-6">
             <section className="border-teal-gray-100 flex flex-col gap-3 rounded-lg border bg-white p-6">
               <h1 className="text-heading-6-semibold text-teal-gray-900">
                 Header Test Page

--- a/src/shared/ui/Counter.tsx
+++ b/src/shared/ui/Counter.tsx
@@ -64,7 +64,7 @@ export function Counter({
       </button>
       <span
         aria-live="polite"
-        className="text-label-1-semibold flex w-8.5 min-w-6 items-center justify-center self-center pt-1 text-teal-500"
+        className="text-label-1-semibold flex w-8.5 min-w-6 items-center justify-center self-center pt-1 pr-0.5 text-teal-500"
       >
         {value}
       </span>

--- a/src/shared/ui/ImageUploader.tsx
+++ b/src/shared/ui/ImageUploader.tsx
@@ -7,8 +7,8 @@ import { cn } from "@/shared/lib/utils"
 type ImageUploaderVariant = "thumbnail" | "logo"
 
 const variantSize: Record<ImageUploaderVariant, string> = {
-  thumbnail: "h-71.5 w-135",
-  logo: "h-50 w-50",
+  thumbnail: "aspect-[540/286] w-full",
+  logo: "aspect-square w-40 max-w-full bp1:w-50",
 }
 
 const variantRound: Record<ImageUploaderVariant, string> = {

--- a/src/shared/ui/question-field/FileUploadField.tsx
+++ b/src/shared/ui/question-field/FileUploadField.tsx
@@ -27,7 +27,7 @@ export function FileUploadField({
     <div className="flex w-full flex-col gap-1">
       <div
         className={cn(
-          "border-teal-gray-150 flex h-15 w-full min-w-200 items-center justify-between gap-1.5 rounded-[12px] border bg-[color-mix(in_srgb,var(--color-teal-50)_40%,white)] py-4 pr-3.5 pl-5",
+          "border-teal-gray-150 flex min-h-15 w-full min-w-0 items-center justify-between gap-1.5 rounded-[12px] border bg-[color-mix(in_srgb,var(--color-teal-50)_40%,white)] py-4 pr-3.5 pl-5",
           error && "border-error-500",
           className,
         )}

--- a/src/shared/ui/question-field/PortfolioField.tsx
+++ b/src/shared/ui/question-field/PortfolioField.tsx
@@ -84,7 +84,7 @@ export function PortfolioField({
   const displayError = linkError || fileError || errorProp
 
   return (
-    <div className={cn("flex w-full max-w-203 flex-col gap-1", className)}>
+    <div className={cn("flex w-full flex-col gap-1", className)}>
       <div className="border-teal-gray-150 flex h-15 w-full items-center justify-between gap-1.5 rounded-[12px] border bg-[color-mix(in_srgb,var(--color-teal-50)_40%,white)] px-5 py-4">
         <input
           type="file"

--- a/src/shared/ui/question-field/QuestionForm.tsx
+++ b/src/shared/ui/question-field/QuestionForm.tsx
@@ -67,7 +67,7 @@ export function QuestionForm({
   return (
     <article
       className={cn(
-        "relative flex w-full flex-col items-center gap-2.5 px-6 pb-6",
+        "bp1:px-6 bp1:pb-6 relative flex w-full flex-col items-center gap-2.5 px-4 pb-5",
         focused ? "" : "mt-4 pt-4",
         className,
       )}
@@ -98,7 +98,7 @@ export function QuestionForm({
       <div className="flex w-full flex-col items-end gap-4">
         {focused ? (
           <div className="flex w-full items-start gap-2">
-            <span className="text-heading-7-semibold w-7 shrink-0 text-teal-600">
+            <span className="text-heading-7-semibold bp1:w-7 w-6 shrink-0 text-teal-600">
               {index}
             </span>
             <div className="flex min-w-0 flex-1 flex-col gap-1">
@@ -149,7 +149,7 @@ export function QuestionForm({
           />
         )}
 
-        <div className="flex w-full flex-col items-start gap-2.5 px-1.5">
+        <div className="bp1:px-1.5 flex w-full min-w-0 flex-col items-start gap-2.5 px-0">
           {children}
         </div>
 

--- a/src/shared/ui/question-field/TextQuestionField.tsx
+++ b/src/shared/ui/question-field/TextQuestionField.tsx
@@ -45,7 +45,7 @@ export function TextQuestionField({
     <div className="flex w-full flex-col gap-1">
       <QuestionFieldBox
         state={state}
-        className={cn("w-full min-w-200", className)}
+        className={cn("w-full min-w-0", className)}
       >
         <textarea
           ref={textareaRef}


### PR DESCRIPTION
## 📸 작업 내용

- 데스크톱 고정폭이던 프로젝트 등록 플로우(기본 정보 / 모집 정보 / 지원 문항)를 모바일~태블릿까지 반응형으로 대응
- `bp2`(960px) 브레이크포인트 토큰을 도입하고 기존 `min-[960px]` 임의값을 일괄 치환 (시각 변화 없는 리팩토링)
- 기본 정보: 프로젝트 카드 + PM 드롭다운을 `xl`(1280px) 기준으로 세로 스택 ↔ 가로 배치 전환
- 모집 정보: 직군 행 라벨+카운터 가로 묶음, 총 모집 인원 라벨 글자 단위 줄바꿈 방지
- 등록 3단계 하단 버튼을 모바일에서도 가로 정렬
- 공용 컴포넌트(ImageUploader, question-field 등) 고정폭 제거, 모바일 푸터 가로 오버플로우 완화

## 🎞️ 주요 코드 설명

### bp2 브레이크포인트 토큰
- `src/app.css`에 `--breakpoint-bp2: 960px` 추가 후 산재한 `min-[960px]:` 임의값을 `bp2:`로 통일

### 프로젝트 카드 / PM 드롭다운 전환점
- `xl`(1280px) 미만에서는 세로 스택 + 드롭다운 80%, 이상에서 가로 배치
- 카드는 `max-w-135`로 들어가는 구간까지 540px 디자인 폭을 유지하고, 안 맞으면 자연 축소(가로 스크롤 회피)

## 🔗 연결된 이슈

- Connected: #283