### PR TITLE
🐛 fix: 비밀번호 변경 폼 확인란 상태 표시 및 버튼 색상 오류 수정

### DIFF
--- a/src/features/settings/ui/ChangePasswordForm.tsx
+++ b/src/features/settings/ui/ChangePasswordForm.tsx
@@ -36,14 +36,9 @@ export function ChangePasswordForm({
   const isConfirmMatch = next === confirm
 
   const [isCurrentPasswordWrong, setIsCurrentPasswordWrong] = useState(false)
-  const [showConfirmError, setShowConfirmError] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const handleSubmit = async () => {
-    if (!isConfirmMatch) {
-      setShowConfirmError(true)
-      return
-    }
     setIsSubmitting(true)
     try {
       await changePassword({ currentPassword: current, newPassword: next })
@@ -183,15 +178,18 @@ export function ChangePasswordForm({
             </div>
             <InputBox
               type="password"
-              state={showConfirmError && !isConfirmMatch ? "error" : "default"}
+              state={
+                confirm.length > 0
+                  ? isConfirmMatch
+                    ? "success"
+                    : "error"
+                  : "default"
+              }
               value={confirm}
-              onChange={(e) => {
-                setConfirm(e.target.value)
-                setShowConfirmError(false)
-              }}
+              onChange={(e) => setConfirm(e.target.value)}
               className="w-full"
             />
-            {showConfirmError && !isConfirmMatch && (
+            {confirm.length > 0 && !isConfirmMatch && (
               <div className="flex items-center gap-1">
                 <CheckIcon className="text-error-500 h-4 w-4 shrink-0" />
                 <p className="text-body-3-medium text-error-500">
@@ -208,10 +206,10 @@ export function ChangePasswordForm({
         variant="fill"
         color="primary"
         size="s"
-        disabled={!current || !isNextValid || !confirm || isSubmitting}
+        disabled={!current || !isNextValid || !isConfirmMatch || isSubmitting}
         isLoading={isSubmitting}
         onClick={() => void handleSubmit()}
-        className="h-11 w-full bg-teal-300 disabled:bg-teal-200"
+        className="h-11 w-full"
       >
         변경하기
       </Button>

--- a/src/shared/ui/input/InputBox.tsx
+++ b/src/shared/ui/input/InputBox.tsx
@@ -133,7 +133,7 @@ export const InputBox = forwardRef<HTMLInputElement, InputBoxProps>(
         )
       }
 
-      if (state === "success") {
+      if (state === "success" && type !== "password") {
         const icon = <CheckIcon width={20} height={20} aria-hidden="true" />
         if (onClear) {
           return (


### PR DESCRIPTION
## 📸 작업 내용

- 새 비밀번호와 일치하지 않는 경우 에러 표시
- 새 비밀번호 다 끝나면 새 비밀번호 볼 수 없는 문제 해결
- 변경하기 버튼 disable 처리 로직 수정

## 🎞️ 주요 코드 설명

## 🖥️ 구현화면

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #348 