### PR TITLE
feat: PM 드롭다운 cursor pagination 적용

### DIFF
--- a/src/features/challenger/api/member.ts
+++ b/src/features/challenger/api/member.ts
@@ -2,6 +2,8 @@ import { api } from "@/shared/lib/axios"
 
 import type {
   MemberInfoResponse,
+  SearchChallengerCursorParams,
+  SearchChallengerCursorResponse,
   SearchMemberParams,
   SearchMemberResponse,
 } from "@/features/challenger/model/types"
@@ -12,6 +14,16 @@ export async function searchMembers(
 ): Promise<SearchMemberResponse> {
   const { data } = await api.get<ApiResponse<SearchMemberResponse>>(
     "/v1/member/search",
+    { params },
+  )
+  return data.result
+}
+
+export async function searchChallengersByCursor(
+  params: SearchChallengerCursorParams,
+): Promise<SearchChallengerCursorResponse> {
+  const { data } = await api.get<ApiResponse<SearchChallengerCursorResponse>>(
+    "/v1/challenger/search/cursor",
     { params },
   )
   return data.result

--- a/src/features/challenger/model/types.ts
+++ b/src/features/challenger/model/types.ts
@@ -143,6 +143,50 @@ export interface SearchMemberParams {
   schoolId?: string
 }
 
+export interface SearchChallengerCursorParams {
+  cursor?: string
+  size?: number
+  challengerId?: string
+  name?: string
+  nickname?: string
+  keyword?: string
+  schoolId?: string
+  chapterId?: string
+  part?: Part
+  gisuId?: string
+}
+
+export interface SearchChallengerItem {
+  challengerId?: string
+  memberId?: string
+  gisuId?: string
+  generation?: string
+  gisu?: string
+  part?: Part
+  name?: string
+  nickname?: string
+  schoolName?: string
+  pointSum?: string
+  profileImageLink?: string | null
+  roleTypes?: RoleType[]
+}
+
+export interface SearchChallengerCursor {
+  content: SearchChallengerItem[]
+  nextCursor?: string
+  hasNext: boolean
+}
+
+export interface PartCount {
+  part: Part
+  count: string
+}
+
+export interface SearchChallengerCursorResponse {
+  cursor: SearchChallengerCursor
+  partCounts?: PartCount[]
+}
+
 export interface MemberRoleInfo {
   id: string
   challengerId: string

--- a/src/features/challenger/ui/shared/Dropdown.tsx
+++ b/src/features/challenger/ui/shared/Dropdown.tsx
@@ -157,7 +157,10 @@ export function Dropdown<T extends string | number>({
             })
           )}
           {isLoadingMore && (
-            <li className="text-body-2-medium text-teal-gray-400 px-4 py-3">
+            <li
+              role="presentation"
+              className="text-body-2-medium text-teal-gray-400 px-4 py-3"
+            >
               불러오는 중입니다.
             </li>
           )}

--- a/src/features/challenger/ui/shared/Dropdown.tsx
+++ b/src/features/challenger/ui/shared/Dropdown.tsx
@@ -17,7 +17,10 @@ interface DropdownProps<T extends string | number> {
   placeholder: string
   disabled?: boolean
   error?: boolean
+  hasMore?: boolean
   className?: string
+  isLoadingMore?: boolean
+  onReachEnd?: () => void
   panelClassName?: string
   id?: string
 }
@@ -29,7 +32,10 @@ export function Dropdown<T extends string | number>({
   placeholder,
   disabled,
   error,
+  hasMore = false,
   className,
+  isLoadingMore = false,
+  onReachEnd,
   panelClassName,
   id,
 }: DropdownProps<T>) {
@@ -93,6 +99,13 @@ export function Dropdown<T extends string | number>({
       {open && (
         <ul
           role="listbox"
+          onScroll={(event) => {
+            if (!hasMore || isLoadingMore || !onReachEnd) return
+            const target = event.currentTarget
+            const remaining =
+              target.scrollHeight - target.scrollTop - target.clientHeight
+            if (remaining <= 24) onReachEnd()
+          }}
           className={cn(
             "border-teal-gray-50 shadow-drop-neutral-1 scrollbar-hide absolute top-[calc(100%+0.25rem)] left-0 z-30 flex max-h-60 w-full flex-col overflow-y-auto rounded-[12px] border bg-white p-0.5",
             panelClassName,
@@ -142,6 +155,11 @@ export function Dropdown<T extends string | number>({
                 </li>
               )
             })
+          )}
+          {isLoadingMore && (
+            <li className="text-body-2-medium text-teal-gray-400 px-4 py-3">
+              불러오는 중입니다.
+            </li>
           )}
         </ul>
       )}

--- a/src/features/challenger/ui/shared/Dropdown.tsx
+++ b/src/features/challenger/ui/shared/Dropdown.tsx
@@ -107,7 +107,7 @@ export function Dropdown<T extends string | number>({
             if (remaining <= 24) onReachEnd()
           }}
           className={cn(
-            "border-teal-gray-50 shadow-drop-neutral-1 scrollbar-hide absolute top-[calc(100%+0.25rem)] left-0 z-30 flex max-h-60 w-full flex-col overflow-y-auto rounded-[12px] border bg-white p-0.5",
+            "border-teal-gray-50 shadow-drop-neutral-1 scrollbar-none absolute top-[calc(100%+0.25rem)] left-0 z-30 flex max-h-60 w-full flex-col overflow-y-auto rounded-[12px] border bg-white p-0.5",
             panelClassName,
           )}
         >

--- a/src/features/project/new/api/memberAdapter.ts
+++ b/src/features/project/new/api/memberAdapter.ts
@@ -1,6 +1,9 @@
 import { formatSchoolName } from "@/shared/lib/formatSchoolName"
 
-import type { SearchMemberItem } from "@/features/challenger/model/types"
+import type {
+  SearchChallengerItem,
+  SearchMemberItem,
+} from "@/features/challenger/model/types"
 import type { MemberItem } from "@/shared/ui/searchbar/MemberSearchBar"
 
 export function toMemberItem(item: SearchMemberItem): MemberItem {
@@ -8,6 +11,18 @@ export function toMemberItem(item: SearchMemberItem): MemberItem {
     id: item.memberId,
     nickname: item.nickname,
     name: item.name,
+    university: formatSchoolName(item.schoolName),
+  }
+}
+
+export function challengerSearchItemToMemberItem(
+  item: SearchChallengerItem,
+): MemberItem | null {
+  if (!item.memberId) return null
+  return {
+    id: item.memberId,
+    nickname: item.nickname ?? "",
+    name: item.name ?? "",
     university: formatSchoolName(item.schoolName),
   }
 }

--- a/src/features/project/new/api/memberAdapter.ts
+++ b/src/features/project/new/api/memberAdapter.ts
@@ -20,7 +20,7 @@ export function challengerSearchItemToMemberItem(
 ): MemberItem | null {
   if (!item.memberId) return null
   return {
-    id: item.memberId,
+    id: String(item.memberId),
     nickname: item.nickname ?? "",
     name: item.name ?? "",
     university: formatSchoolName(item.schoolName),

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -1,5 +1,9 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
 import { isAxiosError } from "axios"
 import {
   forwardRef,
@@ -18,7 +22,7 @@ import {
   isCurrentTermPm,
   isSuperAdmin,
 } from "@/features/auth/model/identity"
-import { searchAllMembers } from "@/features/challenger/api/member"
+import { searchChallengersByCursor } from "@/features/challenger/api/member"
 import { Dropdown } from "@/features/challenger/ui/shared/Dropdown"
 import {
   addProjectMember,
@@ -28,7 +32,7 @@ import {
   updateProjectDraft,
   uploadFileFlow,
 } from "@/features/project/new/api"
-import { toMemberItem } from "@/features/project/new/api/memberAdapter"
+import { challengerSearchItemToMemberItem } from "@/features/project/new/api/memberAdapter"
 import { getActiveGisu } from "@/shared/api/gisu"
 import InfoCircleIcon from "@/shared/assets/icon/infomation/InfoCircleIcon"
 import { formatSchoolName } from "@/shared/lib/formatSchoolName"
@@ -53,6 +57,25 @@ function extractApiErrorCode(error: unknown): string | undefined {
   if (typeof data !== "object" || data === null) return undefined
   const code = (data as { code?: unknown }).code
   return typeof code === "string" ? code : undefined
+}
+
+function isMemberItem(
+  member: MemberItem | null | undefined,
+): member is MemberItem {
+  return member != null
+}
+
+function mergeMemberItems(
+  ...groups: ReadonlyArray<ReadonlyArray<MemberItem | null | undefined>>
+): MemberItem[] {
+  const members = new Map<string, MemberItem>()
+  groups
+    .flat()
+    .filter(isMemberItem)
+    .forEach((member) => {
+      members.set(member.id, member)
+    })
+  return Array.from(members.values())
 }
 
 export interface BasicInfoFormHandle {
@@ -85,20 +108,24 @@ export const BasicInfoForm = forwardRef<
 
   const pmSearchScope = useMemo(() => getProjectPmSearchScope(meData), [meData])
 
-  const pmListQuery = useQuery({
+  const pmListQuery = useInfiniteQuery({
     queryKey: [
       "member",
-      "list",
+      "cursor",
       { part: "PLAN", gisuId: activeGisuId, ...pmSearchScope },
     ],
-    queryFn: () =>
-      searchAllMembers({
+    queryFn: ({ pageParam }) =>
+      searchChallengersByCursor({
+        cursor: pageParam,
         part: "PLAN",
         gisuId: activeGisuId != null ? String(activeGisuId) : undefined,
-        size: 200,
+        size: 50,
         ...pmSearchScope,
       }),
     enabled: activeGisuId != null,
+    getNextPageParam: (lastPage) =>
+      lastPage.cursor.hasNext ? lastPage.cursor.nextCursor : undefined,
+    initialPageParam: undefined as string | undefined,
     staleTime: 60 * 1000,
   })
 
@@ -130,13 +157,48 @@ export const BasicInfoForm = forwardRef<
 
   const isCentral = isCentralStaff(meData) || isSuperAdmin(meData)
 
+  const selfPmMember = useMemo<MemberItem | null>(() => {
+    if (!isPm || !meData) return null
+    return {
+      id: String(meData.id),
+      nickname: meData.nickname,
+      name: meData.name,
+      university: formatSchoolName(meData.schoolName),
+    }
+  }, [isPm, meData])
+
+  const loadedPmMembers = useMemo(
+    () =>
+      (pmListQuery.data?.pages ?? [])
+        .flatMap((page) => page.cursor.content)
+        .map(challengerSearchItemToMemberItem)
+        .filter(isMemberItem),
+    [pmListQuery.data],
+  )
+
   const allPmMembers = useMemo(() => {
-    const members = (pmListQuery.data?.page.content ?? []).map(toMemberItem)
+    const members = mergeMemberItems(loadedPmMembers, [
+      pm1Member,
+      pm2Member,
+      storePmInfo.pm1,
+      storePmInfo.pm2,
+      selfPmMember,
+    ])
     if (isCentral) {
-      return members.sort((a, b) => a.nickname.localeCompare(b.nickname, "ko"))
+      return [...members].sort((a, b) =>
+        a.nickname.localeCompare(b.nickname, "ko"),
+      )
     }
     return members
-  }, [pmListQuery.data, isCentral])
+  }, [
+    isCentral,
+    loadedPmMembers,
+    pm1Member,
+    pm2Member,
+    selfPmMember,
+    storePmInfo.pm1,
+    storePmInfo.pm2,
+  ])
 
   const pm1Options = useMemo(
     () =>
@@ -285,8 +347,7 @@ export const BasicInfoForm = forwardRef<
   }, [storePmInfo])
 
   useEffect(() => {
-    if (!isPm || !meData || pm1Member !== null || allPmMembers.length === 0)
-      return
+    if (!isPm || !meData || pm1Member !== null) return
     const self = allPmMembers.find((m) => m.id === String(meData.id))
     if (self) {
       setPm1Member(self)
@@ -442,6 +503,10 @@ export const BasicInfoForm = forwardRef<
     formatSchoolName(pm1Member?.university ?? meData?.schoolName) || "-"
 
   const pmDropdownDisabled = activeGisuId == null || pmListQuery.isLoading
+  const handlePmDropdownReachEnd = () => {
+    if (!pmListQuery.hasNextPage || pmListQuery.isFetchingNextPage) return
+    void pmListQuery.fetchNextPage()
+  }
 
   return (
     <form
@@ -484,6 +549,9 @@ export const BasicInfoForm = forwardRef<
               }
               error={pm1Error}
               disabled={pmDropdownDisabled}
+              hasMore={pmListQuery.hasNextPage}
+              isLoadingMore={pmListQuery.isFetchingNextPage}
+              onReachEnd={handlePmDropdownReachEnd}
             />
             {isMultiPm && (
               <Dropdown<string>
@@ -499,6 +567,9 @@ export const BasicInfoForm = forwardRef<
                 placeholder="PM 닉네임/이름을 선택하세요."
                 error={pm2Error}
                 disabled={pmDropdownDisabled}
+                hasMore={pmListQuery.hasNextPage}
+                isLoadingMore={pmListQuery.isFetchingNextPage}
+                onReachEnd={handlePmDropdownReachEnd}
               />
             )}
             <button

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -160,7 +160,7 @@ export const BasicInfoForm = forwardRef<
   const selfPmMember = useMemo<MemberItem | null>(() => {
     if (!isPm || !meData) return null
     return {
-      id: String(meData.id),
+      id: meData.id,
       nickname: meData.nickname,
       name: meData.name,
       university: formatSchoolName(meData.schoolName),

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -348,7 +348,7 @@ export const BasicInfoForm = forwardRef<
 
   useEffect(() => {
     if (!isPm || !meData || pm1Member !== null) return
-    const self = allPmMembers.find((m) => m.id === String(meData.id))
+    const self = allPmMembers.find((m) => m.id === meData.id)
     if (self) {
       setPm1Member(self)
       setPm1Error(false)


### PR DESCRIPTION
## 작업 내용

- 프로젝트 등록 step1의 PM 선택 드롭다운을 cursor 기반 challenger 검색 API로 전환했습니다.
- PM 후보 목록을 useInfiniteQuery로 조회하고, 드롭다운 하단 스크롤 시 다음 cursor 페이지를 불러오도록 했습니다.
- 기존 선택 PM이 현재 cursor 페이지에 없어도 선택 라벨이 유지되도록 선택값을 목록에 병합했습니다.

## 주요 코드 설명

### PM 목록 cursor 조회

- /v1/challenger/search/cursor API 래퍼와 응답 타입을 추가했습니다.
- BasicInfoForm에서 active gisu, PLAN part, 역할별 chapterId/schoolId scope를 유지한 채 cursor 페이지를 조회합니다.

### 드롭다운 추가 로드

- 공용 Dropdown에 선택적 hasMore, isLoadingMore, onReachEnd props를 추가했습니다.
- 기존 호출부는 props를 넘기지 않으면 기존 동작을 유지합니다.

## 구현화면

- 네트워크 조회 방식 변경이라 별도 화면 변화는 없습니다.
- 앱 브라우저 확인은 현재 세션에서 iab가 unavailable로 반환되어 첨부하지 못했습니다.
- localhost:5174 프록시 경유 cursor API 200 OK는 확인했습니다.

## 연결된 이슈

- Closes #321

## 검증

- pnpm exec tsc --noEmit
- pnpm exec eslint src/features/challenger/api/member.ts src/features/challenger/model/types.ts src/features/challenger/ui/shared/Dropdown.tsx src/features/project/new/api/memberAdapter.ts src/features/project/new/ui/basic-info/BasicInfoForm.tsx
- localhost:5174 /api/v1/challenger/search/cursor?part=PLAN&gisuId=5&size=2 인증 호출 200 OK 확인
