### PR TITLE
🐛 fix: 강지훈 담당 QA 결함 일괄 수정 (지원 차단·등록 가드·지원 폼 복구)

### DIFF
--- a/src/features/project/list/api/matchingProject.ts
+++ b/src/features/project/list/api/matchingProject.ts
@@ -171,10 +171,11 @@ export type MyProjectApplicationResponse = {
 
 export async function getMyApplications(
   gisuId: number,
+  status?: ApplicationStatus,
 ): Promise<MyProjectApplicationResponse[]> {
   const { data } = await api.get<ApiResponse<MyProjectApplicationResponse[]>>(
     "/v1/projects/me/applications",
-    { params: { gisuId } },
+    { params: status ? { gisuId, status } : { gisuId } },
   )
   return data.result
 }

--- a/src/features/project/list/model/projectDetailCta.test.ts
+++ b/src/features/project/list/model/projectDetailCta.test.ts
@@ -4,6 +4,7 @@ import {
   isApplyButtonDisabled,
   resolveProjectDetailCtaMode,
   selectCurrentApplicationForProject,
+  selectIsAlreadyApproved,
 } from "./projectDetailCta"
 
 const applicable = {
@@ -204,5 +205,46 @@ describe("selectCurrentApplicationForProject", () => {
       activeMatchingRoundId: "2",
     })
     expect(result).toBeUndefined()
+  })
+})
+
+describe("selectIsAlreadyApproved", () => {
+  it("정규 차수에서 합격(APPROVED)한 지원서가 있으면 true", () => {
+    expect(
+      selectIsAlreadyApproved([
+        { status: "APPROVED", matchingRound: { id: "1" } },
+      ]),
+    ).toBe(true)
+  })
+
+  it("이전 차수에서 합격했으면 후속 차수에서도 true (합격자 후속 차수 차단 유지)", () => {
+    expect(
+      selectIsAlreadyApproved([
+        { status: "APPROVED", matchingRound: { id: "1" } },
+        { status: "SUBMITTED", matchingRound: { id: "2" } },
+      ]),
+    ).toBe(true)
+  })
+
+  it("랜덤매칭 카드(matchingRound.id=null)의 APPROVED는 차단 대상에서 제외하여 false", () => {
+    expect(
+      selectIsAlreadyApproved([
+        { status: "APPROVED", matchingRound: { id: null } },
+      ]),
+    ).toBe(false)
+  })
+
+  it("합격 이력이 없으면 false", () => {
+    expect(
+      selectIsAlreadyApproved([
+        { status: "SUBMITTED", matchingRound: { id: "1" } },
+        { status: "CANCELLED", matchingRound: { id: "2" } },
+      ]),
+    ).toBe(false)
+  })
+
+  it("빈 배열과 undefined는 false", () => {
+    expect(selectIsAlreadyApproved([])).toBe(false)
+    expect(selectIsAlreadyApproved(undefined)).toBe(false)
   })
 })

--- a/src/features/project/list/model/projectDetailCta.ts
+++ b/src/features/project/list/model/projectDetailCta.ts
@@ -106,7 +106,7 @@ export function selectIsAlreadyApproved<T extends ApplicationForApprovalCheck>(
 ): boolean {
   return (
     applications?.some(
-      (a) => a.status === "APPROVED" && a.matchingRound?.id != null,
+      (a) => a.status === "APPROVED" && a.matchingRound.id != null,
     ) ?? false
   )
 }

--- a/src/features/project/list/model/projectDetailCta.ts
+++ b/src/features/project/list/model/projectDetailCta.ts
@@ -95,3 +95,18 @@ export function selectCurrentApplicationForProject<
     (a) => Number(a.matchingRound?.id) === Number(activeMatchingRoundId),
   )
 }
+
+type ApplicationForApprovalCheck = {
+  status: string
+  matchingRound: { id: string | null }
+}
+
+export function selectIsAlreadyApproved<T extends ApplicationForApprovalCheck>(
+  applications: T[] | undefined,
+): boolean {
+  return (
+    applications?.some(
+      (a) => a.status === "APPROVED" && a.matchingRound?.id != null,
+    ) ?? false
+  )
+}

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -39,6 +39,7 @@ import {
   isApplyButtonDisabled,
   resolveProjectDetailCtaMode,
   selectCurrentApplicationForProject,
+  selectIsAlreadyApproved,
 } from "../model/projectDetailCta"
 import { ApplyFormSkeleton } from "./apply-modal/ApplyFormSkeleton"
 import { MyApplicationModal } from "./apply-modal/MyApplicationModal"
@@ -245,8 +246,7 @@ export function ProjectDetailCard({
     return id != null ? Number(id) : null
   }, [me])
 
-  const isAlreadyApproved =
-    myApplications?.some((a) => a.status === "APPROVED") ?? false
+  const isAlreadyApproved = selectIsAlreadyApproved(myApplications)
 
   const data = detail
     ? toMatchingProject(detail, detailDataUpdatedAt)

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -215,7 +215,9 @@ export function ProjectApplyModal({
           const gisu = await getActiveGisu().catch(() => null)
           if (gisu) {
             const apps: MyProjectApplicationResponse[] =
-              await getMyApplications(Number(gisu.gisuId)).catch(() => [])
+              await getMyApplications(Number(gisu.gisuId), "DRAFT").catch(
+                () => [],
+              )
             const existing = selectCurrentApplicationForProject({
               applications: apps,
               projectId,

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -68,6 +68,31 @@ export const Route = createFileRoute("/matching/projects/new")({
     }
 
     if (search.projectId !== undefined) {
+      let hasEditPermission = false
+      try {
+        const permission = await context.queryClient.ensureQueryData({
+          queryKey: [
+            "authorization",
+            "resource-permission",
+            "PROJECT",
+            String(search.projectId),
+            "EDIT",
+          ],
+          queryFn: () =>
+            getResourcePermission({
+              resourceType: "PROJECT",
+              resourceId: search.projectId,
+              permissionType: "EDIT",
+            }),
+          staleTime: 0,
+        })
+        hasEditPermission = hasGrantedPermission(permission, "EDIT")
+      } catch {
+        throw redirect({ to: "/matching/projects" })
+      }
+      if (!hasEditPermission) {
+        throw redirect({ to: "/matching/projects" })
+      }
       return
     }
 
@@ -109,7 +134,10 @@ export const Route = createFileRoute("/matching/projects/new")({
             queryKey: projectKeys.managedCheck(gisuId),
             queryFn: () => getManagedProjects(gisuId),
           })
-          if (managed.length > 0) {
+          const blockingProjects = managed.filter(
+            (project) => project.status !== "PENDING_REVIEW",
+          )
+          if (blockingProjects.length > 0) {
             throw redirect({
               to: "/matching/projects/management",
               search: { notice: "duplicate" },
@@ -161,12 +189,11 @@ function ProjectRegisterPage() {
       getMatchingRounds(myChapterId ? Number(myChapterId) : undefined),
     enabled: isEditMode && myChapterId !== undefined,
   })
-  const isApplicationReadOnly = useMemo(
-    () =>
-      isEditMode &&
-      isWithinMatchingPeriod(matchingRoundsQuery.data, new Date()),
-    [isEditMode, matchingRoundsQuery.data],
-  )
+  const isApplicationReadOnly = useMemo(() => {
+    if (!isEditMode) return false
+    if (!matchingRoundsQuery.isSuccess) return true
+    return isWithinMatchingPeriod(matchingRoundsQuery.data, new Date())
+  }, [isEditMode, matchingRoundsQuery.isSuccess, matchingRoundsQuery.data])
   const projectId = useProjectRegisterStore((s) => s.projectId)
   const application = useProjectRegisterStore((s) => s.application)
   const pmInfo = useProjectRegisterStore((s) => s.pmInfo)

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -222,12 +222,10 @@ function ProjectRegisterPage() {
     !isEditMode && projectWritePermissionQuery.isPending
   const canManageProject = projectPermissionsQuery.canManage
   const canManageRecruitInfoByRole = canManageProjectRecruitInfo(me)
-  const canEditRecruitStep = isEditMode
-    ? canManageProject
-    : canManageRecruitInfoByRole
+  const canEditRecruitStep = isEditMode ? canManageProject : false
 
   const resolveCanEditRecruitStep = async (): Promise<boolean> => {
-    if (!isEditMode) return canManageRecruitInfoByRole
+    if (!isEditMode) return false
 
     const pid = useProjectRegisterStore.getState().projectId
     if (pid === null) return false

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -75,7 +75,7 @@ export const Route = createFileRoute("/matching/projects/new")({
             "authorization",
             "resource-permission",
             "PROJECT",
-            String(search.projectId),
+            search.projectId,
             "EDIT",
           ],
           queryFn: () =>


### PR DESCRIPTION
## 📸 작업 내용

강지훈 담당 QA(0612 데모데이 매칭) 결함 3건 + 점검 중 발견된 정원 권한 임시 방어를 포함합니다. 서버 `develop`(dev API) 기준 API 정합성 재확인 완료.

- **(A1) 이전 차수 합격자의 현재 차수 지원 차단 해소**: `isAlreadyApproved`를 정규 차수 합격으로 한정, 랜덤매칭 카드(matchingRound.id=null) 제외.
- **(A2·B8·기간게이트) 등록/편집 라우트 가드 개선**: 검토중(PENDING_REVIEW) 보유 시 신규 등록 재진입 허용, 편집 진입 시 EDIT 권한 검증, 매칭기간 판정 불가 시 지원폼 보수적 읽기전용.
- **(B6) 지원 409 충돌 시 DRAFT 복구**: `getMyApplications`에 status 파라미터 추가, 409 핸들러에서 DRAFT 조회로 applicationId 복구.
- **(추가) 파트 정원 권한 임시 방어**: 서버가 `part-quotas`를 운영진 검토 단계(PENDING_REVIEW) 액션으로 설계해 DRAFT에서 차단됨(AUTHORIZATION-0002). 중앙/지부 운영진도 PM·학교회장단과 동일하게 신규 등록 시 모집정보 step을 건너뛰도록 처리해 호출 자체를 차단. 등록 플로우 설계 정렬은 서버팀 논의 후 확정 예정.

## 🎞️ 주요 코드 설명

- `projectDetailCta.ts`: `selectIsAlreadyApproved` 헬퍼 + 단위 테스트 5건
- `routes/matching/projects/new.tsx`: 편집 EDIT 가드, quota 가드 PENDING_REVIEW 제외, `isApplicationReadOnly`를 매칭차수 쿼리 성공 시에만 판정, 신규 등록 시 모집정보 step 진입 차단(`canEditRecruitStep`/`resolveCanEditRecruitStep`)
- `matchingProject.ts` / `ProjectApplyModal.tsx`: `getMyApplications(gisuId, status?)` + 409 DRAFT 조회

타입체크 통과, 테스트 152건 전부 통과.

## 🔗 연결된 이슈

- Connected: #295
- Closes #295