### PR TITLE
fix: 디자인 QA 반영

### DIFF
--- a/src/features/application/ui/ApplicationDetailModal.tsx
+++ b/src/features/application/ui/ApplicationDetailModal.tsx
@@ -146,12 +146,15 @@ export function ApplicationDetailModal({
       queryClient.invalidateQueries({ queryKey: applicationKeys.all })
     },
     onError: (error, variables) => {
-      // 서버 에러 메시지 토스트
+      // 서버 에러 메시지 -> 사용자 친화 문구 변환
       const serverMessage = isAxiosError(error)
         ? error.response?.data?.message
         : undefined
+      const displayMessage = serverMessage?.includes("최소 선발 인원")
+        ? "팀 인원이 부족해 지금은 불합격 처리할 수 없습니다."
+        : (serverMessage ?? "배정 상태 변경에 실패했습니다.")
       addToast({
-        message: serverMessage ?? "배정 상태 변경에 실패했습니다.",
+        message: displayMessage,
         color: "red",
         variant: "deep",
         type: "default",

--- a/src/features/application/ui/ApplicationDetailModal.tsx
+++ b/src/features/application/ui/ApplicationDetailModal.tsx
@@ -67,7 +67,7 @@ export function ApplicationDetailModal({
     if (project.applicants.length === 0 && !emptyToastShownRef.current) {
       emptyToastShownRef.current = true
       addToast({
-        message: "아직 지원자가 없습니다.",
+        message: "아직 지원자한 챌린저가 없습니다.",
         color: "primary",
         variant: "deep",
         type: "default",
@@ -221,7 +221,7 @@ export function ApplicationDetailModal({
       <Modal.Portal>
         <Modal.Overlay tone="deep" />
         <Modal.Content
-          className="flex max-h-[calc(100vh-60px)] items-start gap-4"
+          className="top-20! bottom-7.5! flex h-[calc(100vh-110px)]! translate-y-0! items-start gap-4"
           aria-describedby={undefined}
           onOpenAutoFocus={(e) => e.preventDefault()}
           onEscapeKeyDown={(e) => {
@@ -244,7 +244,7 @@ export function ApplicationDetailModal({
             {project.projectName} 지원 현황 상세
           </Modal.Title>
 
-          <div className="flex w-185 shrink-0 overflow-hidden rounded-xl bg-white shadow-xl">
+          <div className="flex h-full w-185 shrink-0 overflow-hidden rounded-xl bg-white shadow-xl">
             <ModalApplicantPanel
               project={projectWithOverrides}
               chapterName={chapterName}

--- a/src/features/application/ui/ApplicationStatsSection.tsx
+++ b/src/features/application/ui/ApplicationStatsSection.tsx
@@ -1,3 +1,4 @@
+import { SectionHeader } from "@/features/project/new/ui/shared/SectionHeader"
 import PersonGraphicIcon from "@/shared/assets/icon/people/PersonGraphicIcon"
 import { cn } from "@/shared/lib/utils"
 
@@ -28,7 +29,6 @@ interface ApplicationStatsSectionProps {
 
 const VARIANT_LABELS = {
   application: {
-    sectionTitle: "01 지원 통계",
     completedLabel: "지원 완료",
     pendingLabel: "지원 전",
     roundSuffix: "지원",
@@ -36,7 +36,6 @@ const VARIANT_LABELS = {
     projectSectionTitle: "프로젝트별 지원 현황",
   },
   matching: {
-    sectionTitle: "01 매칭 통계",
     completedLabel: "매칭 완료",
     pendingLabel: "매칭 전",
     roundSuffix: "매칭",
@@ -77,9 +76,11 @@ export function ApplicationStatsSection({
     <div className={cn("flex flex-col gap-4", className)}>
       {/* 섹션 헤더 */}
       <div className="flex items-center justify-between">
-        <h2 className="text-heading-6-semibold text-teal-700">
-          {labels.sectionTitle}
-        </h2>
+        <SectionHeader
+          index={1}
+          title={variant === "application" ? "지원 통계" : "매칭 통계"}
+          level={2}
+        />
         {dataUpdatedAt ? (
           <span className="text-caption-1-regular text-teal-gray-400">
             {formatUpdatedAt(dataUpdatedAt)}

--- a/src/features/application/ui/ApplicationTableSection.tsx
+++ b/src/features/application/ui/ApplicationTableSection.tsx
@@ -311,22 +311,29 @@ export function ApplicationTableSection({
                 }}
               />
 
-              {isExpanded && project.applicants.length > 0 && (
-                <div className="border-teal-gray-150 border-b-[3px] py-1">
-                  {project.applicants.map((applicant) => (
-                    <ApplicantDetailRow
-                      key={applicant.id}
-                      round={applicant.round}
-                      role={applicant.role}
-                      name={applicant.name}
-                      university={applicant.university}
-                      status={applicant.status}
-                      processedAt={applicant.processedAt}
-                      appliedAt={applicant.appliedAt}
-                    />
-                  ))}
-                </div>
-              )}
+              {isExpanded &&
+                (project.applicants.length > 0 ? (
+                  <div className="border-teal-gray-150 py-1">
+                    {project.applicants.map((applicant) => (
+                      <ApplicantDetailRow
+                        key={applicant.id}
+                        round={applicant.round}
+                        role={applicant.role}
+                        name={applicant.name}
+                        university={applicant.university}
+                        status={applicant.status}
+                        processedAt={applicant.processedAt}
+                        appliedAt={applicant.appliedAt}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <div className="border-teal-gray-150 flex h-17 items-center justify-center border-b-[3px]">
+                    <p className="text-body-2-medium text-teal-gray-400">
+                      아직 지원자가 없습니다
+                    </p>
+                  </div>
+                ))}
             </div>
           )
         })}

--- a/src/features/application/ui/ApplicationTableSection.tsx
+++ b/src/features/application/ui/ApplicationTableSection.tsx
@@ -328,7 +328,7 @@ export function ApplicationTableSection({
                     ))}
                   </div>
                 ) : (
-                  <div className="border-teal-gray-150 flex h-17 items-center justify-center border-b-[3px]">
+                  <div className="border-teal-gray-150 flex h-17 items-center justify-center">
                     <p className="text-body-2-medium text-teal-gray-400">
                       아직 지원자가 없습니다
                     </p>

--- a/src/features/application/ui/ApplicationTableSection.tsx
+++ b/src/features/application/ui/ApplicationTableSection.tsx
@@ -5,6 +5,7 @@ import {
   FilterDropdown,
   type FilterDropdownProps,
 } from "@/features/project/list/ui/FilterDropDown"
+import { SectionHeader } from "@/features/project/new/ui/shared/SectionHeader"
 import { cn } from "@/shared/lib/utils"
 import { Pagination } from "@/shared/ui/Pagination"
 
@@ -249,7 +250,7 @@ export function ApplicationTableSection({
   return (
     <div className={cn("flex flex-col gap-6", className)}>
       {/* 섹션 헤더 */}
-      <h2 className="text-heading-6-semibold text-teal-700">02 지원자 목록</h2>
+      <SectionHeader index={2} title="지원자 목록" level={2} />
 
       {/* 검색 + 필터 */}
       <div className="flex items-center justify-between">

--- a/src/features/application/ui/ChallengerStatsSection.tsx
+++ b/src/features/application/ui/ChallengerStatsSection.tsx
@@ -1,3 +1,4 @@
+import { SectionHeader } from "@/features/project/new/ui/shared/SectionHeader"
 import PersonGraphicIcon from "@/shared/assets/icon/people/PersonGraphicIcon"
 import { cn } from "@/shared/lib/utils"
 
@@ -14,18 +15,18 @@ const ROUND_COLORS = [
 
 interface ChallengerStatsSectionProps {
   stats: ChallengerStats
+  currentRound?: number
   className?: string
 }
 
 export function ChallengerStatsSection({
   stats,
+  currentRound,
   className,
 }: ChallengerStatsSectionProps) {
   return (
     <div className={cn("flex flex-col gap-4", className)}>
-      <h2 className="text-heading-6-semibold text-teal-700">
-        01 내 프로젝트 지원 통계
-      </h2>
+      <SectionHeader index={1} title="내 프로젝트 지원 통계" level={2} />
 
       <div className="flex gap-4">
         {/* 매칭 차수별 지원률 */}
@@ -46,7 +47,7 @@ export function ChallengerStatsSection({
             />
           </div>
 
-          {/* 커넥터 라인 (도넛 -> 1차 범례) */}
+          {/* 커넥터 라인 (도넛 -> 범례) */}
           <svg
             width="40"
             height="12"
@@ -60,26 +61,29 @@ export function ChallengerStatsSection({
             />
           </svg>
 
-          {/* 우측 범례: 1차 17명 / 2차 2명 */}
+          {/* 우측 범례: 지원자 수 상위 2개 차수 */}
           <div className="absolute top-20.5 left-53.25 flex w-27.5 flex-col gap-0.5">
-            {stats.rounds.slice(0, 2).map((r) => (
-              <div
-                key={r.round}
-                className="flex items-center justify-between px-0.5"
-              >
-                <span className="text-subtitle-3-semibold text-teal-gray-800 w-7">
-                  {r.round}차
-                </span>
-                <div className="flex items-center gap-px whitespace-nowrap">
-                  <span className="text-subtitle-3-semibold text-teal-500">
-                    {r.applied}
+            {[...stats.rounds]
+              .sort((a, b) => b.applied - a.applied)
+              .slice(0, 2)
+              .map((r) => (
+                <div
+                  key={r.round}
+                  className="flex items-center justify-between px-0.5"
+                >
+                  <span className="text-subtitle-3-semibold text-teal-gray-800 w-7">
+                    {r.round}차
                   </span>
-                  <span className="text-subtitle-3-semibold text-teal-500">
-                    명
-                  </span>
+                  <div className="flex items-center gap-px whitespace-nowrap">
+                    <span className="text-subtitle-3-semibold text-teal-500">
+                      {r.applied}
+                    </span>
+                    <span className="text-subtitle-3-semibold text-teal-500">
+                      명
+                    </span>
+                  </div>
                 </div>
-              </div>
-            ))}
+              ))}
           </div>
 
           {/* 하단 차수별 breakdown */}
@@ -97,7 +101,7 @@ export function ChallengerStatsSection({
                     </span>
                     <div className="text-label-4-medium text-teal-gray-500 flex items-center justify-end gap-0.5">
                       <span>/</span>
-                      <span className="w-8">{r.total}명</span>
+                      <span className="shrink-0">{r.total}명</span>
                     </div>
                   </div>
                 </div>
@@ -106,11 +110,11 @@ export function ChallengerStatsSection({
           </div>
         </div>
 
-        {/* 1차 매칭 지원 */}
+        {/* N차 매칭 지원 */}
         <div className="shadow-drop-neutral-3 border-teal-gray-100 flex w-121 shrink-0 flex-col gap-9.5 rounded-xl border bg-white px-8 pt-7 pb-8">
           <div className="flex items-center justify-between px-2.5">
             <h3 className="text-heading-6-semibold text-teal-700">
-              1차 매칭 지원
+              {currentRound ?? 1}차 매칭 지원
             </h3>
             <div className="flex items-center gap-2.5">
               <PersonGraphicIcon

--- a/src/features/application/ui/detail-modal/ApplicantRoleSection.tsx
+++ b/src/features/application/ui/detail-modal/ApplicantRoleSection.tsx
@@ -40,7 +40,12 @@ export function ApplicantRoleSection({
   return (
     <div className={cn("flex flex-col", className)}>
       {/* 섹션 헤더 */}
-      <div className="flex h-6.5 items-center justify-between pr-0.5 pl-2.5">
+      <div
+        className={cn(
+          "flex items-center justify-between pr-0.5 pl-2.5",
+          applicants.length === 0 ? "h-20" : "h-6.5",
+        )}
+      >
         <div className="flex items-center gap-2.25">
           <PartTagChip role={role} />
           <span className="text-body-1-medium text-teal-gray-400 flex items-center gap-0.5">

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -33,6 +33,7 @@ import { BranchSelector } from "@/features/matching/ui/BranchSelector"
 import { Calendar } from "@/features/matching/ui/Calendar"
 import { CalendarScheduleList } from "@/features/matching/ui/CalendarScheduleList"
 import { RoundForm } from "@/features/matching/ui/RoundForm"
+import { SectionHeader } from "@/features/project/new/ui/shared/SectionHeader"
 import { UsabilitySurvey } from "@/features/usability-survey"
 import InfoCircleIcon from "@/shared/assets/icon/infomation/InfoCircleIcon"
 import { Button } from "@/shared/ui/Button"
@@ -532,9 +533,7 @@ function MatchingRoundsPage() {
             <div className="flex flex-col gap-8.5 pl-4">
               {/* 헤딩 + 지부 선택 */}
               <div className="flex flex-col gap-4">
-                <h2 className="text-heading-6-semibold text-teal-700">
-                  <span className="text-teal-600">01</span> 매칭 기간 설정
-                </h2>
+                <SectionHeader index={1} title="매칭 기간 설정" level={2} />
                 <div className="pl-8.5">
                   <div className="flex items-center gap-6">
                     <span className="text-label-1-semibold text-teal-gray-700">

--- a/src/routes/matching/status.tsx
+++ b/src/routes/matching/status.tsx
@@ -14,6 +14,7 @@ import { useMatchingStatusData } from "@/features/matching/hooks/useMatchingStat
 import { MatchingPartSection } from "@/features/matching/ui/MatchingPartSection"
 import { MatchingResultRow } from "@/features/matching/ui/MatchingResultRow"
 import { MatchingTableHead } from "@/features/matching/ui/MatchingTableHead"
+import { SectionHeader } from "@/features/project/new/ui/shared/SectionHeader"
 import { SegmentButton } from "@/shared/ui/segment-button/SegmentButton"
 import { type Chapter, CHAPTERS } from "@/shared/ui/segment/ChapterSelector"
 
@@ -123,9 +124,7 @@ function MatchingStatusPage() {
 
               {/* 02 매칭 결과 시트 */}
               <div className="flex flex-col gap-4">
-                <h2 className="text-heading-6-semibold text-teal-700">
-                  <span className="text-teal-600">02</span> 매칭 결과 시트
-                </h2>
+                <SectionHeader index={2} title="매칭 결과 시트" level={2} />
 
                 <div className="flex w-263 flex-col gap-6">
                   {displayParts.map((part) => (


### PR DESCRIPTION
## 📸 작업 내용

 - 지원 현황 페이지 전반의 디자인 QA 반영
  - 섹션 제목을 공용 SectionHeader 컴포넌트로 교체
  - 지원자 목록 빈 상태 UI 추가
  - 지원 현황 상세 모달 레이아웃 개선 (높이 확장, 빈 파트 섹션 높이 조정)
  - 합불 처리 에러 토스트 문구 사용자 친화적으로 수정


## 🔗 연결된 이슈

- Closed #363