### PR TITLE
fix: 매칭 결과 시트 UI 수정

### DIFF
--- a/src/features/matching/model/matchingStatusMapper.ts
+++ b/src/features/matching/model/matchingStatusMapper.ts
@@ -63,7 +63,6 @@ function toMatchingProject(
   project: ManagedProjectSummaryResponse,
   applicants: ProjectApplicantResponse[],
   members: ProjectMembersResponse | undefined,
-  maxColsByRole: Record<string, number>,
 ): MatchingProjectData {
   // memberId -> APPROVED 지원서 매핑 (차수 태그 조회용)
   // 서버가 memberId를 string으로 내려주는 경우 대비해 String으로 정규화
@@ -150,29 +149,47 @@ function toMatchingProject(
     .filter((q) => q.part === "SPRINGBOOT" || q.part === "NODEJS")
     .reduce((sum, q) => sum + Number(q.quota), 0)
 
+  // firstRowCols: 프로젝트 첫 행은 4칸 (상태 텍스트 공간), 나머지 행은 5칸
   function buildRoleRow(
     role: string,
     quota: number,
-    maxCols: number,
+    isFirstRole: boolean,
   ): MatchingRoleRow {
     const filledBlocks = blocksByRole.get(role) ?? []
+    const effectiveCount = Math.max(filledBlocks.length, quota)
+    const colsPerRow = 5
+    const firstRowCols = isFirstRole ? 4 : colsPerRow
+
+    let totalSlots: number
+    if (effectiveCount <= firstRowCols) {
+      totalSlots = firstRowCols
+    } else {
+      const remaining = effectiveCount - firstRowCols
+      totalSlots = firstRowCols + Math.ceil(remaining / colsPerRow) * colsPerRow
+    }
+
     const emptyCount = Math.max(0, quota - filledBlocks.length)
     const emptyBlocks: MatchingBlockData[] = Array.from(
       { length: emptyCount },
       () => ({ type: "none" }),
     )
-    const blockedCount = Math.max(0, maxCols - quota)
+    const blockedCount = totalSlots - filledBlocks.length - emptyCount
     const blockedBlocks: MatchingBlockData[] = Array.from(
       { length: blockedCount },
       () => ({ type: "blocked" }),
     )
-    return { role, blocks: [...filledBlocks, ...emptyBlocks, ...blockedBlocks] }
+    return {
+      role,
+      blocks: [...filledBlocks, ...emptyBlocks, ...blockedBlocks],
+      colsPerRow,
+      firstRowCols,
+    }
   }
 
   const roleRows = [
-    buildRoleRow("Design", designQuota, maxColsByRole["Design"] ?? designQuota),
-    buildRoleRow("Frontend", feQuota, maxColsByRole["Frontend"] ?? feQuota),
-    buildRoleRow("Backend", beQuota, maxColsByRole["Backend"] ?? beQuota),
+    buildRoleRow("Design", designQuota, true),
+    buildRoleRow("Frontend", feQuota, false),
+    buildRoleRow("Backend", beQuota, false),
   ]
 
   const hasNodejs = project.partQuotas.some(
@@ -204,23 +221,6 @@ function toMatchingProject(
   }
 }
 
-// 프로젝트 목록에서 역할별 최대 열 수 계산
-function computeMaxCols(
-  projects: ManagedProjectSummaryResponse[],
-): Record<string, number> {
-  const maxCols: Record<string, number> = { Design: 0, Frontend: 0, Backend: 0 }
-  for (const p of projects) {
-    for (const q of p.partQuotas) {
-      const role = PART_TO_ROLE[q.part]
-      const numQuota = Number(q.quota)
-      if (role && numQuota > (maxCols[role] ?? 0)) {
-        maxCols[role] = numQuota
-      }
-    }
-  }
-  return maxCols
-}
-
 export function toMatchingPartDataList(
   projects: ManagedProjectSummaryResponse[],
   applicantsByProject: Map<string, ProjectApplicantResponse[]>,
@@ -246,7 +246,6 @@ export function toMatchingPartDataList(
   return FE_PLATFORM_ORDER.filter((platform) => byPlatform.has(platform)).map(
     (platform) => {
       const platformProjects = byPlatform.get(platform)!
-      const maxCols = computeMaxCols(platformProjects)
       return {
         partName: platform,
         projects: platformProjects.map((p) =>
@@ -254,7 +253,6 @@ export function toMatchingPartDataList(
             p,
             applicantsByProject.get(String(p.id)) ?? [],
             membersByProject.get(String(p.id)),
-            maxCols,
           ),
         ),
       }

--- a/src/features/matching/ui/MatchingResultRow.tsx
+++ b/src/features/matching/ui/MatchingResultRow.tsx
@@ -208,10 +208,7 @@ export function MatchingResultRow({
 
   return (
     <div
-      className={cn(
-        "border-teal-gray-300 flex items-start gap-1.75 border-b py-3 pr-5.5 pl-1.75",
-        className,
-      )}
+      className={cn("flex items-start gap-1.75 py-3 pr-5.5 pl-1.75", className)}
     >
       {/* 프로젝트 이동 버튼 */}
       <div className="w-42.5 shrink-0">

--- a/src/features/matching/ui/MatchingResultRow.tsx
+++ b/src/features/matching/ui/MatchingResultRow.tsx
@@ -42,6 +42,8 @@ export interface MatchingBlockData {
 export interface MatchingRoleRow {
   role: string
   blocks: MatchingBlockData[]
+  colsPerRow: number
+  firstRowCols: number
 }
 
 interface MatchingResultRowProps {
@@ -185,10 +187,26 @@ export function MatchingResultRow({
     )
   }, [roleRows])
 
-  // 각 행의 usable(비 blocked) 슬롯 수
-  const usableCounts = localRoleRows.map((row) => {
-    const idx = row.blocks.findIndex((b) => b.type === "blocked")
-    return idx === -1 ? row.blocks.length : idx
+  // 블록 배열을 firstRowCols / colsPerRow 단위로 청크 분할
+  const chunkedRows = localRoleRows.map((row) => {
+    const chunks: MatchingBlockData[][] = []
+    if (row.blocks.length === 0) return [[]]
+    // 첫 청크: firstRowCols 개
+    chunks.push(row.blocks.slice(0, row.firstRowCols))
+    // 이후 청크: colsPerRow 개씩
+    for (let i = row.firstRowCols; i < row.blocks.length; i += row.colsPerRow) {
+      chunks.push(row.blocks.slice(i, i + row.colsPerRow))
+    }
+    return chunks
+  })
+
+  // 전체 시각적 행 목록 (라운드 코너 계산용)
+  const visualRows = chunkedRows.flat()
+
+  // 각 시각적 행의 usable(비 blocked) 슬롯 수
+  const usableCounts = visualRows.map((chunk) => {
+    const idx = chunk.findIndex((b) => b.type === "blocked")
+    return idx === -1 ? chunk.length : idx
   })
 
   return (
@@ -226,119 +244,145 @@ export function MatchingResultRow({
 
       {/* 역할별 블록 테이블 */}
       <div className="flex flex-1 flex-col gap-px">
-        {localRoleRows.map((row, rowIdx) => (
-          <div
-            key={row.role}
-            className="flex w-full items-center justify-between"
-          >
-            <div className="flex items-center gap-3.5">
-              <span className="text-body-2-medium w-14.5 tracking-[-0.14px] text-teal-900">
-                {row.role}
-              </span>
-              <div className="flex items-center">
-                {row.blocks.map((block, blockIdx) => (
-                  <MatchingBlock
-                    key={blockIdx}
-                    type={block.type}
-                    name={block.name}
-                    tagVariant={block.tagVariant}
-                    onNameClick={
-                      isEditable && block.applicantId
-                        ? () => {
-                            setSelectedApplicantId(block.applicantId!)
-                            setSelectedMemberId(block.memberId ?? null)
-                          }
-                        : isEditable &&
-                            !block.applicantId &&
-                            block.memberId &&
-                            block.type === "filled"
-                          ? () => {
-                              setManualUnmatchTarget({
-                                memberId: block.memberId!,
-                                name: block.name ?? "",
-                              })
-                            }
-                          : undefined
-                    }
-                    onAssignClick={
-                      isEditable && block.type === "none"
-                        ? () =>
-                            setAssignTarget({
-                              rowIdx,
-                              blockIdx,
-                              role: row.role,
-                            })
-                        : undefined
-                    }
-                    className={(() => {
-                      const isLastUsable =
-                        block.type !== "blocked" &&
-                        blockIdx === usableCounts[rowIdx]! - 1 &&
-                        usableCounts[rowIdx]! < row.blocks.length
-                      const isFirstBlocked =
-                        block.type === "blocked" &&
-                        blockIdx === usableCounts[rowIdx]
-                      return cn(
-                        // 경계 블록은 -mr-px 제거 (겹침 방지)
-                        !isLastUsable && "-mr-px",
-                        // 외곽 그리드 모서리
-                        rowIdx === 0 && blockIdx === 0 && "rounded-tl-[6px]",
-                        rowIdx === 0 &&
-                          blockIdx === row.blocks.length - 1 &&
-                          "rounded-tr-[6px]",
-                        rowIdx === localRoleRows.length - 1 &&
-                          blockIdx === 0 &&
-                          "rounded-bl-[6px]",
-                        rowIdx === localRoleRows.length - 1 &&
-                          blockIdx === row.blocks.length - 1 &&
-                          "rounded-br-[6px]",
-                        // usable 마지막 슬롯 경계 모서리
-                        isLastUsable &&
-                          (rowIdx === 0 ||
-                            usableCounts[rowIdx - 1] !==
-                              usableCounts[rowIdx]) &&
-                          "rounded-tr-[6px]",
-                        isLastUsable &&
-                          (rowIdx === localRoleRows.length - 1 ||
-                            usableCounts[rowIdx + 1] !==
-                              usableCounts[rowIdx]) &&
-                          "rounded-br-[6px]",
-                        // blocked 첫 슬롯 경계 모서리
-                        isFirstBlocked &&
-                          rowIdx > 0 &&
-                          usableCounts[rowIdx - 1]! > usableCounts[rowIdx]! &&
-                          "rounded-tl-[6px]",
-                        isFirstBlocked &&
-                          rowIdx < localRoleRows.length - 1 &&
-                          usableCounts[rowIdx + 1]! > usableCounts[rowIdx]! &&
-                          "rounded-bl-[6px]",
-                      )
-                    })()}
-                  />
-                ))}
-              </div>
-            </div>
+        {localRoleRows.map((row, rowIdx) => {
+          const chunks = chunkedRows[rowIdx]!
+          // 이 역할 첫 청크의 시각적 행 인덱스
+          const visualBase = chunkedRows
+            .slice(0, rowIdx)
+            .reduce((sum, c) => sum + c.length, 0)
 
-            {/* 상태 표시 (첫 행 우측) */}
-            {rowIdx === 0 && (
-              <div className="flex items-center gap-1.5">
-                {status === "recruiting" && (
-                  <div className="flex h-6 items-center gap-1.5">
-                    <div className="bg-warning-500 size-3 rounded-full" />
-                    <span className="text-label-2-medium text-warning-500">
-                      모집 중
+          return chunks.map((chunk, chunkIdx) => {
+            const vIdx = visualBase + chunkIdx
+            // 플랫 블록 인덱스 오프셋 (수동 배정용)
+            const flatOffset =
+              chunkIdx === 0
+                ? 0
+                : row.firstRowCols + (chunkIdx - 1) * row.colsPerRow
+            // 연속 행은 라벨 없이 우측 정렬
+            const isContinuation = chunkIdx > 0
+
+            return (
+              <div
+                key={`${row.role}-${chunkIdx}`}
+                className={cn(
+                  "flex w-full items-center",
+                  isContinuation ? "justify-end" : "justify-between",
+                )}
+              >
+                <div
+                  className={cn(
+                    "flex items-center",
+                    !isContinuation && "gap-3.5",
+                  )}
+                >
+                  {!isContinuation && (
+                    <span className="text-body-2-medium w-14.5 tracking-[-0.14px] text-teal-900">
+                      {row.role}
+                    </span>
+                  )}
+                  <div className="flex items-center">
+                    {chunk.map((block, blockIdx) => (
+                      <MatchingBlock
+                        key={blockIdx}
+                        type={block.type}
+                        name={block.name}
+                        tagVariant={block.tagVariant}
+                        onNameClick={
+                          isEditable && block.applicantId
+                            ? () => {
+                                setSelectedApplicantId(block.applicantId!)
+                                setSelectedMemberId(block.memberId ?? null)
+                              }
+                            : isEditable &&
+                                !block.applicantId &&
+                                block.memberId &&
+                                block.type === "filled"
+                              ? () => {
+                                  setManualUnmatchTarget({
+                                    memberId: block.memberId!,
+                                    name: block.name ?? "",
+                                  })
+                                }
+                              : undefined
+                        }
+                        onAssignClick={
+                          isEditable && block.type === "none"
+                            ? () =>
+                                setAssignTarget({
+                                  rowIdx,
+                                  blockIdx: flatOffset + blockIdx,
+                                  role: row.role,
+                                })
+                            : undefined
+                        }
+                        className={(() => {
+                          const chunkUsable = usableCounts[vIdx]!
+                          const isLastUsable =
+                            block.type !== "blocked" &&
+                            blockIdx === chunkUsable - 1 &&
+                            chunkUsable < chunk.length
+                          const isFirstBlocked =
+                            block.type === "blocked" && blockIdx === chunkUsable
+                          return cn(
+                            !isLastUsable && "-mr-px",
+                            // 외곽 그리드 모서리
+                            vIdx === 0 && blockIdx === 0 && "rounded-tl-[6px]",
+                            vIdx === 0 &&
+                              blockIdx === chunk.length - 1 &&
+                              "rounded-tr-[6px]",
+                            vIdx === visualRows.length - 1 &&
+                              blockIdx === 0 &&
+                              "rounded-bl-[6px]",
+                            vIdx === visualRows.length - 1 &&
+                              blockIdx === chunk.length - 1 &&
+                              "rounded-br-[6px]",
+                            // usable 마지막 슬롯 경계 모서리
+                            isLastUsable &&
+                              (vIdx === 0 ||
+                                usableCounts[vIdx - 1] !== chunkUsable) &&
+                              "rounded-tr-[6px]",
+                            isLastUsable &&
+                              (vIdx === visualRows.length - 1 ||
+                                usableCounts[vIdx + 1] !== chunkUsable) &&
+                              "rounded-br-[6px]",
+                            // blocked 첫 슬롯 경계 모서리
+                            isFirstBlocked &&
+                              vIdx > 0 &&
+                              usableCounts[vIdx - 1]! > chunkUsable &&
+                              "rounded-tl-[6px]",
+                            isFirstBlocked &&
+                              vIdx < visualRows.length - 1 &&
+                              usableCounts[vIdx + 1]! > chunkUsable &&
+                              "rounded-bl-[6px]",
+                          )
+                        })()}
+                      />
+                    ))}
+                  </div>
+                </div>
+
+                {/* 상태 표시 (첫 시각 행 우측) */}
+                {vIdx === 0 && (
+                  <div className="flex items-center gap-1.5">
+                    {status === "recruiting" && (
+                      <div className="flex h-6 items-center gap-1.5">
+                        <div className="bg-warning-500 size-3 rounded-full" />
+                        <span className="text-label-2-medium text-warning-500">
+                          모집 중
+                        </span>
+                      </div>
+                    )}
+                    <span className="text-subtitle-3-semibold tracking-[-0.16px] whitespace-nowrap text-teal-700">
+                      {status === "recruiting"
+                        ? `${currentCount}/${totalCount}명`
+                        : `총 ${totalCount}명`}
                     </span>
                   </div>
                 )}
-                <span className="text-subtitle-3-semibold tracking-[-0.16px] whitespace-nowrap text-teal-700">
-                  {status === "recruiting"
-                    ? `${currentCount}/${totalCount}명`
-                    : `총 ${totalCount}명`}
-                </span>
               </div>
-            )}
-          </div>
-        ))}
+            )
+          })
+        })}
       </div>
 
       <Modal.Root

--- a/src/features/matching/ui/MatchingResultRow.tsx
+++ b/src/features/matching/ui/MatchingResultRow.tsx
@@ -200,14 +200,11 @@ export function MatchingResultRow({
     return chunks
   })
 
-  // 전체 시각적 행 목록 (라운드 코너 계산용)
-  const visualRows = chunkedRows.flat()
-
-  // 각 시각적 행의 usable(비 blocked) 슬롯 수
-  const usableCounts = visualRows.map((chunk) => {
-    const idx = chunk.findIndex((b) => b.type === "blocked")
-    return idx === -1 ? chunk.length : idx
-  })
+  // 각 시각 행의 블록 수 (라운드 코너 비교용)
+  const visualBlockCounts = chunkedRows.flatMap((chunks) =>
+    chunks.map((c) => c.length),
+  )
+  const totalVisualRows = visualBlockCounts.length
 
   return (
     <div
@@ -246,7 +243,6 @@ export function MatchingResultRow({
       <div className="flex flex-1 flex-col gap-px">
         {localRoleRows.map((row, rowIdx) => {
           const chunks = chunkedRows[rowIdx]!
-          // 이 역할 첫 청크의 시각적 행 인덱스
           const visualBase = chunkedRows
             .slice(0, rowIdx)
             .reduce((sum, c) => sum + c.length, 0)
@@ -316,44 +312,32 @@ export function MatchingResultRow({
                             : undefined
                         }
                         className={(() => {
-                          const chunkUsable = usableCounts[vIdx]!
-                          const isLastUsable =
-                            block.type !== "blocked" &&
-                            blockIdx === chunkUsable - 1 &&
-                            chunkUsable < chunk.length
-                          const isFirstBlocked =
-                            block.type === "blocked" && blockIdx === chunkUsable
+                          const aboveCount =
+                            vIdx > 0 ? visualBlockCounts[vIdx - 1]! : 0
+                          const belowCount =
+                            vIdx < totalVisualRows - 1
+                              ? visualBlockCounts[vIdx + 1]!
+                              : 0
+                          const isFirst = blockIdx === 0
+                          const isLast = blockIdx === chunk.length - 1
                           return cn(
-                            !isLastUsable && "-mr-px",
-                            // 외곽 그리드 모서리
-                            vIdx === 0 && blockIdx === 0 && "rounded-tl-[6px]",
-                            vIdx === 0 &&
-                              blockIdx === chunk.length - 1 &&
-                              "rounded-tr-[6px]",
-                            vIdx === visualRows.length - 1 &&
-                              blockIdx === 0 &&
+                            "-mr-px",
+                            // 좌측: 모든 행의 좌측 끝 정렬 -> 위/아래 행 유무만 확인
+                            isFirst && vIdx === 0 && "rounded-tl-[6px]",
+                            isFirst &&
+                              vIdx === totalVisualRows - 1 &&
                               "rounded-bl-[6px]",
-                            vIdx === visualRows.length - 1 &&
-                              blockIdx === chunk.length - 1 &&
+                            // 우측: 첫 행(4칸)이 짧아 이후 행이 더 오른쪽으로 확장
+                            isLast && vIdx === 0 && "rounded-tr-[6px]",
+                            isLast &&
+                              vIdx === totalVisualRows - 1 &&
                               "rounded-br-[6px]",
-                            // usable 마지막 슬롯 경계 모서리
-                            isLastUsable &&
-                              (vIdx === 0 ||
-                                usableCounts[vIdx - 1] !== chunkUsable) &&
+                            isLast &&
+                              aboveCount < chunk.length &&
                               "rounded-tr-[6px]",
-                            isLastUsable &&
-                              (vIdx === visualRows.length - 1 ||
-                                usableCounts[vIdx + 1] !== chunkUsable) &&
+                            isLast &&
+                              belowCount < chunk.length &&
                               "rounded-br-[6px]",
-                            // blocked 첫 슬롯 경계 모서리
-                            isFirstBlocked &&
-                              vIdx > 0 &&
-                              usableCounts[vIdx - 1]! > chunkUsable &&
-                              "rounded-tl-[6px]",
-                            isFirstBlocked &&
-                              vIdx < visualRows.length - 1 &&
-                              usableCounts[vIdx + 1]! > chunkUsable &&
-                              "rounded-bl-[6px]",
                           )
                         })()}
                       />
@@ -362,7 +346,7 @@ export function MatchingResultRow({
                 </div>
 
                 {/* 상태 표시 (첫 시각 행 우측) */}
-                {vIdx === 0 && (
+                {rowIdx === 0 && chunkIdx === 0 && (
                   <div className="flex items-center gap-1.5">
                     {status === "recruiting" && (
                       <div className="flex h-6 items-center gap-1.5">


### PR DESCRIPTION
## 📸 작업 내용
  - 매칭 결과 시트 블록 레이아웃 변경: 첫 행 4칸(상태 텍스트 공간 확보), 이후 행 5칸 줄바꿈                                                      
  - 프로젝트별 독립 슬롯 계산으로 변경 (기존: 섹션 내 모든 프로젝트가 동일 maxCols 공유)
  - 연속 행은 라벨 없이 우측 정렬                                                                                                                
  - 라운드 코너를 그리드 외곽 실루엣 기준으로만 적용        
  - 행 구분 하단 테두리 제거

## 🎞️ 주요 코드 설명

### `첫 행 4칸 / 이후 5칸 슬롯 계산`
```typescript
  function buildRoleRow(role: string, quota: number, isFirstRole: boolean): MatchingRoleRow {
    const colsPerRow = 5
    const firstRowCols = isFirstRole ? 4 : colsPerRow

    let totalSlots: number
    if (effectiveCount <= firstRowCols) {
      totalSlots = firstRowCols
    } else {
      const remaining = effectiveCount - firstRowCols
      totalSlots = firstRowCols + Math.ceil(remaining / colsPerRow) * colsPerRow
    }
    // ...
  }
```
  - 첫 역할(Design)의 첫 행만 4칸으로 제한해 상태 텍스트("모집 중", "총 N명")가 잘리지 않도록 함
  - 초과분은 5칸 단위 행으로 줄바꿈, 빈 칸은 blocked 처리

  ### `외곽 실루엣 기준 라운드 코너`

``` typescript
  const aboveCount = vIdx > 0 ? visualBlockCounts[vIdx - 1]! : 0
  const belowCount = vIdx < totalVisualRows - 1 ? visualBlockCounts[vIdx + 1]! : 0

  // 좌측: 모든 행의 좌측 끝 정렬 -> 첫/마지막 시각 행에서만
  isFirst && vIdx === 0 && "rounded-tl-[6px]"
  isFirst && vIdx === totalVisualRows - 1 && "rounded-bl-[6px]"
  // 우측: 인접 행보다 블록 수가 많으면 외곽 꼭짓점
  isLast && aboveCount < chunk.length && "rounded-tr-[6px]"
  isLast && belowCount < chunk.length && "rounded-br-[6px]"
```

  - 인접 행과 맞닿는 꼭짓점은 라운딩하지 않고, 그리드 외곽에 노출된 꼭짓점만 라운딩


## 🖥️ 구현화면

|           A 기능            | 
| :-------------------------: |
| <img width="979" height="454" alt="image" src="https://github.com/user-attachments/assets/874f09f9-f93f-4096-94d9-f61cf2f902a8" /> | <img src = "" width ="250"> |

## 🔗 연결된 이슈
- Closed: #356
