### PR TITLE
🐛 fix: 프로젝트 지원 플로우 QA 이슈 수정 (차수·파트·커서·등록 리다이렉트)

### DIFF
--- a/src/features/project/list/model/projectDetailCta.test.ts
+++ b/src/features/project/list/model/projectDetailCta.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest"
 
-import { isApplyButtonDisabled } from "./projectDetailCta"
+import {
+  isApplyButtonDisabled,
+  resolveProjectDetailCtaMode,
+  selectCurrentApplicationForProject,
+} from "./projectDetailCta"
 
 const applicable = {
   isPmReadonly: false,
@@ -60,5 +64,145 @@ describe("isApplyButtonDisabled", () => {
         hasApplicationForm: false,
       }),
     ).toBe(false)
+  })
+})
+
+const application = (
+  over: Partial<{
+    applicationId: string | null
+    projectId: string
+    status: string
+    matchingRound: { id: string | null }
+  }> = {},
+) => ({
+  applicationId: "1",
+  projectId: "100",
+  status: "SUBMITTED",
+  matchingRound: { id: "1" },
+  ...over,
+})
+
+const ctaParams = {
+  isOperator: false,
+  isPm: false,
+  isSameBranch: true,
+  isApplied: false,
+  hasOtherActiveApplication: false,
+  isAlreadyApproved: false,
+  isPartIneligible: false,
+}
+
+describe("resolveProjectDetailCtaMode", () => {
+  it("기본 조건이면 apply를 반환한다", () => {
+    expect(resolveProjectDetailCtaMode(ctaParams)).toBe("apply")
+  })
+
+  it("내 파트를 모집하지 않는 프로젝트면 apply-blocked-part를 반환한다", () => {
+    expect(
+      resolveProjectDetailCtaMode({ ...ctaParams, isPartIneligible: true }),
+    ).toBe("apply-blocked-part")
+  })
+
+  it("이미 지원한 프로젝트면 파트 부적격이어도 my-application을 우선한다", () => {
+    expect(
+      resolveProjectDetailCtaMode({
+        ...ctaParams,
+        isApplied: true,
+        isPartIneligible: true,
+      }),
+    ).toBe("my-application")
+  })
+
+  it("다른 프로젝트에 지원 중이면 파트 부적격이어도 apply-blocked-other를 반환한다", () => {
+    expect(
+      resolveProjectDetailCtaMode({
+        ...ctaParams,
+        hasOtherActiveApplication: true,
+        isPartIneligible: true,
+      }),
+    ).toBe("apply-blocked-other")
+  })
+})
+
+describe("selectCurrentApplicationForProject", () => {
+  it("활성 차수가 있을 때 이전 차수 지원서는 현재 지원 상태로 보지 않는다", () => {
+    const result = selectCurrentApplicationForProject({
+      applications: [application({ matchingRound: { id: "1" } })],
+      projectId: 100,
+      activeMatchingRoundId: "2",
+    })
+    expect(result).toBeUndefined()
+  })
+
+  it("활성 차수의 지원서가 있으면 해당 지원서를 반환한다", () => {
+    const current = application({
+      applicationId: "9",
+      matchingRound: { id: "2" },
+    })
+    const result = selectCurrentApplicationForProject({
+      applications: [application({ matchingRound: { id: "1" } }), current],
+      projectId: 100,
+      activeMatchingRoundId: "2",
+    })
+    expect(result).toBe(current)
+  })
+
+  it("활성 차수가 없으면(차수 사이) 취소되지 않은 지원서를 조회용으로 반환한다", () => {
+    const past = application({
+      matchingRound: { id: "1" },
+      status: "REJECTED",
+    })
+    const result = selectCurrentApplicationForProject({
+      applications: [past],
+      projectId: 100,
+      activeMatchingRoundId: null,
+    })
+    expect(result).toBe(past)
+  })
+
+  it("활성 차수 조회 중(undefined)이면 폴백 없이 undefined를 반환해 CTA 깜빡임을 막는다", () => {
+    const past = application({
+      matchingRound: { id: "1" },
+      status: "SUBMITTED",
+    })
+    const result = selectCurrentApplicationForProject({
+      applications: [past],
+      projectId: 100,
+      activeMatchingRoundId: undefined,
+    })
+    expect(result).toBeUndefined()
+  })
+
+  it("applicationId가 없는 지원서는 무시한다", () => {
+    const result = selectCurrentApplicationForProject({
+      applications: [
+        application({ applicationId: null, matchingRound: { id: "2" } }),
+      ],
+      projectId: 100,
+      activeMatchingRoundId: "2",
+    })
+    expect(result).toBeUndefined()
+  })
+
+  it("취소된 지원서는 무시한다", () => {
+    const result = selectCurrentApplicationForProject({
+      applications: [
+        application({ status: "CANCELLED", matchingRound: { id: "2" } }),
+      ],
+      projectId: 100,
+      activeMatchingRoundId: "2",
+    })
+    expect(result).toBeUndefined()
+  })
+
+  it("다른 프로젝트의 지원서는 선택하지 않는다", () => {
+    const result = selectCurrentApplicationForProject({
+      applications: [
+        application({ projectId: "999", matchingRound: { id: "2" } }),
+      ],
+      projectId: 100,
+      activeMatchingRoundId: "2",
+    })
+    expect(result).toBeUndefined()
   })
 })

--- a/src/features/project/list/model/projectDetailCta.ts
+++ b/src/features/project/list/model/projectDetailCta.ts
@@ -4,6 +4,7 @@ export type ProjectDetailCtaMode =
   | "apply"
   | "apply-blocked-other"
   | "apply-blocked-approved"
+  | "apply-blocked-part"
   | "plan-only"
 
 interface ResolveCtaParams {
@@ -13,6 +14,7 @@ interface ResolveCtaParams {
   isApplied: boolean
   hasOtherActiveApplication: boolean
   isAlreadyApproved: boolean
+  isPartIneligible: boolean
 }
 
 export function resolveProjectDetailCtaMode({
@@ -22,6 +24,7 @@ export function resolveProjectDetailCtaMode({
   isApplied,
   hasOtherActiveApplication,
   isAlreadyApproved,
+  isPartIneligible,
 }: ResolveCtaParams): ProjectDetailCtaMode {
   if (isOperator) return "recruit-questions"
   if (!isSameBranch) return "plan-only"
@@ -29,6 +32,7 @@ export function resolveProjectDetailCtaMode({
   if (isApplied) return "my-application"
   if (isAlreadyApproved) return "apply-blocked-approved"
   if (hasOtherActiveApplication) return "apply-blocked-other"
+  if (isPartIneligible) return "apply-blocked-part"
   return "apply"
 }
 
@@ -55,5 +59,39 @@ export function isApplyButtonDisabled({
     isWritePermissionLoading ||
     !canWriteApplication ||
     !hasActiveRound
+  )
+}
+
+type ApplicationForSelection = {
+  projectId: string
+  status: string
+  applicationId: string | null
+  matchingRound: { id: string | null }
+}
+
+interface SelectCurrentApplicationParams<T extends ApplicationForSelection> {
+  applications: T[] | undefined
+  projectId: number
+  activeMatchingRoundId: string | null | undefined
+}
+
+export function selectCurrentApplicationForProject<
+  T extends ApplicationForSelection,
+>({
+  applications,
+  projectId,
+  activeMatchingRoundId,
+}: SelectCurrentApplicationParams<T>): T | undefined {
+  const candidates = applications?.filter(
+    (a) =>
+      Number(a.projectId) === projectId &&
+      a.status !== "CANCELLED" &&
+      a.applicationId != null,
+  )
+  if (candidates == null || candidates.length === 0) return undefined
+  if (activeMatchingRoundId === undefined) return undefined
+  if (activeMatchingRoundId === null) return candidates[0]
+  return candidates.find(
+    (a) => Number(a.matchingRound?.id) === Number(activeMatchingRoundId),
   )
 }

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -38,6 +38,7 @@ import { DEFAULT_MATCHING_PROJECT_MOCK } from "../model/matchingProject.mock"
 import {
   isApplyButtonDisabled,
   resolveProjectDetailCtaMode,
+  selectCurrentApplicationForProject,
 } from "../model/projectDetailCta"
 import { ApplyFormSkeleton } from "./apply-modal/ApplyFormSkeleton"
 import { MyApplicationModal } from "./apply-modal/MyApplicationModal"
@@ -244,14 +245,6 @@ export function ProjectDetailCard({
     return id != null ? Number(id) : null
   }, [me])
 
-  const myApplicationForProject = myApplications?.find(
-    (a) =>
-      Number(a.projectId) === projectId &&
-      a.status !== "CANCELLED" &&
-      a.applicationId != null,
-  )
-  const isApplied = myApplicationForProject != null
-
   const isAlreadyApproved =
     myApplications?.some((a) => a.status === "APPROVED") ?? false
 
@@ -345,19 +338,29 @@ export function ProjectDetailCard({
   const devMatchingRoundId =
     Number(import.meta.env.VITE_DEV_MATCHING_ROUND_ID) || null
 
-  const { data: activeMatchingRound } = useQuery({
-    queryKey: ["activeMatchingRound", myChapterId],
-    queryFn: (): Promise<ActiveMatchingRound | null> => {
-      if (devMatchingRoundId)
-        return Promise.resolve({
-          id: String(devMatchingRoundId),
-        } as ActiveMatchingRound)
-      return getActiveMatchingRound(myChapterId!)
-    },
-    enabled:
-      isChallengerView && (myChapterId != null || devMatchingRoundId != null),
-    staleTime: 60 * 1000,
+  const { data: activeMatchingRound, isLoading: isActiveMatchingRoundLoading } =
+    useQuery({
+      queryKey: ["activeMatchingRound", myChapterId],
+      queryFn: (): Promise<ActiveMatchingRound | null> => {
+        if (devMatchingRoundId)
+          return Promise.resolve({
+            id: String(devMatchingRoundId),
+          } as ActiveMatchingRound)
+        return getActiveMatchingRound(myChapterId!)
+      },
+      enabled:
+        isChallengerView && (myChapterId != null || devMatchingRoundId != null),
+      staleTime: 60 * 1000,
+    })
+
+  const myApplicationForProject = selectCurrentApplicationForProject({
+    applications: myApplications,
+    projectId,
+    activeMatchingRoundId: isActiveMatchingRoundLoading
+      ? undefined
+      : (activeMatchingRound?.id ?? null),
   })
+  const isApplied = myApplicationForProject != null
 
   const hasOtherActiveApplication = useMemo(() => {
     if (!myApplications || !activeMatchingRound) return false
@@ -370,6 +373,12 @@ export function ProjectDetailCard({
     )
   }, [myApplications, activeMatchingRound, projectId])
 
+  const isPartIneligible =
+    isChallengerView &&
+    detail != null &&
+    latestChallengerPart != null &&
+    !detail.partQuotas.some((q) => q.part === latestChallengerPart)
+
   const ctaMode =
     viewOnly && !userIsOperator
       ? resolveProjectDetailCtaMode({
@@ -379,6 +388,7 @@ export function ProjectDetailCard({
           isApplied,
           hasOtherActiveApplication,
           isAlreadyApproved,
+          isPartIneligible,
         })
       : resolveProjectDetailCtaMode({
           isOperator: userIsOperator,
@@ -387,6 +397,7 @@ export function ProjectDetailCard({
           isApplied,
           hasOtherActiveApplication,
           isAlreadyApproved,
+          isPartIneligible,
         })
 
   const cover = data.coverImage
@@ -607,7 +618,8 @@ export function ProjectDetailCard({
                     </Button>
                   )}
                 {(ctaMode === "apply-blocked-other" ||
-                  ctaMode === "apply-blocked-approved") && (
+                  ctaMode === "apply-blocked-approved" ||
+                  ctaMode === "apply-blocked-part") && (
                   <Button className="flex-1" disabled>
                     지원하기
                   </Button>
@@ -623,6 +635,11 @@ export function ProjectDetailCard({
           {!viewOnly && ctaMode === "apply-blocked-approved" && (
             <p className="text-caption-2-regular text-error-600 mt-2 w-full text-center">
               이미 합격한 챌린저는 추가로 지원할 수 없습니다.
+            </p>
+          )}
+          {!viewOnly && ctaMode === "apply-blocked-part" && (
+            <p className="text-caption-2-regular text-error-600 mt-2 w-full text-center">
+              지원 가능한 파트가 아니어서 지원할 수 없습니다.
             </p>
           )}
         </div>

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -43,6 +43,7 @@ import {
   type UploadedFileValue,
 } from "../../model/applyValidation"
 import { isRecruitDone } from "../../model/matchingProject"
+import { selectCurrentApplicationForProject } from "../../model/projectDetailCta"
 import { ApplyProjectTitleCard } from "./ApplyProjectTitleCard"
 
 import type { FieldErrors, Resolver } from "react-hook-form"
@@ -52,6 +53,7 @@ import type {
   Section,
 } from "@/features/project/new/model/applicationQuestion"
 
+import type { MyProjectApplicationResponse } from "../../api/matchingProject"
 import type { MatchingProject } from "../../model/matchingProject"
 
 const FILE_UPLOAD_CATEGORY = "POST_ATTACHMENT" as const
@@ -212,10 +214,13 @@ export function ProjectApplyModal({
         if (err instanceof AxiosError && err.response?.status === 409) {
           const gisu = await getActiveGisu().catch(() => null)
           if (gisu) {
-            const apps = await getMyApplications(Number(gisu.gisuId)).catch(
-              () => [],
-            )
-            const existing = apps.find((a) => Number(a.projectId) === projectId)
+            const apps: MyProjectApplicationResponse[] =
+              await getMyApplications(Number(gisu.gisuId)).catch(() => [])
+            const existing = selectCurrentApplicationForProject({
+              applications: apps,
+              projectId,
+              activeMatchingRoundId: String(matchingRoundId),
+            })
             if (existing) setApplicationId(Number(existing.applicationId))
           }
           return

--- a/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
+++ b/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
@@ -291,9 +291,9 @@ export const RecruitInfoForm = forwardRef<
         </div>
         <div className="bg-teal-gray-100 mt-4 mb-21 flex w-full items-center rounded-[8px] px-7 py-2.5">
           <div className="text-subtitle-3-semibold border-teal-gray-200 flex border-r pr-7.5 text-teal-600">
-            <span className="mr-17">총 모집 인원</span>
-            <span className="mr-1">{totalCount}</span>
-            <span>명</span>
+            <div className="mr-17">총 모집 인원</div>
+            <div className="mr-1">{totalCount}</div>
+            <div>명</div>
           </div>
           <span className="text-teal-gray-700 text-body-1-regular ml-7.5">
             {summaryText || "직군별 인원을 선택해 주세요"}

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -507,7 +507,10 @@ function ProjectRegisterPage() {
     }
   }
 
+  const successHandledRef = useRef(false)
   const handleSuccessConfirm = async () => {
+    if (successHandledRef.current) return
+    successHandledRef.current = true
     setShowSuccessModal(false)
     reset()
     queryClient.removeQueries({ queryKey: projectKeys.managed() })
@@ -598,7 +601,9 @@ function ProjectRegisterPage() {
             : "프로젝트 등록이 완료되었습니다."
         }
         confirmText="확인"
-        onOpenChange={setShowSuccessModal}
+        onOpenChange={(open) => {
+          if (!open) void handleSuccessConfirm()
+        }}
         onConfirm={handleSuccessConfirm}
       />
       <CtaModal

--- a/src/shared/ui/question-field/QuestionForm.tsx
+++ b/src/shared/ui/question-field/QuestionForm.tsx
@@ -114,7 +114,11 @@ export function QuestionForm({
                       질문을 작성하세요
                     </span>
                   )}
-                  {required && <span className="text-error-600 ml-1.5">*</span>}
+                  {required && (
+                    <span className="text-error-600 inline-block w-0">
+                      <span className="pl-1.5">*</span>
+                    </span>
+                  )}
                 </div>
                 {!readonlyTitle && (
                   <textarea
@@ -122,7 +126,7 @@ export function QuestionForm({
                     rows={1}
                     value={title}
                     onChange={(e) => onTitleChange?.(e.target.value)}
-                    className="text-heading-7-semibold caret-teal-gray-900 absolute inset-0 h-full w-full resize-none overflow-hidden bg-transparent text-transparent outline-none"
+                    className="text-heading-7-semibold caret-teal-gray-900 absolute inset-0 h-full w-full resize-none overflow-hidden bg-transparent wrap-break-word whitespace-pre-wrap text-transparent outline-none"
                   />
                 )}
               </div>


### PR DESCRIPTION
## 📸 작업 내용

> 0612 데모데이 매칭 QA 시트의 프로젝트 지원/등록 결함을 수정합니다.

- **매칭 차수 스코프**: 매칭 차수가 바뀌어도 이전 차수 지원서로 현재 차수 지원이 막히던 문제 수정 (현재 활성 차수 기준 판단)
- **차수 부가 결함 2건** (적대적 검증으로 발견): 활성 차수 로딩 중 CTA 깜빡임 방지, 지원 모달 409 복구 경로를 현재 차수로 스코프
- **파트 적격성 게이팅**: 내 파트를 모집하지 않는 프로젝트는 지원하기 버튼 비활성 + 사유 안내 (서버 `PROJECT-0205` 대조)
- **지원 문항 커서**: 필수 문항 제목 편집 시 커서가 줄 맨 앞으로 어긋나던 문제 수정
- **등록 완료 리다이렉트**: 등록 완료 모달을 백드롭/Esc로 닫아도 관리 페이지로 이동 (중복 프로젝트 토스트 방지)
- **마크업 정리**: 총 모집 인원 표시 요소 정리

## 🎞️ 주요 코드 설명

### 지원 가능 여부(차수·파트) 판단 분리

```TypeScript
// projectDetailCta.ts
// 활성 차수가 있으면 해당 차수 지원서만 "현재 지원"으로 인정
// (undefined=로딩 → 폴백 없이 undefined 로 깜빡임 방지)
selectCurrentApplicationForProject({ applications, projectId, activeMatchingRoundId })

// resolveProjectDetailCtaMode 에 isPartIneligible 추가 → apply-blocked-part
```

- 파트 적격은 `detail.partQuotas.some(q => q.part === 내 파트)` 로 클라이언트 게이팅(서버 WRITE 권한은 파트 미반영).

### 등록 완료 모달 navigate 보장

```TypeScript
// new.tsx — 어떤 방식으로 닫혀도 navigate 완료 + 중복 가드
onOpenChange={(open) => { if (!open) void handleSuccessConfirm() }}
```

## 🔗 연결된 이슈

- Connected: #285

## 💬 기타 더 이야기해볼 점

- 검증: 유닛 테스트 **143개 통과**, `tsc -b`·ESLint OK.
- **미포함(보류)**: `f373`(로그인→검증화면: 코드 분석상 FE 결함이 아니라 **계정 상태/서버 학교↔지부 매핑** 유력), `16e3`(반응형 사이드바), `3483`(드롭다운 폭 — 디자인 의도 대기). **P5(커서)는 코드 완료, 로컬 시각 확인 권장.**
- `12a3`(지원서 임시저장)은 현행 유지(A안)로 종결.