### PR TITLE
🐛 fix: 프로젝트 QA 화면 표시 오류 수정

### DIFF
--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -482,16 +482,16 @@ export function ProjectDetailCard({
             </div>
           </div>
 
-          <div className="bp1:mt-8.5 bp1:flex-row bp1:items-start mt-6 flex w-full flex-col items-stretch gap-2.5">
+          <div className="bp1:mt-8.5 scrollbar-none mt-6 flex w-full flex-nowrap items-start gap-2.5 overflow-x-auto pb-1">
             <TeamMemberButton
               variant="weak"
-              className="bp1:w-auto w-full"
+              className="w-auto"
               onClick={() => setIsTeamModalOpen(true)}
             />
             <Button
               variant="weak"
               color="primary"
-              className="flex-1"
+              className="min-w-28 flex-1 whitespace-nowrap"
               disabled={!data.externalLink}
               onClick={() => {
                 if (data.externalLink)
@@ -507,7 +507,7 @@ export function ProjectDetailCard({
             {showEditCta ? (
               shouldShowEditCta ? (
                 <Button
-                  className="flex-1"
+                  className="min-w-36 flex-1 whitespace-nowrap"
                   disabled={
                     resolvedEditPermissionLoading || !resolvedCanEditProject
                   }
@@ -531,7 +531,7 @@ export function ProjectDetailCard({
               <>
                 {ctaMode === "recruit-questions" && (
                   <Button
-                    className="flex-1"
+                    className="min-w-32 flex-1 whitespace-nowrap"
                     isLoading={isDetailLoading}
                     disabled={!isDetailLoading && !detail?.applicationFormId}
                     onClick={() => setIsRecruitQuestionsModalOpen(true)}
@@ -541,7 +541,7 @@ export function ProjectDetailCard({
                 )}
                 {ctaMode === "my-application" && !hideMyApplication && (
                   <Button
-                    className="flex-1"
+                    className="min-w-32 flex-1 whitespace-nowrap"
                     disabled={myApplicationForProject == null}
                     onClick={() => setIsMyApplicationModalOpen(true)}
                   >
@@ -554,7 +554,7 @@ export function ProjectDetailCard({
                     : isApplicationWritePermissionLoading ||
                       canWriteProjectApplication) && (
                     <Button
-                      className="flex-1"
+                      className="min-w-28 flex-1 whitespace-nowrap"
                       isLoading={
                         !(viewOnly && userIsPm) &&
                         (isDetailLoading || isApplicationWritePermissionLoading)
@@ -570,7 +570,6 @@ export function ProjectDetailCard({
                       })}
                       onClick={() => {
                         if (viewOnly && userIsPm) {
-                          // PM 읽기 전용: 모집 문항 보기 모달로 열기
                           if (!detail?.applicationFormId) {
                             addToast({
                               message:
@@ -620,7 +619,10 @@ export function ProjectDetailCard({
                 {(ctaMode === "apply-blocked-other" ||
                   ctaMode === "apply-blocked-approved" ||
                   ctaMode === "apply-blocked-part") && (
-                  <Button className="flex-1" disabled>
+                  <Button
+                    className="min-w-28 flex-1 whitespace-nowrap"
+                    disabled
+                  >
                     지원하기
                   </Button>
                 )}

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -456,7 +456,6 @@ export const BasicInfoForm = forwardRef<
             nickname={displayNickname}
             name={displayName}
             university={displayUniversity}
-            subPm={pm2Member}
             register={register}
             setValue={(name, value, options) =>
               setValue(name, value, { shouldDirty: true, ...options })

--- a/src/features/project/new/ui/basic-info/ProjectCardForm.tsx
+++ b/src/features/project/new/ui/basic-info/ProjectCardForm.tsx
@@ -22,7 +22,6 @@ interface ProjectCardFormProps {
   nickname: string
   name: string
   university: string
-  subPm?: { nickname: string; name: string; university: string } | null
   register: UseFormRegister<BasicInfoFormData>
   setValue: UseFormSetValue<BasicInfoFormData>
   watch: UseFormWatch<BasicInfoFormData>
@@ -36,7 +35,6 @@ export function ProjectCardForm({
   nickname,
   name,
   university,
-  subPm,
   register,
   setValue,
   watch,
@@ -110,15 +108,6 @@ export function ProjectCardForm({
               <span>·</span>
               <span>{university}</span>
             </div>
-            {subPm && (
-              <div className="flex max-w-full flex-wrap items-center gap-x-2 gap-y-0.5">
-                <span>
-                  {subPm.nickname}/{subPm.name}
-                </span>
-                <span>·</span>
-                <span>{subPm.university}</span>
-              </div>
-            )}
           </div>
         </div>
         <label htmlFor="project-description" className="sr-only">

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as TestToastRouteImport } from './routes/test/toast'
 import { Route as TestSocialButtonRouteImport } from './routes/test/social-button'
 import { Route as TestRatingFaceRouteImport } from './routes/test/rating-face'
 import { Route as TestQuestionFormRouteImport } from './routes/test/question-form'
+import { Route as TestProjectImageCropRouteImport } from './routes/test/project-image-crop'
 import { Route as TestOptionButtonRouteImport } from './routes/test/option-button'
 import { Route as TestMatchingProjectsRouteImport } from './routes/test/matching-projects'
 import { Route as TestInputBoxRouteImport } from './routes/test/input-box'
@@ -162,6 +163,11 @@ const TestRatingFaceRoute = TestRatingFaceRouteImport.update({
 const TestQuestionFormRoute = TestQuestionFormRouteImport.update({
   id: '/test/question-form',
   path: '/test/question-form',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TestProjectImageCropRoute = TestProjectImageCropRouteImport.update({
+  id: '/test/project-image-crop',
+  path: '/test/project-image-crop',
   getParentRoute: () => rootRouteImport,
 } as any)
 const TestOptionButtonRoute = TestOptionButtonRouteImport.update({
@@ -373,6 +379,7 @@ export interface FileRoutesByFullPath {
   '/test/input-box': typeof TestInputBoxRoute
   '/test/matching-projects': typeof TestMatchingProjectsRoute
   '/test/option-button': typeof TestOptionButtonRoute
+  '/test/project-image-crop': typeof TestProjectImageCropRoute
   '/test/question-form': typeof TestQuestionFormRoute
   '/test/rating-face': typeof TestRatingFaceRoute
   '/test/social-button': typeof TestSocialButtonRoute
@@ -426,6 +433,7 @@ export interface FileRoutesByTo {
   '/test/input-box': typeof TestInputBoxRoute
   '/test/matching-projects': typeof TestMatchingProjectsRoute
   '/test/option-button': typeof TestOptionButtonRoute
+  '/test/project-image-crop': typeof TestProjectImageCropRoute
   '/test/question-form': typeof TestQuestionFormRoute
   '/test/rating-face': typeof TestRatingFaceRoute
   '/test/social-button': typeof TestSocialButtonRoute
@@ -482,6 +490,7 @@ export interface FileRoutesById {
   '/test/input-box': typeof TestInputBoxRoute
   '/test/matching-projects': typeof TestMatchingProjectsRoute
   '/test/option-button': typeof TestOptionButtonRoute
+  '/test/project-image-crop': typeof TestProjectImageCropRoute
   '/test/question-form': typeof TestQuestionFormRoute
   '/test/rating-face': typeof TestRatingFaceRoute
   '/test/social-button': typeof TestSocialButtonRoute
@@ -540,6 +549,7 @@ export interface FileRouteTypes {
     | '/test/input-box'
     | '/test/matching-projects'
     | '/test/option-button'
+    | '/test/project-image-crop'
     | '/test/question-form'
     | '/test/rating-face'
     | '/test/social-button'
@@ -593,6 +603,7 @@ export interface FileRouteTypes {
     | '/test/input-box'
     | '/test/matching-projects'
     | '/test/option-button'
+    | '/test/project-image-crop'
     | '/test/question-form'
     | '/test/rating-face'
     | '/test/social-button'
@@ -648,6 +659,7 @@ export interface FileRouteTypes {
     | '/test/input-box'
     | '/test/matching-projects'
     | '/test/option-button'
+    | '/test/project-image-crop'
     | '/test/question-form'
     | '/test/rating-face'
     | '/test/social-button'
@@ -701,6 +713,7 @@ export interface RootRouteChildren {
   TestInputBoxRoute: typeof TestInputBoxRoute
   TestMatchingProjectsRoute: typeof TestMatchingProjectsRoute
   TestOptionButtonRoute: typeof TestOptionButtonRoute
+  TestProjectImageCropRoute: typeof TestProjectImageCropRoute
   TestQuestionFormRoute: typeof TestQuestionFormRoute
   TestRatingFaceRoute: typeof TestRatingFaceRoute
   TestSocialButtonRoute: typeof TestSocialButtonRoute
@@ -855,6 +868,13 @@ declare module '@tanstack/react-router' {
       path: '/test/question-form'
       fullPath: '/test/question-form'
       preLoaderRoute: typeof TestQuestionFormRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/test/project-image-crop': {
+      id: '/test/project-image-crop'
+      path: '/test/project-image-crop'
+      fullPath: '/test/project-image-crop'
+      preLoaderRoute: typeof TestProjectImageCropRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/test/option-button': {
@@ -1226,6 +1246,7 @@ const rootRouteChildren: RootRouteChildren = {
   TestInputBoxRoute: TestInputBoxRoute,
   TestMatchingProjectsRoute: TestMatchingProjectsRoute,
   TestOptionButtonRoute: TestOptionButtonRoute,
+  TestProjectImageCropRoute: TestProjectImageCropRoute,
   TestQuestionFormRoute: TestQuestionFormRoute,
   TestRatingFaceRoute: TestRatingFaceRoute,
   TestSocialButtonRoute: TestSocialButtonRoute,

--- a/src/routes/test/project-image-crop.tsx
+++ b/src/routes/test/project-image-crop.tsx
@@ -1,0 +1,136 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { useEffect, useState } from "react"
+
+import { ImageUploader } from "@/shared/ui/ImageUploader"
+
+export const Route = createFileRoute("/test/project-image-crop")({
+  component: ProjectImageCropTestPage,
+})
+
+interface PreviewState {
+  file: File
+  url: string
+}
+
+function ProjectImageCropTestPage() {
+  const [thumbnail, setThumbnail] = useState<PreviewState | null>(null)
+  const [logo, setLogo] = useState<PreviewState | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (thumbnail) URL.revokeObjectURL(thumbnail.url)
+      if (logo) URL.revokeObjectURL(logo.url)
+    }
+  }, [thumbnail, logo])
+
+  const handleThumbnailChange = (file: File) => {
+    setThumbnail((prev) => {
+      if (prev) URL.revokeObjectURL(prev.url)
+      return { file, url: URL.createObjectURL(file) }
+    })
+  }
+
+  const handleLogoChange = (file: File) => {
+    setLogo((prev) => {
+      if (prev) URL.revokeObjectURL(prev.url)
+      return { file, url: URL.createObjectURL(file) }
+    })
+  }
+
+  return (
+    <main className="bg-teal-gray-50 flex min-h-screen w-full flex-col gap-8 p-8">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-heading-6-semibold text-teal-gray-900">
+          프로젝트 이미지 크롭 테스트
+        </h1>
+        <p className="text-body-2-medium text-teal-gray-500">
+          로그인 라우팅 가드 없이 썸네일과 로고 업로더의 크롭 결과를 확인합니다.
+        </p>
+      </header>
+
+      <section className="grid gap-6 xl:grid-cols-[minmax(0,540px)_minmax(0,1fr)]">
+        <div className="flex flex-col gap-3">
+          <h2 className="text-body-1-semibold text-teal-gray-900">
+            썸네일 업로드
+          </h2>
+          <ImageUploader
+            variant="thumbnail"
+            onChange={handleThumbnailChange}
+            onRemove={() => setThumbnail(null)}
+          />
+        </div>
+        <PreviewPanel
+          title="썸네일 크롭 결과"
+          preview={thumbnail}
+          expected="540 : 286"
+        />
+      </section>
+
+      <section className="grid gap-6 xl:grid-cols-[minmax(0,540px)_minmax(0,1fr)]">
+        <div className="flex flex-col gap-3">
+          <h2 className="text-body-1-semibold text-teal-gray-900">
+            로고 업로드
+          </h2>
+          <ImageUploader
+            variant="logo"
+            onChange={handleLogoChange}
+            onRemove={() => setLogo(null)}
+          />
+        </div>
+        <PreviewPanel title="로고 크롭 결과" preview={logo} expected="1 : 1" />
+      </section>
+    </main>
+  )
+}
+
+interface PreviewPanelProps {
+  title: string
+  preview: PreviewState | null
+  expected: string
+}
+
+function PreviewPanel({ title, preview, expected }: PreviewPanelProps) {
+  return (
+    <div className="border-teal-gray-100 flex min-h-56 flex-col gap-4 rounded-lg border bg-white p-5">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-body-1-semibold text-teal-gray-900">{title}</h2>
+        <p className="text-body-2-medium text-teal-gray-500">
+          기대 비율: {expected}
+        </p>
+      </div>
+      {preview ? (
+        <div className="flex flex-col gap-4">
+          <img
+            src={preview.url}
+            alt={title}
+            className="border-teal-gray-100 max-h-72 max-w-full self-start rounded-lg border object-contain"
+          />
+          <dl className="text-body-2-medium text-teal-gray-700 grid gap-2 sm:grid-cols-3">
+            <div>
+              <dt className="text-teal-gray-400">파일명</dt>
+              <dd className="break-all">{preview.file.name}</dd>
+            </div>
+            <div>
+              <dt className="text-teal-gray-400">타입</dt>
+              <dd>{preview.file.type || "-"}</dd>
+            </div>
+            <div>
+              <dt className="text-teal-gray-400">용량</dt>
+              <dd>{formatFileSize(preview.file.size)}</dd>
+            </div>
+          </dl>
+        </div>
+      ) : (
+        <div className="text-body-2-medium text-teal-gray-400 border-teal-gray-100 flex min-h-40 items-center justify-center rounded-lg border border-dashed">
+          이미지를 업로드하면 크롭된 파일 정보가 표시됩니다.
+        </div>
+      )}
+    </div>
+  )
+}
+
+function formatFileSize(size: number): string {
+  if (size < 1024) return `${size} B`
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`
+  return `${(size / 1024 / 1024).toFixed(1)} MB`
+}

--- a/src/routes/test/project-image-crop.tsx
+++ b/src/routes/test/project-image-crop.tsx
@@ -19,22 +19,21 @@ function ProjectImageCropTestPage() {
   useEffect(() => {
     return () => {
       if (thumbnail) URL.revokeObjectURL(thumbnail.url)
+    }
+  }, [thumbnail])
+
+  useEffect(() => {
+    return () => {
       if (logo) URL.revokeObjectURL(logo.url)
     }
-  }, [thumbnail, logo])
+  }, [logo])
 
   const handleThumbnailChange = (file: File) => {
-    setThumbnail((prev) => {
-      if (prev) URL.revokeObjectURL(prev.url)
-      return { file, url: URL.createObjectURL(file) }
-    })
+    setThumbnail({ file, url: URL.createObjectURL(file) })
   }
 
   const handleLogoChange = (file: File) => {
-    setLogo((prev) => {
-      if (prev) URL.revokeObjectURL(prev.url)
-      return { file, url: URL.createObjectURL(file) }
-    })
+    setLogo({ file, url: URL.createObjectURL(file) })
   }
 
   return (

--- a/src/shared/lib/imageCrop.test.ts
+++ b/src/shared/lib/imageCrop.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+
+import { calculateCenterCrop, calculateCenterCropOutput } from "./imageCrop"
+
+describe("calculateCenterCrop", () => {
+  it("가로로 긴 이미지는 좌우를 중앙 크롭한다", () => {
+    const crop = calculateCenterCrop(
+      { width: 1200, height: 600 },
+      { width: 540, height: 540 },
+    )
+
+    expect(crop).toEqual({
+      sx: 300,
+      sy: 0,
+      sw: 600,
+      sh: 600,
+    })
+  })
+
+  it("세로로 긴 이미지는 상하를 중앙 크롭한다", () => {
+    const crop = calculateCenterCrop(
+      { width: 600, height: 1200 },
+      { width: 540, height: 286 },
+    )
+
+    expect(crop.sx).toBe(0)
+    expect(crop.sy).toBeCloseTo(441.111)
+    expect(crop.sw).toBe(600)
+    expect(crop.sh).toBeCloseTo(317.778)
+  })
+
+  it("출력 크기는 고정값이 아니라 실제 크롭 영역을 따른다", () => {
+    const { output } = calculateCenterCropOutput(
+      { width: 1200, height: 600 },
+      { width: 540, height: 540 },
+    )
+
+    expect(output).toEqual({
+      width: 600,
+      height: 600,
+    })
+  })
+})

--- a/src/shared/lib/imageCrop.ts
+++ b/src/shared/lib/imageCrop.ts
@@ -1,0 +1,141 @@
+export interface ImageCropRect {
+  sx: number
+  sy: number
+  sw: number
+  sh: number
+}
+
+export interface ImageCropSize {
+  width: number
+  height: number
+}
+
+interface ImageCropOutput {
+  crop: ImageCropRect
+  output: ImageCropSize
+}
+
+export function calculateCenterCrop(
+  source: ImageCropSize,
+  target: ImageCropSize,
+): ImageCropRect {
+  const sourceRatio = source.width / source.height
+  const targetRatio = target.width / target.height
+
+  if (sourceRatio > targetRatio) {
+    const sw = source.height * targetRatio
+
+    return {
+      sx: (source.width - sw) / 2,
+      sy: 0,
+      sw,
+      sh: source.height,
+    }
+  }
+
+  const sh = source.width / targetRatio
+
+  return {
+    sx: 0,
+    sy: (source.height - sh) / 2,
+    sw: source.width,
+    sh,
+  }
+}
+
+export function calculateCenterCropOutput(
+  source: ImageCropSize,
+  target: ImageCropSize,
+): ImageCropOutput {
+  const crop = calculateCenterCrop(source, target)
+
+  return {
+    crop,
+    output: {
+      width: Math.round(crop.sw),
+      height: Math.round(crop.sh),
+    },
+  }
+}
+
+function loadImage(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file)
+    const image = new Image()
+
+    image.onload = () => {
+      URL.revokeObjectURL(url)
+      resolve(image)
+    }
+    image.onerror = () => {
+      URL.revokeObjectURL(url)
+      reject(new Error("이미지를 불러올 수 없습니다."))
+    }
+    image.src = url
+  })
+}
+
+function canvasToBlob(
+  canvas: HTMLCanvasElement,
+  type: string,
+  quality: number,
+): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error("이미지를 변환할 수 없습니다."))
+          return
+        }
+        resolve(blob)
+      },
+      type,
+      quality,
+    )
+  })
+}
+
+export async function cropImageFile(
+  file: File,
+  target: ImageCropSize,
+): Promise<File> {
+  const image = await loadImage(file)
+  const canvas = document.createElement("canvas")
+  const context = canvas.getContext("2d")
+
+  if (!context) {
+    throw new Error("이미지를 편집할 수 없습니다.")
+  }
+  if (image.naturalWidth <= 0 || image.naturalHeight <= 0) {
+    throw new Error("이미지 크기를 확인할 수 없습니다.")
+  }
+
+  const { crop, output } = calculateCenterCropOutput(
+    { width: image.naturalWidth, height: image.naturalHeight },
+    target,
+  )
+
+  canvas.width = output.width
+  canvas.height = output.height
+  context.drawImage(
+    image,
+    crop.sx,
+    crop.sy,
+    crop.sw,
+    crop.sh,
+    0,
+    0,
+    output.width,
+    output.height,
+  )
+
+  const outputType = file.type === "image/jpeg" ? "image/jpeg" : "image/png"
+  const blob = await canvasToBlob(canvas, outputType, 0.92)
+  const extension = outputType === "image/png" ? "png" : "jpg"
+  const baseName = file.name.replace(/\.[^.]*$/, "") || "image"
+
+  return new File([blob], `${baseName}.${extension}`, {
+    lastModified: Date.now(),
+    type: outputType,
+  })
+}

--- a/src/shared/ui/ImageUploader.tsx
+++ b/src/shared/ui/ImageUploader.tsx
@@ -105,10 +105,12 @@ export const ImageUploader = forwardRef<HTMLButtonElement, ImageUploaderProps>(
       setIsProcessing(true)
       setCropError(null)
       try {
-        const croppedFile = await cropImageFile(file, variantCropSize[variant])
-        if (previewUrl) URL.revokeObjectURL(previewUrl)
-        setPreviewUrl(URL.createObjectURL(croppedFile))
-        onChange(croppedFile)
+        const processedFile =
+          file.type === "image/svg+xml"
+            ? file
+            : await cropImageFile(file, variantCropSize[variant])
+        setPreviewUrl(URL.createObjectURL(processedFile))
+        onChange(processedFile)
       } catch {
         setCropError("이미지를 처리할 수 없습니다.")
         if (fileInputRef.current) fileInputRef.current.value = ""
@@ -118,7 +120,6 @@ export const ImageUploader = forwardRef<HTMLButtonElement, ImageUploaderProps>(
     }
 
     const handleRemove = () => {
-      if (previewUrl) URL.revokeObjectURL(previewUrl)
       setPreviewUrl(null)
       setCropError(null)
       if (fileInputRef.current) fileInputRef.current.value = ""

--- a/src/shared/ui/ImageUploader.tsx
+++ b/src/shared/ui/ImageUploader.tsx
@@ -1,7 +1,8 @@
-import { forwardRef, useEffect, useRef, useState } from "react"
+import { forwardRef, useEffect, useId, useRef, useState } from "react"
 
 import CloseCircleIcon from "@/shared/assets/icon/close/CloseCircleIcon"
 import UploadImageIcon from "@/shared/assets/icon/upload/UploadImageIcon"
+import { cropImageFile } from "@/shared/lib/imageCrop"
 import { cn } from "@/shared/lib/utils"
 
 type ImageUploaderVariant = "thumbnail" | "logo"
@@ -47,6 +48,14 @@ const variantAccept: Record<ImageUploaderVariant, string> = {
   logo: "image/jpeg,image/png,image/svg+xml",
 }
 
+const variantCropSize: Record<
+  ImageUploaderVariant,
+  { width: number; height: number }
+> = {
+  thumbnail: { width: 540, height: 286 },
+  logo: { width: 512, height: 512 },
+}
+
 interface ImageUploaderProps {
   variant?: ImageUploaderVariant
   onChange: (file: File) => void
@@ -73,8 +82,13 @@ export const ImageUploader = forwardRef<HTMLButtonElement, ImageUploaderProps>(
     ref,
   ) {
     const [previewUrl, setPreviewUrl] = useState<string | null>(null)
+    const [cropError, setCropError] = useState<string | null>(null)
+    const [isProcessing, setIsProcessing] = useState(false)
     const activePreview = previewUrl ?? initialUrl ?? null
     const fileInputRef = useRef<HTMLInputElement>(null)
+    const fallbackErrorId = useId()
+    const describedBy =
+      error || cropError ? (errorId ?? fallbackErrorId) : undefined
 
     const labels = variantLabels[variant]
     const hint = variantHint[variant]
@@ -85,17 +99,28 @@ export const ImageUploader = forwardRef<HTMLButtonElement, ImageUploaderProps>(
       }
     }, [previewUrl])
 
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
       const file = e.target.files?.[0]
       if (!file) return
-      if (previewUrl) URL.revokeObjectURL(previewUrl)
-      setPreviewUrl(URL.createObjectURL(file))
-      onChange(file)
+      setIsProcessing(true)
+      setCropError(null)
+      try {
+        const croppedFile = await cropImageFile(file, variantCropSize[variant])
+        if (previewUrl) URL.revokeObjectURL(previewUrl)
+        setPreviewUrl(URL.createObjectURL(croppedFile))
+        onChange(croppedFile)
+      } catch {
+        setCropError("이미지를 처리할 수 없습니다.")
+        if (fileInputRef.current) fileInputRef.current.value = ""
+      } finally {
+        setIsProcessing(false)
+      }
     }
 
     const handleRemove = () => {
       if (previewUrl) URL.revokeObjectURL(previewUrl)
       setPreviewUrl(null)
+      setCropError(null)
       if (fileInputRef.current) fileInputRef.current.value = ""
       onRemove?.()
     }
@@ -122,13 +147,16 @@ export const ImageUploader = forwardRef<HTMLButtonElement, ImageUploaderProps>(
             ref={ref}
             type="button"
             aria-label={activePreview ? labels.change : labels.upload}
-            aria-invalid={!!error}
-            aria-describedby={errorId}
+            aria-invalid={!!error || !!cropError}
+            aria-describedby={describedBy}
             data-focus-target={focusTarget}
+            disabled={isProcessing}
             onClick={() => fileInputRef.current?.click()}
             className={cn(
-              "bg-teal-gray-200 hover:bg-teal-gray-400 group relative h-full w-full overflow-hidden transition-colors focus:ring-2 focus:outline-none focus:ring-inset",
-              error ? "focus:ring-error-400" : "focus:ring-teal-300",
+              "bg-teal-gray-200 hover:bg-teal-gray-400 group disabled:hover:bg-teal-gray-200 relative h-full w-full overflow-hidden transition-colors focus:ring-2 focus:outline-none focus:ring-inset disabled:cursor-wait",
+              error || cropError
+                ? "focus:ring-error-400"
+                : "focus:ring-teal-300",
               variantRound[variant],
               variant === "logo" &&
                 activePreview &&
@@ -146,6 +174,10 @@ export const ImageUploader = forwardRef<HTMLButtonElement, ImageUploaderProps>(
                   {hoverContent}
                 </div>
               </>
+            ) : isProcessing ? (
+              <div className="text-teal-gray-400 text-body-2-regular flex h-full items-center justify-center">
+                이미지 처리 중
+              </div>
             ) : (
               <div className="text-teal-gray-400 text-body-2-regular flex flex-col items-center justify-center">
                 <span className="text-center whitespace-pre transition-opacity duration-200 group-hover:opacity-0 group-focus-visible:opacity-0">
@@ -171,12 +203,12 @@ export const ImageUploader = forwardRef<HTMLButtonElement, ImageUploaderProps>(
             </button>
           )}
         </div>
-        {error && (
+        {(error || cropError) && (
           <p
-            id={errorId}
+            id={describedBy}
             className="text-caption-1-regular text-error-500 px-1 pt-1"
           >
-            {error}
+            {error ?? cropError}
           </p>
         )}
         <input


### PR DESCRIPTION
## 작업 내용

- 프로젝트 등록 Step1 이미지 업로더에서 썸네일/로고를 지정 비율로 중앙 크롭하도록 수정
- 크롭 시 고정 크기 리사이즈를 제거하고 실제 크롭 영역 크기를 유지하도록 보정
- 프로젝트 등록 Step1 카드 미리보기에서 sub PM 표시 제거
- 프로젝트 목록 상세 카드 하단 CTA 버튼이 좁은 화면에서도 가로 정렬을 유지하도록 수정
- 로그인 가드 없이 확인 가능한 /test/project-image-crop 테스트 페이지 추가

## 주요 코드 설명

### 이미지 크롭 유틸

- src/shared/lib/imageCrop.ts에서 중앙 크롭 영역과 출력 크기 계산을 분리했습니다.
- 업로드 파일은 비율만 맞춰 크롭하고, 불필요한 고정 크기 리사이즈는 하지 않습니다.

### 프로젝트 카드 표시

- src/features/project/new/ui/basic-info/ProjectCardForm.tsx에서 sub PM 렌더링을 제거했습니다.
- PM 선택 및 저장 로직은 유지하고, 카드 미리보기에는 main PM만 표시합니다.

### 상세 카드 CTA 반응형

- src/features/project/list/ui/ProjectDetailCard.tsx 하단 버튼 영역을 항상 가로 정렬로 유지합니다.
- 좁은 화면에서는 버튼을 찌그러뜨리지 않고 가로 스크롤로 처리합니다.

## 구현화면

- 로컬 확인 경로: http://127.0.0.1:5714/test/project-image-crop

## 연결된 이슈

- Closes #303

## 검증

- pnpm exec tsc -b
- pnpm exec eslint src/features/project/list/ui/ProjectDetailCard.tsx
- pnpm exec eslint src/shared/lib/imageCrop.ts src/shared/lib/imageCrop.test.ts src/shared/ui/ImageUploader.tsx src/routes/test/project-image-crop.tsx
- pnpm exec vitest run src/shared/lib/imageCrop.test.ts
- pnpm exec prettier --check 관련 수정 파일
