### PR TITLE
🐛 fix: 지원서 저장/제출 API 경로를 /me로 환원

### DIFF
--- a/src/features/project/list/api/matchingProject.test.ts
+++ b/src/features/project/list/api/matchingProject.test.ts
@@ -20,7 +20,7 @@ describe("saveApplicationDraft", () => {
     putMock.mockReset()
   })
 
-  it("applicationId 기반 경로로 PUT 호출하고 body는 answers", async () => {
+  it("me 경로로 PUT 호출하고 body는 answers", async () => {
     putMock.mockResolvedValue({
       data: { result: { applicationId: "10", status: "DRAFT" } },
     })
@@ -28,22 +28,24 @@ describe("saveApplicationDraft", () => {
       { questionId: 1, textValue: "answer" },
     ]
 
-    const result = await saveApplicationDraft(7, 10, answers)
+    const result = await saveApplicationDraft(7, answers)
 
-    expect(putMock).toHaveBeenCalledWith("/v1/projects/7/applications/10", {
+    expect(putMock).toHaveBeenCalledWith("/v1/projects/7/applications/me", {
       answers,
     })
     expect(result).toEqual({ applicationId: "10", status: "DRAFT" })
   })
 
-  it("me 레거시 경로를 호출하지 않는다", async () => {
+  it("applicationId 기반 레거시 경로를 호출하지 않는다", async () => {
     putMock.mockResolvedValue({
       data: { result: { applicationId: "10", status: "DRAFT" } },
     })
 
-    await saveApplicationDraft(7, 10, [])
+    await saveApplicationDraft(7, [])
 
-    expect(putMock.mock.calls[0]?.[0]).not.toContain("/applications/me")
+    const calledUrl = putMock.mock.calls[0]?.[0]
+    expect(calledUrl).toMatch(/\/applications\/me$/)
+    expect(calledUrl).not.toMatch(/\/applications\/\d+$/)
   })
 })
 
@@ -52,26 +54,28 @@ describe("submitApplication", () => {
     postMock.mockReset()
   })
 
-  it("applicationId 기반 submit 경로로 POST 호출", async () => {
+  it("me 기반 submit 경로로 POST 호출", async () => {
     postMock.mockResolvedValue({
       data: { result: { applicationId: "10", status: "SUBMITTED" } },
     })
 
-    const result = await submitApplication(7, 10)
+    const result = await submitApplication(7)
 
     expect(postMock).toHaveBeenCalledWith(
-      "/v1/projects/7/applications/10/submit",
+      "/v1/projects/7/applications/me/submit",
     )
     expect(result).toEqual({ applicationId: "10", status: "SUBMITTED" })
   })
 
-  it("me 레거시 경로를 호출하지 않는다", async () => {
+  it("applicationId 기반 레거시 경로를 호출하지 않는다", async () => {
     postMock.mockResolvedValue({
       data: { result: { applicationId: "10", status: "SUBMITTED" } },
     })
 
-    await submitApplication(7, 10)
+    await submitApplication(7)
 
-    expect(postMock.mock.calls[0]?.[0]).not.toContain("/applications/me")
+    const calledUrl = postMock.mock.calls[0]?.[0]
+    expect(calledUrl).toMatch(/\/applications\/me\/submit$/)
+    expect(calledUrl).not.toMatch(/\/applications\/\d+\/submit$/)
   })
 })

--- a/src/features/project/list/api/matchingProject.ts
+++ b/src/features/project/list/api/matchingProject.ts
@@ -231,11 +231,10 @@ export async function createApplicationDraft(
 
 export async function saveApplicationDraft(
   projectId: number,
-  applicationId: number,
   answers: ApplicationAnswerItem[],
 ): Promise<ApplicationStatusResponse> {
   const { data } = await api.put<ApiResponse<ApplicationStatusResponse>>(
-    `/v1/projects/${projectId}/applications/${applicationId}`,
+    `/v1/projects/${projectId}/applications/me`,
     { answers },
   )
   return data.result
@@ -243,10 +242,9 @@ export async function saveApplicationDraft(
 
 export async function submitApplication(
   projectId: number,
-  applicationId: number,
 ): Promise<ApplicationStatusResponse> {
   const { data } = await api.post<ApiResponse<ApplicationStatusResponse>>(
-    `/v1/projects/${projectId}/applications/${applicationId}/submit`,
+    `/v1/projects/${projectId}/applications/me/submit`,
   )
   return data.result
 }

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -320,8 +320,8 @@ export function ProjectApplyModal({
     try {
       if (!isDevMatchingRound && applicationId !== null) {
         const answers = buildAnswerPayload(formValues, sections, sectionEnabled)
-        await saveApplicationDraft(projectId, applicationId, answers)
-        await submitApplication(projectId, applicationId)
+        await saveApplicationDraft(projectId, answers)
+        await submitApplication(projectId)
       }
       setIsCompleteModalOpen(true)
     } catch (err) {


### PR DESCRIPTION
## 📸 작업 내용

> 지원서 저장/제출이 서버에 없는 `/{applicationId}` 경로를 호출해 실패하던 회귀를 수정합니다.

- `saveApplicationDraft`/`submitApplication`의 호출 경로를 서버가 실제로 노출하는 `/me`·`/me/submit`로 환원
- 두 함수에서 불필요해진 `applicationId` 인자 제거, 호출부(`ProjectApplyModal`) 정리
- 단위 테스트를 `/me` 경로 단언으로 갱신 (applicationId 기반 레거시 경로 미호출 검증)

## 🎞️ 주요 코드 설명

> 서버 `ProjectApplicationController`는 임시저장/제출을 인증 주체(`@CurrentMember`) 기반 `/me` 경로로만 노출한다. 생성 타입 `src/types/api.d.ts`도 `/me`만 정의한다. 회귀 커밋 `b014e35`가 `/{applicationId}`로 바꾼 것을 되돌린다.

\`\`\`TypeScript
export async function saveApplicationDraft(
  projectId: number,
  answers: ApplicationAnswerItem[],
): Promise<ApplicationStatusResponse> {
  const { data } = await api.put<ApiResponse<ApplicationStatusResponse>>(
    \`/v1/projects/\${projectId}/applications/me\`,
    { answers },
  )
  return data.result
}
\`\`\`

- 검증: \`tsc --noEmit\` PASS · \`eslint\`(대상 파일) PASS · \`vitest matchingProject.test.ts\` 4/4 PASS
- 라이브 회귀 확인은 dev 환경 제약(활성 차수·필수문항 폼 시드 부재)으로 미실시

> 참고(범위 밖): 별개의 백엔드 이슈(F2)로, 서버 필수검증이 폼 전체 파트 필수문항을 검증(파트 스코핑 없음)하여 본 수정 후 단일 파트 지원자가 `SURVEY-0010`으로 막힐 수 있다. 백엔드 대응 필요. 상세는 `docs/qa/qa-apply-required-questions-2026-06-14.md`.

## 🔗 연결된 이슈

- Connected: #330
- Closes #330