### PR TITLE
fix: Design 행 슬롯을 quota 기반 가변 칸수로 수정

### DIFF
--- a/src/features/matching/model/matchingStatusMapper.ts
+++ b/src/features/matching/model/matchingStatusMapper.ts
@@ -149,24 +149,34 @@ function toMatchingProject(
     .filter((q) => q.part === "SPRINGBOOT" || q.part === "NODEJS")
     .reduce((sum, q) => sum + Number(q.quota), 0)
 
-  // firstRowCols: 프로젝트 첫 행은 4칸 (상태 텍스트 공간), 나머지 행은 5칸
-  function buildRoleRow(
-    role: string,
-    quota: number,
-    isFirstRole: boolean,
-  ): MatchingRoleRow {
+  // Design: blocked 없음, 슬롯 수 = max(quota, filled), 최대 4
+  function buildDesignRow(quota: number): MatchingRoleRow {
+    const filledBlocks = blocksByRole.get("Design") ?? []
+    const totalSlots = Math.min(Math.max(filledBlocks.length, quota), 4)
+    const emptyCount = Math.max(
+      0,
+      Math.min(quota, totalSlots) - filledBlocks.length,
+    )
+    const emptyBlocks: MatchingBlockData[] = Array.from(
+      { length: emptyCount },
+      () => ({ type: "none" }),
+    )
+    return {
+      role: "Design",
+      blocks: [...filledBlocks.slice(0, totalSlots), ...emptyBlocks],
+      colsPerRow: totalSlots,
+    }
+  }
+
+  // FE/BE: 5칸 단위 행, 빈 칸은 blocked
+  function buildRoleRow(role: string, quota: number): MatchingRoleRow {
     const filledBlocks = blocksByRole.get(role) ?? []
     const effectiveCount = Math.max(filledBlocks.length, quota)
     const colsPerRow = 5
-    const firstRowCols = isFirstRole ? 4 : colsPerRow
-
-    let totalSlots: number
-    if (effectiveCount <= firstRowCols) {
-      totalSlots = firstRowCols
-    } else {
-      const remaining = effectiveCount - firstRowCols
-      totalSlots = firstRowCols + Math.ceil(remaining / colsPerRow) * colsPerRow
-    }
+    const totalSlots = Math.max(
+      colsPerRow,
+      Math.ceil(effectiveCount / colsPerRow) * colsPerRow,
+    )
 
     const emptyCount = Math.max(0, quota - filledBlocks.length)
     const emptyBlocks: MatchingBlockData[] = Array.from(
@@ -182,14 +192,13 @@ function toMatchingProject(
       role,
       blocks: [...filledBlocks, ...emptyBlocks, ...blockedBlocks],
       colsPerRow,
-      firstRowCols,
     }
   }
 
   const roleRows = [
-    buildRoleRow("Design", designQuota, true),
-    buildRoleRow("Frontend", feQuota, false),
-    buildRoleRow("Backend", beQuota, false),
+    buildDesignRow(designQuota),
+    buildRoleRow("Frontend", feQuota),
+    buildRoleRow("Backend", beQuota),
   ]
 
   const hasNodejs = project.partQuotas.some(

--- a/src/features/matching/ui/MatchingResultRow.tsx
+++ b/src/features/matching/ui/MatchingResultRow.tsx
@@ -43,7 +43,6 @@ export interface MatchingRoleRow {
   role: string
   blocks: MatchingBlockData[]
   colsPerRow: number
-  firstRowCols: number
 }
 
 interface MatchingResultRowProps {
@@ -187,14 +186,11 @@ export function MatchingResultRow({
     )
   }, [roleRows])
 
-  // 블록 배열을 firstRowCols / colsPerRow 단위로 청크 분할
+  // 블록 배열을 colsPerRow 단위로 청크 분할
   const chunkedRows = localRoleRows.map((row) => {
-    const chunks: MatchingBlockData[][] = []
     if (row.blocks.length === 0) return [[]]
-    // 첫 청크: firstRowCols 개
-    chunks.push(row.blocks.slice(0, row.firstRowCols))
-    // 이후 청크: colsPerRow 개씩
-    for (let i = row.firstRowCols; i < row.blocks.length; i += row.colsPerRow) {
+    const chunks: MatchingBlockData[][] = []
+    for (let i = 0; i < row.blocks.length; i += row.colsPerRow) {
       chunks.push(row.blocks.slice(i, i + row.colsPerRow))
     }
     return chunks
@@ -247,10 +243,7 @@ export function MatchingResultRow({
           return chunks.map((chunk, chunkIdx) => {
             const vIdx = visualBase + chunkIdx
             // 플랫 블록 인덱스 오프셋 (수동 배정용)
-            const flatOffset =
-              chunkIdx === 0
-                ? 0
-                : row.firstRowCols + (chunkIdx - 1) * row.colsPerRow
+            const flatOffset = chunkIdx * row.colsPerRow
             // 연속 행은 라벨 없이 우측 정렬
             const isContinuation = chunkIdx > 0
 


### PR DESCRIPTION
## 📸 작업 내용
- Design 행 슬롯을 quota 기반 가변 칸수로 수정

## 🎞️ 주요 코드 설명
### `Design / FE·BE 슬롯 계산 분리`

```typescript
  // Design: blocked 없음, 슬롯 수 = max(quota, filled), 최대 4
  function buildDesignRow(quota: number): MatchingRoleRow {
    const filledBlocks = blocksByRole.get("Design") ?? []
    const totalSlots = Math.min(Math.max(filledBlocks.length, quota), 4)
    const emptyCount = Math.max(0, Math.min(quota, totalSlots) - filledBlocks.length)
    // ...
    return { role: "Design", blocks: [...filled, ...empty], colsPerRow: totalSlots }
  }

  // FE/BE: 5칸 단위, 빈 칸은 blocked
  function buildRoleRow(role: string, quota: number): MatchingRoleRow {
    const totalSlots = Math.max(5, Math.ceil(effectiveCount / 5) * 5)
    const blockedCount = totalSlots - filledBlocks.length - emptyCount
    // ...
    return { role, blocks: [...filled, ...empty, ...blocked], colsPerRow: 5 }
  }
```
  - Design: quota=2 기준, filled 수에 따라 2~4칸 가변. blocked 슬롯 없음
  - FE/BE: 항상 5칸 단위로 행 구성, 남는 칸은 blocked

## 🖥️ 구현화면
|           A 기능            |
| :-------------------------: |
| <img width="976" height="443" alt="image" src="https://github.com/user-attachments/assets/e46b2ee7-91f2-4750-8748-ce63b2d08502" /> | 

## 🔗 연결된 이슈

- Connected: #356 