### PR TITLE
✨ feat: 사이드바/세그먼트에 FE/BE/D 대상 '내 지원 현황'으로 수정

### DIFF
--- a/src/components/sidebar/MatchingSegmentRegion.tsx
+++ b/src/components/sidebar/MatchingSegmentRegion.tsx
@@ -5,6 +5,8 @@ import {
   canAccessProjectSettings,
   canManageMatchingRounds,
   canManageProjects,
+  isAnyOperator,
+  isCurrentTermPm,
 } from "@/features/auth/model/identity"
 import { SIDEBAR_ITEMS } from "@/shared/config/navigation"
 import { resolveNavigationFromPathname } from "@/shared/config/navigationResolve"
@@ -26,6 +28,7 @@ export function MatchingSegmentRegion({
   const canAccessSettings = canAccessProjectSettings(viewMe)
   const canManage = canManageProjects(viewMe)
   const canManageRounds = canManageMatchingRounds(viewMe)
+  const isRegularChallenger = !isAnyOperator(viewMe) && !isCurrentTermPm(viewMe)
 
   const visibleSections = useMemo(
     () =>
@@ -33,8 +36,9 @@ export function MatchingSegmentRegion({
         canAccessProjectSettings: canAccessSettings,
         canManageProjects: canManage,
         canManageMatchingRounds: canManageRounds,
+        isRegularChallenger,
       }),
-    [canAccessSettings, canManage, canManageRounds],
+    [canAccessSettings, canManage, canManageRounds, isRegularChallenger],
   )
 
   const resolved = resolveNavigationFromPathname(pathname, visibleSections)

--- a/src/components/sidebar/useVisibleSidebarSections.ts
+++ b/src/components/sidebar/useVisibleSidebarSections.ts
@@ -4,6 +4,8 @@ import {
   canAccessProjectSettings,
   canManageMatchingRounds,
   canManageProjects,
+  isAnyOperator,
+  isCurrentTermPm,
 } from "@/features/auth/model/identity"
 import { SIDEBAR_ITEMS } from "@/shared/config/navigation"
 import { useViewMe } from "@/shared/view-mode/useViewMe"
@@ -15,6 +17,7 @@ export function useVisibleSidebarSections() {
   const canAccessSettings = canAccessProjectSettings(viewMe)
   const canManage = canManageProjects(viewMe)
   const canManageRounds = canManageMatchingRounds(viewMe)
+  const isRegularChallenger = !isAnyOperator(viewMe) && !isCurrentTermPm(viewMe)
 
   const visibleSections = useMemo(
     () =>
@@ -22,8 +25,9 @@ export function useVisibleSidebarSections() {
         canAccessProjectSettings: canAccessSettings,
         canManageProjects: canManage,
         canManageMatchingRounds: canManageRounds,
+        isRegularChallenger,
       }),
-    [canAccessSettings, canManage, canManageRounds],
+    [canAccessSettings, canManage, canManageRounds, isRegularChallenger],
   )
 
   return { visibleSections, isLoading }

--- a/src/components/sidebar/utils.ts
+++ b/src/components/sidebar/utils.ts
@@ -4,6 +4,7 @@ export interface SidebarPermissions {
   canAccessProjectSettings: boolean
   canManageProjects: boolean
   canManageMatchingRounds: boolean
+  isRegularChallenger?: boolean
 }
 
 export function filterSectionsByPermission(
@@ -12,6 +13,7 @@ export function filterSectionsByPermission(
     canAccessProjectSettings,
     canManageProjects,
     canManageMatchingRounds,
+    isRegularChallenger = false,
   }: SidebarPermissions,
 ): SideBarSection[] {
   return sections
@@ -35,11 +37,21 @@ export function filterSectionsByPermission(
       if (section.id === SIDEBAR_ID.section.teamMatching) {
         return {
           ...section,
-          menus: section.menus.filter((menu) => {
-            if (menu.id === SIDEBAR_ID.item.matchingRounds)
-              return canManageMatchingRounds
-            return true
-          }),
+          menus: section.menus
+            .filter((menu) => {
+              if (menu.id === SIDEBAR_ID.item.matchingRounds)
+                return canManageMatchingRounds
+              return true
+            })
+            .map((menu) => {
+              if (
+                menu.id === SIDEBAR_ID.item.matchingApplications &&
+                isRegularChallenger
+              ) {
+                return { ...menu, title: "내 지원 현황" }
+              }
+              return menu
+            }),
         }
       }
       return section

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -99,7 +99,7 @@ function MatchingApplicationsPage() {
       <div className="border-teal-gray-100 flex w-6xl flex-col rounded-[12px] border bg-white px-8.5 pt-8 pb-10">
         <div className="flex flex-col gap-1.5">
           <h1 className="text-heading-6-semibold text-teal-gray-900">
-            지원 현황
+            {isOthers ? "내 지원 현황" : "지원 현황"}
           </h1>
           <p className="text-body-2-regular text-teal-gray-600">
             프로젝트 지원 내역을 통합 관리합니다.


### PR DESCRIPTION
## 📸 작업 내용

> FE, BE, Design의 경우, 사이드바/세그먼트의 '지원 현황' 탭을 '내 지원 현황'으로 수정 (권한별 분기)

## 🎞️ 주요 코드 설명

## 🖥️ 구현화면

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #336 