### PR TITLE
💄 style: 프로젝트 등록 디자인 QA 반영

### DIFF
--- a/src/features/project/new/api/adapters.test.ts
+++ b/src/features/project/new/api/adapters.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   buildPartQuotasEntries,
   buildUpsertApplicationFormBody,
+  mapApplicationFormToSections,
   uiRoleToPart,
 } from "./adapters"
 
@@ -189,5 +190,48 @@ describe("buildUpsertApplicationFormBody", () => {
     expect(opts[0]).toMatchObject({ content: "A", orderNo: 0, optionId: 100 })
     expect(opts[1]).toMatchObject({ content: "B", orderNo: 1 })
     expect(opts[1]!.optionId).toBeUndefined()
+  })
+
+  it("선택형이 아닌 문항의 임시 옵션은 전송하지 않음", () => {
+    const textQ = {
+      ...commonQ,
+      options: [{ content: "임시 옵션" }],
+      draftOptions: [{ content: "임시 옵션" }],
+    }
+    const result = buildUpsertApplicationFormBody([textQ], [])
+
+    expect(result.sections[0]!.questions[0]!.options).toEqual([])
+  })
+})
+
+describe("mapApplicationFormToSections", () => {
+  it("backend allowedParts 섹션은 API title 대신 Backend로 표시", () => {
+    const result = mapApplicationFormToSections({
+      sections: [
+        {
+          sectionId: 1,
+          type: "PART",
+          title: "SPRINGBOOT, NODEJS",
+          orderNo: 1,
+          allowedParts: ["SPRINGBOOT", "NODEJS"],
+          questions: [
+            {
+              questionId: 10,
+              type: "LONG_TEXT",
+              title: "백엔드 질문",
+              description: "",
+              isRequired: true,
+              orderNo: 0,
+              options: [],
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(result[0]).toMatchObject({
+      id: "backend",
+      name: "Backend",
+    })
   })
 })

--- a/src/features/project/new/api/adapters.ts
+++ b/src/features/project/new/api/adapters.ts
@@ -29,6 +29,12 @@ const SECTION_TO_ALLOWED_PARTS: Record<UiRoleKey, ApiPart[]> = {
   backend: ["SPRINGBOOT", "NODEJS"],
 }
 
+const SECTION_DISPLAY_NAME: Record<UiRoleKey, string> = {
+  design: "Design",
+  frontend: "Frontend",
+  backend: "Backend",
+}
+
 const FIELD_TYPE_TO_API: Record<FieldType, ApplicationQuestionItem["type"]> = {
   text: "LONG_TEXT",
   radio: "RADIO",
@@ -58,6 +64,9 @@ export function buildPartQuotasEntries(
 }
 
 function toApiQuestion(q: Question, idx: number): ApplicationQuestionItem {
+  const options =
+    q.fieldType === "radio" || q.fieldType === "checkbox" ? q.options : []
+
   return {
     ...(q.questionId !== undefined && { questionId: q.questionId }),
     type: FIELD_TYPE_TO_API[q.fieldType],
@@ -65,7 +74,7 @@ function toApiQuestion(q: Question, idx: number): ApplicationQuestionItem {
     description: q.caption || undefined,
     isRequired: q.required,
     orderNo: idx,
-    options: q.options.map((opt, i) => ({
+    options: options.map((opt, i) => ({
       content: opt.content,
       orderNo: i,
       ...(opt.optionId !== undefined && { optionId: opt.optionId }),
@@ -95,6 +104,10 @@ function allowedPartsToSectionId(
     return "frontend"
   if (partsSet.has("SPRINGBOOT") || partsSet.has("NODEJS")) return "backend"
   return String(fallbackId)
+}
+
+function getSectionDisplayName(id: string, fallbackName: string): string {
+  return SECTION_DISPLAY_NAME[id as UiRoleKey] ?? fallbackName
 }
 
 export function mapApplicationFormToSections(
@@ -135,7 +148,7 @@ export function mapApplicationFormToSections(
 
       return {
         id,
-        name: apiSection.title,
+        name: getSectionDisplayName(id, apiSection.title),
         isEnabled: true,
         questions,
       }

--- a/src/features/project/new/api/adapters.ts
+++ b/src/features/project/new/api/adapters.ts
@@ -35,6 +35,10 @@ const SECTION_DISPLAY_NAME: Record<UiRoleKey, string> = {
   backend: "Backend",
 }
 
+function isUiRoleKey(id: string): id is UiRoleKey {
+  return id in SECTION_DISPLAY_NAME
+}
+
 const FIELD_TYPE_TO_API: Record<FieldType, ApplicationQuestionItem["type"]> = {
   text: "LONG_TEXT",
   radio: "RADIO",
@@ -107,7 +111,7 @@ function allowedPartsToSectionId(
 }
 
 function getSectionDisplayName(id: string, fallbackName: string): string {
-  return SECTION_DISPLAY_NAME[id as UiRoleKey] ?? fallbackName
+  return isUiRoleKey(id) ? SECTION_DISPLAY_NAME[id] : fallbackName
 }
 
 export function mapApplicationFormToSections(

--- a/src/features/project/new/model/applicationQuestion.test.ts
+++ b/src/features/project/new/model/applicationQuestion.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+
+import { getFieldTypePatch, PORTFOLIO_FIXED_TITLE } from "./applicationQuestion"
+
+import type { Question } from "./applicationQuestion"
+
+const baseQuestion: Question = {
+  id: "q-1",
+  title: "질문 제목",
+  caption: "질문 설명",
+  fieldType: "text",
+  required: false,
+  options: [],
+}
+
+describe("getFieldTypePatch", () => {
+  it("포트폴리오 전환 후 기존 타입으로 돌아오면 제목을 복원", () => {
+    const portfolioPatch = getFieldTypePatch("portfolio", baseQuestion)
+    const portfolioQuestion = { ...baseQuestion, ...portfolioPatch }
+    const textPatch = getFieldTypePatch("text", portfolioQuestion)
+
+    expect(portfolioPatch.title).toBe(PORTFOLIO_FIXED_TITLE)
+    expect(textPatch.title).toBe(baseQuestion.title)
+  })
+
+  it("단일 선택에서 복수 선택으로 전환해도 옵션을 유지", () => {
+    const question: Question = {
+      ...baseQuestion,
+      fieldType: "radio",
+      options: [{ content: "옵션 A" }, { content: "옵션 B" }],
+    }
+
+    const patch = getFieldTypePatch("checkbox", question)
+
+    expect(patch.options).toEqual(question.options)
+  })
+
+  it("선택형에서 텍스트로 전환했다가 다시 선택형으로 돌아오면 옵션을 복원", () => {
+    const question: Question = {
+      ...baseQuestion,
+      fieldType: "radio",
+      options: [{ content: "옵션 A" }, { content: "옵션 B" }],
+    }
+    const textQuestion = { ...question, ...getFieldTypePatch("text", question) }
+    const checkboxPatch = getFieldTypePatch("checkbox", textQuestion)
+
+    expect(textQuestion.options).toEqual([])
+    expect(checkboxPatch.options).toEqual(question.options)
+  })
+
+  it("선택형에서 텍스트로 전환해도 제목과 설명은 유지", () => {
+    const question: Question = {
+      ...baseQuestion,
+      fieldType: "checkbox",
+      options: [{ content: "옵션 A" }],
+    }
+
+    const patch = getFieldTypePatch("text", question)
+
+    expect(patch.title).toBeUndefined()
+    expect(patch.caption).toBeUndefined()
+  })
+})

--- a/src/features/project/new/model/applicationQuestion.ts
+++ b/src/features/project/new/model/applicationQuestion.ts
@@ -13,6 +13,8 @@ export interface Question {
   fieldType: FieldType
   required: boolean
   options: QuestionOption[]
+  draftTitle?: string
+  draftOptions?: QuestionOption[]
 }
 
 export interface Section {
@@ -34,13 +36,32 @@ export const PORTFOLIO_FIXED_TITLE =
 
 export function getFieldTypePatch(
   fieldType: FieldType,
-  prevFieldType: FieldType,
+  question: Question,
 ): Partial<Question> {
-  const base: Partial<Question> = { fieldType, options: [] }
+  const prevFieldType = question.fieldType
+  const prevOptions = question.options
+  const prevDraftOptions = question.draftOptions
+  const isPrevOptionField =
+    prevFieldType === "radio" || prevFieldType === "checkbox"
+  const isNextOptionField = fieldType === "radio" || fieldType === "checkbox"
+  const base: Partial<Question> = { fieldType }
+
+  if (isPrevOptionField && !isNextOptionField) {
+    base.options = []
+    base.draftOptions = prevOptions
+  } else if (isNextOptionField) {
+    base.options = isPrevOptionField ? prevOptions : (prevDraftOptions ?? [])
+  } else {
+    base.options = []
+  }
+
   if (fieldType === "portfolio") {
+    if (prevFieldType !== "portfolio") {
+      base.draftTitle = question.title
+    }
     base.title = PORTFOLIO_FIXED_TITLE
   } else if (prevFieldType === "portfolio") {
-    base.title = ""
+    base.title = question.draftTitle ?? ""
   }
   return base
 }

--- a/src/features/project/new/ui/application/ApplicationForm.tsx
+++ b/src/features/project/new/ui/application/ApplicationForm.tsx
@@ -242,6 +242,7 @@ export const ApplicationForm = forwardRef<
                 focused={form.focusedId === q.id}
                 isError={errorQuestionIds.includes(q.id)}
                 canDelete={form.commonQuestions.length > 1}
+                showFocusIndicator={false}
                 onFocus={() => form.setFocusedId(q.id)}
                 onUpdate={(patch) => {
                   form.updateCommonQuestion(q.id, patch)
@@ -259,7 +260,7 @@ export const ApplicationForm = forwardRef<
               onChange={(fieldType) =>
                 form.updateCommonQuestion(
                   focusedCommon.id,
-                  getFieldTypePatch(fieldType, focusedCommon.fieldType),
+                  getFieldTypePatch(fieldType, focusedCommon),
                 )
               }
               onAddAfter={() => form.addCommonQuestion(focusedCommon.id)}
@@ -325,7 +326,7 @@ export const ApplicationForm = forwardRef<
                         focusedSectionEntry.question.id,
                         getFieldTypePatch(
                           fieldType,
-                          focusedSectionEntry.question.fieldType,
+                          focusedSectionEntry.question,
                         ),
                       )
                     }

--- a/src/features/project/new/ui/application/QuestionCard.tsx
+++ b/src/features/project/new/ui/application/QuestionCard.tsx
@@ -68,6 +68,7 @@ interface QuestionCardProps {
   focused: boolean
   isError?: boolean
   canDelete?: boolean
+  showFocusIndicator?: boolean
   onFocus: () => void
   onUpdate: (patch: Partial<Question>) => void
   onDelete: () => void
@@ -79,6 +80,7 @@ export function QuestionCard({
   focused,
   isError = false,
   canDelete = true,
+  showFocusIndicator = true,
   onFocus,
   onUpdate,
   onDelete,
@@ -126,6 +128,7 @@ export function QuestionCard({
           isFirst={index === 0}
           isError={isError}
           readonlyTitle={question.fieldType === "portfolio"}
+          showFocusIndicator={showFocusIndicator}
           required={question.required}
           onRequiredChange={(required) => onUpdate({ required })}
           canDelete={canDelete}

--- a/src/routes/test/application-form.tsx
+++ b/src/routes/test/application-form.tsx
@@ -86,7 +86,7 @@ function ApplicationFormTestPage() {
               onChange={(fieldType) =>
                 form.updateCommonQuestion(
                   focusedCommon.id,
-                  getFieldTypePatch(fieldType, focusedCommon.fieldType),
+                  getFieldTypePatch(fieldType, focusedCommon),
                 )
               }
               onAddAfter={() => form.addCommonQuestion(focusedCommon.id)}
@@ -148,7 +148,7 @@ function ApplicationFormTestPage() {
                         focusedSectionEntry.question.id,
                         getFieldTypePatch(
                           fieldType,
-                          focusedSectionEntry.question.fieldType,
+                          focusedSectionEntry.question,
                         ),
                       )
                     }

--- a/src/routes/test/field-type-button.tsx
+++ b/src/routes/test/field-type-button.tsx
@@ -31,7 +31,7 @@ function FieldTypeButtonTestPage() {
         FieldTypeButton Test Page
       </h1>
 
-      <div className="flex w-[900px] flex-col items-center gap-4">
+      <div className="flex w-225 flex-col items-center gap-4">
         <FieldTypeButtonGroup
           options={FIELD_TYPES}
           selected={selected}

--- a/src/shared/ui/question-field/FileUploadField.tsx
+++ b/src/shared/ui/question-field/FileUploadField.tsx
@@ -27,7 +27,7 @@ export function FileUploadField({
     <div className="flex w-full flex-col gap-1">
       <div
         className={cn(
-          "border-teal-gray-150 flex min-h-15 w-full min-w-0 items-center justify-between gap-1.5 rounded-[12px] border bg-[color-mix(in_srgb,var(--color-teal-50)_40%,white)] py-4 pr-3.5 pl-5",
+          "border-teal-gray-150 flex h-15 w-full min-w-0 items-center justify-between gap-1.5 rounded-[12px] border bg-[color-mix(in_srgb,var(--color-teal-50)_40%,white)] py-4 pr-4 pl-5",
           error && "border-error-500",
           className,
         )}

--- a/src/shared/ui/question-field/PortfolioField.tsx
+++ b/src/shared/ui/question-field/PortfolioField.tsx
@@ -85,7 +85,7 @@ export function PortfolioField({
 
   return (
     <div className={cn("flex w-full flex-col gap-1", className)}>
-      <div className="border-teal-gray-150 flex h-15 w-full items-center justify-between gap-1.5 rounded-[12px] border bg-[color-mix(in_srgb,var(--color-teal-50)_40%,white)] px-5 py-4">
+      <div className="border-teal-gray-150 flex h-15 w-full items-center justify-between gap-1.5 rounded-[12px] border bg-[color-mix(in_srgb,var(--color-teal-50)_40%,white)] py-4 pr-4 pl-5">
         <input
           type="file"
           ref={fileInputRef}

--- a/src/shared/ui/question-field/QuestionForm.tsx
+++ b/src/shared/ui/question-field/QuestionForm.tsx
@@ -24,6 +24,7 @@ interface QuestionFormProps {
   onDelete?: () => void
   children: ReactNode
   className?: string
+  showFocusIndicator?: boolean
   dragHandleProps?: HTMLAttributes<HTMLButtonElement>
 }
 
@@ -49,6 +50,7 @@ export function QuestionForm({
   onDelete,
   children,
   className,
+  showFocusIndicator = true,
   dragHandleProps,
 }: QuestionFormProps) {
   const titleTextareaRef = useRef<HTMLTextAreaElement>(null)
@@ -72,7 +74,7 @@ export function QuestionForm({
         className,
       )}
     >
-      {(focused || isError) && (
+      {((focused && showFocusIndicator) || isError) && (
         <span
           aria-hidden
           className={cn(


### PR DESCRIPTION
## 작업 내용

- 프로젝트 등록 Step3 공통 문항의 왼쪽 focus indicator bar를 제거했습니다.
- 프로젝트 목록의 모집 문항 조회에서 Backend 섹션명이 SPRINGBOOT, NODEJS가 아닌 Backend로 표시되도록 정규화했습니다.
- Step3 문항 타입 전환 중 제목, 설명, 선택 옵션이 불필요하게 초기화되지 않도록 보존했습니다.
- 파일 업로드/포트폴리오 필드와 field type 테스트 페이지의 디자인 QA 조정을 함께 반영했습니다.

## 주요 코드 설명

### 문항 타입 전환 상태 보존

- Question 모델에 draftTitle, draftOptions를 추가해 현재 타입에서 쓰지 않는 작성 값을 임시 보관합니다.
- radio/checkbox 간 전환은 options를 그대로 유지합니다.
- 선택형에서 비선택형으로 전환하면 options는 비우되 draftOptions에 보관하고, 다시 선택형으로 돌아오면 복원합니다.
- portfolio 전환 시 기존 제목을 draftTitle에 보관하고, 다른 타입으로 돌아오면 복원합니다.

### 저장 payload 정리

- buildUpsertApplicationFormBody에서 radio/checkbox가 아닌 문항은 options를 전송하지 않도록 제한했습니다.
- 화면 상태 보존용 draftOptions가 서버 payload에 섞이지 않도록 했습니다.

### 지원 문항 섹션 표시명 정규화

- allowedParts로 판별된 design/frontend/backend 섹션은 API title 대신 UI 표시명을 사용합니다.

## 구현화면

- 로컬 확인 포트: http://127.0.0.1:5173

## 연결된 이슈

- Closes #309

## 검증

- pnpm exec prettier --check 관련 수정 파일
- pnpm exec eslint 관련 수정 파일
- pnpm exec vitest run src/features/project/new/model/applicationQuestion.test.ts src/features/project/new/api/adapters.test.ts
- pnpm exec tsc -b
