### PR TITLE
🐛 fix: 내 지원 현황 더보기 철회 후 목록 자동 갱신 누락 수정

### DIFF
--- a/src/features/application/ui/MyApplicationView.tsx
+++ b/src/features/application/ui/MyApplicationView.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
 
@@ -88,9 +88,13 @@ function toParts(
 
 interface MyApplicationRoundSectionProps {
   item: MyProjectApplicationResponse
+  onCancelled?: () => void
 }
 
-function MyApplicationRoundSection({ item }: MyApplicationRoundSectionProps) {
+function MyApplicationRoundSection({
+  item,
+  onCancelled,
+}: MyApplicationRoundSectionProps) {
   const [detailOpen, setDetailOpen] = useState(false)
 
   const isRandomMatching = item.matchingRound.phase === "RANDOM_MATCHING"
@@ -119,6 +123,7 @@ function MyApplicationRoundSection({ item }: MyApplicationRoundSectionProps) {
               <MyApplicationMoreMenu
                 item={item}
                 isRandomMatching={isRandomMatching}
+                onCancelled={onCancelled}
               />
             }
           />
@@ -144,6 +149,7 @@ function MyApplicationRoundSection({ item }: MyApplicationRoundSectionProps) {
 
 export function MyApplicationView() {
   const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const { data: gisuId } = useActiveGisuId()
   const { data: raw = [] } = useQuery({
     queryKey: ["myApplications", gisuId],
@@ -171,7 +177,15 @@ export function MyApplicationView() {
   return (
     <div className="flex flex-col gap-10">
       {applications.map((item) => (
-        <MyApplicationRoundSection key={item.applicationId} item={item} />
+        <MyApplicationRoundSection
+          key={item.applicationId}
+          item={item}
+          onCancelled={() =>
+            void queryClient.invalidateQueries({
+              queryKey: ["myApplications", gisuId],
+            })
+          }
+        />
       ))}
 
       <UsabilitySurvey


### PR DESCRIPTION
## 📸 작업 내용

> 작업한 내용을 두괄식으로 작성해주세요

- `/matching/applications`(내 지원 현황)에서 더보기 메뉴로 지원을 철회한 뒤 목록이 자동 갱신되지 않던 문제를 수정
- `MyApplicationView`가 `MyApplicationMoreMenu`에 `onCancelled`를 전달하지 않아 철회 성공 후 `["myApplications", gisuId]` 쿼리 무효화가 누락됐던 것이 원인
- `ProjectDetailCard`의 기존 패턴과 동일하게 `useQueryClient`로 invalidate를 배선 → 철회 시 취소된 카드가 목록에서 즉시 사라짐 (목록은 `status !== "CANCELLED"` 필터 보유)
- 더보기 메뉴 직접 취소 / 내 지원서 모달 내 취소 두 경로 모두 동일 콜백을 타므로 함께 해소

## 🎞️ 주요 코드 설명

> 설명이 필요한 코드 위주로 작성해주세요

### onCancelled 배선

```TypeScript
const queryClient = useQueryClient()
// ...
<MyApplicationRoundSection
  key={item.applicationId}
  item={item}
  onCancelled={() =>
    void queryClient.invalidateQueries({
      queryKey: ["myApplications", gisuId],
    })
  }
/>
```

- 콜백을 `MyApplicationRoundSection` → `MyApplicationMoreMenu`로 내려 철회 성공 시 목록을 재조회

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #328
- Closes #328