### PR TITLE
💄 style: 질문 필드 필수 항목 체크박스·라벨 그룹 간격 정리

### DIFF
--- a/src/shared/ui/question-field/QuestionForm.tsx
+++ b/src/shared/ui/question-field/QuestionForm.tsx
@@ -161,15 +161,17 @@ export function QuestionForm({
 
         {focused && (
           <div className="flex items-center gap-4">
-            <Checkbox
-              variant="primary"
-              checked={required}
-              onChange={onRequiredChange ?? (() => {})}
-              aria-label="필수 항목 여부"
-            />
-            <span className="text-body-1-medium text-teal-gray-600">
-              필수 항목
-            </span>
+            <div className="flex items-center gap-2">
+              <Checkbox
+                variant="primary"
+                checked={required}
+                onChange={onRequiredChange ?? (() => {})}
+                aria-label="필수 항목 여부"
+              />
+              <span className="text-body-1-medium text-teal-gray-600">
+                필수 항목
+              </span>
+            </div>
             {canDelete && (
               <button
                 type="button"


### PR DESCRIPTION
## 📸 작업 내용

> 작업한 내용을 두괄식으로 작성해주세요

- 질문 필드(`QuestionForm`)에서 "필수 항목" 체크박스와 라벨을 별도 그룹(`gap-2`)으로 묶어, 삭제 버튼과의 간격(`gap-4`)과 분리했습니다.
- 기존에는 체크박스·라벨·삭제 버튼이 동일한 `gap-4` 간격으로 나열되어 시각적 그룹핑이 불명확했습니다.

## 🎞️ 주요 코드 설명

> 설명이 필요한 코드 위주로 작성해주세요

### 필수 항목 체크박스·라벨 그룹화

```TypeScript
<div className="flex items-center gap-2">
  <Checkbox
    variant="primary"
    checked={required}
    onChange={onRequiredChange ?? (() => {})}
    aria-label="필수 항목 여부"
  />
  <span className="text-body-1-medium text-teal-gray-600">
    필수 항목
  </span>
</div>
```

- 체크박스와 라벨을 하나의 `gap-2` 컨테이너로 묶어 의미 단위로 그룹화하고, 외부 컨테이너의 `gap-4`는 삭제 버튼과의 간격으로 유지했습니다.

## 🔗 연결된 이슈

- Connected: #326
- Closes #326
