### PR TITLE
🐛 fix: 지원 API 엔드포인트 me → applicationId 변경 대응

### DIFF
--- a/src/features/project/list/api/matchingProject.test.ts
+++ b/src/features/project/list/api/matchingProject.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  type ApplicationAnswerItem,
+  saveApplicationDraft,
+  submitApplication,
+} from "./matchingProject"
+
+const { putMock, postMock } = vi.hoisted(() => ({
+  putMock: vi.fn(),
+  postMock: vi.fn(),
+}))
+
+vi.mock("@/shared/lib/axios", () => ({
+  api: { put: putMock, post: postMock },
+}))
+
+describe("saveApplicationDraft", () => {
+  beforeEach(() => {
+    putMock.mockReset()
+  })
+
+  it("applicationId 기반 경로로 PUT 호출하고 body는 answers", async () => {
+    putMock.mockResolvedValue({
+      data: { result: { applicationId: "10", status: "DRAFT" } },
+    })
+    const answers: ApplicationAnswerItem[] = [
+      { questionId: 1, textValue: "answer" },
+    ]
+
+    const result = await saveApplicationDraft(7, 10, answers)
+
+    expect(putMock).toHaveBeenCalledWith("/v1/projects/7/applications/10", {
+      answers,
+    })
+    expect(result).toEqual({ applicationId: "10", status: "DRAFT" })
+  })
+
+  it("me 레거시 경로를 호출하지 않는다", async () => {
+    putMock.mockResolvedValue({
+      data: { result: { applicationId: "10", status: "DRAFT" } },
+    })
+
+    await saveApplicationDraft(7, 10, [])
+
+    expect(putMock.mock.calls[0]?.[0]).not.toContain("/applications/me")
+  })
+})
+
+describe("submitApplication", () => {
+  beforeEach(() => {
+    postMock.mockReset()
+  })
+
+  it("applicationId 기반 submit 경로로 POST 호출", async () => {
+    postMock.mockResolvedValue({
+      data: { result: { applicationId: "10", status: "SUBMITTED" } },
+    })
+
+    const result = await submitApplication(7, 10)
+
+    expect(postMock).toHaveBeenCalledWith(
+      "/v1/projects/7/applications/10/submit",
+    )
+    expect(result).toEqual({ applicationId: "10", status: "SUBMITTED" })
+  })
+
+  it("me 레거시 경로를 호출하지 않는다", async () => {
+    postMock.mockResolvedValue({
+      data: { result: { applicationId: "10", status: "SUBMITTED" } },
+    })
+
+    await submitApplication(7, 10)
+
+    expect(postMock.mock.calls[0]?.[0]).not.toContain("/applications/me")
+  })
+})

--- a/src/features/project/list/api/matchingProject.ts
+++ b/src/features/project/list/api/matchingProject.ts
@@ -230,10 +230,11 @@ export async function createApplicationDraft(
 
 export async function saveApplicationDraft(
   projectId: number,
+  applicationId: number,
   answers: ApplicationAnswerItem[],
 ): Promise<ApplicationStatusResponse> {
   const { data } = await api.put<ApiResponse<ApplicationStatusResponse>>(
-    `/v1/projects/${projectId}/applications/me`,
+    `/v1/projects/${projectId}/applications/${applicationId}`,
     { answers },
   )
   return data.result
@@ -241,9 +242,10 @@ export async function saveApplicationDraft(
 
 export async function submitApplication(
   projectId: number,
+  applicationId: number,
 ): Promise<ApplicationStatusResponse> {
   const { data } = await api.post<ApiResponse<ApplicationStatusResponse>>(
-    `/v1/projects/${projectId}/applications/me/submit`,
+    `/v1/projects/${projectId}/applications/${applicationId}/submit`,
   )
   return data.result
 }

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -304,12 +304,22 @@ export function ProjectApplyModal({
     const formValues = pendingFormValuesRef.current
     if (!formValues) return
     setIsSubmitConfirmModalOpen(false)
+    if (!isDevMatchingRound && applicationId === null) {
+      addToast({
+        message: "지원서 정보를 불러오지 못했습니다. 다시 시도해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return
+    }
     setIsSubmitting(true)
     try {
-      if (!isDevMatchingRound) {
+      if (!isDevMatchingRound && applicationId !== null) {
         const answers = buildAnswerPayload(formValues, sections, sectionEnabled)
-        await saveApplicationDraft(projectId, answers)
-        await submitApplication(projectId)
+        await saveApplicationDraft(projectId, applicationId, answers)
+        await submitApplication(projectId, applicationId)
       }
       setIsCompleteModalOpen(true)
     } catch (err) {


### PR DESCRIPTION
## 📸 작업 내용

> 서버의 지원서 임시저장/최종제출 API 엔드포인트 변경(`/applications/me` → `/applications/{applicationId}`)에 프론트를 맞췄습니다.

- `saveApplicationDraft`: `PUT /v1/projects/{projectId}/applications/me` → `.../applications/{applicationId}` (인자에 `applicationId` 추가)
- `submitApplication`: `POST .../applications/me/submit` → `.../applications/{applicationId}/submit` (인자에 `applicationId` 추가)
- request body는 기존과 동일 (`{ answers }` / 본문 없음)
- 호출처(`ProjectApplyModal`)는 이미 보유한 `applicationId` 상태를 전달, draft 미생성 시 방어 처리 추가
- 회귀 방지 단위 테스트 추가 (api 모듈 mock, 서버 불필요)

## 🎞️ 주요 코드 설명

### 새 엔드포인트 적용

```TypeScript
export async function saveApplicationDraft(
  projectId: number,
  applicationId: number,
  answers: ApplicationAnswerItem[],
) {
  const { data } = await api.put(
    `/v1/projects/${projectId}/applications/${applicationId}`,
    { answers },
  )
  return data.result
}
```

- 컴포넌트가 draft 생성 응답으로 받은 `applicationId`를 PUT/submit 경로에 전달합니다.

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #288, #289
- Closes #288
- Closes #289