### PR TITLE
🐛 fix: 프로젝트 관리 '중단하기' 클릭 시 프로젝트 정보 모달 동시 표시 버그 수정

### DIFF
--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import { isAxiosError } from "axios"
 import { Popover } from "radix-ui"
-import { useMemo, useState } from "react"
+import { useMemo, useRef, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
 import { getProjectApplications } from "@/features/application/api/applicationApi"
@@ -65,6 +65,7 @@ export function ProjectManagementMoreMenu({
   const [abortOpen, setAbortOpen] = useState(false)
   const [applicationOpen, setApplicationOpen] = useState(false)
   const [teamModalOpen, setTeamModalOpen] = useState(false)
+  const willOpenModalOnCloseRef = useRef(false)
   const addToast = useToastStore((s) => s.addToast)
 
   const numericProjectId = Number(projectId)
@@ -211,23 +212,27 @@ export function ProjectManagementMoreMenu({
 
   const handleDeleteClick = () => {
     if (!canDeleteProject || isPermissionLoading) return
+    willOpenModalOnCloseRef.current = true
     setPopoverOpen(false)
     setDeleteOpen(true)
   }
 
   const handleAbortClick = () => {
     if (!canPublishProject || isPermissionLoading) return
+    willOpenModalOnCloseRef.current = true
     setPopoverOpen(false)
     setAbortOpen(true)
   }
 
   const handlePublishClick = () => {
     if (!canPublishProject || isPermissionLoading) return
+    willOpenModalOnCloseRef.current = true
     setPopoverOpen(false)
     setPublishOpen(true)
   }
 
   const handleApplicationClick = () => {
+    willOpenModalOnCloseRef.current = true
     setPopoverOpen(false)
     setApplicationOpen(true)
   }
@@ -249,6 +254,7 @@ export function ProjectManagementMoreMenu({
   }
 
   const handleTeamViewClick = () => {
+    willOpenModalOnCloseRef.current = true
     setPopoverOpen(false)
     setTeamModalOpen(true)
   }
@@ -289,6 +295,12 @@ export function ProjectManagementMoreMenu({
             sideOffset={10}
             avoidCollisions={false}
             onOpenAutoFocus={(e) => e.preventDefault()}
+            onCloseAutoFocus={(e) => {
+              if (willOpenModalOnCloseRef.current) {
+                e.preventDefault()
+                willOpenModalOnCloseRef.current = false
+              }
+            }}
             className="shadow-drop-neutral-1 border-teal-gray-50 z-1100 flex w-38 flex-col items-start gap-1 rounded-lg border bg-white px-0.5 pt-2.5 pb-0.5"
           >
             <span className="text-label-3-semibold text-teal-gray-400 px-4">

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -65,7 +65,7 @@ export function ProjectManagementMoreMenu({
   const [abortOpen, setAbortOpen] = useState(false)
   const [applicationOpen, setApplicationOpen] = useState(false)
   const [teamModalOpen, setTeamModalOpen] = useState(false)
-  const willOpenModalOnCloseRef = useRef(false)
+  const shouldPreventFocusRestoreRef = useRef(false)
   const addToast = useToastStore((s) => s.addToast)
 
   const numericProjectId = Number(projectId)
@@ -212,27 +212,27 @@ export function ProjectManagementMoreMenu({
 
   const handleDeleteClick = () => {
     if (!canDeleteProject || isPermissionLoading) return
-    willOpenModalOnCloseRef.current = true
+    shouldPreventFocusRestoreRef.current = true
     setPopoverOpen(false)
     setDeleteOpen(true)
   }
 
   const handleAbortClick = () => {
     if (!canPublishProject || isPermissionLoading) return
-    willOpenModalOnCloseRef.current = true
+    shouldPreventFocusRestoreRef.current = true
     setPopoverOpen(false)
     setAbortOpen(true)
   }
 
   const handlePublishClick = () => {
     if (!canPublishProject || isPermissionLoading) return
-    willOpenModalOnCloseRef.current = true
+    shouldPreventFocusRestoreRef.current = true
     setPopoverOpen(false)
     setPublishOpen(true)
   }
 
   const handleApplicationClick = () => {
-    willOpenModalOnCloseRef.current = true
+    shouldPreventFocusRestoreRef.current = true
     setPopoverOpen(false)
     setApplicationOpen(true)
   }
@@ -254,7 +254,7 @@ export function ProjectManagementMoreMenu({
   }
 
   const handleTeamViewClick = () => {
-    willOpenModalOnCloseRef.current = true
+    shouldPreventFocusRestoreRef.current = true
     setPopoverOpen(false)
     setTeamModalOpen(true)
   }
@@ -296,9 +296,9 @@ export function ProjectManagementMoreMenu({
             avoidCollisions={false}
             onOpenAutoFocus={(e) => e.preventDefault()}
             onCloseAutoFocus={(e) => {
-              if (willOpenModalOnCloseRef.current) {
+              if (shouldPreventFocusRestoreRef.current) {
                 e.preventDefault()
-                willOpenModalOnCloseRef.current = false
+                shouldPreventFocusRestoreRef.current = false
               }
             }}
             className="shadow-drop-neutral-1 border-teal-gray-50 z-1100 flex w-38 flex-col items-start gap-1 rounded-lg border bg-white px-0.5 pt-2.5 pb-0.5"

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -83,7 +83,7 @@ export function ProjectManagementMoreMenu({
   const applicantsQuery = useQuery({
     queryKey: applicationKeys.applicants(numericProjectId),
     queryFn: () => getProjectApplications(numericProjectId),
-    enabled: applicationOpen && numericProjectId > 0,
+    enabled: (applicationOpen || popoverOpen) && numericProjectId > 0,
   })
 
   const projectApplication = useMemo((): ProjectApplication | null => {


### PR DESCRIPTION
## 📸 작업 내용

> 프로젝트 관리 더보기 메뉴에서 '중단하기' 클릭 시 프로젝트 정보 모달이 함께 뜨던 버그 수정

- 더보기 메뉴 항목 클릭으로 radix `Popover`가 닫힐 때, `onCloseAutoFocus`가 트리거 버튼(클릭 가능한 카드 div의 DOM 자식)으로 포커스를 복원하면서 카드의 `openDetailModal`이 유발되어 프로젝트 정보 모달이 함께 열리던 문제를 해결
- 모달을 여는 메뉴 항목(중단/삭제/공개/지원 현황/팀원 구성)에 한해 Popover 닫힘 시 트리거로의 포커스 복원을 차단
- 모달을 열지 않는 항목(수정하기/기획 보기)은 기존 포커스 복원·키보드 접근성을 유지
- 같은 Popover를 공유하는 모든 메뉴 항목을 메뉴 컴포넌트 한 곳에서 중앙집중식으로 보호

## 🎞️ 주요 코드 설명

> `ProjectManagementMoreMenu.tsx`

\`\`\`TypeScript
const willOpenModalOnCloseRef = useRef(false)

const handleAbortClick = () => {
  if (!canPublishProject || isPermissionLoading) return
  willOpenModalOnCloseRef.current = true
  setPopoverOpen(false)
  setAbortOpen(true)
}

<Popover.Content
  onOpenAutoFocus={(e) => e.preventDefault()}
  onCloseAutoFocus={(e) => {
    if (willOpenModalOnCloseRef.current) {
      e.preventDefault()
      willOpenModalOnCloseRef.current = false
    }
  }}
>
\`\`\`

- 모달을 여는 핸들러에서만 플래그를 세팅하고, `onCloseAutoFocus`에서 해당 경우에만 `preventDefault()`로 트리거 버튼으로의 포커스 복원을 차단한다. 모달이 열릴 때는 Dialog의 FocusScope가 자체적으로 포커스를 잡으므로 접근성도 유지된다.

## 🔗 연결된 이슈

- Connected: #323
- Closes #323