### PR TITLE
✨ feat: 프로젝트 상세 카드 엣지 케이스 3개 추가

### DIFF
--- a/src/features/project/list/model/projectDetailCta.ts
+++ b/src/features/project/list/model/projectDetailCta.ts
@@ -6,6 +6,7 @@ export type ProjectDetailCtaMode =
   | "apply-blocked-approved"
   | "apply-blocked-part"
   | "apply-blocked-closed"
+  | "no-active-round"
   | "plan-only"
 
 interface ResolveCtaParams {
@@ -18,6 +19,7 @@ interface ResolveCtaParams {
   isAlreadyApproved: boolean
   isPartIneligible: boolean
   isPartRecruitClosed: boolean
+  hasActiveRound?: boolean
 }
 
 export function resolveProjectDetailCtaMode({
@@ -30,6 +32,7 @@ export function resolveProjectDetailCtaMode({
   isAlreadyApproved,
   isPartIneligible,
   isPartRecruitClosed,
+  hasActiveRound,
 }: ResolveCtaParams): ProjectDetailCtaMode {
   if (isOperator) return "recruit-questions"
   if (!isSameBranch) return "plan-only"
@@ -37,6 +40,7 @@ export function resolveProjectDetailCtaMode({
   if (isApplied && isDraftApplication) return "apply"
   if (isApplied) return "my-application"
   if (isAlreadyApproved) return "apply-blocked-approved"
+  if (hasActiveRound === false) return "no-active-round"
   if (hasOtherActiveApplication) return "apply-blocked-other"
   if (isPartIneligible) return "apply-blocked-part"
   if (isPartRecruitClosed) return "apply-blocked-closed"

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/features/project/new/api"
 import { UsabilitySurvey } from "@/features/usability-survey"
 import { getActiveGisu } from "@/shared/api/gisu"
+import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
 import { ProjectLogo } from "@/shared/assets/icon/logo/ProjectLogo"
 import { formatSchoolName } from "@/shared/lib/formatSchoolName"
 import { withImageCacheKey } from "@/shared/lib/withImageCacheKey"
@@ -403,6 +404,11 @@ export function ProjectDetailCard({
       (q) => q.part === latestChallengerPart && q.status === "COMPLETED",
     )
 
+  const hasActiveRoundForCtaMode: boolean | undefined =
+    isChallengerView && !isActiveMatchingRoundLoading
+      ? activeMatchingRound != null
+      : undefined
+
   const ctaMode =
     viewOnly && !userIsOperator
       ? resolveProjectDetailCtaMode({
@@ -426,6 +432,7 @@ export function ProjectDetailCard({
           isAlreadyApproved,
           isPartIneligible,
           isPartRecruitClosed,
+          hasActiveRound: hasActiveRoundForCtaMode,
         })
 
   const cover = data.coverImage
@@ -509,14 +516,23 @@ export function ProjectDetailCard({
               variant="weak"
               color="primary"
               className="min-w-28 flex-1 whitespace-nowrap"
-              disabled={!data.externalLink}
+              disabled={
+                ctaMode !== "apply-blocked-approved" && !data.externalLink
+              }
               onClick={() => {
-                if (data.externalLink)
-                  window.open(
-                    data.externalLink,
-                    "_blank",
-                    "noopener,noreferrer",
-                  )
+                if (!data.externalLink) {
+                  if (ctaMode === "apply-blocked-approved") {
+                    addToast({
+                      message: "업로드된 기획안이 없습니다.",
+                      color: "primary",
+                      variant: "deep",
+                      type: "default",
+                      duration: 3000,
+                    })
+                  }
+                  return
+                }
+                window.open(data.externalLink, "_blank", "noopener,noreferrer")
               }}
             >
               기획 보기
@@ -634,8 +650,18 @@ export function ProjectDetailCard({
                       {isDraftApplication ? "이어서 작성하기" : "지원하기"}
                     </Button>
                   )}
+                {ctaMode === "apply-blocked-approved" && (
+                  <Button
+                    variant="weak"
+                    color="primary"
+                    className="min-w-32 flex-1 whitespace-nowrap"
+                    disabled={!detail?.applicationFormId}
+                    onClick={() => setIsRecruitQuestionsModalOpen(true)}
+                  >
+                    모집 문항 보기
+                  </Button>
+                )}
                 {(ctaMode === "apply-blocked-other" ||
-                  ctaMode === "apply-blocked-approved" ||
                   ctaMode === "apply-blocked-part" ||
                   ctaMode === "apply-blocked-closed") && (
                   <>
@@ -678,6 +704,14 @@ export function ProjectDetailCard({
             <p className="text-caption-2-regular text-error-600 mt-2 w-full text-center">
               모집이 마감된 파트라 지원할 수 없습니다.
             </p>
+          )}
+          {!viewOnly && ctaMode === "no-active-round" && (
+            <div className="mt-2 flex w-full items-center justify-center gap-1">
+              <CheckIcon className="text-teal-gray-500 h-4 w-4 shrink-0" />
+              <p className="text-caption-2-regular text-teal-gray-500 text-center">
+                현재 지원할 수 있는 매칭 기간이 아닙니다.
+              </p>
+            </div>
           )}
         </div>
       </div>


### PR DESCRIPTION
## 📸 작업 내용

> 프로젝트 상세 카드 엣지 케이스 3개 추가

- 이미 합격한 사람이, **소속된 지부의 다른 프로젝트** 카드 클릭 시
- 매칭 기간이 아닐 때
- 매칭 기간이 아닐 때 + 기획안이 없을 때

## 🎞️ 주요 코드 설명


## 🖥️ 구현화면


## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #350 