### PR TITLE
✨ feat: 사용성 조사 모달 서버 API 연동 및 트리거 구현

### DIFF
--- a/src/features/application/ui/MyApplicationView.tsx
+++ b/src/features/application/ui/MyApplicationView.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/features/project/list/api/matchingProject"
 import { ProjectDetailCard } from "@/features/project/list/ui/ProjectDetailCard"
 import { ProjectManagementSubTitle } from "@/features/project/management/ui/ProjectManagementSubTitle"
+import { UsabilitySurvey } from "@/features/usability-survey"
 import { StatusChipTag } from "@/shared/ui/chip/StatusChipTag"
 import { EmptyState } from "@/shared/ui/EmptyState"
 import { Modal } from "@/shared/ui/Modal"
@@ -150,6 +151,9 @@ export function MyApplicationView() {
     enabled: gisuId != null,
   })
   const applications = raw.filter((a) => a.status !== "CANCELLED")
+  const hasMatchingResult = applications.some(
+    (a) => a.status === "APPROVED" || a.status === "REJECTED",
+  )
 
   if (!applications?.length) {
     return (
@@ -169,6 +173,11 @@ export function MyApplicationView() {
       {applications.map((item) => (
         <MyApplicationRoundSection key={item.applicationId} item={item} />
       ))}
+
+      <UsabilitySurvey
+        context="MATCHING_COMPLETED"
+        active={hasMatchingResult}
+      />
     </div>
   )
 }

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -16,6 +16,7 @@ import {
   mapApplicationFormToSections,
   projectKeys,
 } from "@/features/project/new/api"
+import { UsabilitySurvey } from "@/features/usability-survey"
 import { getActiveGisu } from "@/shared/api/gisu"
 import { ProjectLogo } from "@/shared/assets/icon/logo/ProjectLogo"
 import { formatSchoolName } from "@/shared/lib/formatSchoolName"
@@ -218,6 +219,7 @@ export function ProjectDetailCard({
     useState(false)
   const [isRecruitQuestionsModalOpen, setIsRecruitQuestionsModalOpen] =
     useState(false)
+  const [isSurveyActive, setIsSurveyActive] = useState(false)
   const {
     data: detail,
     dataUpdatedAt: detailDataUpdatedAt,
@@ -713,6 +715,7 @@ export function ProjectDetailCard({
                   void queryClient.invalidateQueries({
                     queryKey: ["myApplications", activeGisuId],
                   })
+                  setIsSurveyActive(true)
                 }}
               />
             )}
@@ -755,6 +758,11 @@ export function ProjectDetailCard({
           </Modal.Content>
         </Modal.Portal>
       </Modal.Root>
+
+      <UsabilitySurvey
+        context="APPLICATION_SUBMITTED"
+        active={isSurveyActive}
+      />
     </>
   )
 }

--- a/src/features/usability-survey/api/queryKeys.ts
+++ b/src/features/usability-survey/api/queryKeys.ts
@@ -1,0 +1,7 @@
+import type { FeedbackContext } from "./types"
+
+export const feedbackKeys = {
+  all: ["user-feedbacks"] as const,
+  template: (context: FeedbackContext) =>
+    [...feedbackKeys.all, "template", context] as const,
+}

--- a/src/features/usability-survey/api/types.ts
+++ b/src/features/usability-survey/api/types.ts
@@ -1,0 +1,23 @@
+import type { components } from "@/types/api"
+
+export type FeedbackContext =
+  components["schemas"]["GetUserFeedbackTemplateResponse"]["context"]
+
+export type FeedbackTargetType =
+  components["schemas"]["GetUserFeedbackTemplateResponse"]["targetType"]
+
+export type GetUserFeedbackTemplateResponse =
+  components["schemas"]["GetUserFeedbackTemplateResponse"]
+
+export type FeedbackForm = components["schemas"]["FeedbackForm"]
+export type FeedbackSection = components["schemas"]["FeedbackSection"]
+export type FeedbackQuestion = components["schemas"]["FeedbackQuestion"]
+export type FeedbackOption = components["schemas"]["FeedbackOption"]
+export type FeedbackQuestionType = NonNullable<FeedbackQuestion["type"]>
+
+export type SubmitUserFeedbackResponseRequest =
+  components["schemas"]["SubmitUserFeedbackResponseRequest"]
+export type UserFeedbackAnswerItem =
+  components["schemas"]["UserFeedbackAnswerItem"]
+export type UserFeedbackSubmitResponse =
+  components["schemas"]["UserFeedbackSubmitResponse"]

--- a/src/features/usability-survey/api/userFeedbackApi.ts
+++ b/src/features/usability-survey/api/userFeedbackApi.ts
@@ -1,0 +1,27 @@
+import { api } from "@/shared/lib/axios"
+
+import type { ApiResponse } from "@/shared/lib/apiResponse"
+
+import type {
+  FeedbackContext,
+  GetUserFeedbackTemplateResponse,
+  SubmitUserFeedbackResponseRequest,
+  UserFeedbackSubmitResponse,
+} from "./types"
+
+export async function getFeedbackTemplate(context: FeedbackContext) {
+  const { data } = await api.get<
+    ApiResponse<GetUserFeedbackTemplateResponse | null>
+  >("/v1/user-feedbacks/templates", { params: { context } })
+  return data.result
+}
+
+export async function submitFeedbackResponse(
+  body: SubmitUserFeedbackResponseRequest,
+) {
+  const { data } = await api.post<ApiResponse<UserFeedbackSubmitResponse>>(
+    "/v1/user-feedbacks/responses",
+    body,
+  )
+  return data.result
+}

--- a/src/features/usability-survey/hooks/useUserFeedback.ts
+++ b/src/features/usability-survey/hooks/useUserFeedback.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQuery } from "@tanstack/react-query"
+
+import { feedbackKeys } from "../api/queryKeys"
+import {
+  getFeedbackTemplate,
+  submitFeedbackResponse,
+} from "../api/userFeedbackApi"
+
+import type { FeedbackContext } from "../api/types"
+
+export function useFeedbackTemplate(
+  context: FeedbackContext,
+  options?: { enabled?: boolean },
+) {
+  return useQuery({
+    queryKey: feedbackKeys.template(context),
+    queryFn: () => getFeedbackTemplate(context),
+    enabled: options?.enabled ?? true,
+    staleTime: Infinity,
+  })
+}
+
+export function useSubmitFeedback() {
+  return useMutation({
+    mutationFn: submitFeedbackResponse,
+  })
+}

--- a/src/features/usability-survey/index.ts
+++ b/src/features/usability-survey/index.ts
@@ -1,3 +1,6 @@
+export type { FeedbackContext } from "./api/types"
+export { useFeedbackTemplate, useSubmitFeedback } from "./hooks/useUserFeedback"
+export { resolveVariantKey, toAnswerItems } from "./model/mappers"
 export type {
   SurveyAnswers,
   SurveyAnswerValue,
@@ -7,9 +10,12 @@ export type {
   SurveyStep,
   SurveyVariantConfig,
 } from "./model/types"
+
 export { useMultistepSurvey } from "./model/useMultistepSurvey"
 export { SURVEY_VARIANTS } from "./model/variants"
 export type { SurveyVariantKey } from "./model/variants"
-
 export { SurveyQuestionList } from "./ui/SurveyQuestionList"
+
+export { UsabilitySurvey } from "./ui/UsabilitySurvey"
 export { UsabilitySurveyModal } from "./ui/UsabilitySurveyModal"
+export { UsabilitySurveyView } from "./ui/UsabilitySurveyView"

--- a/src/features/usability-survey/model/mappers.test.ts
+++ b/src/features/usability-survey/model/mappers.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveVariantKey, toAnswerItems } from "./mappers"
+import { getScaleTextKey } from "./types"
+import { SURVEY_VARIANTS } from "./variants"
+
+import type { FeedbackForm } from "../api/types"
+import type { SurveyAnswers } from "./types"
+
+// dev 서버 APPLICATION_SUBMITTED (template 1) 응답 기반
+const applyForm: FeedbackForm = {
+  formId: 2,
+  sections: [
+    {
+      sectionId: 2,
+      orderNo: 1,
+      questions: [
+        {
+          questionId: 2,
+          type: "RADIO",
+          orderNo: 1,
+          options: [
+            { optionId: 2, content: "쉬움", orderNo: 1 },
+            { optionId: 3, content: "조금 쉬움", orderNo: 2 },
+            { optionId: 4, content: "보통", orderNo: 3 },
+            { optionId: 5, content: "조금 어려움", orderNo: 4 },
+            { optionId: 6, content: "어려움", orderNo: 5 },
+          ],
+        },
+        {
+          questionId: 3,
+          type: "RADIO",
+          orderNo: 2,
+          options: [
+            { optionId: 7, content: "만족스러워요", orderNo: 1 },
+            { optionId: 8, content: "아쉬워요", orderNo: 2 },
+          ],
+        },
+        { questionId: 4, type: "LONG_TEXT", orderNo: 3, options: [] },
+        { questionId: 5, type: "LONG_TEXT", orderNo: 4, options: [] },
+      ],
+    },
+  ],
+}
+
+// dev 서버 APPLICATION_MONITORING (template 5, ADMIN) 응답 기반
+const adminForm: FeedbackForm = {
+  formId: 6,
+  sections: [
+    {
+      sectionId: 6,
+      orderNo: 1,
+      questions: [
+        {
+          questionId: 20,
+          type: "RADIO",
+          orderNo: 1,
+          options: [
+            { optionId: 34, content: "쉬움", orderNo: 1 },
+            { optionId: 35, content: "조금 쉬움", orderNo: 2 },
+            { optionId: 36, content: "보통", orderNo: 3 },
+            { optionId: 37, content: "조금 어려움", orderNo: 4 },
+            { optionId: 38, content: "어려움", orderNo: 5 },
+          ],
+        },
+        {
+          questionId: 21,
+          type: "RADIO",
+          orderNo: 2,
+          options: [
+            { optionId: 39, content: "전보다 편해요", orderNo: 1 },
+            { optionId: 40, content: "전보다 불편해요", orderNo: 2 },
+          ],
+        },
+        {
+          questionId: 22,
+          type: "RADIO",
+          orderNo: 3,
+          options: [
+            { optionId: 41, content: "전혀 없었어요", orderNo: 1 },
+            { optionId: 42, content: "조금 있었어요", orderNo: 2 },
+            { optionId: 43, content: "많이 있었어요", orderNo: 3 },
+          ],
+        },
+        { questionId: 23, type: "LONG_TEXT", orderNo: 4, options: [] },
+        {
+          questionId: 24,
+          type: "RADIO",
+          orderNo: 5,
+          options: [
+            { optionId: 44, content: "좋아요", orderNo: 1 },
+            { optionId: 45, content: "아니요", orderNo: 2 },
+          ],
+        },
+        { questionId: 25, type: "LONG_TEXT", orderNo: 6, options: [] },
+        {
+          questionId: 26,
+          type: "RADIO",
+          orderNo: 7,
+          options: [
+            { optionId: 46, content: "공지 작성", orderNo: 1 },
+            { optionId: 47, content: "프로젝트 목록 및 정보 확인", orderNo: 2 },
+            { optionId: 48, content: "지원 현황", orderNo: 3 },
+            { optionId: 49, content: "매칭 현황", orderNo: 4 },
+            { optionId: 50, content: "매칭 차수 설정", orderNo: 5 },
+            { optionId: 51, content: "기타", orderNo: 6, isOther: true },
+          ],
+        },
+        { questionId: 27, type: "LONG_TEXT", orderNo: 8, options: [] },
+      ],
+    },
+  ],
+}
+
+describe("resolveVariantKey", () => {
+  it("context와 targetType 조합을 variant 키로 매핑한다", () => {
+    expect(resolveVariantKey("APPLICATION_SUBMITTED", "NEW_CHALLENGER")).toBe(
+      "new-gisu-general-apply",
+    )
+    expect(
+      resolveVariantKey("APPLICATION_SUBMITTED", "EXPERIENCED_CHALLENGER"),
+    ).toBe("prev-gisu-general-apply")
+    expect(resolveVariantKey("MATCHING_COMPLETED", "NEW_CHALLENGER")).toBe(
+      "new-gisu-general-matching",
+    )
+    expect(
+      resolveVariantKey("MATCHING_COMPLETED", "EXPERIENCED_CHALLENGER"),
+    ).toBe("prev-gisu-general-matching")
+    expect(resolveVariantKey("APPLICATION_MONITORING", "ADMIN")).toBe(
+      "admin-matching",
+    )
+  })
+
+  it("대응되지 않는 조합은 null을 반환한다", () => {
+    expect(resolveVariantKey("APPLICATION_SUBMITTED", "ADMIN")).toBeNull()
+    expect(
+      resolveVariantKey("APPLICATION_MONITORING", "NEW_CHALLENGER"),
+    ).toBeNull()
+    expect(resolveVariantKey(undefined, undefined)).toBeNull()
+  })
+})
+
+describe("toAnswerItems", () => {
+  it("scale/choice/text 답변을 서버 answer 포맷으로 변환한다", () => {
+    const answers: SurveyAnswers = {
+      difficulty: 4,
+      "apply-process": "positive",
+      feedback: "좋았어요",
+      extra: "",
+    }
+
+    const result = toAnswerItems(
+      SURVEY_VARIANTS["new-gisu-general-apply"],
+      applyForm,
+      answers,
+    )
+
+    expect(result).toEqual([
+      { questionId: 2, selectedOptionIds: [3] },
+      { questionId: 3, selectedOptionIds: [7] },
+      { questionId: 4, textValue: "좋았어요" },
+    ])
+  })
+
+  it("scale 값을 scores 인덱스로 옵션과 매핑한다", () => {
+    const result = toAnswerItems(
+      SURVEY_VARIANTS["new-gisu-general-apply"],
+      applyForm,
+      { difficulty: 1, "apply-process": "negative" },
+    )
+
+    expect(result).toContainEqual({ questionId: 2, selectedOptionIds: [6] })
+    expect(result).toContainEqual({ questionId: 3, selectedOptionIds: [8] })
+  })
+
+  it("admin variant의 scale-with-text 분리와 single-select를 매핑한다", () => {
+    const answers: SurveyAnswers = {
+      difficulty: 5,
+      "matching-process": "negative",
+      "info-difficulty": 3,
+      [getScaleTextKey("info-difficulty")]: "정보 부족",
+      reuse: "positive",
+      feedback: "",
+      "worst-step": "matching-status",
+      extra: "끝",
+    }
+
+    const result = toAnswerItems(
+      SURVEY_VARIANTS["admin-matching"],
+      adminForm,
+      answers,
+    )
+
+    expect(result).toEqual([
+      { questionId: 20, selectedOptionIds: [34] },
+      { questionId: 21, selectedOptionIds: [40] },
+      { questionId: 22, selectedOptionIds: [42] },
+      { questionId: 23, textValue: "정보 부족" },
+      { questionId: 24, selectedOptionIds: [44] },
+      { questionId: 26, selectedOptionIds: [49] },
+      { questionId: 27, textValue: "끝" },
+    ])
+  })
+
+  it("문자열로 직렬화된 id를 number로 정규화한다", () => {
+    const stringIdForm = {
+      formId: "2",
+      sections: [
+        {
+          sectionId: "2",
+          orderNo: "1",
+          questions: [
+            {
+              questionId: "2",
+              type: "RADIO",
+              orderNo: "1",
+              options: [
+                { optionId: "2", content: "쉬움", orderNo: "1" },
+                { optionId: "3", content: "조금 쉬움", orderNo: "2" },
+                { optionId: "4", content: "보통", orderNo: "3" },
+                { optionId: "5", content: "조금 어려움", orderNo: "4" },
+                { optionId: "6", content: "어려움", orderNo: "5" },
+              ],
+            },
+            {
+              questionId: "3",
+              type: "RADIO",
+              orderNo: "2",
+              options: [
+                { optionId: "7", content: "만족스러워요", orderNo: "1" },
+                { optionId: "8", content: "아쉬워요", orderNo: "2" },
+              ],
+            },
+            { questionId: "4", type: "LONG_TEXT", orderNo: "3", options: [] },
+            { questionId: "5", type: "LONG_TEXT", orderNo: "4", options: [] },
+          ],
+        },
+      ],
+    } as unknown as FeedbackForm
+
+    const result = toAnswerItems(
+      SURVEY_VARIANTS["new-gisu-general-apply"],
+      stringIdForm,
+      { difficulty: 4, "apply-process": "positive" },
+    )
+
+    expect(result).toEqual([
+      { questionId: 2, selectedOptionIds: [3] },
+      { questionId: 3, selectedOptionIds: [7] },
+    ])
+  })
+
+  it("슬롯과 서버 질문 개수가 다르면 예외를 던진다", () => {
+    const brokenForm: FeedbackForm = {
+      formId: 2,
+      sections: [
+        {
+          sectionId: 2,
+          orderNo: 1,
+          questions: [
+            { questionId: 2, type: "RADIO", orderNo: 1, options: [] },
+          ],
+        },
+      ],
+    }
+
+    expect(() =>
+      toAnswerItems(SURVEY_VARIANTS["new-gisu-general-apply"], brokenForm, {}),
+    ).toThrow()
+  })
+})

--- a/src/features/usability-survey/model/mappers.ts
+++ b/src/features/usability-survey/model/mappers.ts
@@ -1,0 +1,151 @@
+import { getScaleTextKey } from "./types"
+
+import type {
+  FeedbackContext,
+  FeedbackForm,
+  FeedbackOption,
+  FeedbackQuestion,
+  FeedbackTargetType,
+  UserFeedbackAnswerItem,
+} from "../api/types"
+import type { SurveyAnswers, SurveyVariantConfig } from "./types"
+import type { SurveyVariantKey } from "./variants"
+
+export function resolveVariantKey(
+  context: FeedbackContext,
+  targetType: FeedbackTargetType,
+): SurveyVariantKey | null {
+  switch (context) {
+    case "APPLICATION_SUBMITTED":
+      if (targetType === "NEW_CHALLENGER") return "new-gisu-general-apply"
+      if (targetType === "EXPERIENCED_CHALLENGER")
+        return "prev-gisu-general-apply"
+      return null
+    case "MATCHING_COMPLETED":
+      if (targetType === "NEW_CHALLENGER") return "new-gisu-general-matching"
+      if (targetType === "EXPERIENCED_CHALLENGER")
+        return "prev-gisu-general-matching"
+      return null
+    case "APPLICATION_MONITORING":
+      if (targetType === "ADMIN") return "admin-matching"
+      return null
+    default:
+      return null
+  }
+}
+
+type Slot =
+  | { kind: "scale"; id: string; scores: number[] }
+  | { kind: "choice"; id: string }
+  | { kind: "select"; id: string; optionValues: string[] }
+  | { kind: "text"; id: string }
+
+function flattenSlots(config: SurveyVariantConfig): Slot[] {
+  const slots: Slot[] = []
+  for (const step of config.steps) {
+    for (const item of step.items) {
+      switch (item.kind) {
+        case "divider":
+          break
+        case "emoji-scale":
+          slots.push({ kind: "scale", id: item.id, scores: item.scores })
+          break
+        case "emoji-scale-with-text":
+          slots.push({ kind: "scale", id: item.id, scores: item.scores })
+          slots.push({ kind: "text", id: getScaleTextKey(item.id) })
+          break
+        case "emoji-choice":
+          slots.push({ kind: "choice", id: item.id })
+          break
+        case "text":
+          slots.push({ kind: "text", id: item.id })
+          break
+        case "single-select":
+          slots.push({
+            kind: "select",
+            id: item.id,
+            optionValues: item.options.map((option) => option.value),
+          })
+          break
+      }
+    }
+  }
+  return slots
+}
+
+const byOrderNo = (a: { orderNo?: number }, b: { orderNo?: number }): number =>
+  Number(a.orderNo ?? 0) - Number(b.orderNo ?? 0)
+
+function flattenQuestions(form: FeedbackForm): FeedbackQuestion[] {
+  return [...(form.sections ?? [])]
+    .sort(byOrderNo)
+    .flatMap((section) => [...(section.questions ?? [])].sort(byOrderNo))
+}
+
+function sortedOptions(question: FeedbackQuestion): FeedbackOption[] {
+  return [...(question.options ?? [])].sort(byOrderNo)
+}
+
+export function toAnswerItems(
+  config: SurveyVariantConfig,
+  form: FeedbackForm,
+  answers: SurveyAnswers,
+): UserFeedbackAnswerItem[] {
+  const slots = flattenSlots(config)
+  const questions = flattenQuestions(form)
+
+  if (slots.length !== questions.length) {
+    throw new Error(
+      `[usability-survey] 슬롯/질문 개수 불일치 (${slots.length} vs ${questions.length})`,
+    )
+  }
+
+  const items: UserFeedbackAnswerItem[] = []
+
+  slots.forEach((slot, index) => {
+    const question = questions[index]
+    const questionId = Number(question.questionId)
+    const options = sortedOptions(question)
+    const raw = answers[slot.id]
+
+    switch (slot.kind) {
+      case "scale": {
+        if (typeof raw !== "number") break
+        const option = options[slot.scores.indexOf(raw)]
+        if (option)
+          items.push({
+            questionId,
+            selectedOptionIds: [Number(option.optionId)],
+          })
+        break
+      }
+      case "choice": {
+        if (raw !== "positive" && raw !== "negative") break
+        const option = options[raw === "positive" ? 0 : 1]
+        if (option)
+          items.push({
+            questionId,
+            selectedOptionIds: [Number(option.optionId)],
+          })
+        break
+      }
+      case "select": {
+        if (typeof raw !== "string" || raw === "") break
+        const option = options[slot.optionValues.indexOf(raw)]
+        if (option)
+          items.push({
+            questionId,
+            selectedOptionIds: [Number(option.optionId)],
+          })
+        break
+      }
+      case "text": {
+        if (typeof raw !== "string" || raw.trim() === "") break
+        items.push({ questionId, textValue: raw })
+        break
+      }
+    }
+  })
+
+  return items
+}

--- a/src/features/usability-survey/model/mappers.ts
+++ b/src/features/usability-survey/model/mappers.ts
@@ -104,6 +104,7 @@ export function toAnswerItems(
 
   slots.forEach((slot, index) => {
     const question = questions[index]
+    if (!question) return
     const questionId = Number(question.questionId)
     const options = sortedOptions(question)
     const raw = answers[slot.id]

--- a/src/features/usability-survey/ui/UsabilitySurvey.tsx
+++ b/src/features/usability-survey/ui/UsabilitySurvey.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react"
+
+import { useToastStore } from "@/components/toast/useToastStore"
+
+import {
+  useFeedbackTemplate,
+  useSubmitFeedback,
+} from "../hooks/useUserFeedback"
+import { resolveVariantKey, toAnswerItems } from "../model/mappers"
+import { useMultistepSurvey } from "../model/useMultistepSurvey"
+import { SURVEY_VARIANTS } from "../model/variants"
+import { UsabilitySurveyView } from "./UsabilitySurveyView"
+
+import type { FeedbackContext, FeedbackForm } from "../api/types"
+import type { SurveyVariantKey } from "../model/variants"
+
+interface UsabilitySurveyProps {
+  context: FeedbackContext
+  active: boolean
+}
+
+export function UsabilitySurvey({ context, active }: UsabilitySurveyProps) {
+  const [dismissed, setDismissed] = useState(false)
+
+  const { data: template } = useFeedbackTemplate(context, {
+    enabled: active && !dismissed,
+  })
+
+  if (!active || dismissed) return null
+  if (!template?.form || template.templateId == null) return null
+
+  const variantKey = resolveVariantKey(template.context, template.targetType)
+  if (!variantKey) return null
+
+  return (
+    <UsabilitySurveyRunner
+      variantKey={variantKey}
+      form={template.form}
+      templateId={Number(template.templateId)}
+      onClose={() => setDismissed(true)}
+    />
+  )
+}
+
+interface UsabilitySurveyRunnerProps {
+  variantKey: SurveyVariantKey
+  form: FeedbackForm
+  templateId: number
+  onClose: () => void
+}
+
+function UsabilitySurveyRunner({
+  variantKey,
+  form,
+  templateId,
+  onClose,
+}: UsabilitySurveyRunnerProps) {
+  const config = SURVEY_VARIANTS[variantKey]
+  const addToast = useToastStore((s) => s.addToast)
+  const mutation = useSubmitFeedback()
+  const survey = useMultistepSurvey(config)
+  const [open, setOpen] = useState(true)
+
+  const close = () => {
+    setOpen(false)
+    onClose()
+  }
+
+  const handleSubmit = () => {
+    if (!survey.isStepComplete || mutation.isPending) return
+
+    let answers
+    try {
+      answers = toAnswerItems(config, form, survey.answers)
+    } catch {
+      addToast({
+        message: "제출 중 문제가 발생했어요. 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return
+    }
+
+    mutation.mutate(
+      { templateId, answers },
+      {
+        onSuccess: () => {
+          addToast({
+            message: "소중한 의견 감사합니다!",
+            color: "primary",
+            variant: "deep",
+            type: "default",
+            duration: 3000,
+          })
+          close()
+        },
+        onError: () => {
+          addToast({
+            message: "제출에 실패했어요. 다시 시도해주세요.",
+            color: "red",
+            variant: "deep",
+            type: "default",
+            duration: 3000,
+          })
+        },
+      },
+    )
+  }
+
+  return (
+    <UsabilitySurveyView
+      open={open}
+      preventClose={config.preventClose}
+      survey={survey}
+      onSubmit={handleSubmit}
+      isSubmitting={mutation.isPending}
+    />
+  )
+}

--- a/src/features/usability-survey/ui/UsabilitySurveyView.tsx
+++ b/src/features/usability-survey/ui/UsabilitySurveyView.tsx
@@ -1,0 +1,82 @@
+import { Button } from "@/shared/ui/Button"
+
+import { SurveyQuestionList } from "./SurveyQuestionList"
+import { UsabilitySurveyModal } from "./UsabilitySurveyModal"
+
+import type { useMultistepSurvey } from "../model/useMultistepSurvey"
+
+interface UsabilitySurveyViewProps {
+  open: boolean
+  onOpenChange?: (open: boolean) => void
+  survey: ReturnType<typeof useMultistepSurvey>
+  preventClose?: boolean
+  onSubmit: () => void
+  isSubmitting?: boolean
+}
+
+export function UsabilitySurveyView({
+  open,
+  onOpenChange,
+  survey,
+  preventClose,
+  onSubmit,
+  isSubmitting,
+}: UsabilitySurveyViewProps) {
+  const submitButton = (
+    <Button
+      variant="fill"
+      color="primary"
+      onClick={onSubmit}
+      disabled={!survey.isStepComplete}
+      isLoading={isSubmitting}
+    >
+      전달하기
+    </Button>
+  )
+
+  const footer = (() => {
+    const footerKind = survey.currentStep.footer
+    if (footerKind === "next-only") {
+      return (
+        <Button
+          variant="fill"
+          color="primary"
+          onClick={survey.goNext}
+          disabled={!survey.isStepComplete}
+        >
+          다음
+        </Button>
+      )
+    }
+    if (footerKind === "back-submit") {
+      return (
+        <div className="flex gap-3">
+          <Button variant="weak" color="neutral" onClick={survey.goPrev}>
+            이전
+          </Button>
+          {submitButton}
+        </div>
+      )
+    }
+    return submitButton
+  })()
+
+  return (
+    <UsabilitySurveyModal
+      open={open}
+      onOpenChange={onOpenChange}
+      title={survey.currentStep.title}
+      preventClose={preventClose}
+      scrollRef={survey.scrollRef}
+      footer={footer}
+    >
+      <SurveyQuestionList
+        items={survey.currentStep.items}
+        answers={survey.answers}
+        onAnswer={survey.onAnswer}
+        startNumber={survey.startNumber}
+        reveal={survey.currentStep.reveal}
+      />
+    </UsabilitySurveyModal>
+  )
+}

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -33,6 +33,7 @@ import { BranchSelector } from "@/features/matching/ui/BranchSelector"
 import { Calendar } from "@/features/matching/ui/Calendar"
 import { CalendarScheduleList } from "@/features/matching/ui/CalendarScheduleList"
 import { RoundForm } from "@/features/matching/ui/RoundForm"
+import { UsabilitySurvey } from "@/features/usability-survey"
 import InfoCircleIcon from "@/shared/assets/icon/infomation/InfoCircleIcon"
 import { Button } from "@/shared/ui/Button"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
@@ -93,6 +94,7 @@ function MatchingRoundsPage() {
     "idle",
   )
   const [showSaveModal, setShowSaveModal] = useState(false)
+  const [isSurveyActive, setIsSurveyActive] = useState(false)
   const [roundErrors, setRoundErrors] = useState(() =>
     PHASES.map(() => ({ startDate: false, endDate: false })),
   )
@@ -666,7 +668,15 @@ function MatchingRoundsPage() {
         title="저장 완료"
         content="매칭 설정이 완료되었습니다."
         confirmText="확인"
-        onConfirm={() => setShowSaveModal(false)}
+        onConfirm={() => {
+          setShowSaveModal(false)
+          setIsSurveyActive(true)
+        }}
+      />
+
+      <UsabilitySurvey
+        context="APPLICATION_MONITORING"
+        active={isSurveyActive}
       />
 
       {/* 페이지 이탈 모달 */}

--- a/src/routes/test/usability-survey.tsx
+++ b/src/routes/test/usability-survey.tsx
@@ -5,12 +5,14 @@ import { useToastStore } from "@/components/toast/useToastStore"
 import {
   SURVEY_VARIANTS,
   SurveyQuestionList,
+  UsabilitySurvey,
   UsabilitySurveyModal,
   useMultistepSurvey,
 } from "@/features/usability-survey"
 import { Button } from "@/shared/ui/Button"
 
 import type {
+  FeedbackContext,
   SurveyAnswers,
   SurveyVariantKey,
 } from "@/features/usability-survey"
@@ -27,8 +29,16 @@ const VARIANT_LABELS: Record<SurveyVariantKey, string> = {
   "admin-matching": "운영진·매칭(멀티스텝)",
 }
 
+const LIVE_CONTEXTS: { context: FeedbackContext; label: string }[] = [
+  { context: "APPLICATION_SUBMITTED", label: "지원 완료" },
+  { context: "MATCHING_COMPLETED", label: "매칭 완료" },
+  { context: "APPLICATION_MONITORING", label: "운영진 모니터링" },
+]
+
 function UsabilitySurveyTestPage() {
   const [open, setOpen] = useState(false)
+  const [liveContext, setLiveContext] = useState<FeedbackContext | null>(null)
+  const [liveNonce, setLiveNonce] = useState(0)
   const [variant, setVariant] = useState<SurveyVariantKey>(
     "prev-gisu-general-apply",
   )
@@ -116,7 +126,36 @@ function UsabilitySurveyTestPage() {
         ))}
       </div>
 
-      <Button onClick={handleOpen}>모달 열기</Button>
+      <Button onClick={handleOpen}>모달 열기 (목업 디자인)</Button>
+
+      <div className="flex flex-col items-center gap-2">
+        <h2 className="text-label-1-medium text-teal-gray-700">
+          실서버 연동 (context별 템플릿 조회 → 제출)
+        </h2>
+        <div className="flex flex-wrap justify-center gap-2">
+          {LIVE_CONTEXTS.map(({ context, label }) => (
+            <Button
+              key={context}
+              variant="weak"
+              color="neutral"
+              onClick={() => {
+                setLiveContext(context)
+                setLiveNonce((n) => n + 1)
+              }}
+            >
+              {label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {liveContext && (
+        <UsabilitySurvey
+          key={`${liveContext}-${liveNonce}`}
+          context={liveContext}
+          active
+        />
+      )}
 
       <UsabilitySurveyModal
         open={open}


### PR DESCRIPTION
## 📸 작업 내용

- 사용성 조사 모달을 백엔드 `user-feedbacks` API와 연동 (템플릿 조회 + 응답 제출)
- 서버 동적 템플릿을 기존 이모지 디자인 variant에 **orderNo 인덱스 기반**으로 매핑 (디자인 유지 + ID 매핑 방식)
- `targetType`(NEW/EXPERIENCED/ADMIN)으로 variant 디자인을 결정하는 어댑터 추가
- 3개 context 트리거 연결: 지원 완료 / 매칭 완료 / 운영진 모니터링(매칭 차수 저장 완료)
- 매핑 어댑터 단위 테스트 7개 추가

> 참고: 응답 완료 재노출 차단(#307)과 테스트 페이지 초기화 버튼(#308)은 이 PR 머지 이후 작업분이라 후속 PR #311 에서 다룹니다.

## 🎞️ 주요 코드 설명

### 서버 템플릿 → 이모지 variant 매핑

```TypeScript
// emoji-scale-with-text는 서버에서 RADIO + LONG_TEXT 2개 질문으로 분리되므로 슬롯도 분리
// int64가 문자열로 직렬화되어 오므로 Number()로 정규화
slots.forEach((slot, index) => {
  const question = questions[index]
  const questionId = Number(question.questionId)
  // scale: scores 배열 인덱스로 옵션(orderNo) 매핑
  // choice: positive→옵션[0], negative→옵션[1]
  // text: textValue, 빈 값(optional 미응답)은 생략
})
```

- 서버 질문 순서(orderNo)와 프론트 variant 항목이 1:1 대응함을 dev 실제 응답으로 확인 후, content 비의존 일반 알고리즘으로 구현

## 🖥️ 구현화면

| 운영진 모니터링 (실서버 템플릿 연동) |
| :-------------------------: |
| 운영진 모니터링 트리거 → `admin-matching` 디자인 모달 정상 렌더 확인 |

## 🔗 연결된 이슈

- Connected: #301
- Closes #301