### PR TITLE
task: 계정 설정 관련 에러 개선

### DIFF
--- a/src/features/settings/ui/AccountSettingsPage.tsx
+++ b/src/features/settings/ui/AccountSettingsPage.tsx
@@ -368,10 +368,11 @@ export function AccountSettingsPage() {
           if (!open) setUnlinkTarget(null)
         }}
         onCancel={() => setUnlinkTarget(null)}
-        onConfirm={() =>
-          unlinkTarget !== null &&
+        onConfirm={() => {
+          if (unlinkTarget === null) return
           void handleUnlink(unlinkTarget.id, unlinkTarget.social)
-        }
+          setUnlinkTarget(null)
+        }}
       />
 
       <CtaModal

--- a/src/features/settings/ui/ChangePasswordForm.tsx
+++ b/src/features/settings/ui/ChangePasswordForm.tsx
@@ -1,3 +1,4 @@
+import { AxiosError } from "axios"
 import { useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
@@ -34,6 +35,7 @@ export function ChangePasswordForm({
     isValidPassword(next) && !isSameAsCurrent && !hasInvalidSpecial
   const isConfirmMatch = next === confirm
 
+  const [isCurrentPasswordWrong, setIsCurrentPasswordWrong] = useState(false)
   const [showConfirmError, setShowConfirmError] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
@@ -53,14 +55,22 @@ export function ChangePasswordForm({
         duration: 3000,
       })
       onSuccess()
-    } catch {
-      addToast({
-        message: "잠시 후 다시 시도해 주세요.",
-        color: "red",
-        variant: "deep",
-        type: "default",
-        duration: 3000,
-      })
+    } catch (err) {
+      const code =
+        err instanceof AxiosError
+          ? (err.response?.data as { code?: string })?.code
+          : undefined
+      if (code === "AUTHENTICATION-0022") {
+        setIsCurrentPasswordWrong(true)
+      } else {
+        addToast({
+          message: "잠시 후 다시 시도해 주세요.",
+          color: "red",
+          variant: "deep",
+          type: "default",
+          duration: 3000,
+        })
+      }
     } finally {
       setIsSubmitting(false)
     }
@@ -85,9 +95,21 @@ export function ChangePasswordForm({
             <InputBox
               type="password"
               value={current}
-              onChange={(e) => setCurrent(e.target.value)}
+              state={isCurrentPasswordWrong ? "error" : "default"}
+              onChange={(e) => {
+                setCurrent(e.target.value)
+                setIsCurrentPasswordWrong(false)
+              }}
               className="w-full"
             />
+            {isCurrentPasswordWrong && (
+              <div className="flex items-center gap-1">
+                <CheckIcon className="text-error-500 h-4 w-4 shrink-0" />
+                <p className="text-body-3-medium text-error-500">
+                  현재 비밀번호가 올바르지 않습니다
+                </p>
+              </div>
+            )}
           </div>
 
           {/* 새 비밀번호 */}


### PR DESCRIPTION
## 📸 작업 내용

> 작업한 내용을 두괄식으로 작성해주세요

- 비밀번호 변경 시 현재 비밀번호 불일치 에러 인라인 표시
   "변경하기" 클릭 후 서버가 AUTHENTICATION-0022 반환하면 현재 비밀번호 입력란 아래에 에러 메시지 표시
- 소셜 연동 해제 후 모달 자동 닫힘 버그 수정
    해제 확인 클릭 시 unlinkTarget이 초기화되지 않아 모달이 그대로 열려있던 문제 수정


## 🖥️ 구현화면

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #306 