### PR TITLE
🐛 fix: 지원서 제출 후 초기 로딩 구간 타 프로젝트 지원 버튼 노출 차단

### DIFF
--- a/src/features/project/list/model/projectDetailCta.test.ts
+++ b/src/features/project/list/model/projectDetailCta.test.ts
@@ -14,6 +14,7 @@ const applicable = {
   isWritePermissionLoading: false,
   canWriteApplication: true,
   hasActiveRound: true,
+  isApplicationStatusResolving: false,
 }
 
 describe("isApplyButtonDisabled", () => {
@@ -43,6 +44,25 @@ describe("isApplyButtonDisabled", () => {
     expect(
       isApplyButtonDisabled({ ...applicable, isWritePermissionLoading: true }),
     ).toBe(true)
+  })
+
+  it("지원 이력 조회 중에는 비활성화한다(타 프로젝트 활성 지원서 판단 보류)", () => {
+    expect(
+      isApplyButtonDisabled({
+        ...applicable,
+        isApplicationStatusResolving: true,
+      }),
+    ).toBe(true)
+  })
+
+  it("PM 읽기 전용 컨텍스트에서는 지원 이력 조회 중이어도 비활성화하지 않는다", () => {
+    expect(
+      isApplyButtonDisabled({
+        ...applicable,
+        isPmReadonly: true,
+        isApplicationStatusResolving: true,
+      }),
+    ).toBe(false)
   })
 
   it("PM 읽기 전용 컨텍스트에서는 라운드가 없어도 비활성화하지 않는다", () => {

--- a/src/features/project/list/model/projectDetailCta.ts
+++ b/src/features/project/list/model/projectDetailCta.ts
@@ -43,6 +43,7 @@ interface ApplyButtonDisabledParams {
   isWritePermissionLoading: boolean
   canWriteApplication: boolean
   hasActiveRound: boolean
+  isApplicationStatusResolving: boolean
 }
 
 export function isApplyButtonDisabled({
@@ -52,13 +53,15 @@ export function isApplyButtonDisabled({
   isWritePermissionLoading,
   canWriteApplication,
   hasActiveRound,
+  isApplicationStatusResolving,
 }: ApplyButtonDisabledParams): boolean {
   if (isPmReadonly) return false
   return (
     (!isDetailLoading && !hasApplicationForm) ||
     isWritePermissionLoading ||
     !canWriteApplication ||
-    !hasActiveRound
+    !hasActiveRound ||
+    isApplicationStatusResolving
   )
 }
 

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -376,6 +376,9 @@ export function ProjectDetailCard({
     )
   }, [myApplications, activeMatchingRound, projectId])
 
+  const isApplicationStatusResolving =
+    isChallengerView && (myApplications == null || activeMatchingRound == null)
+
   const isPartIneligible =
     isChallengerView &&
     detail != null &&
@@ -559,6 +562,7 @@ export function ProjectDetailCard({
                           isApplicationWritePermissionLoading,
                         canWriteApplication: canWriteProjectApplication,
                         hasActiveRound: activeMatchingRound != null,
+                        isApplicationStatusResolving,
                       })}
                       onClick={() => {
                         if (viewOnly && userIsPm) {


### PR DESCRIPTION
## 📸 작업 내용

- 같은 차수 타 프로젝트에 지원서 제출(SUBMITTED) 후, 프로젝트 상세 콜드 진입 시 **지원 이력이 로드되기 전 활성 "지원하기" 버튼이 순간 노출되던 레이스**를 차단
- `isApplyButtonDisabled`에 `isApplicationStatusResolving` 게이트를 추가해, 지원 이력/활성 차수 데이터가 미해결인 동안 지원 버튼을 비활성으로 유지 (`isPmReadonly`는 기존대로 우회)
- 데이터 로드 후 동일 차수 타 프로젝트 활성 지원서가 있으면 `apply-blocked-other`(비활성 + 안내문구)로 자연 전환
- 단위 테스트 2건 추가 (총 25건) + 전체 테스트 177건 통과, `tsc --noEmit`·ESLint 클린

## 🎞️ 주요 코드 설명

### CTA 비활성 판단에 "데이터 미해결" 게이트 추가

```TypeScript
export function isApplyButtonDisabled({
  isPmReadonly,
  // ...
  hasActiveRound,
  isApplicationStatusResolving,
}: ApplyButtonDisabledParams): boolean {
  if (isPmReadonly) return false
  return (
    (!isDetailLoading && !hasApplicationForm) ||
    isWritePermissionLoading ||
    !canWriteApplication ||
    !hasActiveRound ||
    isApplicationStatusResolving
  )
}
```

- 디폴트를 허용(`apply`)에서 안전 방향(비활성)으로 전환

### 챌린저 컨텍스트에서 미해결 상태 계산

```TypeScript
const isApplicationStatusResolving =
  isChallengerView && (myApplications == null || activeMatchingRound == null)
```

- `selectCurrentApplicationForProject`의 "로딩 중 판단 보류" 가드와 정합성을 맞춤

## 🔗 연결된 이슈

- Connected: #339
- Closes #339