### PR TITLE
fix: 지원 현황 권한별 조회 및 API 연동 수정

### DIFF
--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -1,8 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { useMemo } from "react"
 
-import { useMe } from "@/features/auth/hooks/useMe"
-import { getViewerBranch } from "@/features/auth/model/identity"
 import {
   getAllChapters,
   getAllSchools,
@@ -78,69 +76,11 @@ export function useChallengerPageData() {
   const gisuQuery = useActiveGisuId()
   const gisuId = gisuQuery.data ?? 0
 
-  const meQuery = useMe()
-  const chapterName = useMemo(
-    () => getViewerBranch(meQuery.data),
-    [meQuery.data],
-  )
-
-  // 지부 소속 학교 -> 지부 총원 계산 (availableMemberCount 보정용)
-  const chaptersWithSchoolsQuery = useQuery({
-    queryKey: ["chapters-with-schools", gisuId],
-    queryFn: () => getChaptersWithSchools(String(gisuId)),
-    enabled: gisuId > 0,
-  })
-  const chapterSchoolIds = useMemo(() => {
-    if (!chapterName || !chaptersWithSchoolsQuery.data) return null
-    const chapter = chaptersWithSchoolsQuery.data.chapters.find(
-      (c) => c.chapterName === chapterName,
-    )
-    if (!chapter) return null
-    return new Set(chapter.schools.map((s) => String(s.schoolId)))
-  }, [chapterName, chaptersWithSchoolsQuery.data])
-
-  // chapterName -> chapterId 매핑
-  const chaptersQuery = useChapters()
-  const chapterId = useMemo(() => {
-    if (!chapterName) return undefined
-    const found = (chaptersQuery.data?.chapters ?? []).find(
-      (c) => c.name === chapterName,
-    )
-    return found ? Number(found.id) : undefined
-  }, [chapterName, chaptersQuery.data])
-
-  // 지부 통계 조회 (지부 총원 계산용)
-  const chapterStatsQuery = useQuery({
-    queryKey: applicationKeys.chapterStatistics(chapterId ?? 0),
-    queryFn: () => getChapterStatistics(chapterId!),
-    enabled: !!chapterId,
-  })
-
-  // 지부 총원 = 지부 소속 학교의 schoolMatchingStatistics.totalMemberCount 합산
-  const chapterTotal = useMemo(() => {
-    const stats = chapterStatsQuery.data?.summary.schoolMatchingStatistics
-    if (!stats) return undefined
-    const filtered = chapterSchoolIds
-      ? stats.filter((s) => chapterSchoolIds.has(String(s.schoolId)))
-      : stats
-    return filtered.reduce((s, x) => s + Number(x.totalMemberCount), 0)
-  }, [chapterStatsQuery.data, chapterSchoolIds])
-
   const projectsQuery = useQuery({
     queryKey: applicationKeys.managedProjects(gisuId),
     queryFn: () => getManagedProjects(gisuId),
     enabled: gisuId > 0,
   })
-
-  // 매칭 차수 조회 (PM은 챕터 선택 없으므로 전체 조회)
-  const roundsQuery = useQuery({
-    queryKey: applicationKeys.matchingRounds(undefined),
-    queryFn: () => getMatchingRounds(),
-  })
-  const { currentRound, activeRound } = useMemo(
-    () => getCurrentRound(roundsQuery.data ?? []),
-    [roundsQuery.data],
-  )
 
   // 프로젝트 목록이 로드되면 각 프로젝트의 지원자 목록도 함께 조회
   const projects = useMemo(
@@ -183,17 +123,44 @@ export function useChallengerPageData() {
     enabled: projects.length > 0,
   })
 
-  // 차수별 지원 가용 인원 (지부 총원 기준)
+  // 현재 차수: 서버 통계에 존재하는 가장 높은 차수
+  const currentRound = useMemo(() => {
+    const firstStat = (projectStatsQuery.data ?? [])[0]
+    if (!firstStat) return undefined
+    let max = 0
+    for (const r of firstStat.roundApplicationStatistics) {
+      const n = toRoundNumber(r.matchingRound.phase)
+      if (n > max) max = n
+    }
+    return max || undefined
+  }, [projectStatsQuery.data])
+
+  // 차수별 지원 가용 인원 (서버 roundApplicationStatistics 직접 사용)
   const availablePerRound = useMemo(() => {
     const map = new Map<number, number>()
-    if (chapterTotal === undefined) return map
     const firstStat = (projectStatsQuery.data ?? [])[0]
     if (!firstStat) return map
     for (const r of firstStat.roundApplicationStatistics) {
-      map.set(toRoundNumber(r.matchingRound.phase), chapterTotal)
+      map.set(
+        toRoundNumber(r.matchingRound.phase),
+        Number(r.availableMemberCount),
+      )
     }
     return map
-  }, [projectStatsQuery.data, chapterTotal])
+  }, [projectStatsQuery.data])
+
+  // schoolId -> schoolName 매핑 (학교별 지원 통계 표시용)
+  const schoolsQuery = useQuery({
+    queryKey: ["schools", "all"],
+    queryFn: getAllSchools,
+  })
+  const schoolIdToName = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const s of schoolsQuery.data?.schools ?? []) {
+      map.set(s.schoolId, s.schoolName)
+    }
+    return map
+  }, [schoolsQuery.data])
 
   // 서버 데이터 -> 프론트 타입으로 변환
   const transformed: ProjectApplication[] = useMemo(
@@ -221,12 +188,11 @@ export function useChallengerPageData() {
     projects: transformed,
     projectInfo,
     currentRound,
-    activeRound,
     availablePerRound,
     projectStats: projectStatsQuery.data ?? [],
+    schoolIdToName,
     isLoading:
       gisuQuery.isLoading ||
-      roundsQuery.isLoading ||
       projectsQuery.isLoading ||
       applicantsQuery.isLoading ||
       projectStatsQuery.isLoading,

--- a/src/features/application/ui/ApplicationStatsSection.tsx
+++ b/src/features/application/ui/ApplicationStatsSection.tsx
@@ -178,7 +178,7 @@ export function ApplicationStatsSection({
                       </span>
                       <div className="text-label-4-medium text-teal-gray-500 flex items-center justify-end gap-0.5">
                         <span>/</span>
-                        <span className="w-8">{r.total}명</span>
+                        <span className="shrink-0">{r.total}명</span>
                       </div>
                     </div>
                   </div>
@@ -271,7 +271,7 @@ export function ApplicationStatsSection({
                 </span>
                 <div className="flex items-center gap-1 text-[12px] leading-[1.4]">
                   <span className="text-label-3-semibold text-teal-500">
-                    {String(u.applied).padStart(2, "0")}명
+                    {u.applied}명
                   </span>
                   <span className="text-label-4-medium text-teal-gray-500">
                     / {u.total}명

--- a/src/features/application/ui/ChallengerApplicationView.tsx
+++ b/src/features/application/ui/ChallengerApplicationView.tsx
@@ -2,14 +2,18 @@ import { useMemo } from "react"
 
 import { cn } from "@/shared/lib/utils"
 
+import { shortenSchoolName, toRoundNumber } from "../model/mappers"
 import { ApplicationTableSection } from "./ApplicationTableSection"
 import { ChallengerStatsSection } from "./ChallengerStatsSection"
 
+import type { ProjectStatisticsResponse } from "../model/apiTypes"
 import type { ChallengerStats, ProjectApplication } from "../model/types"
 
 interface ChallengerApplicationViewProps {
   projects: ProjectApplication[]
   availablePerRound?: Map<number, number>
+  projectStats?: ProjectStatisticsResponse[]
+  schoolIdToName?: Map<string, string>
   currentRound?: number
   className?: string
 }
@@ -18,16 +22,60 @@ interface ChallengerApplicationViewProps {
 function computeStats(
   projects: ProjectApplication[],
   availablePerRound?: Map<number, number>,
+  projectStats?: ProjectStatisticsResponse[],
+  schoolIdToName?: Map<string, string>,
+  currentRound?: number,
 ): ChallengerStats {
+  const firstStat = projectStats?.[0]
+
+  // 서버 통계가 있으면 직접 사용
+  if (firstStat) {
+    const rounds = firstStat.roundApplicationStatistics
+      .map((r) => ({
+        round: toRoundNumber(r.matchingRound.phase),
+        applied: Number(r.appliedMemberCount),
+        total: Number(r.availableMemberCount),
+      }))
+      .sort((a, b) => a.round - b.round)
+
+    // 현재 차수 학교별 지원자 수 (상위 5개)
+    const targetPhase =
+      currentRound === 1
+        ? "FIRST"
+        : currentRound === 2
+          ? "SECOND"
+          : currentRound === 3
+            ? "THIRD"
+            : "FIRST"
+    const targetSchools = firstStat.schoolApplicationStatistics.find(
+      (s) => s.matchingRound.phase === targetPhase,
+    )
+    const universities = (targetSchools?.schools ?? [])
+      .map((s) => ({
+        name: shortenSchoolName(schoolIdToName?.get(s.schoolId) ?? s.schoolId),
+        count: Number(s.applicantCount),
+      }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5)
+
+    // 현재 차수 기준 지원률
+    const targetRound = rounds.find((r) => r.round === (currentRound ?? 1))
+    const totalApplicants = targetRound?.applied ?? 0
+    const available = targetRound?.total ?? 0
+    const completionRate =
+      available > 0 ? Math.round((totalApplicants / available) * 100) : 0
+
+    return { completionRate, rounds, universities, totalApplicants }
+  }
+
+  // 폴백: 서버 통계 없을 때 FE 재집계
   const allApplicants = projects.flatMap((p) => p.applicants)
 
-  // 지원 가용자 = 전체 파트 quota 합산 (availablePerRound 없을 때 폴백용)
   const totalQuota = projects.reduce(
     (sum, p) => sum + p.designCount.total + p.feCount.total + p.beCount.total,
     0,
   )
 
-  // 차수별 지원자 수 집계
   const roundMap = new Map<number, number>()
   for (const a of allApplicants) {
     roundMap.set(a.round, (roundMap.get(a.round) ?? 0) + 1)
@@ -41,7 +89,6 @@ function computeStats(
       total: availablePerRound?.get(round) ?? totalQuota,
     }))
 
-  // 대학별 지원자 수 (상위 5개)
   const uniMap = new Map<string, number>()
   for (const a of allApplicants) {
     uniMap.set(a.university, (uniMap.get(a.university) ?? 0) + 1)
@@ -51,7 +98,6 @@ function computeStats(
     .slice(0, 5)
     .map(([name, count]) => ({ name, count }))
 
-  // 지원률 = 지원자 / 지원 가용자 (지부 총원)
   const available = availablePerRound?.values().next().value ?? totalQuota
   const completionRate =
     available > 0 ? Math.round((allApplicants.length / available) * 100) : 0
@@ -67,17 +113,26 @@ function computeStats(
 export function ChallengerApplicationView({
   projects,
   availablePerRound,
+  projectStats,
+  schoolIdToName,
   currentRound,
   className,
 }: ChallengerApplicationViewProps) {
   const stats = useMemo(
-    () => computeStats(projects, availablePerRound),
-    [projects, availablePerRound],
+    () =>
+      computeStats(
+        projects,
+        availablePerRound,
+        projectStats,
+        schoolIdToName,
+        currentRound,
+      ),
+    [projects, availablePerRound, projectStats, schoolIdToName, currentRound],
   )
 
   return (
     <div className={cn("flex flex-col gap-14.25 pl-4", className)}>
-      <ChallengerStatsSection stats={stats} />
+      <ChallengerStatsSection stats={stats} currentRound={currentRound} />
       <ApplicationTableSection
         projects={projects}
         searchPlaceholder="닉네임/이름으로 검색하세요."

--- a/src/features/application/ui/ChallengerStatsSection.tsx
+++ b/src/features/application/ui/ChallengerStatsSection.tsx
@@ -14,11 +14,13 @@ const ROUND_COLORS = [
 
 interface ChallengerStatsSectionProps {
   stats: ChallengerStats
+  currentRound?: number
   className?: string
 }
 
 export function ChallengerStatsSection({
   stats,
+  currentRound,
   className,
 }: ChallengerStatsSectionProps) {
   return (
@@ -62,24 +64,27 @@ export function ChallengerStatsSection({
 
           {/* 우측 범례: 1차 17명 / 2차 2명 */}
           <div className="absolute top-20.5 left-53.25 flex w-27.5 flex-col gap-0.5">
-            {stats.rounds.slice(0, 2).map((r) => (
-              <div
-                key={r.round}
-                className="flex items-center justify-between px-0.5"
-              >
-                <span className="text-subtitle-3-semibold text-teal-gray-800 w-7">
-                  {r.round}차
-                </span>
-                <div className="flex items-center gap-px whitespace-nowrap">
-                  <span className="text-subtitle-3-semibold text-teal-500">
-                    {r.applied}
+            {[...stats.rounds]
+              .sort((a, b) => b.applied - a.applied)
+              .slice(0, 2)
+              .map((r) => (
+                <div
+                  key={r.round}
+                  className="flex items-center justify-between px-0.5"
+                >
+                  <span className="text-subtitle-3-semibold text-teal-gray-800 w-7">
+                    {r.round}차
                   </span>
-                  <span className="text-subtitle-3-semibold text-teal-500">
-                    명
-                  </span>
+                  <div className="flex items-center gap-px whitespace-nowrap">
+                    <span className="text-subtitle-3-semibold text-teal-500">
+                      {r.applied}
+                    </span>
+                    <span className="text-subtitle-3-semibold text-teal-500">
+                      명
+                    </span>
+                  </div>
                 </div>
-              </div>
-            ))}
+              ))}
           </div>
 
           {/* 하단 차수별 breakdown */}
@@ -97,7 +102,7 @@ export function ChallengerStatsSection({
                     </span>
                     <div className="text-label-4-medium text-teal-gray-500 flex items-center justify-end gap-0.5">
                       <span>/</span>
-                      <span className="w-8">{r.total}명</span>
+                      <span className="shrink-0">{r.total}명</span>
                     </div>
                   </div>
                 </div>
@@ -110,7 +115,7 @@ export function ChallengerStatsSection({
         <div className="shadow-drop-neutral-3 border-teal-gray-100 flex w-121 shrink-0 flex-col gap-9.5 rounded-xl border bg-white px-8 pt-7 pb-8">
           <div className="flex items-center justify-between px-2.5">
             <h3 className="text-heading-6-semibold text-teal-700">
-              1차 매칭 지원
+              {currentRound ?? 1}차 매칭 지원
             </h3>
             <div className="flex items-center gap-2.5">
               <PersonGraphicIcon

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -20,7 +20,7 @@ import {
   isChapterPresident,
   isCurrentTermPm,
   isOperator,
-  isSchoolStaff,
+  isSchoolLeadership,
   isSuperAdmin,
 } from "@/features/auth/model/identity"
 import { ProjectTitleCard } from "@/shared/ui/ProjectTitleCard"
@@ -55,12 +55,12 @@ function MatchingApplicationsPage() {
   // 지부장 본인 지부 추적 (auto-select 후 갱신)
   const ownChapter = useRef<string>(defaultChapter)
 
-  const canApprove = isOperator(viewMe)
-  // 지부장 본인 지부만 조회 가능 (SUPER_ADMIN/중앙 운영진 제외)
+  const canApprove = isOperator(viewMe) || isSchoolLeadership(viewMe)
+  // 지부장·학교 회장: 본인 지부만 조회 가능 (SUPER_ADMIN/중앙 운영진 제외)
   const isRestrictedToChapter =
-    isChapterPresident(me) && !isSuperAdmin(me) && !isCentralStaff(me)
-  // SCHOOL_PRESIDENT 등 학교 운영진: APPLY-101 목록 조회 가능, APPLY-102 상세 불가
-  const isSchoolView = !canApprove && isSchoolStaff(viewMe)
+    (isChapterPresident(me) || isSchoolLeadership(me)) &&
+    !isSuperAdmin(me) &&
+    !isCentralStaff(me)
   const isPm = isCurrentTermPm(viewMe)
   const isOthers = !isAnyOperator(viewMe) && !isPm
 
@@ -82,11 +82,7 @@ function MatchingApplicationsPage() {
     }
   }, [me, chapters, userChapter])
 
-  // SCHOOL_PRESIDENT: 챕터 필터 없이 조회 후 프론트에서 본인 학교 프로젝트만 필터링
-  const admin = useAdminPageData(
-    selectedChapter,
-    isSchoolView ? (me?.schoolName ?? undefined) : undefined,
-  )
+  const admin = useAdminPageData(selectedChapter)
   const adminStats = admin.stats
   const adminProjects = admin.projects
 
@@ -146,49 +142,6 @@ function MatchingApplicationsPage() {
                     projects={adminProjects}
                     currentRound={admin.currentRound}
                     chapterName={selectedChapter}
-                  />
-                </div>
-              )}
-            </div>
-          )}
-
-          {isSchoolView && (
-            <div className="flex w-263 flex-col gap-13">
-              <SegmentButton
-                items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
-                value={selectedChapter}
-                onValueChange={(v) => {
-                  if (v !== selectedChapter) {
-                    addToast({
-                      message: "본인 학교의 지원 현황만 조회할 수 있습니다.",
-                      color: "red",
-                      variant: "deep",
-                      type: "default",
-                      duration: 3000,
-                    })
-                  }
-                }}
-                className="w-full min-w-0 [&>button>span:last-child]:min-w-0 [&>button>span:last-child]:truncate"
-                itemClassName="min-w-0 flex-1 basis-0 shrink px-2"
-              />
-              {admin.isLoading ? (
-                <div className="flex items-center justify-center py-20">
-                  <p className="text-body-2-regular text-teal-gray-400">
-                    데이터를 불러오는 중...
-                  </p>
-                </div>
-              ) : (
-                <div className="flex flex-col gap-14.25">
-                  <ApplicationStatsSection
-                    stats={adminStats}
-                    dataUpdatedAt={admin.dataUpdatedAt}
-                    currentRound={admin.currentRound}
-                    activeRound={admin.activeRound}
-                  />
-                  <ApplicationTableSection
-                    projects={adminProjects}
-                    currentRound={admin.currentRound}
-                    disableFormPanel
                   />
                 </div>
               )}

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -160,6 +160,8 @@ function MatchingApplicationsPage() {
                 <ChallengerApplicationView
                   projects={[]}
                   availablePerRound={availablePerRound}
+                  projectStats={challenger.projectStats}
+                  schoolIdToName={challenger.schoolIdToName}
                   currentRound={challenger.currentRound}
                 />
               ) : (
@@ -175,6 +177,10 @@ function MatchingApplicationsPage() {
                     <ChallengerApplicationView
                       projects={[project]}
                       availablePerRound={availablePerRound}
+                      projectStats={challenger.projectStats.filter(
+                        (s) => s.projectId === String(project.id),
+                      )}
+                      schoolIdToName={challenger.schoolIdToName}
                       currentRound={challenger.currentRound}
                     />
                   </div>


### PR DESCRIPTION
## 📸 작업 내용

- PM 지원 통계를 FE 재집계에서 서버 projectStatistics API 값 직접 사용으로 전환
- PM 현재 차수 판별을 getMatchingRounds 대신 서버 통계 기반으로 변경
- SCHOOL_PRESIDENT 지원 현황을 지부장과 동일한 뷰로 통합
- 총원 카드 0n명 -> n명 표시 수정


## 🎞️ 주요 코드 설명
### `SCHOOL_PRESIDENT 뷰 통합`

```typescript
  // applications.tsx
  const canApprove = isOperator(viewMe) || isSchoolLeadership(viewMe)
  const isRestrictedToChapter =
    (isChapterPresident(me) || isSchoolLeadership(me)) &&
    !isSuperAdmin(me) && !isCentralStaff(me)
```
  - 기존 isSchoolView 분기 제거, 지부장과 동일한 Admin 뷰 사용
  - 본인 지부 외 선택 시 토스트 제한 동일 적용

## 🔗 연결된 이슈
- Closed #361 