### PR TITLE
✨ feat: 지원서 작성 임시저장 지원 (+ 매칭 기간 수정 버튼 자동 갱신)

### DIFF
--- a/src/features/project/list/model/applyDraftHydration.test.ts
+++ b/src/features/project/list/model/applyDraftHydration.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest"
+
+import { buildFormValuesFromDetail } from "./applyDraftHydration"
+
+import type { Section } from "@/features/project/new/model/applicationQuestion"
+
+import type { AnswerView, ApplicationDetail } from "../api/matchingProject"
+
+const sections: Section[] = [
+  {
+    id: "common",
+    name: "공통 문항",
+    isEnabled: true,
+    questions: [
+      {
+        id: "101",
+        title: "자기소개",
+        caption: "",
+        fieldType: "text",
+        required: true,
+        options: [],
+      },
+      {
+        id: "102",
+        title: "단일 선택",
+        caption: "",
+        fieldType: "radio",
+        required: true,
+        options: [
+          { content: "A", optionId: 1001 },
+          { content: "B", optionId: 1002 },
+        ],
+      },
+      {
+        id: "103",
+        title: "복수 선택",
+        caption: "",
+        fieldType: "checkbox",
+        required: false,
+        options: [
+          { content: "C", optionId: 2001 },
+          { content: "D", optionId: 2002 },
+        ],
+      },
+      {
+        id: "104",
+        title: "파일",
+        caption: "",
+        fieldType: "file",
+        required: false,
+        options: [],
+      },
+      {
+        id: "105",
+        title: "포트폴리오",
+        caption: "",
+        fieldType: "portfolio",
+        required: false,
+        options: [],
+      },
+    ],
+  },
+]
+
+function detailWith(answers: Record<string, AnswerView>): ApplicationDetail {
+  return {
+    applicationId: "9",
+    applicant: {
+      memberId: "1",
+      nickname: "n",
+      name: "이름",
+      schoolName: "학교",
+      part: "WEB",
+    },
+    matchingRound: { id: "1", type: "REGULAR", phase: "OPEN" },
+    status: "DRAFT",
+    formResponse: {
+      formResponseId: "1",
+      formId: "1",
+      status: "DRAFT",
+      sections: [
+        {
+          sectionId: "common",
+          type: "COMMON",
+          allowedParts: [],
+          title: "공통 문항",
+          orderNo: "1",
+          questions: Object.entries(answers).map(([questionId, answer]) => ({
+            questionId,
+            type: answer.answeredAsType,
+            title: "",
+            isRequired: false,
+            orderNo: "1",
+            options: [],
+            answer,
+          })),
+        },
+      ],
+    },
+  } as ApplicationDetail
+}
+
+describe("buildFormValuesFromDetail", () => {
+  it("저장된 답변을 폼 값으로 역매핑한다", () => {
+    const detail = detailWith({
+      "101": {
+        answerId: "1",
+        answeredAsType: "LONG_TEXT",
+        textValue: "안녕하세요",
+      },
+      "102": {
+        answerId: "2",
+        answeredAsType: "RADIO",
+        selectedOptions: [{ questionOptionId: "1002", answeredAsContent: "B" }],
+      },
+      "103": {
+        answerId: "3",
+        answeredAsType: "CHECKBOX",
+        selectedOptions: [
+          { questionOptionId: "2001", answeredAsContent: "C" },
+          { questionOptionId: "2002", answeredAsContent: "D" },
+        ],
+      },
+      "104": {
+        answerId: "4",
+        answeredAsType: "FILE",
+        files: [
+          { fileId: "f1", originalFileName: "a.pdf", url: "http://x/a.pdf" },
+        ],
+      },
+      "105": {
+        answerId: "5",
+        answeredAsType: "PORTFOLIO",
+        textValue: "https://github.com/me",
+      },
+    })
+
+    const values = buildFormValuesFromDetail(detail, sections)
+
+    expect(values["101"]).toBe("안녕하세요")
+    expect(values["102"]).toBe("1002")
+    expect(values["103"]).toEqual(["2001", "2002"])
+    expect(values["104"]).toEqual({ fileId: "f1", fileName: "a.pdf" })
+    expect(values["105"]).toEqual({
+      kind: "link",
+      url: "https://github.com/me",
+    })
+  })
+
+  it("포트폴리오 파일 답변은 file 종류로 매핑한다", () => {
+    const detail = detailWith({
+      "105": {
+        answerId: "5",
+        answeredAsType: "PORTFOLIO",
+        files: [
+          {
+            fileId: "p1",
+            originalFileName: "port.pdf",
+            url: "http://x/port.pdf",
+          },
+        ],
+      },
+    })
+
+    const values = buildFormValuesFromDetail(detail, sections)
+
+    expect(values["105"]).toEqual({
+      kind: "file",
+      fileId: "p1",
+      fileName: "port.pdf",
+    })
+  })
+
+  it("답변이 없는 문항은 fieldType별 기본값을 채운다", () => {
+    const values = buildFormValuesFromDetail(detailWith({}), sections)
+
+    expect(values["101"]).toBe("")
+    expect(values["102"]).toBe("")
+    expect(values["103"]).toEqual([])
+    expect(values["104"]).toBeNull()
+    expect(values["105"]).toBeNull()
+  })
+})

--- a/src/features/project/list/model/applyDraftHydration.ts
+++ b/src/features/project/list/model/applyDraftHydration.ts
@@ -1,0 +1,62 @@
+import { defaultByFieldType } from "./applyValidation"
+
+import type {
+  Question,
+  Section,
+} from "@/features/project/new/model/applicationQuestion"
+
+import type { AnswerView, ApplicationDetail } from "../api/matchingProject"
+import type { ApplyAnswerValue } from "./applyAnswerPayload"
+
+function mapAnswerToValue(
+  question: Question,
+  answer: AnswerView | undefined,
+): ApplyAnswerValue {
+  if (!answer) return defaultByFieldType(question)
+
+  switch (question.fieldType) {
+    case "text":
+      return answer.textValue ?? ""
+    case "radio":
+      return answer.selectedOptions?.[0]?.questionOptionId ?? ""
+    case "checkbox":
+      return answer.selectedOptions?.map((o) => o.questionOptionId) ?? []
+    case "file": {
+      const file = answer.files?.[0]
+      return file
+        ? { fileId: file.fileId, fileName: file.originalFileName }
+        : null
+    }
+    case "portfolio": {
+      const file = answer.files?.[0]
+      if (file) {
+        return {
+          kind: "file",
+          fileId: file.fileId,
+          fileName: file.originalFileName,
+        }
+      }
+      return answer.textValue ? { kind: "link", url: answer.textValue } : null
+    }
+  }
+}
+
+export function buildFormValuesFromDetail(
+  detail: ApplicationDetail,
+  sections: Section[],
+): Record<string, ApplyAnswerValue> {
+  const answerByQuestionId = new Map<string, AnswerView>()
+  detail.formResponse.sections.forEach((section) => {
+    section.questions.forEach((q) => {
+      if (q.answer) answerByQuestionId.set(q.questionId, q.answer)
+    })
+  })
+
+  const values: Record<string, ApplyAnswerValue> = {}
+  sections.forEach((section) => {
+    section.questions.forEach((q) => {
+      values[q.id] = mapAnswerToValue(q, answerByQuestionId.get(q.id))
+    })
+  })
+  return values
+}

--- a/src/features/project/list/model/projectDetailCta.test.ts
+++ b/src/features/project/list/model/projectDetailCta.test.ts
@@ -135,6 +135,28 @@ describe("resolveProjectDetailCtaMode", () => {
     ).toBe("my-application")
   })
 
+  it("임시저장(DRAFT) 지원서면 이어쓰기를 위해 apply를 반환한다", () => {
+    expect(
+      resolveProjectDetailCtaMode({
+        ...ctaParams,
+        isApplied: true,
+        isDraftApplication: true,
+      }),
+    ).toBe("apply")
+  })
+
+  it("DRAFT 이어쓰기는 합격/타프로젝트 지원 차단보다 우선한다", () => {
+    expect(
+      resolveProjectDetailCtaMode({
+        ...ctaParams,
+        isApplied: true,
+        isDraftApplication: true,
+        isAlreadyApproved: true,
+        hasOtherActiveApplication: true,
+      }),
+    ).toBe("apply")
+  })
+
   it("다른 프로젝트에 지원 중이면 파트 부적격이어도 apply-blocked-other를 반환한다", () => {
     expect(
       resolveProjectDetailCtaMode({

--- a/src/features/project/list/model/projectDetailCta.ts
+++ b/src/features/project/list/model/projectDetailCta.ts
@@ -13,6 +13,7 @@ interface ResolveCtaParams {
   isPm: boolean
   isSameBranch: boolean
   isApplied: boolean
+  isDraftApplication?: boolean
   hasOtherActiveApplication: boolean
   isAlreadyApproved: boolean
   isPartIneligible: boolean
@@ -24,6 +25,7 @@ export function resolveProjectDetailCtaMode({
   isPm,
   isSameBranch,
   isApplied,
+  isDraftApplication = false,
   hasOtherActiveApplication,
   isAlreadyApproved,
   isPartIneligible,
@@ -32,6 +34,7 @@ export function resolveProjectDetailCtaMode({
   if (isOperator) return "recruit-questions"
   if (!isSameBranch) return "plan-only"
   if (isPm) return "recruit-questions"
+  if (isApplied && isDraftApplication) return "apply"
   if (isApplied) return "my-application"
   if (isAlreadyApproved) return "apply-blocked-approved"
   if (hasOtherActiveApplication) return "apply-blocked-other"

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -1,7 +1,7 @@
 /** 피그마 기준 Project Card Lg입니다. */
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
 import { useResourcePermission } from "@/features/auth/hooks/useResourcePermission"
@@ -45,7 +45,10 @@ import {
 } from "../model/projectDetailCta"
 import { ApplyFormSkeleton } from "./apply-modal/ApplyFormSkeleton"
 import { MyApplicationModal } from "./apply-modal/MyApplicationModal"
-import { ProjectApplyModal } from "./apply-modal/ProjectApplyModal"
+import {
+  ProjectApplyModal,
+  type ProjectApplyModalHandle,
+} from "./apply-modal/ProjectApplyModal"
 import { RecruitQuestionsViewModal } from "./apply-modal/RecruitQuestionsViewModal"
 import { TeamMemberModal } from "./team-member-modal/TeamMemberModal"
 
@@ -219,6 +222,7 @@ export function ProjectDetailCard({
     applicationWritePermissionQuery.isPending
   const [isTeamModalOpen, setIsTeamModalOpen] = useState(false)
   const [isApplyModalOpen, setIsApplyModalOpen] = useState(false)
+  const applyModalRef = useRef<ProjectApplyModalHandle>(null)
   const [isMyApplicationModalOpen, setIsMyApplicationModalOpen] =
     useState(false)
   const [isRecruitQuestionsModalOpen, setIsRecruitQuestionsModalOpen] =
@@ -267,7 +271,7 @@ export function ProjectDetailCard({
     queryKey: projectKeys.applicationForm(projectId),
     queryFn: () => getApplicationForm(projectId),
     enabled: isShowingFormModal,
-    staleTime: 5 * 60 * 1000,
+    staleTime: 0,
   })
 
   const [minSkeletonElapsed, setMinSkeletonElapsed] = useState(false)
@@ -367,6 +371,7 @@ export function ProjectDetailCard({
       : (activeMatchingRound?.id ?? null),
   })
   const isApplied = myApplicationForProject != null
+  const isDraftApplication = myApplicationForProject?.status === "DRAFT"
 
   const hasOtherActiveApplication = useMemo(() => {
     if (!myApplications || !activeMatchingRound) return false
@@ -405,6 +410,7 @@ export function ProjectDetailCard({
           isPm: false,
           isSameBranch,
           isApplied,
+          isDraftApplication,
           hasOtherActiveApplication,
           isAlreadyApproved,
           isPartIneligible,
@@ -415,6 +421,7 @@ export function ProjectDetailCard({
           isPm: userIsPm,
           isSameBranch,
           isApplied,
+          isDraftApplication,
           hasOtherActiveApplication,
           isAlreadyApproved,
           isPartIneligible,
@@ -624,7 +631,7 @@ export function ProjectDetailCard({
                         setIsApplyModalOpen(true)
                       }}
                     >
-                      지원하기
+                      {isDraftApplication ? "이어서 작성하기" : "지원하기"}
                     </Button>
                   )}
                 {(ctaMode === "apply-blocked-other" ||
@@ -719,8 +726,16 @@ export function ProjectDetailCard({
           <Modal.Overlay tone="deep" />
           <Modal.Content
             aria-describedby={undefined}
-            onInteractOutside={(e) => e.preventDefault()}
-            onEscapeKeyDown={(e) => e.preventDefault()}
+            onInteractOutside={(e) => {
+              e.preventDefault()
+              if (applyModalRef.current) applyModalRef.current.requestClose()
+              else setIsApplyModalOpen(false)
+            }}
+            onEscapeKeyDown={(e) => {
+              e.preventDefault()
+              if (applyModalRef.current) applyModalRef.current.requestClose()
+              else setIsApplyModalOpen(false)
+            }}
           >
             {showFormSkeleton ? (
               <ApplyFormSkeleton />
@@ -732,12 +747,18 @@ export function ProjectDetailCard({
               </div>
             ) : activeMatchingRound == null ? null : (
               <ProjectApplyModal
+                ref={applyModalRef}
                 data={data}
                 projectId={projectId}
                 matchingRoundId={Number(activeMatchingRound.id)}
                 sections={visibleSections}
                 canToggleSection={userIsOperator || userIsPm}
                 onBack={() => setIsApplyModalOpen(false)}
+                onDraftSaved={() => {
+                  void queryClient.invalidateQueries({
+                    queryKey: ["myApplications", activeGisuId],
+                  })
+                }}
                 onSubmitSuccess={() => {
                   setIsApplyModalOpen(false)
                   void queryClient.invalidateQueries({

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -753,6 +753,11 @@ export function ProjectDetailCard({
                 matchingRoundId={Number(activeMatchingRound.id)}
                 sections={visibleSections}
                 canToggleSection={userIsOperator || userIsPm}
+                initialApplicationId={
+                  isDraftApplication && myApplicationForProject
+                    ? Number(myApplicationForProject.applicationId)
+                    : undefined
+                }
                 onBack={() => setIsApplyModalOpen(false)}
                 onDraftSaved={() => {
                   void queryClient.invalidateQueries({

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -171,6 +171,7 @@ interface ProjectApplyModalProps {
   onBack: () => void
   onDraftSaved?: () => void
   onSubmitSuccess: () => void
+  initialApplicationId?: number
 }
 
 export interface ProjectApplyModalHandle {
@@ -190,6 +191,7 @@ export const ProjectApplyModal = forwardRef<
     onBack,
     onDraftSaved,
     onSubmitSuccess,
+    initialApplicationId,
   },
   ref,
 ) {
@@ -229,9 +231,21 @@ export const ProjectApplyModal = forwardRef<
   useEffect(() => {
     if (draftInitializedRef.current) return
     draftInitializedRef.current = true
+    async function hydrateDraft(id: number) {
+      const detail = await getApplicationDetail(projectId, id).catch(() => null)
+      if (!detail) return
+      const values = buildFormValuesFromDetail(detail, sections)
+      reset(values)
+      savedSnapshotRef.current = JSON.stringify(values)
+    }
     async function initDraft() {
       if (isDevMatchingRound) return
       try {
+        if (initialApplicationId != null) {
+          setApplicationId(initialApplicationId)
+          await hydrateDraft(initialApplicationId)
+          return
+        }
         const draft = await createApplicationDraft(projectId, matchingRoundId)
         setApplicationId(Number(draft.applicationId))
       } catch (err) {
@@ -250,15 +264,7 @@ export const ProjectApplyModal = forwardRef<
             if (existing) {
               const existingId = Number(existing.applicationId)
               setApplicationId(existingId)
-              const detail = await getApplicationDetail(
-                projectId,
-                existingId,
-              ).catch(() => null)
-              if (detail) {
-                const values = buildFormValuesFromDetail(detail, sections)
-                reset(values)
-                savedSnapshotRef.current = JSON.stringify(values)
-              }
+              await hydrateDraft(existingId)
             }
           }
           return

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -1,6 +1,13 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { AxiosError } from "axios"
-import { useEffect, useMemo, useRef, useState } from "react"
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import { Controller, useForm } from "react-hook-form"
 
 import { useToastStore } from "@/components/toast/useToastStore"
@@ -26,6 +33,7 @@ import { TextQuestionField } from "@/shared/ui/question-field/TextQuestionField"
 
 import {
   createApplicationDraft,
+  getApplicationDetail,
   getMyApplications,
   saveApplicationDraft,
   submitApplication,
@@ -37,6 +45,7 @@ import {
   isApplyPortfolioValue,
   isUploadedFileValue,
 } from "../../model/applyAnswerPayload"
+import { buildFormValuesFromDetail } from "../../model/applyDraftHydration"
 import {
   buildApplyAnswersSchema,
   defaultByFieldType,
@@ -44,6 +53,7 @@ import {
 } from "../../model/applyValidation"
 import { isRecruitDone } from "../../model/matchingProject"
 import { selectCurrentApplicationForProject } from "../../model/projectDetailCta"
+import { ApplyFormSkeleton } from "./ApplyFormSkeleton"
 import { ApplyProjectTitleCard } from "./ApplyProjectTitleCard"
 
 import type { FieldErrors, Resolver } from "react-hook-form"
@@ -159,25 +169,39 @@ interface ProjectApplyModalProps {
   sections: Section[]
   canToggleSection?: boolean
   onBack: () => void
+  onDraftSaved?: () => void
   onSubmitSuccess: () => void
 }
 
-export function ProjectApplyModal({
-  data,
-  projectId,
-  matchingRoundId,
-  sections,
-  canToggleSection = false,
-  onBack,
-  onSubmitSuccess,
-}: ProjectApplyModalProps) {
+export interface ProjectApplyModalHandle {
+  requestClose: () => void
+}
+
+export const ProjectApplyModal = forwardRef<
+  ProjectApplyModalHandle,
+  ProjectApplyModalProps
+>(function ProjectApplyModal(
+  {
+    data,
+    projectId,
+    matchingRoundId,
+    sections,
+    canToggleSection = false,
+    onBack,
+    onDraftSaved,
+    onSubmitSuccess,
+  },
+  ref,
+) {
   const addToast = useToastStore((s) => s.addToast)
   const isDevMatchingRound = Boolean(import.meta.env.VITE_DEV_MATCHING_ROUND_ID)
   const [sectionEnabled, setSectionEnabled] = useState<Record<string, boolean>>(
     () => Object.fromEntries(sections.map((s) => [s.id, s.isEnabled])),
   )
   const [applicationId, setApplicationId] = useState<number | null>(null)
+  const [isInitializing, setIsInitializing] = useState(!isDevMatchingRound)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isSavingDraft, setIsSavingDraft] = useState(false)
   const [isFileUploading, setIsFileUploading] = useState(false)
   const [isPortfolioUploading, setIsPortfolioUploading] = useState(false)
   const portfolioUploadTokenRef = useRef(0)
@@ -223,7 +247,19 @@ export function ProjectApplyModal({
               projectId,
               activeMatchingRoundId: String(matchingRoundId),
             })
-            if (existing) setApplicationId(Number(existing.applicationId))
+            if (existing) {
+              const existingId = Number(existing.applicationId)
+              setApplicationId(existingId)
+              const detail = await getApplicationDetail(
+                projectId,
+                existingId,
+              ).catch(() => null)
+              if (detail) {
+                const values = buildFormValuesFromDetail(detail, sections)
+                reset(values)
+                savedSnapshotRef.current = JSON.stringify(values)
+              }
+            }
           }
           return
         }
@@ -235,6 +271,8 @@ export function ProjectApplyModal({
           duration: 3000,
         })
         onBack()
+      } finally {
+        setIsInitializing(false)
       }
     }
     void initDraft()
@@ -256,16 +294,15 @@ export function ProjectApplyModal({
     [sections],
   )
 
-  const {
-    control,
-    handleSubmit,
-    clearErrors,
-    formState: { isDirty },
-  } = useForm<Record<string, ApplyAnswerValue>>({
+  const { control, handleSubmit, clearErrors, getValues, reset } = useForm<
+    Record<string, ApplyAnswerValue>
+  >({
     resolver: zodResolver(schema) as Resolver<Record<string, ApplyAnswerValue>>,
     mode: "onChange",
     defaultValues,
   })
+
+  const savedSnapshotRef = useRef(JSON.stringify(defaultValues))
 
   useEffect(() => {
     clearErrors()
@@ -289,11 +326,71 @@ export function ProjectApplyModal({
     onBack()
   }
 
+  function hasUnsavedChanges() {
+    return JSON.stringify(getValues()) !== savedSnapshotRef.current
+  }
+
   function handleBackClick() {
-    if (isDirty) {
+    if (hasUnsavedChanges()) {
       setIsLeaveModalOpen(true)
     } else {
       onBack()
+    }
+  }
+
+  useImperativeHandle(ref, () => ({ requestClose: handleBackClick }))
+
+  async function handleSaveDraft() {
+    if (isDevMatchingRound) {
+      addToast({
+        message: "작성한 내용이 임시 저장되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return
+    }
+    if (applicationId === null) {
+      addToast({
+        message: "지원서 정보를 불러오지 못했습니다. 다시 시도해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return
+    }
+    setIsSavingDraft(true)
+    try {
+      const formValues = getValues()
+      const answers = buildAnswerPayload(formValues, sections, sectionEnabled)
+      await saveApplicationDraft(projectId, applicationId, answers)
+      reset(formValues)
+      savedSnapshotRef.current = JSON.stringify(formValues)
+      onDraftSaved?.()
+      addToast({
+        message: "작성한 내용이 임시 저장되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } catch (err) {
+      const serverMessage =
+        err instanceof AxiosError
+          ? (err.response?.data as { message?: string } | undefined)?.message
+          : undefined
+      addToast({
+        message:
+          serverMessage ?? "임시 저장에 실패했습니다. 다시 시도해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } finally {
+      setIsSavingDraft(false)
     }
   }
 
@@ -543,6 +640,10 @@ export function ProjectApplyModal({
   const SUB_MODAL_CLASS =
     "shadow-drop-neutral-1 flex w-115 max-w-[calc(100vw-32px)] flex-col gap-8 rounded-[9.2px] border border-neutral-200 bg-white px-6 py-6 focus:outline-none"
 
+  if (isInitializing) {
+    return <ApplyFormSkeleton />
+  }
+
   return (
     <>
       <div className="flex w-232 flex-col">
@@ -641,30 +742,49 @@ export function ProjectApplyModal({
             </div>
           </div>
 
-          <div className="border-teal-gray-100 flex justify-center gap-3 border-t px-6 py-4">
+          <div className="border-teal-gray-100 flex items-center justify-between gap-3 border-t px-6 py-4">
             <Button
               variant="weak"
               color="neutral"
               size="xl"
-              onClick={handleBackClick}
-              disabled={isSubmitting}
-            >
-              돌아가기
-            </Button>
-            <Button
-              size="xl"
+              onClick={() => void handleSaveDraft()}
+              isLoading={isSavingDraft}
               disabled={
                 isSubmitting ||
+                isSavingDraft ||
                 isFileUploading ||
                 isPortfolioUploading ||
                 isApplicationEditPermissionLoading
               }
-              onClick={() => {
-                void handleSubmit(onValid, onInvalid)()
-              }}
             >
-              제출하기
+              임시저장
             </Button>
+            <div className="flex gap-3">
+              <Button
+                variant="weak"
+                color="neutral"
+                size="xl"
+                onClick={handleBackClick}
+                disabled={isSubmitting || isSavingDraft}
+              >
+                돌아가기
+              </Button>
+              <Button
+                size="xl"
+                disabled={
+                  isSubmitting ||
+                  isSavingDraft ||
+                  isFileUploading ||
+                  isPortfolioUploading ||
+                  isApplicationEditPermissionLoading
+                }
+                onClick={() => {
+                  void handleSubmit(onValid, onInvalid)()
+                }}
+              >
+                제출하기
+              </Button>
+            </div>
           </div>
         </div>
       </div>
@@ -773,4 +893,4 @@ export function ProjectApplyModal({
       </Modal.Root>
     </>
   )
-}
+})

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.ui.test.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.ui.test.tsx
@@ -1,13 +1,36 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { AxiosError } from "axios"
+import { createRef } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import { ProjectApplyModal } from "./ProjectApplyModal"
+import { getActiveGisu } from "@/shared/api/gisu"
+
+import {
+  createApplicationDraft,
+  getApplicationDetail,
+  getMyApplications,
+} from "../../api/matchingProject"
+import {
+  ProjectApplyModal,
+  type ProjectApplyModalHandle,
+} from "./ProjectApplyModal"
 
 import type { MatchingProject } from "@/features/project/list/model/matchingProject"
 import type { Section } from "@/features/project/new/model/applicationQuestion"
 
 vi.mock("@/features/auth/hooks/useResourcePermission", () => ({
   useResourcePermission: () => ({ isPending: false }),
+}))
+
+vi.mock("@/shared/api/gisu", () => ({
+  getActiveGisu: vi.fn(),
+}))
+
+vi.mock("../../api/matchingProject", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../api/matchingProject")>()),
+  createApplicationDraft: vi.fn(),
+  getMyApplications: vi.fn(),
+  getApplicationDetail: vi.fn(),
 }))
 
 const originalScrollIntoView = HTMLElement.prototype.scrollIntoView
@@ -81,6 +104,145 @@ describe("ProjectApplyModal radio answer", () => {
     await waitFor(() => {
       expect(screen.getByText("선택해 주세요.")).toBeInTheDocument()
     })
+  })
+})
+
+describe("ProjectApplyModal draft hydration", () => {
+  it("기존 DRAFT가 있으면 스켈레톤 이후 저장된 답변을 복원한다", async () => {
+    const conflict = new AxiosError(
+      "conflict",
+      "ERR_CONFLICT",
+      undefined,
+      undefined,
+      { status: 409 } as never,
+    )
+    vi.mocked(createApplicationDraft).mockRejectedValue(conflict)
+    vi.mocked(getActiveGisu).mockResolvedValue({ gisuId: 10 } as never)
+    vi.mocked(getMyApplications).mockResolvedValue([
+      {
+        projectId: "1",
+        status: "DRAFT",
+        applicationId: "9",
+        matchingRound: { id: "1" },
+      },
+    ] as never)
+    vi.mocked(getApplicationDetail).mockResolvedValue({
+      applicationId: "9",
+      status: "DRAFT",
+      formResponse: {
+        sections: [
+          {
+            sectionId: "common",
+            questions: [
+              {
+                questionId: "101",
+                type: "RADIO",
+                answer: {
+                  answerId: "1",
+                  answeredAsType: "RADIO",
+                  selectedOptions: [
+                    { questionOptionId: "1002", answeredAsContent: "두 번째" },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    } as never)
+
+    render(
+      <ProjectApplyModal
+        data={project}
+        projectId={1}
+        matchingRoundId={1}
+        sections={sections}
+        onBack={vi.fn()}
+        onSubmitSuccess={vi.fn()}
+      />,
+    )
+
+    const secondOption = await screen.findByRole("radio", { name: "두 번째" })
+    await waitFor(() => {
+      expect(secondOption).toHaveAttribute("aria-checked", "true")
+    })
+    expect(screen.getByRole("radio", { name: "첫 번째" })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    )
+  })
+})
+
+const textSections: Section[] = [
+  {
+    id: "common",
+    name: "공통 문항",
+    isEnabled: true,
+    questions: [
+      {
+        id: "201",
+        title: "자기소개",
+        caption: "",
+        fieldType: "text",
+        required: false,
+        options: [],
+      },
+    ],
+  },
+]
+
+describe("ProjectApplyModal requestClose (배경 클릭/ESC)", () => {
+  it("변경사항이 있으면 이탈 확인 모달을 띄운다", async () => {
+    vi.stubEnv("VITE_DEV_MATCHING_ROUND_ID", "1")
+    const ref = createRef<ProjectApplyModalHandle>()
+    const onBack = vi.fn()
+
+    render(
+      <ProjectApplyModal
+        ref={ref}
+        data={project}
+        projectId={1}
+        matchingRoundId={1}
+        sections={textSections}
+        onBack={onBack}
+        onSubmitSuccess={vi.fn()}
+      />,
+    )
+
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: "지원 동기 작성 중" },
+    })
+    act(() => {
+      ref.current?.requestClose()
+    })
+
+    expect(await screen.findByText("페이지 이탈")).toBeInTheDocument()
+    expect(onBack).not.toHaveBeenCalled()
+  })
+
+  it("변경사항이 없으면 확인 없이 바로 닫는다", () => {
+    vi.stubEnv("VITE_DEV_MATCHING_ROUND_ID", "1")
+    const ref = createRef<ProjectApplyModalHandle>()
+    const onBack = vi.fn()
+
+    render(
+      <ProjectApplyModal
+        ref={ref}
+        data={project}
+        projectId={1}
+        matchingRoundId={1}
+        sections={sections}
+        onBack={onBack}
+        onSubmitSuccess={vi.fn()}
+      />,
+    )
+
+    act(() => {
+      ref.current?.requestClose()
+    })
+
+    expect(onBack).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText("페이지 이탈")).not.toBeInTheDocument()
   })
 })
 

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.ui.test.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.ui.test.tsx
@@ -171,6 +171,52 @@ describe("ProjectApplyModal draft hydration", () => {
       "false",
     )
   })
+
+  it("initialApplicationId가 있으면 createApplicationDraft 없이 바로 복원한다", async () => {
+    vi.mocked(createApplicationDraft).mockClear()
+    vi.mocked(getApplicationDetail).mockResolvedValue({
+      applicationId: "9",
+      status: "DRAFT",
+      formResponse: {
+        sections: [
+          {
+            sectionId: "common",
+            questions: [
+              {
+                questionId: "101",
+                type: "RADIO",
+                answer: {
+                  answerId: "1",
+                  answeredAsType: "RADIO",
+                  selectedOptions: [
+                    { questionOptionId: "1002", answeredAsContent: "두 번째" },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    } as never)
+
+    render(
+      <ProjectApplyModal
+        data={project}
+        projectId={1}
+        matchingRoundId={1}
+        sections={sections}
+        initialApplicationId={9}
+        onBack={vi.fn()}
+        onSubmitSuccess={vi.fn()}
+      />,
+    )
+
+    const secondOption = await screen.findByRole("radio", { name: "두 번째" })
+    await waitFor(() => {
+      expect(secondOption).toHaveAttribute("aria-checked", "true")
+    })
+    expect(createApplicationDraft).not.toHaveBeenCalled()
+  })
 })
 
 const textSections: Section[] = [

--- a/src/features/project/new/hooks/useIsMatchingPeriod.ts
+++ b/src/features/project/new/hooks/useIsMatchingPeriod.ts
@@ -1,12 +1,17 @@
 import { useQuery } from "@tanstack/react-query"
-import { useMemo } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import { getMatchingRounds } from "@/features/application/api/applicationApi"
 import { applicationKeys } from "@/features/application/api/applicationKeys"
 import { useMe } from "@/features/auth/hooks/useMe"
 import { getLatestChallengerRecord } from "@/features/auth/model/identity"
 
-import { isWithinMatchingPeriod } from "../model/matchingPeriod"
+import {
+  getNextMatchingBoundary,
+  isWithinMatchingPeriod,
+} from "../model/matchingPeriod"
+
+const MAX_TIMER_DELAY_MS = 24 * 60 * 60 * 1000
 
 export function useIsMatchingPeriod() {
   const { data: me } = useMe()
@@ -20,8 +25,22 @@ export function useIsMatchingPeriod() {
     enabled: chapterId !== undefined,
   })
 
+  const [now, setNow] = useState(() => new Date())
+
+  useEffect(() => {
+    if (!isSuccess) return
+    const boundary = getNextMatchingBoundary(rounds, now)
+    if (!boundary) return
+    const delay = Math.min(
+      Math.max(0, boundary.getTime() - now.getTime()) + 1000,
+      MAX_TIMER_DELAY_MS,
+    )
+    const timer = setTimeout(() => setNow(new Date()), delay)
+    return () => clearTimeout(timer)
+  }, [isSuccess, rounds, now])
+
   return useMemo(
-    () => (isSuccess ? isWithinMatchingPeriod(rounds, new Date()) : false),
-    [isSuccess, rounds],
+    () => (isSuccess ? isWithinMatchingPeriod(rounds, now) : false),
+    [isSuccess, rounds, now],
   )
 }

--- a/src/features/project/new/hooks/useIsMatchingPeriod.ts
+++ b/src/features/project/new/hooks/useIsMatchingPeriod.ts
@@ -12,6 +12,7 @@ import {
 } from "../model/matchingPeriod"
 
 const MAX_TIMER_DELAY_MS = 24 * 60 * 60 * 1000
+const BOUNDARY_PASS_MS = 50
 
 export function useIsMatchingPeriod() {
   const { data: me } = useMe()
@@ -32,7 +33,7 @@ export function useIsMatchingPeriod() {
     const boundary = getNextMatchingBoundary(rounds, now)
     if (!boundary) return
     const delay = Math.min(
-      Math.max(0, boundary.getTime() - now.getTime()) + 1000,
+      Math.max(0, boundary.getTime() - now.getTime()) + BOUNDARY_PASS_MS,
       MAX_TIMER_DELAY_MS,
     )
     const timer = setTimeout(() => setNow(new Date()), delay)

--- a/src/features/project/new/model/matchingPeriod.test.ts
+++ b/src/features/project/new/model/matchingPeriod.test.ts
@@ -142,6 +142,14 @@ describe("getNextMatchingBoundary", () => {
     ).toBeNull()
   })
 
+  it("현재 시각과 같은 경계는 제외하고 다음 미래 경계를 반환한다", () => {
+    const boundary = getNextMatchingBoundary(
+      [makeRound("2026-06-13T12:00:00Z", "2026-06-14T00:00:00Z")],
+      now,
+    )
+    expect(boundary?.toISOString()).toBe("2026-06-14T00:00:00.000Z")
+  })
+
   it("빈 배열/undefined는 null", () => {
     expect(getNextMatchingBoundary([], now)).toBeNull()
     expect(getNextMatchingBoundary(undefined, now)).toBeNull()

--- a/src/features/project/new/model/matchingPeriod.test.ts
+++ b/src/features/project/new/model/matchingPeriod.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { isWithinMatchingPeriod } from "./matchingPeriod"
+import {
+  getNextMatchingBoundary,
+  isWithinMatchingPeriod,
+} from "./matchingPeriod"
 
 import type { MatchingRoundResponse } from "@/features/application/model/apiTypes"
 
@@ -97,5 +100,50 @@ describe("isWithinMatchingPeriod", () => {
   it("빈 배열/undefined는 false", () => {
     expect(isWithinMatchingPeriod([], now)).toBe(false)
     expect(isWithinMatchingPeriod(undefined, now)).toBe(false)
+  })
+})
+
+describe("getNextMatchingBoundary", () => {
+  const now = new Date("2026-06-13T12:00:00Z")
+
+  it("매칭 중이면 종료 시각을 다음 경계로 반환한다", () => {
+    const boundary = getNextMatchingBoundary(
+      [makeRound("2026-06-13T00:00:00Z", "2026-06-14T00:00:00Z")],
+      now,
+    )
+    expect(boundary?.toISOString()).toBe("2026-06-14T00:00:00.000Z")
+  })
+
+  it("매칭 전이면 시작 시각을 다음 경계로 반환한다", () => {
+    const boundary = getNextMatchingBoundary(
+      [makeRound("2026-06-14T00:00:00Z", "2026-06-15T00:00:00Z")],
+      now,
+    )
+    expect(boundary?.toISOString()).toBe("2026-06-14T00:00:00.000Z")
+  })
+
+  it("여러 경계 중 가장 가까운 미래 경계를 반환한다", () => {
+    const boundary = getNextMatchingBoundary(
+      [
+        makeRound("2026-06-10T00:00:00Z", "2026-06-13T18:00:00Z"),
+        makeRound("2026-06-20T00:00:00Z", "2026-06-21T00:00:00Z"),
+      ],
+      now,
+    )
+    expect(boundary?.toISOString()).toBe("2026-06-13T18:00:00.000Z")
+  })
+
+  it("모든 차수가 과거면 null", () => {
+    expect(
+      getNextMatchingBoundary(
+        [makeRound("2026-06-10T00:00:00Z", "2026-06-11T00:00:00Z")],
+        now,
+      ),
+    ).toBeNull()
+  })
+
+  it("빈 배열/undefined는 null", () => {
+    expect(getNextMatchingBoundary([], now)).toBeNull()
+    expect(getNextMatchingBoundary(undefined, now)).toBeNull()
   })
 })

--- a/src/features/project/new/model/matchingPeriod.ts
+++ b/src/features/project/new/model/matchingPeriod.ts
@@ -15,3 +15,21 @@ export function isWithinMatchingPeriod(
     return !current.isBefore(start) && !current.isAfter(end)
   })
 }
+
+export function getNextMatchingBoundary(
+  rounds: MatchingRoundResponse[] | undefined,
+  now: Date,
+): Date | null {
+  if (!rounds?.length) return null
+  const currentMs = now.getTime()
+  let nextMs: number | null = null
+  for (const round of rounds) {
+    for (const ts of [round.startsAt, round.endsAt]) {
+      if (!ts) continue
+      const ms = dayjs(ts).valueOf()
+      if (!Number.isFinite(ms) || ms < currentMs) continue
+      if (nextMs === null || ms < nextMs) nextMs = ms
+    }
+  }
+  return nextMs === null ? null : new Date(nextMs)
+}

--- a/src/features/project/new/model/matchingPeriod.ts
+++ b/src/features/project/new/model/matchingPeriod.ts
@@ -27,7 +27,7 @@ export function getNextMatchingBoundary(
     for (const ts of [round.startsAt, round.endsAt]) {
       if (!ts) continue
       const ms = dayjs(ts).valueOf()
-      if (!Number.isFinite(ms) || ms < currentMs) continue
+      if (!Number.isFinite(ms) || ms <= currentMs) continue
       if (nextMs === null || ms < nextMs) nextMs = ms
     }
   }

--- a/src/features/project/new/ui/application/ApplicationForm.tsx
+++ b/src/features/project/new/ui/application/ApplicationForm.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import {
   forwardRef,
   useEffect,
@@ -11,6 +11,7 @@ import {
 import { useToastStore } from "@/components/toast/useToastStore"
 import {
   buildUpsertApplicationFormBody,
+  projectKeys,
   upsertApplicationForm,
 } from "@/features/project/new/api"
 import {
@@ -62,6 +63,7 @@ export const ApplicationForm = forwardRef<
   ref,
 ) {
   const addToast = useToastStore((s) => s.addToast)
+  const queryClient = useQueryClient()
   const form = useApplicationForm()
   const projectId = useProjectRegisterStore((s) => s.projectId)
   const commonSectionId = useProjectRegisterStore(
@@ -101,6 +103,11 @@ export const ApplicationForm = forwardRef<
     onSuccess: () => {
       lastSavedSnapshotRef.current = currentSnapshot
       setHasSavedOnce(true)
+      if (projectId) {
+        void queryClient.invalidateQueries({
+          queryKey: projectKeys.applicationForm(projectId),
+        })
+      }
       addToast({
         message: "작성한 내용이 임시 저장되었습니다.",
         color: "primary",


### PR DESCRIPTION
## 📸 작업 내용

- **지원서 임시저장 지원**: 작성 폼에 '임시저장' 버튼 추가(DRAFT 단독 저장) + 재진입 시 저장한 답변 복원(text/radio/checkbox/file/portfolio)
- DRAFT 지원서는 읽기 전용이 아니라 **'이어서 작성하기'** 로 작성 폼에 연결(CTA 분기). 복원 완료 전 스켈레톤 게이트로 입력 레이스(덮어쓰기) 방지
- 배경 클릭 / ESC로 닫을 때 변경사항이 있으면 **이탈 확인 모달** 노출
- **지원/모집 문항 조회 시 항상 서버 최신값 반영** (모달 쿼리 staleTime 0 + 폼 저장 시 캐시 무효화)
- **매칭 기간 수정 버튼 자동 갱신**: 차수 종료/시작 시 페이지 이동 없이 '프로젝트 수정하기' 노출/숨김이 즉시 반영(클라이언트 타이머 재평가, 서버 폴링 없음)

## 🎞️ 주요 코드 설명

### 지원 폼 변경 감지 — 값 스냅샷 비교

RHF `isDirty`/`dirtyFields`가 이 폼(zodResolver + Controller)에서 불안정해, 저장 시점 스냅샷과 `getValues()`를 직접 비교한다.

```ts
const hasUnsavedChanges = () =>
  JSON.stringify(getValues()) !== savedSnapshotRef.current
```

### 매칭 기간 경계 자동 갱신

다음 경계(startsAt/endsAt)까지 `setTimeout`으로 재평가. 서버 폴링 없이 시계만으로 판단하며, setTimeout 오버플로 방지 상한을 둔다.

## 🔗 연결된 이슈

- Connected: #351, #352
- Closes #351
- Closes #352