### PR TITLE
feat: 계정 설정 UI 및 api 구현

### DIFF
--- a/src/features/auth/api/me.ts
+++ b/src/features/auth/api/me.ts
@@ -146,6 +146,14 @@ export async function updateMemberInfo(body: {
   return data.result
 }
 
+// TODO: API CI 반영 후 확인 필요
+export async function changeEmail(body: {
+  newEmail: string
+  emailVerificationToken: string
+}): Promise<void> {
+  await api.patch("/v1/member/email", body)
+}
+
 export interface DeleteMemberRequest {
   googleAccessToken?: string
   kakaoAccessToken?: string

--- a/src/features/auth/hooks/useEmailVerification.ts
+++ b/src/features/auth/hooks/useEmailVerification.ts
@@ -4,6 +4,7 @@ import { useToastStore } from "@/components/toast/useToastStore"
 import {
   completeEmailVerification,
   getEmailAvailability,
+  resendEmailVerification,
   sendEmailVerification,
 } from "@/features/auth/api/emailVerification"
 
@@ -15,9 +16,9 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 /**
  * 이메일 인증 플로우를 관리하는 훅
  * 1단계: 이메일 입력 → 중복 확인 → 인증 코드 발송
- * 2단계: 인증 코드 입력 → 코드 검증 → emailVerificationToken 발급
+ * 2단계: 인증 코드 입력 → 코드 검증 → emailVerificationToken 반환
  *
- * @param purpose 인증 목적 (REGISTER | PASSWORD_RESET 등 백엔드 정의 값)
+ * @param purpose 인증 목적 (REGISTER | PASSWORD_RESET | CHANGE_EMAIL 등 백엔드 정의 값)
  * @returns 이메일/코드 상태, 각 단계 핸들러, UI 조건 플래그
  */
 export function useEmailVerification(purpose: EmailVerificationPurpose) {
@@ -29,9 +30,6 @@ export function useEmailVerification(purpose: EmailVerificationPurpose) {
   const [remainingSeconds, setRemainingSeconds] = useState(0)
   const [isDuplicated, setIsDuplicated] = useState(false)
   const [isCodeInvalid, setIsCodeInvalid] = useState(false)
-  const [verificationToken, setVerificationToken] = useState<string | null>(
-    null,
-  )
   const addToast = useToastStore((s) => s.addToast)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
@@ -69,18 +67,16 @@ export function useEmailVerification(purpose: EmailVerificationPurpose) {
     setIsDuplicated(false)
     if (isCodeVisible) {
       setIsCodeVisible(false)
-      setVerificationToken(null)
     }
   }
 
   /**
    * 인증 코드 입력 변경 시 호출
-   * 코드 불일치 에러 및 이전 토큰을 초기화한다
+   * 코드 불일치 에러를 초기화한다
    */
   const setCode = (value: string) => {
     setCodeState(value)
     setIsCodeInvalid(false)
-    setVerificationToken(null)
   }
 
   /**
@@ -100,7 +96,6 @@ export function useEmailVerification(purpose: EmailVerificationPurpose) {
       setVerificationId(Number(res.emailVerificationId))
       setIsCodeVisible(true)
       setCodeState("")
-      setVerificationToken(null)
       startTimer()
     } catch (err) {
       const message =
@@ -118,21 +113,45 @@ export function useEmailVerification(purpose: EmailVerificationPurpose) {
   }
 
   /**
-   * [확인] 버튼 핸들러
-   * 입력한 코드로 인증을 완료하고 emailVerificationToken을 발급받는다
-   * 이후 폼에서 변경 API 호출 시 이 토큰을 사용한다
+   * [인증 메일을 받지 못하셨나요?] 핸들러
+   * 기존 verificationId로 인증 코드를 재발송하고 타이머를 리셋한다
    */
-  const handleCodeVerify = async () => {
+  const handleResend = async () => {
     if (!verificationId) return
+    try {
+      await resendEmailVerification({ emailVerificationId: verificationId })
+      setCodeState("")
+      startTimer()
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "인증 메일 재발송에 실패했습니다."
+      addToast({
+        message,
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    }
+  }
+
+  /**
+   * 코드 검증 후 emailVerificationToken 반환
+   * 폼의 최종 제출(변경하기) 시 호출하여 반환값을 변경 API에 전달한다
+   * 실패 시 null 반환 + isCodeInvalid 플래그 세팅
+   */
+  const handleCodeVerify = async (): Promise<string | null> => {
+    if (!verificationId) return null
     setIsCodeInvalid(false)
     try {
       const res = await completeEmailVerification({
         emailVerificationId: verificationId,
         verificationCode: code,
       })
-      setVerificationToken(res.emailVerificationToken)
+      return res.emailVerificationToken
     } catch {
       setIsCodeInvalid(true)
+      return null
     }
   }
 
@@ -148,8 +167,8 @@ export function useEmailVerification(purpose: EmailVerificationPurpose) {
     isCodeInvalid,
     isExpired,
     isEmailValid,
-    verificationToken,
     handleVerificationClick,
+    handleResend,
     handleCodeVerify,
   }
 }

--- a/src/features/auth/hooks/useEmailVerification.ts
+++ b/src/features/auth/hooks/useEmailVerification.ts
@@ -12,6 +12,7 @@ import { emailSchema } from "@/features/signup/validation"
 import type { EmailVerificationPurpose } from "@/features/auth/model/types"
 
 const VERIFICATION_SECONDS = 600
+const RATE_LIMIT_SECONDS = 60
 
 /**
  * 이메일 인증 플로우를 관리하는 훅
@@ -30,8 +31,11 @@ export function useEmailVerification(purpose: EmailVerificationPurpose) {
   const [remainingSeconds, setRemainingSeconds] = useState(0)
   const [isDuplicated, setIsDuplicated] = useState(false)
   const [isCodeInvalid, setIsCodeInvalid] = useState(false)
+  const [attemptCount, setAttemptCount] = useState(0)
+  const [rateLimitSeconds, setRateLimitSeconds] = useState(0)
   const addToast = useToastStore((s) => s.addToast)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const rateLimitTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
   /** 10분 카운트다운 타이머 시작 (재발송 시 리셋) */
   const startTimer = () => {
@@ -48,15 +52,35 @@ export function useEmailVerification(purpose: EmailVerificationPurpose) {
     }, 1000)
   }
 
+  /** 1분 쿨다운 타이머 시작 (발송/재발송 시 호출) */
+  const startRateLimitTimer = () => {
+    if (rateLimitTimerRef.current) clearInterval(rateLimitTimerRef.current)
+    setRateLimitSeconds(RATE_LIMIT_SECONDS)
+    rateLimitTimerRef.current = setInterval(() => {
+      setRateLimitSeconds((prev) => {
+        if (prev <= 1) {
+          clearInterval(rateLimitTimerRef.current!)
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+  }
+
   useEffect(() => {
     return () => {
       if (timerRef.current) clearInterval(timerRef.current)
+      if (rateLimitTimerRef.current) clearInterval(rateLimitTimerRef.current)
     }
   }, [])
 
   const isEmailValid = emailSchema.safeParse(email).success
   /** 타이머가 만료된 상태 (코드 입력 불가) */
   const isExpired = isCodeVisible && remainingSeconds === 0
+  /** 발송 후 1분 쿨다운 중 (인증하기 버튼 비활성) */
+  const isRateLimited = rateLimitSeconds > 0
+  /** 인증번호 입력 5회 초과 */
+  const isAttemptsExceeded = attemptCount >= 5
 
   /**
    * 이메일 입력 변경 시 호출
@@ -96,7 +120,9 @@ export function useEmailVerification(purpose: EmailVerificationPurpose) {
       setVerificationId(Number(res.emailVerificationId))
       setIsCodeVisible(true)
       setCodeState("")
+      setAttemptCount(0)
       startTimer()
+      startRateLimitTimer()
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "인증 메일 발송에 실패했습니다."
@@ -121,7 +147,9 @@ export function useEmailVerification(purpose: EmailVerificationPurpose) {
     try {
       await resendEmailVerification({ emailVerificationId: verificationId })
       setCodeState("")
+      setAttemptCount(0)
       startTimer()
+      startRateLimitTimer()
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "인증 메일 재발송에 실패했습니다."
@@ -151,6 +179,7 @@ export function useEmailVerification(purpose: EmailVerificationPurpose) {
       return res.emailVerificationToken
     } catch {
       setIsCodeInvalid(true)
+      setAttemptCount((prev) => prev + 1)
       return null
     }
   }
@@ -167,6 +196,8 @@ export function useEmailVerification(purpose: EmailVerificationPurpose) {
     isCodeInvalid,
     isExpired,
     isEmailValid,
+    isRateLimited,
+    isAttemptsExceeded,
     handleVerificationClick,
     handleResend,
     handleCodeVerify,

--- a/src/features/auth/hooks/useEmailVerification.ts
+++ b/src/features/auth/hooks/useEmailVerification.ts
@@ -1,0 +1,155 @@
+import { useEffect, useRef, useState } from "react"
+
+import { useToastStore } from "@/components/toast/useToastStore"
+import {
+  completeEmailVerification,
+  getEmailAvailability,
+  sendEmailVerification,
+} from "@/features/auth/api/emailVerification"
+
+import type { EmailVerificationPurpose } from "@/features/auth/model/types"
+
+const VERIFICATION_SECONDS = 600
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+/**
+ * 이메일 인증 플로우를 관리하는 훅
+ * 1단계: 이메일 입력 → 중복 확인 → 인증 코드 발송
+ * 2단계: 인증 코드 입력 → 코드 검증 → emailVerificationToken 발급
+ *
+ * @param purpose 인증 목적 (REGISTER | PASSWORD_RESET 등 백엔드 정의 값)
+ * @returns 이메일/코드 상태, 각 단계 핸들러, UI 조건 플래그
+ */
+export function useEmailVerification(purpose: EmailVerificationPurpose) {
+  const [email, setEmailState] = useState("")
+  const [code, setCodeState] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+  const [verificationId, setVerificationId] = useState<number | null>(null)
+  const [isCodeVisible, setIsCodeVisible] = useState(false)
+  const [remainingSeconds, setRemainingSeconds] = useState(0)
+  const [isDuplicated, setIsDuplicated] = useState(false)
+  const [isCodeInvalid, setIsCodeInvalid] = useState(false)
+  const [verificationToken, setVerificationToken] = useState<string | null>(
+    null,
+  )
+  const addToast = useToastStore((s) => s.addToast)
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  /** 10분 카운트다운 타이머 시작 (재발송 시 리셋) */
+  const startTimer = () => {
+    if (timerRef.current) clearInterval(timerRef.current)
+    setRemainingSeconds(VERIFICATION_SECONDS)
+    timerRef.current = setInterval(() => {
+      setRemainingSeconds((prev) => {
+        if (prev <= 1) {
+          clearInterval(timerRef.current!)
+          return 0
+        }
+        return prev - 1
+      })
+    }, 1000)
+  }
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current)
+    }
+  }, [])
+
+  const isEmailValid = EMAIL_REGEX.test(email)
+  /** 타이머가 만료된 상태 (코드 입력 불가) */
+  const isExpired = isCodeVisible && remainingSeconds === 0
+
+  /**
+   * 이메일 입력 변경 시 호출
+   * 중복 에러 및 진행 중이던 인증 상태를 초기화한다
+   */
+  const setEmail = (value: string) => {
+    setEmailState(value)
+    setIsDuplicated(false)
+    if (isCodeVisible) {
+      setIsCodeVisible(false)
+      setVerificationToken(null)
+    }
+  }
+
+  /**
+   * 인증 코드 입력 변경 시 호출
+   * 코드 불일치 에러 및 이전 토큰을 초기화한다
+   */
+  const setCode = (value: string) => {
+    setCodeState(value)
+    setIsCodeInvalid(false)
+    setVerificationToken(null)
+  }
+
+  /**
+   * [인증하기] 버튼 핸들러
+   * 이메일 중복 확인 후 인증 코드 발송, 타이머 시작
+   */
+  const handleVerificationClick = async () => {
+    setIsLoading(true)
+    setIsDuplicated(false)
+    try {
+      const availability = await getEmailAvailability({ email })
+      if (!availability.available) {
+        setIsDuplicated(true)
+        return
+      }
+      const res = await sendEmailVerification({ email, purpose })
+      setVerificationId(Number(res.emailVerificationId))
+      setIsCodeVisible(true)
+      setCodeState("")
+      setVerificationToken(null)
+      startTimer()
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "인증 메일 발송에 실패했습니다."
+      addToast({
+        message,
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  /**
+   * [확인] 버튼 핸들러
+   * 입력한 코드로 인증을 완료하고 emailVerificationToken을 발급받는다
+   * 이후 폼에서 변경 API 호출 시 이 토큰을 사용한다
+   */
+  const handleCodeVerify = async () => {
+    if (!verificationId) return
+    setIsCodeInvalid(false)
+    try {
+      const res = await completeEmailVerification({
+        emailVerificationId: verificationId,
+        verificationCode: code,
+      })
+      setVerificationToken(res.emailVerificationToken)
+    } catch {
+      setIsCodeInvalid(true)
+    }
+  }
+
+  return {
+    email,
+    setEmail,
+    code,
+    setCode,
+    isLoading,
+    isCodeVisible,
+    remainingSeconds,
+    isDuplicated,
+    isCodeInvalid,
+    isExpired,
+    isEmailValid,
+    verificationToken,
+    handleVerificationClick,
+    handleCodeVerify,
+  }
+}

--- a/src/features/auth/hooks/useEmailVerification.ts
+++ b/src/features/auth/hooks/useEmailVerification.ts
@@ -7,11 +7,11 @@ import {
   resendEmailVerification,
   sendEmailVerification,
 } from "@/features/auth/api/emailVerification"
+import { emailSchema } from "@/features/signup/validation"
 
 import type { EmailVerificationPurpose } from "@/features/auth/model/types"
 
 const VERIFICATION_SECONDS = 600
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 /**
  * 이메일 인증 플로우를 관리하는 훅
@@ -54,7 +54,7 @@ export function useEmailVerification(purpose: EmailVerificationPurpose) {
     }
   }, [])
 
-  const isEmailValid = EMAIL_REGEX.test(email)
+  const isEmailValid = emailSchema.safeParse(email).success
   /** 타이머가 만료된 상태 (코드 입력 불가) */
   const isExpired = isCodeVisible && remainingSeconds === 0
 

--- a/src/features/auth/hooks/useOAuthLinking.ts
+++ b/src/features/auth/hooks/useOAuthLinking.ts
@@ -121,9 +121,32 @@ export function useOAuthLinking() {
     startKakaoSignIn()
   }
 
-  const handleUnlink = async (memberOAuthId: number) => {
+  const handleUnlink = async (
+    memberOAuthId: number,
+    social: "google" | "kakao" | "apple",
+  ) => {
+    let googleAccessToken: string | undefined
+
+    if (social === "google") {
+      try {
+        const result = await signInWithGoogle()
+        googleAccessToken = result.accessToken
+      } catch (err) {
+        if (!isGooglePopupCancelled(err)) {
+          addToast({
+            message: "Google 인증에 실패했습니다. 다시 시도해주세요.",
+            color: "red",
+            variant: "deep",
+            type: "default",
+            duration: 3000,
+          })
+        }
+        return
+      }
+    }
+
     try {
-      await removeMemberOAuth(memberOAuthId)
+      await removeMemberOAuth(memberOAuthId, { googleAccessToken })
       await queryClient.invalidateQueries({ queryKey: MEMBER_OAUTH_QUERY_KEY })
       addToast({
         message: "소셜 연동이 해제되었습니다.",
@@ -132,9 +155,12 @@ export function useOAuthLinking() {
         type: "default",
         duration: 3000,
       })
-    } catch {
+    } catch (err) {
       addToast({
-        message: "연동 해제에 실패했습니다. 다시 시도해주세요.",
+        message:
+          err instanceof Error
+            ? err.message
+            : "연동 해제에 실패했습니다. 다시 시도해주세요.",
         color: "red",
         variant: "deep",
         type: "default",

--- a/src/features/auth/model/types.ts
+++ b/src/features/auth/model/types.ts
@@ -32,7 +32,10 @@ export interface AppleLoginRequest {
   clientType: ClientType
 }
 
-export type EmailVerificationPurpose = "REGISTER" | "PASSWORD_RESET"
+export type EmailVerificationPurpose =
+  | "REGISTER"
+  | "PASSWORD_RESET"
+  | "CHANGE_EMAIL"
 
 export interface SendEmailVerificationRequest {
   email: string

--- a/src/features/settings/ui/AccountSettingsPage.tsx
+++ b/src/features/settings/ui/AccountSettingsPage.tsx
@@ -21,7 +21,9 @@ import { RoleTagChip } from "@/shared/ui/chip/RoleTagChip"
 import { InputBox } from "@/shared/ui/input/InputBox"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
 
+import { ChangeEmailForm } from "./ChangeEmailForm"
 import { ChangePasswordForm } from "./ChangePasswordForm"
+import { ChangeUsernameForm } from "./ChangeUsernameForm"
 import { SocialButton } from "./SocialButton"
 
 import type { OAuthProvider } from "@/features/auth/model/types"
@@ -38,6 +40,8 @@ export function AccountSettingsPage() {
   const { data: me } = useMe()
   const { data: oauths = [] } = useMemberOAuthList()
   const role = me?.roles?.[0] ? toRoleTag(me.roles[0].roleType) : "challenger"
+  const [showEmailChange, setShowEmailChange] = useState(false)
+  const [showUsernameChange, setShowUsernameChange] = useState(false)
   const [showPasswordChange, setShowPasswordChange] = useState(false)
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const [isUploadingImage, setIsUploadingImage] = useState(false)
@@ -201,21 +205,21 @@ export function AccountSettingsPage() {
 
           {/* 설정 카드 */}
           <div className="border-teal-gray-100 relative mt-8 flex w-full items-start gap-2.5 rounded-xl border bg-white py-9 pl-11">
-            {showPasswordChange ? (
-              <>
-                <ChangePasswordForm
-                  onSuccess={() => setShowPasswordChange(false)}
-                />
-                <Button
-                  variant="weak"
-                  color="neutral"
-                  size="s"
-                  className="absolute right-11 bottom-10 h-11"
-                  onClick={() => setShowPasswordChange(false)}
-                >
-                  이전
-                </Button>
-              </>
+            {showEmailChange ? (
+              <ChangeEmailForm
+                onSuccess={() => setShowEmailChange(false)}
+                onBack={() => setShowEmailChange(false)}
+              />
+            ) : !isSocialOnly && showUsernameChange ? (
+              <ChangeUsernameForm
+                onSuccess={() => setShowUsernameChange(false)}
+                onBack={() => setShowUsernameChange(false)}
+              />
+            ) : !isSocialOnly && showPasswordChange ? (
+              <ChangePasswordForm
+                onSuccess={() => setShowPasswordChange(false)}
+                onBack={() => setShowPasswordChange(false)}
+              />
             ) : (
               <div className="flex w-full max-w-100 flex-col items-start gap-20">
                 <div className="flex w-full flex-col items-start gap-14">
@@ -240,45 +244,72 @@ export function AccountSettingsPage() {
                     </div>
                   </div>
 
-                  {/* 아이디 */}
-                  <div className="flex w-full flex-col items-start gap-4">
-                    <span className="text-heading-7-semibold text-teal-gray-900">
-                      아이디
-                    </span>
-                    <div className="flex h-11 w-full items-start justify-between gap-1.5">
-                      <InputBox
-                        state="disabled"
-                        value={me?.email ?? ""}
-                        onChange={() => {}}
-                        inputClassName={emailInputClass}
-                      />
-                      <Button
-                        variant="weak"
-                        color="neutral"
-                        size="s"
-                        className="h-11"
-                      >
-                        변경하기
-                      </Button>
-                    </div>
-                  </div>
-
-                  {/* 비밀번호: 소셜 전용 로그인 유저는 표시하지 않음 */}
-                  {!isSocialOnly && (
+                  {/* 소셜 로그인: 이메일 변경란 */}
+                  {isSocialOnly && (
                     <div className="flex w-full flex-col items-start gap-4">
                       <span className="text-heading-7-semibold text-teal-gray-900">
-                        비밀번호
+                        이메일
                       </span>
-                      <Button
-                        variant="weak"
-                        color="neutral"
-                        size="s"
-                        onClick={() => setShowPasswordChange(true)}
-                        className="w-full"
-                      >
-                        비밀번호 변경
-                      </Button>
+                      <div className="flex h-11 w-full items-start justify-between gap-1.5">
+                        <InputBox
+                          state="disabled"
+                          value={me?.email ?? ""}
+                          onChange={() => {}}
+                          inputClassName={emailInputClass}
+                        />
+                        <Button
+                          variant="weak"
+                          color="neutral"
+                          size="s"
+                          onClick={() => setShowEmailChange(true)}
+                          className="h-11"
+                        >
+                          변경하기
+                        </Button>
+                      </div>
                     </div>
+                  )}
+
+                  {/* 로컬 로그인: 아이디 변경란 + 비밀번호 */}
+                  {!isSocialOnly && (
+                    <>
+                      <div className="flex w-full flex-col items-start gap-4">
+                        <span className="text-heading-7-semibold text-teal-gray-900">
+                          아이디
+                        </span>
+                        <div className="flex h-11 w-full items-start justify-between gap-1.5">
+                          <InputBox
+                            state="disabled"
+                            value={me?.email ?? ""}
+                            onChange={() => {}}
+                            inputClassName={emailInputClass}
+                          />
+                          <Button
+                            variant="weak"
+                            color="neutral"
+                            size="s"
+                            onClick={() => setShowUsernameChange(true)}
+                            className="h-11"
+                          >
+                            변경하기
+                          </Button>
+                        </div>
+                      </div>
+                      <div className="flex w-full flex-col items-start gap-4">
+                        <span className="text-heading-7-semibold text-teal-gray-900">
+                          비밀번호
+                        </span>
+                        <Button
+                          variant="weak"
+                          color="neutral"
+                          size="s"
+                          onClick={() => setShowPasswordChange(true)}
+                          className="w-full"
+                        >
+                          비밀번호 변경
+                        </Button>
+                      </div>
+                    </>
                   )}
                 </div>
 

--- a/src/features/settings/ui/AccountSettingsPage.tsx
+++ b/src/features/settings/ui/AccountSettingsPage.tsx
@@ -45,7 +45,10 @@ export function AccountSettingsPage() {
   const [showPasswordChange, setShowPasswordChange] = useState(false)
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const [isUploadingImage, setIsUploadingImage] = useState(false)
-  const [unlinkTarget, setUnlinkTarget] = useState<number | null>(null)
+  const [unlinkTarget, setUnlinkTarget] = useState<{
+    id: number
+    social: Social
+  } | null>(null)
   const navigate = useNavigate()
   const addToast = useToastStore((s) => s.addToast)
   const queryClient = useQueryClient()
@@ -140,7 +143,7 @@ export function AccountSettingsPage() {
         : social === "google"
           ? handleGoogleLink
           : handleAppleLink
-    const onUnlink = () => setUnlinkTarget(memberOAuthId!)
+    const onUnlink = () => setUnlinkTarget({ id: memberOAuthId!, social })
     return { linked, onClick: linked ? onUnlink : onLink }
   }
 
@@ -351,8 +354,14 @@ export function AccountSettingsPage() {
       <CtaModal
         open={unlinkTarget !== null}
         variant="error"
-        title="연동을 해제하시겠습니까?"
-        content="해제하면 해당 소셜 계정으로 로그인할 수 없게 됩니다."
+        title={`${unlinkTarget?.social === "kakao" ? "카카오" : unlinkTarget?.social === "apple" ? "애플" : "구글"} 계정 연동을 해제하시겠습니까?`}
+        content={
+          <>
+            계정 연동을 해제하더라도 기존 데이터는 안전하게 유지됩니다.
+            <br />
+            필요할 때 언제든 다시 연동하여 이용하실 수 있습니다.
+          </>
+        }
         cancelText="돌아가기"
         confirmText="연동 해제"
         onOpenChange={(open) => {
@@ -360,7 +369,8 @@ export function AccountSettingsPage() {
         }}
         onCancel={() => setUnlinkTarget(null)}
         onConfirm={() =>
-          unlinkTarget !== null && void handleUnlink(unlinkTarget)
+          unlinkTarget !== null &&
+          void handleUnlink(unlinkTarget.id, unlinkTarget.social)
         }
       />
 

--- a/src/features/settings/ui/AccountSettingsPage.tsx
+++ b/src/features/settings/ui/AccountSettingsPage.tsx
@@ -152,14 +152,14 @@ export function AccountSettingsPage() {
 
   return (
     <div className="flex w-full justify-center pt-14 pb-33.75">
-      <div className="flex w-full max-w-250 flex-col items-start gap-11">
+      <div className="flex w-full max-w-lg flex-col items-start gap-11">
         <h1 className="text-heading-5-semibold text-teal-gray-900 self-stretch">
           계정 설정
         </h1>
 
-        <div className="flex w-full flex-col items-start">
+        <div className="flex w-full flex-col items-center">
           {/* 프로필 헤더 */}
-          <div className="flex items-center gap-4.5 px-3.5 py-0">
+          <div className="flex w-full max-w-lg items-center gap-4.5 px-3.5 py-0">
             <div className="relative flex h-25 w-25 shrink-0 items-center justify-center">
               <div className="bg-teal-gray-100 flex h-25 w-25 items-center justify-center overflow-hidden rounded-full">
                 {me?.profileImageLink ? (
@@ -204,7 +204,7 @@ export function AccountSettingsPage() {
           </div>
 
           {/* 설정 카드 */}
-          <div className="border-teal-gray-100 relative mt-8 flex w-full items-start gap-2.5 rounded-xl border bg-white py-9 pl-11">
+          <div className="border-teal-gray-100 relative mt-8 flex w-full max-w-lg items-start gap-2.5 rounded-xl border bg-white px-11 pt-8 pb-10">
             {showEmailChange ? (
               <ChangeEmailForm
                 onSuccess={() => setShowEmailChange(false)}
@@ -324,6 +324,25 @@ export function AccountSettingsPage() {
               </div>
             )}
           </div>
+
+          {/* 이전 버튼 추가 */}
+          {(showEmailChange ||
+            (!isSocialOnly && showUsernameChange) ||
+            (!isSocialOnly && showPasswordChange)) && (
+            <Button
+              variant="weak"
+              color="neutral"
+              size="s"
+              className="mt-4 h-11 self-end"
+              onClick={() => {
+                if (showEmailChange) setShowEmailChange(false)
+                else if (showUsernameChange) setShowUsernameChange(false)
+                else if (showPasswordChange) setShowPasswordChange(false)
+              }}
+            >
+              이전
+            </Button>
+          )}
         </div>
       </div>
 

--- a/src/features/settings/ui/AccountSettingsPage.tsx
+++ b/src/features/settings/ui/AccountSettingsPage.tsx
@@ -212,6 +212,7 @@ export function AccountSettingsPage() {
               />
             ) : !isSocialOnly && showUsernameChange ? (
               <ChangeUsernameForm
+                currentEmail={me?.email ?? ""}
                 onSuccess={() => setShowUsernameChange(false)}
                 onBack={() => setShowUsernameChange(false)}
               />

--- a/src/features/settings/ui/ChangeEmailForm.tsx
+++ b/src/features/settings/ui/ChangeEmailForm.tsx
@@ -1,0 +1,16 @@
+interface ChangeEmailFormProps {
+  onSuccess: () => void
+  onBack: () => void
+}
+
+export function ChangeEmailForm({ onBack: _ }: ChangeEmailFormProps) {
+  return (
+    <div className="flex w-full max-w-100 flex-col items-start gap-11">
+      <div className="flex w-full flex-col items-start gap-4">
+        <span className="text-heading-7-semibold text-teal-gray-900">
+          이메일 변경
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/features/settings/ui/ChangeEmailForm.tsx
+++ b/src/features/settings/ui/ChangeEmailForm.tsx
@@ -1,16 +1,213 @@
+import { useState } from "react"
+
+import { useToastStore } from "@/components/toast/useToastStore"
+import { changeEmail } from "@/features/auth/api/me"
+import { useEmailVerification } from "@/features/auth/hooks/useEmailVerification"
+import CircleBang from "@/shared/assets/icon/bang/CircleBang"
+import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
+import { Button } from "@/shared/ui/Button"
+import { InputBox } from "@/shared/ui/input/InputBox"
+import { CtaModal } from "@/shared/ui/modal/CtaModal"
+
+// 소셜 로그인 사용자 기준으로 하드코딩
+const isSocialLogin = true
+
 interface ChangeEmailFormProps {
   onSuccess: () => void
   onBack: () => void
 }
 
-export function ChangeEmailForm({ onBack: _ }: ChangeEmailFormProps) {
+export function ChangeEmailForm({
+  onSuccess,
+  onBack: _,
+}: ChangeEmailFormProps) {
+  const {
+    email: next,
+    setEmail: setNext,
+    code,
+    setCode,
+    isLoading,
+    isCodeVisible,
+    remainingSeconds,
+    isDuplicated,
+    isCodeInvalid,
+    isExpired,
+    isEmailValid,
+    handleVerificationClick,
+    handleResend,
+    handleCodeVerify,
+  } = useEmailVerification("CHANGE_EMAIL")
+  const [openResendModal, setOpenResendModal] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const addToast = useToastStore((s) => s.addToast)
+
+  const handleSubmit = async () => {
+    setIsSubmitting(true)
+    try {
+      const token = await handleCodeVerify()
+      if (!token) return
+      await changeEmail({ newEmail: next, emailVerificationToken: token })
+      addToast({
+        message: "이메일이 변경되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      onSuccess()
+    } catch {
+      addToast({
+        message: "이메일 변경에 실패했습니다. 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
   return (
-    <div className="flex w-full max-w-100 flex-col items-start gap-11">
+    <div className="flex w-full flex-col gap-6">
       <div className="flex w-full flex-col items-start gap-4">
         <span className="text-heading-7-semibold text-teal-gray-900">
           이메일 변경
         </span>
       </div>
+      <div className="flex w-full flex-col items-start gap-8">
+        {/* 새 이메일 */}
+        <div className="flex w-full flex-col items-start gap-1.5">
+          <div className="flex items-center gap-0.5">
+            <span className="text-body-1-medium text-teal-gray-600">
+              {isSocialLogin ? "연결할 이메일" : "새 이메일"}
+            </span>
+            <span className="text-body-1-medium text-error-500">*</span>
+          </div>
+          <div className="flex h-11 w-full items-start justify-between gap-1.5">
+            <InputBox
+              value={next}
+              onChange={(e) => setNext(e.target.value)}
+              placeholder="이메일 형식의 아이디"
+              state={isDuplicated ? "error" : "default"}
+              className="w-full"
+            />
+            <Button
+              variant="weak"
+              color="neutral"
+              size="s"
+              disabled={
+                !isEmailValid ||
+                isLoading ||
+                isDuplicated ||
+                (isCodeVisible && !isExpired)
+              }
+              isLoading={isLoading}
+              onClick={() => void handleVerificationClick()}
+              className="h-11"
+            >
+              인증하기
+            </Button>
+          </div>
+          {isDuplicated && (
+            <div className="flex items-center gap-1">
+              <CheckIcon className="text-error-500 h-4 w-4" />
+              <p className="text-error-500 text-body-2-medium">
+                이미 가입된 이메일입니다.
+              </p>
+            </div>
+          )}
+          {isCodeVisible && (
+            <button
+              type="button"
+              onClick={() => setOpenResendModal(true)}
+              className="flex items-center gap-1"
+            >
+              <CircleBang className="text-teal-gray-300 h-4 w-4" />
+              <p className="text-teal-gray-300 text-body-2-medium underline">
+                인증 메일을 받지 못하셨나요?
+              </p>
+            </button>
+          )}
+        </div>
+
+        {/* 인증번호 */}
+        {isCodeVisible && (
+          <div className="flex w-full flex-col items-start gap-1.5 pb-[21px]">
+            <div className="flex items-center gap-0.5">
+              <span className="text-body-1-medium text-teal-gray-600">
+                인증번호
+              </span>
+              <span className="text-body-1-medium text-error-500">*</span>
+            </div>
+            <InputBox
+              type="verification"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              placeholder="숫자 6자리 입력"
+              remainingSeconds={remainingSeconds}
+              inputMode="numeric"
+              maxLength={6}
+              state={isCodeInvalid ? "error" : "default"}
+              className="w-full"
+            />
+            <div className="flex h-5.5 items-center gap-1">
+              {isCodeInvalid && !isExpired && (
+                <>
+                  <CheckIcon className="text-error-500 h-4 w-4" />
+                  <p className="text-error-500 text-body-2-medium">
+                    인증번호가 일치하지 않습니다.
+                  </p>
+                </>
+              )}
+              {isExpired && (
+                <>
+                  <CheckIcon className="text-error-500 h-4 w-4" />
+                  <p className="text-error-500 text-body-2-medium">
+                    인증번호 입력 시간이 지났습니다.
+                  </p>
+                </>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <Button
+        type="button"
+        variant="fill"
+        color="primary"
+        size="s"
+        disabled={
+          !isCodeVisible || code.length !== 6 || isExpired || isSubmitting
+        }
+        isLoading={isSubmitting}
+        onClick={() => void handleSubmit()}
+        className="h-11 w-full bg-teal-300 disabled:bg-teal-200"
+      >
+        변경하기
+      </Button>
+
+      <CtaModal
+        open={openResendModal}
+        variant="success"
+        title="인증 메일을 받지 못하셨나요?"
+        content={
+          <>
+            인증 메일이 스팸 메일함으로 분류되었을 수 있습니다.
+            <br />
+            스팸 메일함을 먼저 확인한 뒤 다시 보내기를 눌러주세요.
+          </>
+        }
+        cancelText="닫기"
+        confirmText="다시 보내기"
+        onOpenChange={setOpenResendModal}
+        onCancel={() => setOpenResendModal(false)}
+        onConfirm={() => {
+          setOpenResendModal(false)
+          void handleResend()
+        }}
+      />
     </div>
   )
 }

--- a/src/features/settings/ui/ChangeEmailForm.tsx
+++ b/src/features/settings/ui/ChangeEmailForm.tsx
@@ -33,6 +33,8 @@ export function ChangeEmailForm({
     isCodeInvalid,
     isExpired,
     isEmailValid,
+    isRateLimited,
+    isAttemptsExceeded,
     handleVerificationClick,
     handleResend,
     handleCodeVerify,
@@ -97,10 +99,7 @@ export function ChangeEmailForm({
               color="neutral"
               size="s"
               disabled={
-                !isEmailValid ||
-                isLoading ||
-                isDuplicated ||
-                (isCodeVisible && !isExpired)
+                !isEmailValid || isLoading || isDuplicated || isRateLimited
               }
               isLoading={isLoading}
               onClick={() => void handleVerificationClick()}
@@ -148,11 +147,26 @@ export function ChangeEmailForm({
               remainingSeconds={remainingSeconds}
               inputMode="numeric"
               maxLength={6}
-              state={isCodeInvalid ? "error" : "default"}
+              state={
+                isAttemptsExceeded
+                  ? "disabled"
+                  : isCodeInvalid
+                    ? "error"
+                    : "default"
+              }
               className="w-full"
             />
             <div className="flex h-5.5 items-center gap-1">
-              {isCodeInvalid && !isExpired && (
+              {isAttemptsExceeded && (
+                <>
+                  <CheckIcon className="text-error-500 h-4 w-4" />
+                  <p className="text-error-500 text-body-2-medium">
+                    인증번호 입력 횟수(5회)를 초과했습니다. 인증번호를 재발송해
+                    주세요.
+                  </p>
+                </>
+              )}
+              {isCodeInvalid && !isExpired && !isAttemptsExceeded && (
                 <>
                   <CheckIcon className="text-error-500 h-4 w-4" />
                   <p className="text-error-500 text-body-2-medium">
@@ -179,7 +193,11 @@ export function ChangeEmailForm({
         color="primary"
         size="s"
         disabled={
-          !isCodeVisible || code.length !== 6 || isExpired || isSubmitting
+          !isCodeVisible ||
+          code.length !== 6 ||
+          isExpired ||
+          isAttemptsExceeded ||
+          isSubmitting
         }
         isLoading={isSubmitting}
         onClick={() => void handleSubmit()}

--- a/src/features/settings/ui/ChangePasswordForm.tsx
+++ b/src/features/settings/ui/ChangePasswordForm.tsx
@@ -32,11 +32,16 @@ export function ChangePasswordForm({
   const hasInvalidSpecial = /[^a-zA-Z0-9!#$&*@?]/.test(next)
   const isNextValid =
     isValidPassword(next) && !isSameAsCurrent && !hasInvalidSpecial
-  const isConfirmMatch = confirm.length > 0 && next === confirm
+  const isConfirmMatch = next === confirm
 
+  const [showConfirmError, setShowConfirmError] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const handleSubmit = async () => {
+    if (!isConfirmMatch) {
+      setShowConfirmError(true)
+      return
+    }
     setIsSubmitting(true)
     try {
       await changePassword({ currentPassword: current, newPassword: next })
@@ -156,21 +161,21 @@ export function ChangePasswordForm({
             </div>
             <InputBox
               type="password"
-              state={
-                confirm.length > 0
-                  ? isConfirmMatch
-                    ? "success"
-                    : "error"
-                  : "default"
-              }
+              state={showConfirmError && !isConfirmMatch ? "error" : "default"}
               value={confirm}
-              onChange={(e) => setConfirm(e.target.value)}
+              onChange={(e) => {
+                setConfirm(e.target.value)
+                setShowConfirmError(false)
+              }}
               className="w-full"
             />
-            {confirm.length > 0 && !isConfirmMatch && (
-              <span className="text-body-3-medium text-error-500">
-                비밀번호가 일치하지 않습니다
-              </span>
+            {showConfirmError && !isConfirmMatch && (
+              <div className="flex items-center gap-1">
+                <CheckIcon className="text-error-500 h-4 w-4 shrink-0" />
+                <p className="text-body-3-medium text-error-500">
+                  비밀번호가 일치하지 않습니다
+                </p>
+              </div>
             )}
           </div>
         </div>
@@ -181,7 +186,7 @@ export function ChangePasswordForm({
         variant="fill"
         color="primary"
         size="s"
-        disabled={!current || !isNextValid || !isConfirmMatch || isSubmitting}
+        disabled={!current || !isNextValid || !confirm || isSubmitting}
         isLoading={isSubmitting}
         onClick={() => void handleSubmit()}
         className="h-11 w-full bg-teal-300 disabled:bg-teal-200"

--- a/src/features/settings/ui/ChangePasswordForm.tsx
+++ b/src/features/settings/ui/ChangePasswordForm.tsx
@@ -10,7 +10,7 @@ function isValidPassword(pw: string): boolean {
   if (pw.length < 8) return false
   const hasLetter = /[a-zA-Z]/.test(pw)
   const hasNumber = /[0-9]/.test(pw)
-  const hasSpecial = /[^a-zA-Z0-9]/.test(pw)
+  const hasSpecial = /[!#$&*@?]/.test(pw)
   return [hasLetter, hasNumber, hasSpecial].filter(Boolean).length >= 2
 }
 
@@ -28,7 +28,10 @@ export function ChangePasswordForm({
   const [confirm, setConfirm] = useState("")
   const addToast = useToastStore((s) => s.addToast)
 
-  const isNextValid = isValidPassword(next)
+  const isSameAsCurrent = next.length > 0 && next === current
+  const hasInvalidSpecial = /[^a-zA-Z0-9!#$&*@?]/.test(next)
+  const isNextValid =
+    isValidPassword(next) && !isSameAsCurrent && !hasInvalidSpecial
   const isConfirmMatch = confirm.length > 0 && next === confirm
 
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -105,22 +108,39 @@ export function ChangePasswordForm({
             />
             {/* TODO: API 연결 후 서버 응답 메시지로 대체 */}
             {next.length > 0 && (
-              <div className="flex items-center gap-1">
-                {isNextValid ? (
-                  <>
+              <div className="flex flex-col gap-1">
+                {isSameAsCurrent ? (
+                  <div className="flex items-center gap-1">
+                    <CheckIcon className="text-error-500 h-4 w-4 shrink-0" />
+                    <p className="text-body-3-medium text-error-500">
+                      새 비밀번호는 현재 비밀번호와 다르게 설정해 주세요
+                    </p>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-1">
                     <CheckIcon
                       width={16}
                       height={16}
-                      className="text-success-500 shrink-0"
+                      className={
+                        isNextValid
+                          ? "text-success-500 shrink-0"
+                          : "text-error-500 shrink-0"
+                      }
                     />
-                    <span className="text-body-3-medium text-success-500">
+                    <p
+                      className={`text-body-3-medium ${isNextValid ? "text-success-500" : "text-error-500"}`}
+                    >
                       영문, 숫자, 특수문자 중 2종류 이상 포함한 8자 이상
-                    </span>
-                  </>
-                ) : (
-                  <span className="text-body-3-medium text-error-500">
-                    영문, 숫자, 특수문자 중 2종류 이상 포함한 8자 이상
-                  </span>
+                    </p>
+                  </div>
+                )}
+                {!isSameAsCurrent && hasInvalidSpecial && (
+                  <div className="flex items-center gap-1">
+                    <CheckIcon className="text-error-500 h-4 w-4 shrink-0" />
+                    <p className="text-body-3-medium text-error-500">
+                      사용 가능한 특수문자 !#$&*@?
+                    </p>
+                  </div>
                 )}
               </div>
             )}

--- a/src/features/settings/ui/ChangePasswordForm.tsx
+++ b/src/features/settings/ui/ChangePasswordForm.tsx
@@ -55,7 +55,7 @@ export function ChangePasswordForm({
       onSuccess()
     } catch {
       addToast({
-        message: "비밀번호 변경에 실패했습니다. 다시 시도해주세요.",
+        message: "잠시 후 다시 시도해 주세요.",
         color: "red",
         variant: "deep",
         type: "default",

--- a/src/features/settings/ui/ChangePasswordForm.tsx
+++ b/src/features/settings/ui/ChangePasswordForm.tsx
@@ -21,7 +21,7 @@ interface ChangePasswordFormProps {
 
 export function ChangePasswordForm({
   onSuccess,
-  onBack,
+  onBack: _,
 }: ChangePasswordFormProps) {
   const [current, setCurrent] = useState("")
   const [next, setNext] = useState("")
@@ -167,16 +167,6 @@ export function ChangePasswordForm({
         className="h-11 w-full bg-teal-300 disabled:bg-teal-200"
       >
         변경하기
-      </Button>
-      <Button
-        type="button"
-        variant="weak"
-        color="neutral"
-        size="s"
-        onClick={onBack}
-        className="absolute right-11 bottom-10 h-11"
-      >
-        이전
       </Button>
     </div>
   )

--- a/src/features/settings/ui/ChangePasswordForm.tsx
+++ b/src/features/settings/ui/ChangePasswordForm.tsx
@@ -16,9 +16,13 @@ function isValidPassword(pw: string): boolean {
 
 interface ChangePasswordFormProps {
   onSuccess: () => void
+  onBack: () => void
 }
 
-export function ChangePasswordForm({ onSuccess }: ChangePasswordFormProps) {
+export function ChangePasswordForm({
+  onSuccess,
+  onBack,
+}: ChangePasswordFormProps) {
   const [current, setCurrent] = useState("")
   const [next, setNext] = useState("")
   const [confirm, setConfirm] = useState("")
@@ -163,6 +167,16 @@ export function ChangePasswordForm({ onSuccess }: ChangePasswordFormProps) {
         className="h-11 w-full bg-teal-300 disabled:bg-teal-200"
       >
         변경하기
+      </Button>
+      <Button
+        type="button"
+        variant="weak"
+        color="neutral"
+        size="s"
+        onClick={onBack}
+        className="absolute right-11 bottom-10 h-11"
+      >
+        이전
       </Button>
     </div>
   )

--- a/src/features/settings/ui/ChangeUsernameForm.tsx
+++ b/src/features/settings/ui/ChangeUsernameForm.tsx
@@ -68,6 +68,7 @@ export function ChangeUsernameForm({
               value={next}
               onChange={(e) => setNext(e.target.value)}
               placeholder="이메일 형식의 아이디"
+              state={isDuplicated ? "error" : "default"}
               className="w-full"
             />
             <Button
@@ -86,7 +87,7 @@ export function ChangeUsernameForm({
             <div className="flex items-center gap-1">
               <CheckIcon className="text-error-500 h-4 w-4" />
               <p className="text-error-500 text-body-2-medium">
-                이미 사용 중인 아이디입니다.
+                이미 가입된 아이디입니다.
               </p>
             </div>
           )}

--- a/src/features/settings/ui/ChangeUsernameForm.tsx
+++ b/src/features/settings/ui/ChangeUsernameForm.tsx
@@ -32,6 +32,8 @@ export function ChangeUsernameForm({
     isCodeInvalid,
     isExpired,
     isEmailValid,
+    isRateLimited,
+    isAttemptsExceeded,
     handleVerificationClick,
     handleResend,
     handleCodeVerify,
@@ -112,10 +114,7 @@ export function ChangeUsernameForm({
               color="neutral"
               size="s"
               disabled={
-                !isEmailValid ||
-                isLoading ||
-                isDuplicated ||
-                (isCodeVisible && !isExpired)
+                !isEmailValid || isLoading || isDuplicated || isRateLimited
               }
               isLoading={isLoading}
               onClick={() => void handleVerificationClick()}
@@ -163,11 +162,26 @@ export function ChangeUsernameForm({
               remainingSeconds={remainingSeconds}
               inputMode="numeric"
               maxLength={6}
-              state={isCodeInvalid ? "error" : "default"}
+              state={
+                isAttemptsExceeded
+                  ? "disabled"
+                  : isCodeInvalid
+                    ? "error"
+                    : "default"
+              }
               className="w-full"
             />
             <div className="flex h-5.5 items-center gap-1">
-              {isCodeInvalid && !isExpired && (
+              {isAttemptsExceeded && (
+                <>
+                  <CheckIcon className="text-error-500 h-4 w-4" />
+                  <p className="text-error-500 text-body-2-medium">
+                    인증번호 입력 횟수(5회)를 초과했습니다. 인증번호를 재발송해
+                    주세요.
+                  </p>
+                </>
+              )}
+              {isCodeInvalid && !isExpired && !isAttemptsExceeded && (
                 <>
                   <CheckIcon className="text-error-500 h-4 w-4" />
                   <p className="text-error-500 text-body-2-medium">
@@ -194,7 +208,11 @@ export function ChangeUsernameForm({
         color="primary"
         size="s"
         disabled={
-          !isCodeVisible || code.length !== 6 || isExpired || isSubmitting
+          !isCodeVisible ||
+          code.length !== 6 ||
+          isExpired ||
+          isAttemptsExceeded ||
+          isSubmitting
         }
         isLoading={isSubmitting}
         onClick={() => void handleSubmit()}

--- a/src/features/settings/ui/ChangeUsernameForm.tsx
+++ b/src/features/settings/ui/ChangeUsernameForm.tsx
@@ -1,7 +1,13 @@
+import { useState } from "react"
+
+import { useToastStore } from "@/components/toast/useToastStore"
+import { changeEmail } from "@/features/auth/api/me"
 import { useEmailVerification } from "@/features/auth/hooks/useEmailVerification"
+import CircleBang from "@/shared/assets/icon/bang/CircleBang"
 import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
 import { Button } from "@/shared/ui/Button"
 import { InputBox } from "@/shared/ui/input/InputBox"
+import { CtaModal } from "@/shared/ui/modal/CtaModal"
 
 interface ChangeUsernameFormProps {
   currentEmail: string
@@ -11,7 +17,7 @@ interface ChangeUsernameFormProps {
 
 export function ChangeUsernameForm({
   currentEmail,
-  onSuccess: _,
+  onSuccess,
   onBack: _2,
 }: ChangeUsernameFormProps) {
   const {
@@ -26,10 +32,40 @@ export function ChangeUsernameForm({
     isCodeInvalid,
     isExpired,
     isEmailValid,
-    verificationToken,
     handleVerificationClick,
+    handleResend,
     handleCodeVerify,
-  } = useEmailVerification("REGISTER")
+  } = useEmailVerification("CHANGE_EMAIL")
+  const [openResendModal, setOpenResendModal] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const addToast = useToastStore((s) => s.addToast)
+
+  const handleSubmit = async () => {
+    setIsSubmitting(true)
+    try {
+      const token = await handleCodeVerify()
+      if (!token) return
+      await changeEmail({ newEmail: next, emailVerificationToken: token })
+      addToast({
+        message: "아이디가 변경되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      onSuccess()
+    } catch {
+      addToast({
+        message: "아이디 변경에 실패했습니다. 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
 
   return (
     <div className="flex w-full flex-col gap-6">
@@ -75,7 +111,12 @@ export function ChangeUsernameForm({
               variant="weak"
               color="neutral"
               size="s"
-              disabled={!isEmailValid || isLoading || isDuplicated}
+              disabled={
+                !isEmailValid ||
+                isLoading ||
+                isDuplicated ||
+                (isCodeVisible && !isExpired)
+              }
               isLoading={isLoading}
               onClick={() => void handleVerificationClick()}
               className="h-11"
@@ -91,6 +132,18 @@ export function ChangeUsernameForm({
               </p>
             </div>
           )}
+          {isCodeVisible && (
+            <button
+              type="button"
+              onClick={() => setOpenResendModal(true)}
+              className="flex items-center gap-1"
+            >
+              <CircleBang className="text-teal-gray-300 h-4 w-4" />
+              <p className="text-teal-gray-300 text-body-2-medium underline">
+                인증 메일을 받지 못하셨나요?
+              </p>
+            </button>
+          )}
         </div>
 
         {/* 인증번호 */}
@@ -102,35 +155,23 @@ export function ChangeUsernameForm({
               </span>
               <span className="text-body-1-medium text-error-500">*</span>
             </div>
-            <div className="flex h-11 w-full items-start justify-between gap-1.5">
-              <InputBox
-                type="verification"
-                value={code}
-                onChange={(e) => setCode(e.target.value)}
-                placeholder="숫자 6자리 입력"
-                remainingSeconds={remainingSeconds}
-                inputMode="numeric"
-                maxLength={6}
-                state={isCodeInvalid ? "error" : "default"}
-                className="w-full"
-              />
-              <Button
-                variant="weak"
-                color="neutral"
-                size="s"
-                disabled={code.length !== 6 || isExpired || !!verificationToken}
-                onClick={() => void handleCodeVerify()}
-                className="h-11"
-              >
-                확인
-              </Button>
-            </div>
+            <InputBox
+              type="verification"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              placeholder="숫자 6자리 입력"
+              remainingSeconds={remainingSeconds}
+              inputMode="numeric"
+              maxLength={6}
+              state={isCodeInvalid ? "error" : "default"}
+              className="w-full"
+            />
             <div className="flex h-5.5 items-center gap-1">
               {isCodeInvalid && !isExpired && (
                 <>
                   <CheckIcon className="text-error-500 h-4 w-4" />
                   <p className="text-error-500 text-body-2-medium">
-                    인증번호가 일치하지 않아요.
+                    인증번호가 일치하지 않습니다.
                   </p>
                 </>
               )}
@@ -138,15 +179,7 @@ export function ChangeUsernameForm({
                 <>
                   <CheckIcon className="text-error-500 h-4 w-4" />
                   <p className="text-error-500 text-body-2-medium">
-                    인증번호 입력 시간이 지났어요.
-                  </p>
-                </>
-              )}
-              {verificationToken && (
-                <>
-                  <CheckIcon className="text-success-500 h-4 w-4" />
-                  <p className="text-success-500 text-body-2-medium">
-                    인증이 완료되었습니다.
+                    인증번호 입력 시간이 지났습니다.
                   </p>
                 </>
               )}
@@ -160,11 +193,36 @@ export function ChangeUsernameForm({
         variant="fill"
         color="primary"
         size="s"
-        disabled={!verificationToken}
+        disabled={
+          !isCodeVisible || code.length !== 6 || isExpired || isSubmitting
+        }
+        isLoading={isSubmitting}
+        onClick={() => void handleSubmit()}
         className="h-11 w-full bg-teal-300 disabled:bg-teal-200"
       >
         변경하기
       </Button>
+
+      <CtaModal
+        open={openResendModal}
+        variant="success"
+        title="인증 메일을 받지 못하셨나요?"
+        content={
+          <>
+            인증 메일이 스팸 메일함으로 분류되었을 수 있습니다.
+            <br />
+            스팸 메일함을 먼저 확인한 뒤 다시 보내기를 눌러주세요.
+          </>
+        }
+        cancelText="닫기"
+        confirmText="다시 보내기"
+        onOpenChange={setOpenResendModal}
+        onCancel={() => setOpenResendModal(false)}
+        onConfirm={() => {
+          setOpenResendModal(false)
+          void handleResend()
+        }}
+      />
     </div>
   )
 }

--- a/src/features/settings/ui/ChangeUsernameForm.tsx
+++ b/src/features/settings/ui/ChangeUsernameForm.tsx
@@ -1,0 +1,169 @@
+import { useEmailVerification } from "@/features/auth/hooks/useEmailVerification"
+import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
+import { Button } from "@/shared/ui/Button"
+import { InputBox } from "@/shared/ui/input/InputBox"
+
+interface ChangeUsernameFormProps {
+  currentEmail: string
+  onSuccess: () => void
+  onBack: () => void
+}
+
+export function ChangeUsernameForm({
+  currentEmail,
+  onSuccess: _,
+  onBack: _2,
+}: ChangeUsernameFormProps) {
+  const {
+    email: next,
+    setEmail: setNext,
+    code,
+    setCode,
+    isLoading,
+    isCodeVisible,
+    remainingSeconds,
+    isDuplicated,
+    isCodeInvalid,
+    isExpired,
+    isEmailValid,
+    verificationToken,
+    handleVerificationClick,
+    handleCodeVerify,
+  } = useEmailVerification("REGISTER")
+
+  return (
+    <div className="flex w-full flex-col gap-6">
+      <div className="flex w-full flex-col items-start gap-4">
+        <span className="text-heading-7-semibold text-teal-gray-900">
+          아이디 변경
+        </span>
+      </div>
+      <div className="flex w-full flex-col items-start gap-8">
+        {/* 현재 아이디 */}
+        <div className="flex w-full flex-col items-start gap-1.5">
+          <div className="flex items-center gap-0.5">
+            <span className="text-body-1-medium text-teal-gray-600">
+              현재 아이디
+            </span>
+            <span className="text-body-1-medium text-error-500">*</span>
+          </div>
+          <InputBox
+            state="disabled"
+            value={currentEmail}
+            onChange={() => {}}
+            className="w-full"
+          />
+        </div>
+
+        {/* 새 아이디 */}
+        <div className="flex w-full flex-col items-start gap-1.5">
+          <div className="flex items-center gap-0.5">
+            <span className="text-body-1-medium text-teal-gray-600">
+              새 아이디
+            </span>
+            <span className="text-body-1-medium text-error-500">*</span>
+          </div>
+          <div className="flex h-11 w-full items-start justify-between gap-1.5">
+            <InputBox
+              value={next}
+              onChange={(e) => setNext(e.target.value)}
+              placeholder="이메일 형식의 아이디"
+              className="w-full"
+            />
+            <Button
+              variant="weak"
+              color="neutral"
+              size="s"
+              disabled={!isEmailValid || isLoading || isDuplicated}
+              isLoading={isLoading}
+              onClick={() => void handleVerificationClick()}
+              className="h-11"
+            >
+              인증하기
+            </Button>
+          </div>
+          {isDuplicated && (
+            <div className="flex items-center gap-1">
+              <CheckIcon className="text-error-500 h-4 w-4" />
+              <p className="text-error-500 text-body-2-medium">
+                이미 사용 중인 아이디입니다.
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* 인증번호 */}
+        {isCodeVisible && (
+          <div className="flex w-full flex-col items-start gap-1.5 pb-[21px]">
+            <div className="flex items-center gap-0.5">
+              <span className="text-body-1-medium text-teal-gray-600">
+                인증번호
+              </span>
+              <span className="text-body-1-medium text-error-500">*</span>
+            </div>
+            <div className="flex h-11 w-full items-start justify-between gap-1.5">
+              <InputBox
+                type="verification"
+                value={code}
+                onChange={(e) => setCode(e.target.value)}
+                placeholder="숫자 6자리 입력"
+                remainingSeconds={remainingSeconds}
+                inputMode="numeric"
+                maxLength={6}
+                state={isCodeInvalid ? "error" : "default"}
+                className="w-full"
+              />
+              <Button
+                variant="weak"
+                color="neutral"
+                size="s"
+                disabled={code.length !== 6 || isExpired || !!verificationToken}
+                onClick={() => void handleCodeVerify()}
+                className="h-11"
+              >
+                확인
+              </Button>
+            </div>
+            <div className="flex h-5.5 items-center gap-1">
+              {isCodeInvalid && !isExpired && (
+                <>
+                  <CheckIcon className="text-error-500 h-4 w-4" />
+                  <p className="text-error-500 text-body-2-medium">
+                    인증번호가 일치하지 않아요.
+                  </p>
+                </>
+              )}
+              {isExpired && (
+                <>
+                  <CheckIcon className="text-error-500 h-4 w-4" />
+                  <p className="text-error-500 text-body-2-medium">
+                    인증번호 입력 시간이 지났어요.
+                  </p>
+                </>
+              )}
+              {verificationToken && (
+                <>
+                  <CheckIcon className="text-success-500 h-4 w-4" />
+                  <p className="text-success-500 text-body-2-medium">
+                    인증이 완료되었습니다.
+                  </p>
+                </>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <Button
+        type="button"
+        variant="fill"
+        color="primary"
+        size="s"
+        disabled={!verificationToken}
+        className="h-11 w-full bg-teal-300 disabled:bg-teal-200"
+      >
+        변경하기
+      </Button>
+    </div>
+  )
+}

--- a/src/features/settings/ui/ChangeUsernameForm.tsx
+++ b/src/features/settings/ui/ChangeUsernameForm.tsx
@@ -56,7 +56,7 @@ export function ChangeUsernameForm({
       onSuccess()
     } catch {
       addToast({
-        message: "아이디 변경에 실패했습니다. 다시 시도해주세요.",
+        message: "잠시 후 다시 시도해주세요.",
         color: "red",
         variant: "deep",
         type: "default",

--- a/src/shared/ui/input/InputBox.tsx
+++ b/src/shared/ui/input/InputBox.tsx
@@ -154,7 +154,7 @@ export const InputBox = forwardRef<HTMLInputElement, InputBoxProps>(
         return <span className="shrink-0 text-teal-600">{icon}</span>
       }
 
-      if (state === "error") {
+      if (state === "error" && type !== "password") {
         return (
           <span className="text-error-500 shrink-0">
             <CircleBang width={24} height={24} aria-hidden="true" />


### PR DESCRIPTION
## 📸 작업 내용

> 계정 설정 페이지의 UI 및 API를 구현하고, 로그인 수단(로컬/소셜)에 따라 분기 처리했습니다.

- 로그인 수단에 따라 계정 설정 화면 분기 (소셜 전용: 이메일 변경 / 로컬: 아이디·비밀번호 변경)
- 아이디 변경 폼 구현 (ChangeUsernameForm) 및 소셜 로그인 이메일 변경 폼 구현 (ChangeEmailForm)
- 이메일 인증 플로우 공통 훅 분리 (useEmailVerification) — 회원가입 로직과 유효성 검사 통일
- 비밀번호 변경 폼 개선 (특수문자 허용 범위 제한, 새 비밀번호 일치 여부 검증 로직 수정)
- 소셜 연동 해제 모달에 소셜별 타이틀 적용
- 인증번호 재전송 기능 구현

## 🎞️ 주요 코드 설명

> 설명이 필요한 코드 위주로 작성해주세요

### 이메일 인증 공통 훅 분리 (useEmailVerification.ts)

```TypeScript
export function useEmailVerification(purpose: EmailVerificationPurpose) {
  // 이메일 입력 → 중복 확인 → 인증 코드 발송 → 코드 검증 → 토큰 반환
  // purpose로 REGISTER / CHANGE_EMAIL 등 분기
}

```

- 회원가입, 아이디 변경, 이메일 변경에서 공통으로 사용하는 인증 플로우를 훅으로 분리
- 이메일 변경 시 setEmail 호출하면 진행 중인 인증 상태와 중복 에러가 자동 초기화됨
- 10분 카운트다운 타이머 내장, 재전송 시 리셋

### 로그인 수단 분기 (AccountSettingsPage)

```TypeScript
const isSocialOnly = me?.hasLocalCredential === false

// 소셜 전용: 이메일 변경란만 노출
{isSocialOnly && <ChangeEmailForm ... />}

// 로컬 계정: 아이디 + 비밀번호 변경란 노출
{!isSocialOnly && <ChangeUsernameForm ... />}
{!isSocialOnly && <ChangePasswordForm ... />}

```

- hasLocalCredential 플래그로 UI 분기 처리

## 🖥️ 구현화면

> localhost 캡쳐 사진을 첨부해 주세요.


## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #263 