### PR TITLE
fix: 역할 기반 지원 현황 뷰 분리 및 QA 수정

### DIFF
--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -277,8 +277,9 @@ export function useAdminPageData(chapterName?: string) {
     [projects, applicantsQuery.data],
   )
 
-  // 통계: summary 기반 (universities는 schoolMatchingStatistics + schools API로 계산)
-  // 서버가 schoolMatchingStatistics를 챕터 필터링 없이 내려주므로 프론트에서 필터링
+  // 통계: summary 기반
+  // universities.applied = roundSchoolRankings 전 차수 지원자 수 합산 (매칭 완료 수 아님)
+  // 서버가 schoolMatchingStatistics/roundSchoolRankings를 챕터 필터링 없이 내려주므로 프론트에서 필터링
   const stats: ApplicationStats = useMemo(() => {
     if (!chapterStatsQuery.data) {
       return {
@@ -309,13 +310,28 @@ export function useAdminPageData(chapterName?: string) {
       : chapterStatsQuery.data.summary
 
     const partial = summaryToStats(filteredSummary, projectIdToName)
+
+    // 학교별 지원자 수 집계 (roundSchoolRankings 전 차수 합산, 챕터 소속 학교만)
+    const schoolApplicantCounts = new Map<string, number>()
+    for (const ranking of chapterStatsQuery.data.summary.roundSchoolRankings ??
+      []) {
+      for (const s of ranking.schools) {
+        const id = String(s.schoolId)
+        if (chapterSchoolIds && !chapterSchoolIds.has(id)) continue
+        schoolApplicantCounts.set(
+          id,
+          (schoolApplicantCounts.get(id) ?? 0) + Number(s.applicantCount),
+        )
+      }
+    }
+
     const universities: UniversityCount[] =
       filteredSummary.schoolMatchingStatistics
         .map((s) => ({
           name: shortenSchoolName(
             schoolIdToName.get(String(s.schoolId)) ?? String(s.schoolId),
           ),
-          applied: Number(s.matchedMemberCount),
+          applied: schoolApplicantCounts.get(String(s.schoolId)) ?? 0,
           total: Number(s.totalMemberCount),
         }))
         .sort((a, b) => b.applied - a.applied)

--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -167,7 +167,7 @@ export function useChapters() {
 }
 
 // Admin 뷰용 데이터
-export function useAdminPageData(chapterName?: string) {
+export function useAdminPageData(chapterName?: string, schoolName?: string) {
   const gisuQuery = useActiveGisuId()
   const gisuId = gisuQuery.data ?? 0
 
@@ -202,14 +202,16 @@ export function useAdminPageData(chapterName?: string) {
   // 전체 프로젝트 목록 조회 (지원자 테이블용)
   const projectsQuery = useQuery({
     queryKey: applicationKeys.allProjects(gisuId, chapterId),
-    queryFn: () => getAllProjects(gisuId, { chapterId }),
+    queryFn: () => getAllProjects(gisuId, { chapterId, size: 100 }),
     enabled: gisuId > 0,
   })
 
-  const projects = useMemo(
-    () => projectsQuery.data?.content ?? [],
-    [projectsQuery.data],
-  )
+  const projects = useMemo(() => {
+    const content = projectsQuery.data?.content ?? []
+    // SCHOOL_PRESIDENT: 본인 학교 소속 PM의 프로젝트만 표시
+    if (!schoolName) return content
+    return content.filter((p) => p.productOwner.schoolName === schoolName)
+  }, [projectsQuery.data, schoolName])
 
   // 각 프로젝트의 지원자 목록 조회 (테이블 + 학교별 통계용)
   const applicantsQuery = useQuery({

--- a/src/features/application/model/mappers.ts
+++ b/src/features/application/model/mappers.ts
@@ -160,6 +160,7 @@ export function toProjectApplication(
       ? `${project.productOwner.nickname}/${project.productOwner.name}`
       : project.productOwner.name,
     challengerUniversity: project.productOwner.schoolName,
+    thumbnailUrl: project.thumbnailImageUrl || undefined,
     statusLabel,
     designCount: getQuotaCount(project.partQuotas, "DESIGN"),
     feCount: getQuotaCount(project.partQuotas, "WEB"),
@@ -175,14 +176,17 @@ export function summaryToStats(
   projectIdToName: Map<string, string>,
   filterRound?: number, // 미지정 시 전 차수 합산, 0 = 완료된 차수 없음, N = N차까지 표시
 ): Omit<ApplicationStats, "universities"> {
-  // 차수별 지원 현황 (완료된 차수만)
+  // 차수별 지원 현황 (완료 차수 + 1차 최소 표시)
+  // filterRound=0(1차 진행 중)이어도 r.total(availableMemberCount)이 표시되도록 최소 1차 포함
   const rounds = summary.roundApplicationStatistics
     .map((r) => ({
       round: toRoundNumber(r.matchingRound.phase),
       applied: Number(r.appliedMemberCount),
       total: Number(r.availableMemberCount),
     }))
-    .filter((r) => filterRound === undefined || r.round <= filterRound)
+    .filter(
+      (r) => filterRound === undefined || r.round <= Math.max(1, filterRound),
+    )
 
   // 총원 / 매칭 완료 (schoolMatchingStatistics 합산)
   // 서버가 숫자 필드를 문자열로 내려주므로 Number() 변환 필요

--- a/src/features/application/model/types.ts
+++ b/src/features/application/model/types.ts
@@ -87,6 +87,7 @@ export interface ProjectApplication {
   parts: Role[] // 프로젝트에 할당된 파트 목록 (quota > 0)
   challengerName: string
   challengerUniversity: string
+  thumbnailUrl?: string
   statusLabel: string
   designCount: AssignmentCount
   feCount: AssignmentCount

--- a/src/features/application/ui/ApplicantDetailRow.tsx
+++ b/src/features/application/ui/ApplicantDetailRow.tsx
@@ -46,7 +46,7 @@ export function ApplicantDetailRow({
         </div>
 
         {/* 파트 */}
-        <div className="flex h-12.5 w-30.5 items-center px-2.5">
+        <div className="flex h-12.5 w-30.5 items-center justify-center px-2.5">
           <PartTagChip role={role} />
         </div>
 
@@ -61,7 +61,7 @@ export function ApplicantDetailRow({
         </div>
 
         {/* 합불 상태 */}
-        <div className="flex h-12.5 w-34 items-center px-2.5">
+        <div className="flex h-12.5 w-34 items-center justify-center px-2.5">
           <StatusChipTag value={status} type="tag" />
         </div>
 

--- a/src/features/application/ui/ApplicantDetailRow.tsx
+++ b/src/features/application/ui/ApplicantDetailRow.tsx
@@ -33,39 +33,40 @@ export function ApplicantDetailRow({
     <div
       role="row"
       className={cn(
-        "border-teal-gray-150/60 flex h-[60px] items-center border-b bg-white pr-[64px] pl-[136px]",
+        "border-teal-gray-150/60 flex h-15 items-center border-b bg-white pr-16 pl-30",
         className,
       )}
     >
       <div className="flex items-center">
         {/* 차수 */}
-        <div className="flex h-[50px] w-[74px] items-center justify-center">
+        <div className="flex h-12.5 w-18.5 items-center justify-center">
           <span className="text-body-2-medium text-teal-gray-800">
             {round}차
           </span>
         </div>
 
         {/* 파트 */}
-        <div className="flex h-[50px] w-[122px] items-center px-2.5">
+        <div className="flex h-12.5 w-30.5 items-center px-2.5">
           <PartTagChip role={role} />
         </div>
 
         {/* 챌린저 */}
-        <div className="w-[200px] px-0.5">
+        <div className="w-50 px-0.5">
           <ChallengerLinkButton
             name={name}
             university={university}
             onClick={onChallengerClick}
+            className="hover:bg-transparent"
           />
         </div>
 
         {/* 합불 상태 */}
-        <div className="flex h-[50px] w-[136px] items-center px-2.5">
+        <div className="flex h-12.5 w-34 items-center px-2.5">
           <StatusChipTag value={status} type="tag" />
         </div>
 
         {/* 처리 시간 */}
-        <div className="flex h-[50px] w-[160px] items-center justify-center">
+        <div className="flex h-12.5 w-40 items-center justify-center">
           {processedAt ? (
             <TimestampLabel
               date={processedAt.date}
@@ -78,7 +79,7 @@ export function ApplicantDetailRow({
         </div>
 
         {/* 지원 시간 */}
-        <div className="flex h-[50px] w-[160px] items-center justify-center">
+        <div className="flex h-12.5 w-40 items-center justify-center">
           <TimestampLabel
             date={appliedAt.date}
             time={appliedAt.time}

--- a/src/features/application/ui/ApplicantTableHead.tsx
+++ b/src/features/application/ui/ApplicantTableHead.tsx
@@ -3,9 +3,9 @@ import ExpandAllIcon from "@/shared/assets/icon/expand-collapse/ExpandAllIcon"
 import { cn } from "@/shared/lib/utils"
 
 const COLUMNS = [
-  { label: "프로젝트", width: "w-[12.5rem]", align: "justify-center pr-4" },
-  { label: "파트", width: "w-[7.625rem]", align: "px-4" },
-  { label: "챌린저", width: "w-[12.5rem]", align: "px-16" },
+  { label: "프로젝트", width: "w-[184px]", align: "justify-center pr-4" },
+  { label: "파트", width: "w-[7.625rem]", align: "px-4 justify-center" },
+  { label: "챌린저", width: "w-[12.5rem]", align: "pl-4" },
   { label: "상태", width: "w-[8.5rem]", align: "px-[1.625rem] justify-center" },
   { label: "Design 배정", width: "w-[6.5rem]", align: "justify-center" },
   { label: "FE 배정", width: "w-[6.5625rem]", align: "justify-center" },

--- a/src/features/application/ui/ApplicationDetailModal.tsx
+++ b/src/features/application/ui/ApplicationDetailModal.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { isAxiosError } from "axios"
 import { useEffect, useMemo, useRef, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
@@ -146,9 +147,9 @@ export function ApplicationDetailModal({
     },
     onError: (error, variables) => {
       // 서버 에러 메시지 토스트
-      const serverMessage = (
-        error as { response?: { data?: { message?: string } } }
-      )?.response?.data?.message
+      const serverMessage = isAxiosError(error)
+        ? error.response?.data?.message
+        : undefined
       addToast({
         message: serverMessage ?? "배정 상태 변경에 실패했습니다.",
         color: "red",

--- a/src/features/application/ui/ApplicationDetailModal.tsx
+++ b/src/features/application/ui/ApplicationDetailModal.tsx
@@ -23,6 +23,10 @@ interface ApplicationDetailModalProps {
   onOpenChange: (open: boolean) => void
   /** 현재 활성 차수 (이전 차수의 상태 칩 disabled 처리) */
   currentRound?: number
+  /** APPLY-102 권한 없는 역할(SCHOOL_PRESIDENT 등) - 지원자 행 클릭 시 폼 패널 열리지 않음 */
+  disableFormPanel?: boolean
+  /** 플랜 챌린저(PM) 뷰: 대기 상태 옵션 숨김 */
+  hidePendingStatus?: boolean
 }
 
 function toApplicationId(applicantId: string): number | null {
@@ -36,6 +40,8 @@ export function ApplicationDetailModal({
   open,
   onOpenChange,
   currentRound,
+  disableFormPanel = false,
+  hidePendingStatus = false,
 }: ApplicationDetailModalProps) {
   const addToast = useToastStore((s) => s.addToast)
 
@@ -130,7 +136,19 @@ export function ApplicationDetailModal({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: applicationKeys.all })
     },
-    onError: (_error, variables) => {
+    onError: (error, variables) => {
+      // 서버 에러 메시지 토스트
+      const serverMessage = (
+        error as { response?: { data?: { message?: string } } }
+      )?.response?.data?.message
+      addToast({
+        message: serverMessage ?? "배정 상태 변경에 실패했습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      // 낙관적 업데이트 롤백
       setStatusOverrides((prev) => {
         const next = { ...prev }
         delete next[variables.appId]
@@ -223,12 +241,15 @@ export function ApplicationDetailModal({
               onRoundFilterChange={setRoundFilter}
               onStatusFilterChange={setStatusFilter}
               selectedApplicantId={selectedApplicantId}
-              onApplicantClick={setSelectedApplicantId}
+              onApplicantClick={
+                disableFormPanel ? () => {} : setSelectedApplicantId
+              }
               onStatusChange={handleApplicantStatusChange}
               onClose={handleClose}
               currentRound={currentRound}
               canApproveApplicant={canApproveApplicant}
               approvePermissionLoading={isApprovePermissionLoading}
+              statusOptions={hidePendingStatus ? ["pass", "fail"] : undefined}
               className="w-full"
             />
           </div>
@@ -251,6 +272,7 @@ export function ApplicationDetailModal({
                   selectedApplicant.round,
                 )
               }
+              hidePendingStatus={hidePendingStatus}
               className="max-h-[calc(100vh-60px)] shadow-xl"
             />
           )}

--- a/src/features/application/ui/ApplicationDetailModal.tsx
+++ b/src/features/application/ui/ApplicationDetailModal.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
 import { useResourcePermissionsBatch } from "@/features/auth/hooks/useResourcePermissionsBatch"
@@ -54,9 +54,17 @@ export function ApplicationDetailModal({
     Record<string, StatusValue>
   >({})
 
+  // 이중 실행 방지용 ref (Strict Mode 대응)
+  const emptyToastShownRef = useRef(false)
+
   // 지원자 없는 프로젝트 모달 오픈 시 토스트 노출
   useEffect(() => {
-    if (open && project.applicants.length === 0) {
+    if (!open) {
+      emptyToastShownRef.current = false
+      return
+    }
+    if (project.applicants.length === 0 && !emptyToastShownRef.current) {
+      emptyToastShownRef.current = true
       addToast({
         message: "아직 지원자가 없습니다.",
         color: "primary",
@@ -65,7 +73,7 @@ export function ApplicationDetailModal({
         duration: 3000,
       })
     }
-  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [open, addToast])
 
   const applicationIds = useMemo(() => {
     const ids = new Set<number>()

--- a/src/features/application/ui/ApplicationTableSection.tsx
+++ b/src/features/application/ui/ApplicationTableSection.tsx
@@ -66,6 +66,10 @@ interface ApplicationTableSectionProps {
   currentRound?: number
   /** 현재 선택된 챕터 이름 (상세 모달 전달용) */
   chapterName?: string
+  /** APPLY-102 단건 상세 권한 없는 역할(SCHOOL_PRESIDENT 등)일 때 true - 모달은 열리지만 폼 패널 비활성 */
+  disableFormPanel?: boolean
+  /** 플랜 챌린저(PM) 뷰: 대기 상태 옵션 숨김 */
+  hidePendingStatus?: boolean
   className?: string
 }
 
@@ -77,6 +81,8 @@ export function ApplicationTableSection({
   visibleFilters = DEFAULT_FILTERS,
   currentRound,
   chapterName,
+  disableFormPanel = false,
+  hidePendingStatus = false,
   className,
 }: ApplicationTableSectionProps) {
   const [searchQuery, setSearchQuery] = useState("")
@@ -342,6 +348,8 @@ export function ApplicationTableSection({
           open={detailModalOpen}
           onOpenChange={setDetailModalOpen}
           currentRound={currentRound}
+          disableFormPanel={disableFormPanel}
+          hidePendingStatus={hidePendingStatus}
         />
       )}
     </div>

--- a/src/features/application/ui/ChallengerApplicationView.tsx
+++ b/src/features/application/ui/ChallengerApplicationView.tsx
@@ -74,6 +74,7 @@ export function ChallengerApplicationView({
         searchPlaceholder="닉네임/이름으로 검색하세요."
         visibleFilters={["part", "school"]}
         currentRound={currentRound}
+        hidePendingStatus
       />
     </div>
   )

--- a/src/features/application/ui/ProjectStatusRow.tsx
+++ b/src/features/application/ui/ProjectStatusRow.tsx
@@ -59,21 +59,20 @@ export function ProjectStatusRow({
     >
       <div className="flex flex-1 items-center">
         {/* 프로젝트 */}
-        <div className="w-50 pr-4">
-          <ProjectLinkButton
-            name={projectName}
-            isSelected={isExpanded}
-            onClick={onProjectClick}
-          />
-        </div>
+        <ProjectLinkButton
+          name={projectName}
+          isSelected={isExpanded}
+          onClick={onProjectClick}
+          className="w-46 px-2.5"
+        />
 
         {/* 파트 */}
-        <div className="flex h-12.5 w-30.5 items-center px-2.5">
+        <div className="flex h-12.5 w-30.5 items-center justify-center px-2.5">
           <PartTagChip role={role} />
         </div>
 
         {/* 챌린저 */}
-        <div className="flex h-12.5 w-50 items-center rounded-lg px-16">
+        <div className="flex h-12.5 w-50 items-center px-4">
           <div className="flex flex-col whitespace-nowrap">
             <span className="text-body-2-medium text-teal-gray-900">
               {challengerName}

--- a/src/features/application/ui/detail-modal/ApplicantRoleSection.tsx
+++ b/src/features/application/ui/detail-modal/ApplicantRoleSection.tsx
@@ -15,6 +15,7 @@ interface ApplicantRoleSectionProps {
   currentRound?: number
   canApproveApplicant: (applicantId: string) => boolean
   approvePermissionLoading: boolean
+  statusOptions?: StatusValue[]
   className?: string
 }
 
@@ -28,6 +29,7 @@ export function ApplicantRoleSection({
   currentRound,
   canApproveApplicant,
   approvePermissionLoading,
+  statusOptions,
   className,
 }: ApplicantRoleSectionProps) {
   const roundCounts = applicants.reduce<Record<number, number>>((acc, a) => {
@@ -84,6 +86,7 @@ export function ApplicantRoleSection({
               onClick={() => onApplicantClick(applicant.id)}
               onStatusChange={(s) => onStatusChange?.(applicant.id, s)}
               statusDisabled={statusDisabled}
+              statusOptions={statusOptions}
             />
           )
         })}

--- a/src/features/application/ui/detail-modal/ApplicantRow.tsx
+++ b/src/features/application/ui/detail-modal/ApplicantRow.tsx
@@ -15,6 +15,7 @@ interface ApplicantRowProps {
   onClick?: () => void
   onStatusChange?: (status: StatusValue) => void
   statusDisabled?: boolean
+  statusOptions?: StatusValue[]
 }
 
 export function ApplicantRow({
@@ -28,6 +29,7 @@ export function ApplicantRow({
   onClick,
   onStatusChange,
   statusDisabled = false,
+  statusOptions,
 }: ApplicantRowProps) {
   return (
     <div
@@ -64,6 +66,7 @@ export function ApplicantRow({
               <StatusChipDropdown
                 value={status}
                 onValueChange={onStatusChange}
+                options={statusOptions}
               />
             )}
           </div>

--- a/src/features/application/ui/detail-modal/ModalApplicantPanel.tsx
+++ b/src/features/application/ui/detail-modal/ModalApplicantPanel.tsx
@@ -39,6 +39,7 @@ interface ModalApplicantPanelProps {
   currentRound?: number
   canApproveApplicant: (applicantId: string) => boolean
   approvePermissionLoading: boolean
+  statusOptions?: StatusValue[]
   className?: string
 }
 
@@ -56,6 +57,7 @@ export function ModalApplicantPanel({
   currentRound,
   canApproveApplicant,
   approvePermissionLoading,
+  statusOptions,
   className,
 }: ModalApplicantPanelProps) {
   const filteredApplicants = useMemo(() => {
@@ -250,6 +252,7 @@ export function ModalApplicantPanel({
               currentRound={currentRound}
               canApproveApplicant={canApproveApplicant}
               approvePermissionLoading={approvePermissionLoading}
+              statusOptions={statusOptions}
             />
           ))
         ) : (
@@ -266,6 +269,7 @@ export function ModalApplicantPanel({
                 currentRound={currentRound}
                 canApproveApplicant={canApproveApplicant}
                 approvePermissionLoading={approvePermissionLoading}
+                statusOptions={statusOptions}
               />
             ))}
 

--- a/src/features/application/ui/detail-modal/ModalFormPanel.tsx
+++ b/src/features/application/ui/detail-modal/ModalFormPanel.tsx
@@ -55,6 +55,7 @@ interface ModalFormPanelProps {
   onUnmatch?: () => void
   onClose: () => void
   statusDisabled?: boolean
+  hidePendingStatus?: boolean
   className?: string
 }
 
@@ -70,6 +71,7 @@ export function ModalFormPanel({
   onUnmatch,
   onClose,
   statusDisabled = false,
+  hidePendingStatus = false,
   className,
 }: ModalFormPanelProps) {
   const roleLabel = ROLE_LABEL[applicant.role] ?? applicant.role
@@ -151,13 +153,15 @@ export function ModalFormPanel({
                   >
                     불합격
                   </OptionButton>
-                  <OptionButton
-                    value="pending"
-                    disabled={statusDisabled}
-                    className="h-7.5 gap-0.5 font-normal!"
-                  >
-                    대기
-                  </OptionButton>
+                  {!hidePendingStatus && (
+                    <OptionButton
+                      value="pending"
+                      disabled={statusDisabled}
+                      className="h-7.5 gap-0.5 font-normal!"
+                    >
+                      대기
+                    </OptionButton>
+                  )}
                 </OptionButtonGroup>
               )}
             </div>
@@ -172,6 +176,7 @@ export function ModalFormPanel({
                 <StatusChipDropdown
                   value={applicant.status}
                   onValueChange={onStatusChange}
+                  options={hidePendingStatus ? ["pass", "fail"] : undefined}
                 />
               )}
             </div>

--- a/src/features/matching/ui/MatchingPartSection.tsx
+++ b/src/features/matching/ui/MatchingPartSection.tsx
@@ -21,7 +21,7 @@ export function MatchingPartSection({
       </div>
 
       {/* 테이블 영역 */}
-      <div className="border-teal-gray-300 overflow-clip rounded-b-xl border-x border-b">
+      <div className="overflow-clip rounded-b-xl border-x border-b border-teal-200">
         {children}
       </div>
     </div>

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -107,7 +107,7 @@ function MatchingApplicationsPage() {
 
         <div className="mt-6 flex flex-col gap-13">
           {canApprove && (
-            <div className="ml-4 flex w-263 flex-col gap-13">
+            <div className="flex w-263 flex-col gap-13">
               <SegmentButton
                 items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
                 value={selectedChapter}
@@ -152,7 +152,7 @@ function MatchingApplicationsPage() {
           )}
 
           {isSchoolView && (
-            <div className="ml-4 flex w-263 flex-col gap-13">
+            <div className="flex w-263 flex-col gap-13">
               <SegmentButton
                 items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
                 value={selectedChapter}

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -18,6 +18,7 @@ import {
   isChapterPresident,
   isCurrentTermPm,
   isOperator,
+  isSchoolStaff,
 } from "@/features/auth/model/identity"
 import { ProjectTitleCard } from "@/shared/ui/ProjectTitleCard"
 import { SegmentButton } from "@/shared/ui/segment-button/SegmentButton"
@@ -48,6 +49,8 @@ function MatchingApplicationsPage() {
   const [selectedChapter, setSelectedChapter] = useState(defaultChapter)
 
   const canApprove = isOperator(viewMe)
+  // SCHOOL_PRESIDENT 등 학교 운영진: APPLY-101 목록 조회 가능, APPLY-102 상세 불가
+  const isSchoolView = !canApprove && isSchoolStaff(viewMe)
   const isPm = isCurrentTermPm(viewMe)
   const isOthers = !isAnyOperator(viewMe) && !isPm
 
@@ -68,13 +71,13 @@ function MatchingApplicationsPage() {
     }
   }, [me, chapters, userChapter])
 
-  const admin = useAdminPageData(selectedChapter)
+  // SCHOOL_PRESIDENT는 챕터 필터 없이 조회 (서버가 학교 단위로 APPLY-101 결과를 필터링)
+  const admin = useAdminPageData(isSchoolView ? undefined : selectedChapter)
   const adminStats = admin.stats
   const adminProjects = admin.projects
 
   const challenger = useChallengerPageData()
   const pmProjects = challenger.projects
-  const pmProjectInfo = challenger.projectInfo
 
   return (
     <section className="flex w-full flex-col">
@@ -87,17 +90,6 @@ function MatchingApplicationsPage() {
             프로젝트 지원 내역을 통합 관리합니다.
           </p>
         </div>
-
-        {isPm && pmProjectInfo && (
-          <ProjectTitleCard
-            className="mt-6"
-            projectName={pmProjectInfo.projectName}
-            challengerName={pmProjectInfo.pmName}
-            challengerUniversity={pmProjectInfo.pmUniversity}
-            thumbnailUrl={pmProjectInfo.thumbnailUrl}
-            size="lg"
-          />
-        )}
 
         <div className="mt-6 flex flex-col gap-13">
           {canApprove && (
@@ -133,6 +125,32 @@ function MatchingApplicationsPage() {
             </div>
           )}
 
+          {isSchoolView && (
+            <div className="ml-4 flex w-263 flex-col gap-13">
+              {admin.isLoading ? (
+                <div className="flex items-center justify-center py-20">
+                  <p className="text-body-2-regular text-teal-gray-400">
+                    데이터를 불러오는 중...
+                  </p>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-14.25">
+                  <ApplicationStatsSection
+                    stats={adminStats}
+                    dataUpdatedAt={admin.dataUpdatedAt}
+                    currentRound={admin.currentRound}
+                    activeRound={admin.activeRound}
+                  />
+                  <ApplicationTableSection
+                    projects={adminProjects}
+                    currentRound={admin.currentRound}
+                    disableFormPanel
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
           {isPm && (
             <>
               {challenger.isLoading ? (
@@ -141,11 +159,27 @@ function MatchingApplicationsPage() {
                     데이터를 불러오는 중...
                   </p>
                 </div>
-              ) : (
+              ) : pmProjects.length === 0 ? (
                 <ChallengerApplicationView
-                  projects={pmProjects}
+                  projects={[]}
                   currentRound={challenger.currentRound}
                 />
+              ) : (
+                pmProjects.map((project) => (
+                  <div key={project.id} className="flex flex-col gap-6">
+                    <ProjectTitleCard
+                      projectName={project.projectName}
+                      challengerName={project.challengerName}
+                      challengerUniversity={project.challengerUniversity}
+                      thumbnailUrl={project.thumbnailUrl}
+                      size="lg"
+                    />
+                    <ChallengerApplicationView
+                      projects={[project]}
+                      currentRound={challenger.currentRound}
+                    />
+                  </div>
+                ))
               )}
             </>
           )}

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -153,6 +153,23 @@ function MatchingApplicationsPage() {
 
           {isSchoolView && (
             <div className="ml-4 flex w-263 flex-col gap-13">
+              <SegmentButton
+                items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
+                value={selectedChapter}
+                onValueChange={(v) => {
+                  if (v !== selectedChapter) {
+                    addToast({
+                      message: "본인 학교의 지원 현황만 조회할 수 있습니다.",
+                      color: "red",
+                      variant: "deep",
+                      type: "default",
+                      duration: 3000,
+                    })
+                  }
+                }}
+                className="w-full min-w-0 [&>button>span:last-child]:min-w-0 [&>button>span:last-child]:truncate"
+                itemClassName="min-w-0 flex-1 basis-0 shrink px-2"
+              />
               {admin.isLoading ? (
                 <div className="flex items-center justify-center py-20">
                   <p className="text-body-2-regular text-teal-gray-400">

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { useLayoutEffect, useRef, useState } from "react"
 
+import { useToastStore } from "@/components/toast/useToastStore"
 import {
   useAdminPageData,
   useChallengerPageData,
@@ -15,10 +16,12 @@ import { ensureMe } from "@/features/auth/lib/ensureMe"
 import {
   getViewerBranch,
   isAnyOperator,
+  isCentralStaff,
   isChapterPresident,
   isCurrentTermPm,
   isOperator,
   isSchoolStaff,
+  isSuperAdmin,
 } from "@/features/auth/model/identity"
 import { ProjectTitleCard } from "@/shared/ui/ProjectTitleCard"
 import { SegmentButton } from "@/shared/ui/segment-button/SegmentButton"
@@ -35,6 +38,7 @@ export const Route = createFileRoute("/matching/applications")({
 function MatchingApplicationsPage() {
   const { data: me } = useMe()
   const { viewMe } = useViewMe()
+  const addToast = useToastStore((s) => s.addToast)
   const chaptersQuery = useChapters()
   const chapters = chaptersQuery.data?.chapters ?? []
 
@@ -48,7 +52,13 @@ function MatchingApplicationsPage() {
 
   const [selectedChapter, setSelectedChapter] = useState(defaultChapter)
 
+  // 지부장 본인 지부 추적 (auto-select 후 갱신)
+  const ownChapter = useRef<string>(defaultChapter)
+
   const canApprove = isOperator(viewMe)
+  // 지부장 본인 지부만 조회 가능 (SUPER_ADMIN/중앙 운영진 제외)
+  const isRestrictedToChapter =
+    isChapterPresident(me) && !isSuperAdmin(me) && !isCentralStaff(me)
   // SCHOOL_PRESIDENT 등 학교 운영진: APPLY-101 목록 조회 가능, APPLY-102 상세 불가
   const isSchoolView = !canApprove && isSchoolStaff(viewMe)
   const isPm = isCurrentTermPm(viewMe)
@@ -67,6 +77,7 @@ function MatchingApplicationsPage() {
     const myChapter = chapters.find((c) => c.id === myChapterId)
     if (myChapter) {
       setSelectedChapter(myChapter.name)
+      ownChapter.current = myChapter.name
       hasAutoSelected.current = true
     }
   }, [me, chapters, userChapter])
@@ -97,7 +108,19 @@ function MatchingApplicationsPage() {
               <SegmentButton
                 items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
                 value={selectedChapter}
-                onValueChange={(v) => setSelectedChapter(v)}
+                onValueChange={(v) => {
+                  if (isRestrictedToChapter && v !== ownChapter.current) {
+                    addToast({
+                      message: "본인 지부의 지원 현황만 조회할 수 있습니다.",
+                      color: "red",
+                      variant: "deep",
+                      type: "default",
+                      duration: 3000,
+                    })
+                    return
+                  }
+                  setSelectedChapter(v)
+                }}
                 className="w-full min-w-0 [&>button>span:last-child]:min-w-0 [&>button>span:last-child]:truncate"
                 itemClassName="min-w-0 flex-1 basis-0 shrink px-2"
               />

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -82,8 +82,11 @@ function MatchingApplicationsPage() {
     }
   }, [me, chapters, userChapter])
 
-  // SCHOOL_PRESIDENT는 챕터 필터 없이 조회 (서버가 학교 단위로 APPLY-101 결과를 필터링)
-  const admin = useAdminPageData(isSchoolView ? undefined : selectedChapter)
+  // SCHOOL_PRESIDENT: 챕터 필터 없이 조회 후 프론트에서 본인 학교 프로젝트만 필터링
+  const admin = useAdminPageData(
+    isSchoolView ? undefined : selectedChapter,
+    isSchoolView ? (me?.schoolName ?? undefined) : undefined,
+  )
   const adminStats = admin.stats
   const adminProjects = admin.projects
 

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -434,24 +434,6 @@ function MatchingRoundsPage() {
       return
     }
 
-    // 시작 또는 종료 일시가 현재 시각보다 이전인 경우
-    const now = new Date()
-    const hasPastDate = filledRounds.some((r) => {
-      const start = new Date(`${r.startDate}T${r.startTime}:00`)
-      const end = new Date(`${r.endDate}T${r.endTime}:00`)
-      return start < now || end < now
-    })
-    if (hasPastDate) {
-      addToast({
-        message: "매칭 날짜를 다시 확인해 주세요.",
-        color: "red",
-        variant: "deep",
-        type: "default",
-        duration: 3000,
-      })
-      return
-    }
-
     // Case 4: 단일 차수 기간 3일 초과
     const hasExceededMaxDays = filledRounds.some((r) => {
       if (!r.startDate || !r.endDate) return false

--- a/src/routes/matching/route.tsx
+++ b/src/routes/matching/route.tsx
@@ -1,11 +1,10 @@
-import { createFileRoute, Outlet, useMatchRoute } from "@tanstack/react-router"
+import { createFileRoute, Outlet } from "@tanstack/react-router"
 
 import Footer from "@/components/footer/Footer"
 import Header from "@/components/header/Header"
 import { MatchingSegmentRegion } from "@/components/sidebar/MatchingSegmentRegion"
 import SideBar from "@/components/sidebar/SideBar"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
-import { cn } from "@/shared/lib/utils"
 
 export const Route = createFileRoute("/matching")({
   beforeLoad: async ({ context }) => {
@@ -15,20 +14,13 @@ export const Route = createFileRoute("/matching")({
 })
 
 function MatchingLayout() {
-  const matchRoute = useMatchRoute()
-  const isProjectsIndex = Boolean(matchRoute({ to: "/matching/projects" }))
   return (
     <main className="flex h-full min-h-screen w-full flex-col">
       <Header />
       <div className="flex w-full flex-1">
         <SideBar />
         <div className="flex min-w-0 flex-1 flex-col">
-          <div
-            className={cn(
-              "px-4 pt-6 min-[960px]:pt-12",
-              isProjectsIndex ? "min-[960px]:px-9.5" : "min-[960px]:px-11",
-            )}
-          >
+          <div className="px-4 pt-6 min-[960px]:px-11 min-[960px]:pt-12">
             <MatchingSegmentRegion />
             <div className="flex min-w-0 flex-1 flex-col pt-6 pb-20 min-[960px]:pt-8">
               <Outlet />

--- a/src/routes/matching/status.tsx
+++ b/src/routes/matching/status.tsx
@@ -95,7 +95,7 @@ function MatchingStatusPage() {
         </div>
 
         {/* 지부 선택 + 콘텐츠 */}
-        <div className="mt-6 ml-4 flex w-263 flex-col gap-13">
+        <div className="mt-6 flex w-263 flex-col gap-13">
           <SegmentButton
             items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
             value={selectedChapter}

--- a/src/shared/ui/chip/StatusChipDropdown.tsx
+++ b/src/shared/ui/chip/StatusChipDropdown.tsx
@@ -13,6 +13,7 @@ interface StatusChipDropdownProps {
   value: StatusValue
   onValueChange?: (value: StatusValue) => void
   disabled?: boolean
+  options?: StatusValue[]
   children?: ReactNode
   className?: string
 }
@@ -21,6 +22,7 @@ export function StatusChipDropdown({
   value,
   onValueChange,
   disabled = false,
+  options = STATUS_OPTIONS,
   children,
   className,
 }: StatusChipDropdownProps) {
@@ -55,7 +57,7 @@ export function StatusChipDropdown({
               배정 상태 변경
             </span>
             <div className="flex flex-col gap-2.5">
-              {STATUS_OPTIONS.map((status) => (
+              {options.map((status) => (
                 <button
                   key={status}
                   type="button"


### PR DESCRIPTION
## 📸 작업 내용                                                                                               
  
  > 지원 현황 페이지 역할별 뷰 분기 및 통계 데이터 정확도 개선                                                  
                                                            
  - PM(플랜 챌린저) 배정 상태 변경 시 "대기" 옵션 제거 — 합격/불합격만 선택 가능                                
  - 배정 상태 변경 실패 시 서버 에러 메시지를 토스트로 노출 
  - SCHOOL_PRESIDENT 역할에 대한 지원 현황 뷰 추가 (폼 패널 비활성, 챕터 필터 미적용)
  - 학교별 지원자 수 집계 기준을 `matchedMemberCount` → `roundSchoolRankings` 전 차수 합산으로 변경
  - `filterRound=0`(1차 진행 중) 상태에서도 1차 차수 통계가 항상 표시되도록 수정

  ## 🎞️  주요 코드 설명

  ### `PM 뷰 대기 옵션 제거`

  ```TypeScript
  // StatusChipDropdown.tsx
  interface StatusChipDropdownProps {
    options?: StatusValue[] // 기본값: ["pass", "fail", "pending"]
  }

  // ChallengerApplicationView.tsx
  <ApplicationTableSection hidePendingStatus />

  - hidePendingStatus prop을 ChallengerApplicationView → ApplicationTableSection → ApplicationDetailModal →
  ModalApplicantPanel/ModalFormPanel 까지 전달
  - StatusChipDropdown에 options prop 추가해 PM 뷰에서는 ["pass", "fail"]만 렌더링

  roundSchoolRankings 기반 지원자 수 집계

  const schoolApplicantCounts = new Map<string, number>()
  for (const ranking of chapterStatsQuery.data.summary.roundSchoolRankings ?? []) {
    for (const s of ranking.schools) {
      const id = String(s.schoolId)
      if (chapterSchoolIds && !chapterSchoolIds.has(id)) continue
      schoolApplicantCounts.set(
        id,
        (schoolApplicantCounts.get(id) ?? 0) + Number(s.applicantCount),
      )
    }
  }
```

  - 기존 matchedMemberCount(매칭 완료 수)가 아닌 실제 지원자 수 집계로 변경
  - 챕터 소속 학교 필터링 병행 적용

  ### `1차 차수 항상 표시`
```
  .filter(
    (r) => filterRound === undefined || r.round <= Math.max(1, filterRound),
  )
```
  - filterRound=0일 때 기존 로직은 모든 차수를 필터링해 availableMemberCount 미표시
  - Math.max(1, filterRound)로 최소 1차는 항상 포함


  🔗 연결된 이슈

  - Closed #269 