### PR TITLE
✨ feat: 사용성 조사 응답 완료 사용자 재노출 차단

### DIFF
--- a/src/features/usability-survey/index.ts
+++ b/src/features/usability-survey/index.ts
@@ -1,5 +1,6 @@
 export type { FeedbackContext } from "./api/types"
 export { useFeedbackTemplate, useSubmitFeedback } from "./hooks/useUserFeedback"
+export { clearSubmittedTemplates } from "./lib/submittedStore"
 export { resolveVariantKey, toAnswerItems } from "./model/mappers"
 export type {
   SurveyAnswers,

--- a/src/features/usability-survey/lib/submittedStore.test.ts
+++ b/src/features/usability-survey/lib/submittedStore.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { hasSubmittedTemplate, markTemplateSubmitted } from "./submittedStore"
+
+const STORAGE_KEY = "usability-survey:submitted-templates"
+
+describe("submittedStore", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it("기록하지 않은 templateId는 false를 반환한다", () => {
+    expect(hasSubmittedTemplate(5)).toBe(false)
+  })
+
+  it("mark 후 같은 templateId는 true를 반환한다", () => {
+    markTemplateSubmitted(5)
+    expect(hasSubmittedTemplate(5)).toBe(true)
+    expect(hasSubmittedTemplate(3)).toBe(false)
+  })
+
+  it("여러 templateId를 누적 기록한다", () => {
+    markTemplateSubmitted(1)
+    markTemplateSubmitted(3)
+    expect(hasSubmittedTemplate(1)).toBe(true)
+    expect(hasSubmittedTemplate(3)).toBe(true)
+  })
+
+  it("같은 templateId를 중복 기록해도 한 번만 저장한다", () => {
+    markTemplateSubmitted(5)
+    markTemplateSubmitted(5)
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]")).toEqual([5])
+  })
+
+  it("손상된 JSON이 저장돼 있어도 안전하게 false를 반환한다", () => {
+    localStorage.setItem(STORAGE_KEY, "not-json")
+    expect(hasSubmittedTemplate(5)).toBe(false)
+  })
+})

--- a/src/features/usability-survey/lib/submittedStore.test.ts
+++ b/src/features/usability-survey/lib/submittedStore.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest"
 
-import { hasSubmittedTemplate, markTemplateSubmitted } from "./submittedStore"
+import {
+  clearSubmittedTemplates,
+  hasSubmittedTemplate,
+  markTemplateSubmitted,
+} from "./submittedStore"
 
 const STORAGE_KEY = "usability-survey:submitted-templates"
 
@@ -35,5 +39,16 @@ describe("submittedStore", () => {
   it("손상된 JSON이 저장돼 있어도 안전하게 false를 반환한다", () => {
     localStorage.setItem(STORAGE_KEY, "not-json")
     expect(hasSubmittedTemplate(5)).toBe(false)
+  })
+
+  it("clearSubmittedTemplates는 기록을 모두 삭제한다", () => {
+    markTemplateSubmitted(1)
+    markTemplateSubmitted(3)
+
+    clearSubmittedTemplates()
+
+    expect(hasSubmittedTemplate(1)).toBe(false)
+    expect(hasSubmittedTemplate(3)).toBe(false)
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
   })
 })

--- a/src/features/usability-survey/lib/submittedStore.ts
+++ b/src/features/usability-survey/lib/submittedStore.ts
@@ -1,0 +1,30 @@
+const STORAGE_KEY = "usability-survey:submitted-templates"
+
+function readSubmitted(): number[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((id): id is number => typeof id === "number")
+  } catch {
+    return []
+  }
+}
+
+export function hasSubmittedTemplate(templateId: number): boolean {
+  return readSubmitted().includes(templateId)
+}
+
+export function markTemplateSubmitted(templateId: number): void {
+  try {
+    const submitted = readSubmitted()
+    if (submitted.includes(templateId)) return
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([...submitted, templateId]),
+    )
+  } catch {
+    // localStorage 접근 불가(프라이빗 모드 등) 시 무시
+  }
+}

--- a/src/features/usability-survey/lib/submittedStore.ts
+++ b/src/features/usability-survey/lib/submittedStore.ts
@@ -28,3 +28,11 @@ export function markTemplateSubmitted(templateId: number): void {
     // localStorage 접근 불가(프라이빗 모드 등) 시 무시
   }
 }
+
+export function clearSubmittedTemplates(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY)
+  } catch {
+    // localStorage 접근 불가 시 무시
+  }
+}

--- a/src/features/usability-survey/ui/UsabilitySurvey.tsx
+++ b/src/features/usability-survey/ui/UsabilitySurvey.tsx
@@ -1,3 +1,4 @@
+import { AxiosError } from "axios"
 import { useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
@@ -6,6 +7,10 @@ import {
   useFeedbackTemplate,
   useSubmitFeedback,
 } from "../hooks/useUserFeedback"
+import {
+  hasSubmittedTemplate,
+  markTemplateSubmitted,
+} from "../lib/submittedStore"
 import { resolveVariantKey, toAnswerItems } from "../model/mappers"
 import { useMultistepSurvey } from "../model/useMultistepSurvey"
 import { SURVEY_VARIANTS } from "../model/variants"
@@ -13,6 +18,8 @@ import { UsabilitySurveyView } from "./UsabilitySurveyView"
 
 import type { FeedbackContext, FeedbackForm } from "../api/types"
 import type { SurveyVariantKey } from "../model/variants"
+
+const DUPLICATE_RESPONSE_CODE = "SURVEY-0027"
 
 interface UsabilitySurveyProps {
   context: FeedbackContext
@@ -28,6 +35,7 @@ export function UsabilitySurvey({ context, active }: UsabilitySurveyProps) {
 
   if (!active || dismissed) return null
   if (!template?.form || template.templateId == null) return null
+  if (hasSubmittedTemplate(Number(template.templateId))) return null
 
   const variantKey = resolveVariantKey(template.context, template.targetType)
   if (!variantKey) return null
@@ -87,6 +95,7 @@ function UsabilitySurveyRunner({
       { templateId, answers },
       {
         onSuccess: () => {
+          markTemplateSubmitted(templateId)
           addToast({
             message: "소중한 의견 감사합니다!",
             color: "primary",
@@ -96,7 +105,27 @@ function UsabilitySurveyRunner({
           })
           close()
         },
-        onError: () => {
+        onError: (error) => {
+          const data =
+            error instanceof AxiosError
+              ? (error.response?.data as
+                  | { code?: string; message?: string }
+                  | undefined)
+              : undefined
+
+          if (data?.code === DUPLICATE_RESPONSE_CODE) {
+            markTemplateSubmitted(templateId)
+            addToast({
+              message: data.message ?? "이미 제출한 응답이 있어요.",
+              color: "primary",
+              variant: "deep",
+              type: "default",
+              duration: 3000,
+            })
+            close()
+            return
+          }
+
           addToast({
             message: "제출에 실패했어요. 다시 시도해주세요.",
             color: "red",

--- a/src/routes/test/usability-survey.tsx
+++ b/src/routes/test/usability-survey.tsx
@@ -3,6 +3,7 @@ import { useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
 import {
+  clearSubmittedTemplates,
   SURVEY_VARIANTS,
   SurveyQuestionList,
   UsabilitySurvey,
@@ -147,6 +148,17 @@ function UsabilitySurveyTestPage() {
             </Button>
           ))}
         </div>
+        <Button
+          variant="weak"
+          color="neutral"
+          onClick={() => {
+            clearSubmittedTemplates()
+            setLiveContext(null)
+            surveyToast("제출 기록을 초기화했어요. 다시 테스트할 수 있어요.")
+          }}
+        >
+          제출 기록 초기화
+        </Button>
       </div>
 
       {liveContext && (


### PR DESCRIPTION
## 📸 작업 내용

- **응답 완료 사용자에게 같은 `templateId`의 사용성 조사 모달 재노출 차단** (PR #302 후속)
- 제출 완료한 `templateId`를 `localStorage`에 기록(`submittedStore`), 모달 진입 시 차단
- localStorage 차단을 피한 새 기기·캐시 초기화 사용자가 제출 시 서버 중복 에러(`SURVEY-0027`) 수신 → 안내 토스트 + 닫기 + 기록
- 테스트 페이지에 **제출 기록 초기화 버튼** 추가(반복 QA 편의)
- `submittedStore` 단위 테스트 5개 추가

## 🎞️ 주요 코드 설명

### 응답 완료 재노출 차단

```TypeScript
// 서버는 GET templates에서 응답 완료 여부를 주지 않아 클라가 templateId를 기록
if (hasSubmittedTemplate(Number(template.templateId))) return null

// 제출 성공 또는 서버 중복 에러(SURVEY-0027) 시 기록 → 이후 미노출
onError: (error) => {
  const data = error instanceof AxiosError ? error.response?.data : undefined
  if (data?.code === "SURVEY-0027") {
    markTemplateSubmitted(templateId)
    // 안내 토스트 + close()
  }
}
```

- 차단 단위는 `templateId`라 기수 교체로 새 템플릿이 내려오면 다시 노출됨
- 테스트 페이지는 `clearSubmittedTemplates()`로 기록을 비워 반복 검증 가능(서버 중복 차단은 유지)

## 🔗 연결된 이슈

- Connected: #307, #308
- Closes #307
- Closes #308