### PR TITLE
QA 토스트 및 지원서 선택 동작 수정

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -234,6 +234,17 @@
   }
 }
 
+@keyframes toast-resolve {
+  0% {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
 @utility scrollbar-none {
   -ms-overflow-style: none;
   scrollbar-width: none;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -23,6 +23,14 @@ interface HeaderProps {
   activePathname?: string
 }
 
+function getDisabledNavMessage(label: string) {
+  if (label === "리크루팅") {
+    return "리크루팅 서비스는 11기 모집 때 공개됩니다. 많은 관심 부탁드립니다!"
+  }
+
+  return `${label} 서비스는 준비 중입니다. 더 나은 UMC 웹사이트로 찾아뵙겠습니다!`
+}
+
 export default function Header({ activePathname }: HeaderProps = {}) {
   const location = useLocation()
   const pathname = activePathname ?? location.pathname
@@ -37,7 +45,7 @@ export default function Header({ activePathname }: HeaderProps = {}) {
 
   const handleDisabledClick = (label: string) => {
     addToast({
-      message: `${label} 서비스는 준비 중입니다. 더 나은 UMC 웹사이트로 찾아뵙겠습니다!`,
+      message: getDisabledNavMessage(label),
       color: "primary",
       variant: "deep",
       type: "notice",

--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 
+import { cn } from "@/shared/lib/utils"
+
 import { FADE_OUT_DURATION, Toast } from "./Toast"
 import { type ToastItem, useToastStore } from "./useToastStore"
 
@@ -7,11 +9,9 @@ const MAX_VISIBLE = 3
 const STACK_OFFSET = 8
 const STACK_SCALE = 0.04
 
-function getToastAnimation(color: ToastItem["color"], isFront: boolean) {
+function getToastAnimationClass(color: ToastItem["color"], isFront: boolean) {
   if (!isFront) return undefined
-  return color === "red"
-    ? "toast-shake 0.4s ease-in-out"
-    : "toast-resolve 0.24s ease-out"
+  return color === "red" ? "animate-shake" : "animate-toast-resolve"
 }
 
 export function ToastProvider() {
@@ -131,10 +131,12 @@ export function ToastProvider() {
             style={{ zIndex }}
           >
             <div
-              className="origin-bottom transition-all duration-300"
+              className={cn(
+                "origin-bottom transition-all duration-300",
+                getToastAnimationClass(toast.color, isFront),
+              )}
               style={{
                 transform: `translateY(${translateY}px) scale(${scale})`,
-                animation: getToastAnimation(toast.color, isFront),
               }}
             >
               <Toast

--- a/src/components/toast/ToastProvider.tsx
+++ b/src/components/toast/ToastProvider.tsx
@@ -1,11 +1,18 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { FADE_OUT_DURATION, Toast } from "./Toast"
-import { useToastStore } from "./useToastStore"
+import { type ToastItem, useToastStore } from "./useToastStore"
 
 const MAX_VISIBLE = 3
 const STACK_OFFSET = 8
 const STACK_SCALE = 0.04
+
+function getToastAnimation(color: ToastItem["color"], isFront: boolean) {
+  if (!isFront) return undefined
+  return color === "red"
+    ? "toast-shake 0.4s ease-in-out"
+    : "toast-resolve 0.24s ease-out"
+}
 
 export function ToastProvider() {
   const { toasts, removeToast } = useToastStore()
@@ -127,7 +134,7 @@ export function ToastProvider() {
               className="origin-bottom transition-all duration-300"
               style={{
                 transform: `translateY(${translateY}px) scale(${scale})`,
-                animation: isFront ? "toast-shake 0.4s ease-in-out" : undefined,
+                animation: getToastAnimation(toast.color, isFront),
               }}
             >
               <Toast

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -448,7 +448,7 @@ export function ProjectApplyModal({
                     key={`${optionValue}-${index}`}
                     checked={value === optionValue}
                     onChange={(checked) => {
-                      if (checked) onChange(optionValue)
+                      onChange(checked ? optionValue : "")
                     }}
                   >
                     {opt.content}

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.ui.test.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.ui.test.tsx
@@ -1,0 +1,83 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ProjectApplyModal } from "./ProjectApplyModal"
+
+import type { Section } from "@/features/project/new/model/applicationQuestion"
+
+import type { MatchingProject } from "../../model/matchingProject"
+
+vi.mock("@/features/auth/hooks/useResourcePermission", () => ({
+  useResourcePermission: () => ({ isPending: false }),
+}))
+
+const project: MatchingProject = {
+  id: "1",
+  branch: "중앙",
+  school: "테스트대학교",
+  title: "테스트 프로젝트",
+  description: "테스트 프로젝트 설명",
+  authorSchoolLine: "테스트대학교",
+  recruitRows: [{ part: "프론트엔드", current: 0, total: 1 }],
+}
+
+const sections: Section[] = [
+  {
+    id: "common",
+    name: "공통 문항",
+    isEnabled: true,
+    questions: [
+      {
+        id: "101",
+        title: "단일 선택",
+        caption: "",
+        fieldType: "radio",
+        required: true,
+        options: [
+          { content: "첫 번째", optionId: 1001 },
+          { content: "두 번째", optionId: 1002 },
+        ],
+      },
+    ],
+  },
+]
+
+beforeEach(() => {
+  HTMLElement.prototype.scrollIntoView = vi.fn()
+})
+
+describe("ProjectApplyModal radio answer", () => {
+  it("선택된 단일 선택지를 다시 누르면 선택을 해제한다", async () => {
+    vi.stubEnv("VITE_DEV_MATCHING_ROUND_ID", "1")
+
+    render(
+      <ProjectApplyModal
+        data={project}
+        projectId={1}
+        matchingRoundId={1}
+        sections={sections}
+        onBack={vi.fn()}
+        onSubmitSuccess={vi.fn()}
+      />,
+    )
+
+    const firstOption = screen.getByRole("radio", { name: "첫 번째" })
+
+    fireEvent.click(firstOption)
+    expect(firstOption).toHaveAttribute("aria-checked", "true")
+
+    fireEvent.click(firstOption)
+    expect(firstOption).toHaveAttribute("aria-checked", "false")
+
+    fireEvent.click(screen.getByRole("button", { name: "제출하기" }))
+
+    await waitFor(() => {
+      expect(screen.getByText("선택해 주세요.")).toBeInTheDocument()
+    })
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+  vi.restoreAllMocks()
+})

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.ui.test.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.ui.test.tsx
@@ -3,13 +3,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ProjectApplyModal } from "./ProjectApplyModal"
 
+import type { MatchingProject } from "@/features/project/list/model/matchingProject"
 import type { Section } from "@/features/project/new/model/applicationQuestion"
-
-import type { MatchingProject } from "../../model/matchingProject"
 
 vi.mock("@/features/auth/hooks/useResourcePermission", () => ({
   useResourcePermission: () => ({ isPending: false }),
 }))
+
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView
 
 const project: MatchingProject = {
   id: "1",
@@ -43,7 +44,13 @@ const sections: Section[] = [
 ]
 
 beforeEach(() => {
-  HTMLElement.prototype.scrollIntoView = vi.fn()
+  if (!originalScrollIntoView) {
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      configurable: true,
+      value: () => undefined,
+    })
+  }
+  vi.spyOn(HTMLElement.prototype, "scrollIntoView").mockImplementation(vi.fn())
 })
 
 describe("ProjectApplyModal radio answer", () => {
@@ -80,4 +87,7 @@ describe("ProjectApplyModal radio answer", () => {
 afterEach(() => {
   vi.unstubAllEnvs()
   vi.restoreAllMocks()
+  if (!originalScrollIntoView) {
+    Reflect.deleteProperty(HTMLElement.prototype, "scrollIntoView")
+  }
 })

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -25,3 +25,11 @@
     animation: none;
   }
 }
+
+@utility animate-toast-resolve {
+  animation: toast-resolve 0.24s ease-out;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## 📸 작업 내용

> 작업한 내용을 두괄식으로 작성해주세요

- 토스트 메시지 진입 애니메이션을 상태별로 분리했습니다.
- 프로젝트 지원서 단일 선택 문항에서 선택된 항목을 다시 클릭하면 해제되도록 수정했습니다.
- 헤더 리크루팅 비활성 메뉴 클릭 시 11기 모집 공개 안내 문구가 표시되도록 변경했습니다.

## 🎞️ 주요 코드 설명

> 설명이 필요한 코드 위주로 작성해주세요

### 토스트 상태별 애니메이션 분기

```TypeScript
function getToastAnimation(color: ToastItem["color"], isFront: boolean) {
  if (!isFront) return undefined
  return color === "red"
    ? "toast-shake 0.4s ease-in-out"
    : "toast-resolve 0.24s ease-out"
}
```

- 에러 토스트는 기존 `toast-shake` 애니메이션을 유지합니다.
- 성공 토스트는 새 `toast-resolve` 애니메이션을 사용해 흔들림 없이 진입합니다.

### 지원서 단일 선택 해제 처리

```TypeScript
onChange={(checked) => {
  onChange(checked ? optionValue : "")
}}
```

- `RadioList`는 선택된 항목 재클릭 시 `checked=false`를 전달합니다.
- 기존에는 `checked=true`만 처리해 해제가 무시됐고, 이제 `""`로 되돌려 미선택 상태를 반영합니다.

### 리크루팅 비활성 메뉴 문구 분기

```TypeScript
function getDisabledNavMessage(label: string) {
  if (label === "리크루팅") {
    return "리크루팅 서비스는 11기 모집 때 공개됩니다. 많은 관심 부탁드립니다!"
  }

  return `${label} 서비스는 준비 중입니다. 더 나은 UMC 웹사이트로 찾아뵙겠습니다!`
}
```

- 리크루팅 메뉴는 별도 안내 문구를 사용합니다.
- 다른 비활성 메뉴는 기존 공통 준비 중 문구를 유지합니다.

## 🖥️ 구현화면

> localhost 캡쳐 사진을 첨부해 주세요.

| 토스트 애니메이션 | 지원서 단일 선택 |
| :---------------: | :--------------: |
|        추후 첨부        |       추후 첨부       |

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #298
- Connected: #299
- Connected: #300
- Closes #298
- Closes #299
- Closes #300

## 💬 기타 더 이야기해볼 점

- 검증
  - `pnpm exec vitest run src/features/project/list/ui/apply-modal/ProjectApplyModal.ui.test.tsx src/features/project/list/ui/apply-modal/ProjectApplyModal.test.ts`
  - `pnpm exec tsc -b --pretty false`
  - `pnpm exec eslint src/components/header/Header.tsx`
  - `pnpm exec eslint src/components/toast/ToastProvider.tsx`
  - `pnpm exec eslint src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx src/features/project/list/ui/apply-modal/ProjectApplyModal.ui.test.tsx`
