### PR TITLE
🔖 chore: 버전 1.0.0으로 bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "umc-product-web-v2",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## 📸 작업 내용

> v1.0.0 첫 공식 배포에 맞춰 패키지 버전을 명시합니다.

- `package.json` version `0.0.0` → `1.0.0`
- 1차 main 배포(PR #369, 이슈 #368)에 따른 버전 확정

## 🔗 연결된 이슈

- Connected: #368