### PR TITLE
🐛 fix: 지원 차단 모드에서 모집 문항 보기 버튼 노출

### DIFF
--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -611,12 +611,24 @@ export function ProjectDetailCard({
                 {(ctaMode === "apply-blocked-other" ||
                   ctaMode === "apply-blocked-approved" ||
                   ctaMode === "apply-blocked-part") && (
-                  <Button
-                    className="min-w-28 flex-1 whitespace-nowrap"
-                    disabled
-                  >
-                    지원하기
-                  </Button>
+                  <>
+                    <Button
+                      variant="weak"
+                      color="primary"
+                      className="min-w-32 flex-1 whitespace-nowrap"
+                      isLoading={isDetailLoading}
+                      disabled={!isDetailLoading && !detail?.applicationFormId}
+                      onClick={() => setIsRecruitQuestionsModalOpen(true)}
+                    >
+                      모집 문항 보기
+                    </Button>
+                    <Button
+                      className="min-w-28 flex-1 whitespace-nowrap"
+                      disabled
+                    >
+                      지원하기
+                    </Button>
+                  </>
                 )}
               </>
             )}

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -616,8 +616,7 @@ export function ProjectDetailCard({
                       variant="weak"
                       color="primary"
                       className="min-w-32 flex-1 whitespace-nowrap"
-                      isLoading={isDetailLoading}
-                      disabled={!isDetailLoading && !detail?.applicationFormId}
+                      disabled={!detail?.applicationFormId}
                       onClick={() => setIsRecruitQuestionsModalOpen(true)}
                     >
                       모집 문항 보기


### PR DESCRIPTION
## 📸 작업 내용

> 합격(APPROVED) 챌린저 등 지원 차단 상태에서도 모집 문항을 열람할 수 있도록 진입점을 추가합니다.

- `apply-blocked-approved` / `apply-blocked-other` / `apply-blocked-part` 3개 모드에서 비활성 "지원하기" 버튼만 노출되던 것을, **"모집 문항 보기" 버튼을 함께 노출**하도록 수정
- 비즈니스 룰 #3("합격자는 후속 차수 지원 불가, 단 모집 문항 조회는 가능") 충족
- "모집 문항 보기" 위계는 "기획 보기"와 동일(`variant="weak" color="primary"`), 활성/로딩 조건은 `recruit-questions` 모드와 동일

## 🎞️ 주요 코드 설명

> `ProjectDetailCard.tsx` — blocked 3모드 CTA 렌더링

```TypeScript
{(ctaMode === "apply-blocked-other" ||
  ctaMode === "apply-blocked-approved" ||
  ctaMode === "apply-blocked-part") && (
  <>
    <Button
      variant="weak"
      color="primary"
      isLoading={isDetailLoading}
      disabled={!isDetailLoading && !detail?.applicationFormId}
      onClick={() => setIsRecruitQuestionsModalOpen(true)}
    >
      모집 문항 보기
    </Button>
    <Button disabled>지원하기</Button>
  </>
)}
```

- 모집 문항이 등록된 프로젝트(`detail?.applicationFormId`)에서만 버튼이 활성화됩니다.
- 모달(`RecruitQuestionsViewModal`)은 `enabled: isShowingFormModal`이라 권한과 무관하게 로드되며, 챌린저 파트 필터(`filterApplicationSectionsByPart`)는 기존 apply 모드와 동일하게 적용됩니다.

## 🔗 연결된 이슈

- Connected: #332
- Closes #332