### PR TITLE
✨ feat: 프로젝트 카드 이미지 fallback 및 관리 카드 상태 점검

### DIFF
--- a/src/features/project/list/ui/MatchingProjectCard.tsx
+++ b/src/features/project/list/ui/MatchingProjectCard.tsx
@@ -5,6 +5,7 @@ import { DEFAULT_MATCHING_PROJECT_MOCK } from "@/features/project/list/model/mat
 import { cn } from "@/shared/lib/utils"
 import { RecruitStatusChip } from "@/shared/ui/chip/RecruitStatusChip"
 import MemberCount from "@/shared/ui/MemberCount"
+import { ProjectThumbnail } from "@/shared/ui/ProjectThumbnail"
 
 import type {
   MatchingProject,
@@ -49,21 +50,10 @@ function CardBody({ data }: { data: MatchingProject }) {
   return (
     <div className="flex w-full min-w-0 flex-col items-stretch self-stretch">
       <div className="bg-teal-gray-200 relative z-0 aspect-[348/184] w-full min-w-0 shrink-0 self-stretch overflow-hidden">
-        {cover?.src ? (
-          <img
-            src={cover.src}
-            alt={cover.alt ?? `${data.title} 대표 이미지`}
-            className="h-full w-full object-cover"
-            loading="lazy"
-            decoding="async"
-          />
-        ) : (
-          <div className="text-body-2-medium text-teal-gray-400 flex h-full w-full items-center justify-center py-1 text-center">
-            프로젝트 대표 이미지
-            <br />
-            348*184
-          </div>
-        )}
+        <ProjectThumbnail
+          src={cover?.src}
+          alt={cover?.alt ?? `${data.title} 대표 이미지`}
+        />
       </div>
 
       <div className="flex w-full min-w-0 flex-col items-start gap-4 p-5">

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -26,6 +26,7 @@ import { TeamMemberButton } from "@/shared/ui/button/TeamMemberButton"
 import { RecruitStatusChip } from "@/shared/ui/chip/RecruitStatusChip"
 import MemberCount from "@/shared/ui/MemberCount"
 import { Modal } from "@/shared/ui/Modal"
+import { ProjectThumbnail } from "@/shared/ui/ProjectThumbnail"
 import { useViewMe } from "@/shared/view-mode/useViewMe"
 
 import {
@@ -415,21 +416,10 @@ export function ProjectDetailCard({
     <>
       <div className="flex max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-135 min-w-0 flex-col items-start overflow-x-hidden overflow-y-auto rounded-2xl bg-white">
         <div className="bg-teal-gray-200 flex aspect-[540/286] w-full shrink-0 items-center justify-center overflow-hidden">
-          {cover?.src ? (
-            <img
-              src={cover.src}
-              alt={cover.alt ?? `${data.title} 대표 이미지`}
-              className="h-full w-full object-cover"
-              loading="lazy"
-              decoding="async"
-            />
-          ) : (
-            <div className="text-body-2-regular text-teal-gray-400 text-center">
-              프로젝트 대표 이미지
-              <br />
-              540*286
-            </div>
-          )}
+          <ProjectThumbnail
+            src={cover?.src}
+            alt={cover?.alt ?? `${data.title} 대표 이미지`}
+          />
         </div>
 
         <div className="bp1:p-5 flex w-full flex-col items-start p-4">

--- a/src/features/project/management/ui/ProjectManagementCard.tsx
+++ b/src/features/project/management/ui/ProjectManagementCard.tsx
@@ -9,6 +9,7 @@ import { ProjectStatusChip } from "@/shared/ui/chip/ProjectStatusChip"
 import { RecruitStatusChip } from "@/shared/ui/chip/RecruitStatusChip"
 import MemberCount from "@/shared/ui/MemberCount"
 import { Modal } from "@/shared/ui/Modal"
+import { ProjectThumbnail } from "@/shared/ui/ProjectThumbnail"
 
 import { isRecruitDone } from "../../list/model/matchingProject"
 import { ProjectManagementMoreMenu } from "./ProjectManagementMoreMenu"
@@ -62,21 +63,10 @@ export function ProjectManagementCard({
         }}
       >
         <div className="bg-teal-gray-200 bp2:h-[10.5625rem] bp2:w-[clamp(13rem,28vw,20rem)] flex aspect-[320/169] w-full shrink-0 overflow-hidden rounded-[0.625rem]">
-          {cover?.src ? (
-            <img
-              src={cover.src}
-              alt={cover.alt ?? `${data.title} 대표 이미지`}
-              className="h-full w-full object-cover"
-              loading="lazy"
-              decoding="async"
-            />
-          ) : (
-            <div className="text-body-2-medium text-teal-gray-400 flex h-full w-full items-center justify-center text-center">
-              프로젝트 대표 이미지
-              <br />
-              320*169
-            </div>
-          )}
+          <ProjectThumbnail
+            src={cover?.src}
+            alt={cover?.alt ?? `${data.title} 대표 이미지`}
+          />
         </div>
 
         <div className="bp2:items-end flex min-w-0 flex-1 flex-col items-stretch gap-4">

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -241,37 +241,11 @@ export function ProjectManagementMoreMenu({
     })
   }
 
-  const handlePlanViewClick = async () => {
+  const handlePlanViewClick = () => {
     setPopoverOpen(false)
-    const newWindow = window.open(
-      "about:blank",
-      "_blank",
-      "noopener,noreferrer",
-    )
-    try {
-      const detail = await getProjectDetail(Number(projectId))
-      if (detail.externalLink) {
-        if (newWindow) newWindow.location.href = detail.externalLink
-      } else {
-        if (newWindow) newWindow.close()
-        addToast({
-          message: "등록된 기획안 링크가 없습니다.",
-          color: "red",
-          variant: "deep",
-          type: "default",
-          duration: 3000,
-        })
-      }
-    } catch {
-      if (newWindow) newWindow.close()
-      addToast({
-        message: "기획 보기를 불러오는 데 실패했습니다.",
-        color: "red",
-        variant: "deep",
-        type: "default",
-        duration: 3000,
-      })
-    }
+    const externalLink = projectDetailQuery.data?.externalLink
+    if (!externalLink) return
+    window.open(externalLink, "_blank", "noopener,noreferrer")
   }
 
   const handleTeamViewClick = () => {
@@ -287,7 +261,7 @@ export function ProjectManagementMoreMenu({
     { label: "지원 현황 확인하기", onClick: handleApplicationClick },
     {
       label: "기획 보기",
-      onClick: () => void handlePlanViewClick(),
+      onClick: handlePlanViewClick,
       disabled: isPlanViewDisabled,
     },
     { label: "팀원 구성 보기", onClick: handleTeamViewClick },

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -72,8 +72,11 @@ export function ProjectManagementMoreMenu({
   const projectDetailQuery = useQuery({
     queryKey: ["projectDetail", numericProjectId],
     queryFn: () => getProjectDetail(numericProjectId),
-    enabled: applicationOpen && numericProjectId > 0,
+    enabled: (applicationOpen || popoverOpen) && numericProjectId > 0,
   })
+
+  const hasNoPlanLink =
+    projectDetailQuery.isSuccess && !projectDetailQuery.data.externalLink
 
   const applicantsQuery = useQuery({
     queryKey: applicationKeys.applicants(numericProjectId),
@@ -275,9 +278,17 @@ export function ProjectManagementMoreMenu({
     setTeamModalOpen(true)
   }
 
-  const menuItems = [
+  const menuItems: {
+    label: string
+    onClick: () => void
+    disabled?: boolean
+  }[] = [
     { label: "지원 현황 확인하기", onClick: handleApplicationClick },
-    { label: "기획 보기", onClick: () => void handlePlanViewClick() },
+    {
+      label: "기획 보기",
+      onClick: () => void handlePlanViewClick(),
+      disabled: hasNoPlanLink,
+    },
     { label: "팀원 구성 보기", onClick: handleTeamViewClick },
   ]
 
@@ -285,6 +296,7 @@ export function ProjectManagementMoreMenu({
     menuItems.splice(2, 0, {
       label: "프로젝트 수정하기",
       onClick: handleEditClick,
+      disabled: isPermissionLoading,
     })
   }
 
@@ -309,13 +321,11 @@ export function ProjectManagementMoreMenu({
             </span>
 
             <div className="flex w-full flex-col">
-              {menuItems.map(({ label, onClick }) => (
+              {menuItems.map(({ label, onClick, disabled }) => (
                 <DropdownItem
                   key={label}
                   label={label}
-                  disabled={
-                    label === "프로젝트 수정하기" && isPermissionLoading
-                  }
+                  disabled={disabled}
                   onClick={onClick}
                 />
               ))}

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -76,8 +76,8 @@ export function ProjectManagementMoreMenu({
     staleTime: 5 * 60 * 1000,
   })
 
-  const hasNoPlanLink =
-    projectDetailQuery.isSuccess && !projectDetailQuery.data.externalLink
+  const isPlanViewDisabled =
+    !projectDetailQuery.isSuccess || !projectDetailQuery.data.externalLink
 
   const applicantsQuery = useQuery({
     queryKey: applicationKeys.applicants(numericProjectId),
@@ -288,7 +288,7 @@ export function ProjectManagementMoreMenu({
     {
       label: "기획 보기",
       onClick: () => void handlePlanViewClick(),
-      disabled: hasNoPlanLink,
+      disabled: isPlanViewDisabled,
     },
     { label: "팀원 구성 보기", onClick: handleTeamViewClick },
   ]

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -73,6 +73,7 @@ export function ProjectManagementMoreMenu({
     queryKey: ["projectDetail", numericProjectId],
     queryFn: () => getProjectDetail(numericProjectId),
     enabled: (applicationOpen || popoverOpen) && numericProjectId > 0,
+    staleTime: 5 * 60 * 1000,
   })
 
   const hasNoPlanLink =

--- a/src/shared/assets/icon/logo/ProjectLogo.tsx
+++ b/src/shared/assets/icon/logo/ProjectLogo.tsx
@@ -1,14 +1,34 @@
 /** 프로젝트 상세 카드 중 프로젝트 로고 이미지 */
 /** 피그마 기준 40 Logo Frame */
+import { useState } from "react"
+
+import UmcLogo from "@/shared/assets/icon/logo/UmcLogo"
 import { cn } from "@/shared/lib/utils"
 
 type ProjectLogoSize = 30 | 32 | 40 | 50
 
-const sizeClass: Record<ProjectLogoSize, string> = {
-  30: "h-[1.875rem] w-[1.875rem]",
-  32: "h-8 w-8",
-  40: "h-10 w-10",
-  50: "h-[3.125rem] w-[3.125rem]",
+type ProjectLogoSizeConfig = {
+  box: string
+  logo: string
+}
+
+const sizeConfig: Record<ProjectLogoSize, ProjectLogoSizeConfig> = {
+  30: {
+    box: "h-[1.875rem] w-[1.875rem] px-[5px]",
+    logo: "h-[6px] w-[20px]",
+  },
+  32: {
+    box: "h-8 w-8 px-[4px]",
+    logo: "h-[7px] w-[24px]",
+  },
+  40: {
+    box: "h-10 w-10 px-[5px]",
+    logo: "h-[9px] w-[30px]",
+  },
+  50: {
+    box: "h-[3.125rem] w-[3.125rem] pr-[8.365px] pl-[7.999px]",
+    logo: "h-[10px] w-[33.636px]",
+  },
 }
 
 export function ProjectLogo({
@@ -18,17 +38,24 @@ export function ProjectLogo({
   src?: string
   size?: ProjectLogoSize
 }) {
+  const [erroredSrc, setErroredSrc] = useState<string | null>(null)
+  const showFallback = !src || erroredSrc === src
+  const { box, logo } = sizeConfig[size]
+
   return (
     <div
       className={cn(
-        "bg-teal-gray-200 overflow-hidden rounded-lg",
-        sizeClass[size],
+        "bg-teal-gray-200 flex shrink-0 items-center justify-center overflow-hidden rounded-lg",
+        box,
       )}
     >
-      {src && (
+      {showFallback ? (
+        <UmcLogo className={cn("text-teal-gray-300 shrink-0", logo)} />
+      ) : (
         <img
           src={src}
           alt="project logo"
+          onError={() => setErroredSrc(src)}
           className="h-full w-full object-cover"
         />
       )}

--- a/src/shared/assets/icon/logo/ProjectLogo.tsx
+++ b/src/shared/assets/icon/logo/ProjectLogo.tsx
@@ -55,7 +55,7 @@ export function ProjectLogo({
         <img
           src={src}
           alt="project logo"
-          onError={() => setErroredSrc(src)}
+          onError={() => setErroredSrc(src ?? null)}
           className="h-full w-full object-cover"
         />
       )}

--- a/src/shared/ui/ProjectThumbnail.tsx
+++ b/src/shared/ui/ProjectThumbnail.tsx
@@ -27,9 +27,9 @@ export function ProjectThumbnail({
 
   return (
     <img
-      src={src}
-      alt={alt}
-      onError={() => setErroredSrc(src)}
+      src={src ?? undefined}
+      alt={alt ?? ""}
+      onError={() => setErroredSrc(src ?? null)}
       className={cn("h-full w-full object-cover", className)}
       loading="lazy"
       decoding="async"

--- a/src/shared/ui/ProjectThumbnail.tsx
+++ b/src/shared/ui/ProjectThumbnail.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react"
+
+import UmcLogo from "@/shared/assets/icon/logo/UmcLogo"
+import { cn } from "@/shared/lib/utils"
+
+interface ProjectThumbnailProps {
+  src?: string | null
+  alt?: string
+  className?: string
+}
+
+export function ProjectThumbnail({
+  src,
+  alt,
+  className,
+}: ProjectThumbnailProps) {
+  const [erroredSrc, setErroredSrc] = useState<string | null>(null)
+  const showFallback = !src || erroredSrc === src
+
+  if (showFallback) {
+    return (
+      <div className="flex h-full w-full items-center justify-center py-1.5">
+        <UmcLogo className="text-teal-gray-300 aspect-[37/11] w-[23.2%]" />
+      </div>
+    )
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      onError={() => setErroredSrc(src)}
+      className={cn("h-full w-full object-cover", className)}
+      loading="lazy"
+      decoding="async"
+    />
+  )
+}

--- a/src/shared/ui/chip/ProjectStatusChip.tsx
+++ b/src/shared/ui/chip/ProjectStatusChip.tsx
@@ -8,15 +8,20 @@ const projectStatusChipVariants = cva(
   "inline-flex items-center justify-center rounded-md px-2 py-0.5 text-center text-body-3-medium",
 )
 
-const STATUS_CHIP: Partial<
-  Record<ProjectStatus, { label: string; className: string }>
-> = {
-  IN_PROGRESS: { label: "공개됨", className: "bg-teal-100 text-teal-600" },
-  PENDING_REVIEW: {
-    label: "검토 대기",
-    className: "bg-error-100 text-error-500",
-  },
-}
+const STATUS_CHIP: Record<ProjectStatus, { label: string; className: string }> =
+  {
+    DRAFT: { label: "초안", className: "bg-teal-gray-100 text-teal-gray-500" },
+    PENDING_REVIEW: {
+      label: "검토 대기",
+      className: "bg-warning-100 text-warning-600",
+    },
+    IN_PROGRESS: { label: "공개됨", className: "bg-teal-100 text-teal-600" },
+    COMPLETED: { label: "완료", className: "bg-success-100 text-success-600" },
+    ABORTED: {
+      label: "중단됨",
+      className: "bg-error-100 text-error-500",
+    },
+  }
 
 interface ProjectStatusChipProps {
   status?: ProjectStatus


### PR DESCRIPTION
## 📸 작업 내용

> 프로젝트 목록·관리 카드와 상세 모달의 이미지/상태 표시를 개선합니다.

- 썸네일/로고 미등록 프로젝트에 UMC 로고 기반 fallback 이미지 표시(이미지 등록 시 서버 이미지로 즉시 교체, 깨진 링크 onError 대응)
- `ProjectThumbnail` 공통 컴포넌트 신규 + 목록/관리 카드·상세 모달의 인라인 썸네일 렌더 치환
- `ProjectLogo` variant(30/32/40/50)별 정확 스펙 + UMC 로고 fallback + onError
- 관리 카드 상태 칩을 서버 상태 5종(초안/검토 대기/공개됨/완료/중단됨) 전체 매핑으로 보강
- 관리 더보기 '기획 보기'를 기획안 미등록(externalLink 없음) 시 비활성화하여 빈 탭 이동 제거

## 🎞️ 주요 코드 설명

### 이미지 fallback 자동 교체

```TypeScript
const showFallback = !src || erroredSrc === src
```

- `erroredSrc === src` 비교로 `src`가 바뀌면 에러 상태가 자동 무효화되어, 이후 서버 이미지가 등록되면 별도 처리 없이 정상 이미지로 전환됩니다.

### 기획 보기 비활성화

```TypeScript
const projectDetailQuery = useQuery({
  queryKey: ["projectDetail", numericProjectId],
  queryFn: () => getProjectDetail(numericProjectId),
  enabled: (applicationOpen || popoverOpen) && numericProjectId > 0,
})
const hasNoPlanLink =
  projectDetailQuery.isSuccess && !projectDetailQuery.data.externalLink
```

- 관리 목록 응답엔 `externalLink`가 없어 팝오버 오픈 시 상세를 조회(카드 로고 조회와 캐시 공유)해 링크 유무로 항목을 비활성화합니다.

## 🖥️ 구현화면

> 추후 캡처 첨부 예정

## 🔗 연결된 이슈

- Connected: #313, #314, #315
- Closes #313
- Closes #314
- Closes #315