### PR TITLE
🚀 chore: v1.0.1 main 배포 (develop → main)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "umc-product-web-v2",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -92,7 +92,7 @@ export function Toast({
           />
           <span
             className={cn(
-              "text-center wrap-break-word",
+              "text-center wrap-break-word whitespace-pre-line",
               textColorMap[resolvedColor],
             )}
           >
@@ -115,7 +115,10 @@ export function Toast({
               className={cn("shrink-0", iconColorMap[resolvedColor])}
             />
             <span
-              className={cn("wrap-break-word", textColorMap[resolvedColor])}
+              className={cn(
+                "wrap-break-word whitespace-pre-line",
+                textColorMap[resolvedColor],
+              )}
             >
               {message}
             </span>

--- a/src/features/auth/hooks/useOAuthLinking.ts
+++ b/src/features/auth/hooks/useOAuthLinking.ts
@@ -1,4 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query"
+import { isAxiosError } from "axios"
 import { useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
@@ -156,11 +157,15 @@ export function useOAuthLinking() {
         duration: 3000,
       })
     } catch (err) {
+      const errorCode = isAxiosError(err)
+        ? (err.response?.data as { code?: string } | undefined)?.code
+        : undefined
+      const message =
+        errorCode === "AUTHENTICATION-0016"
+          ? "비밀번호가 없는 계정은 마지막 소셜 연동을 해제할 수 없어요.\n비밀번호를 먼저 설정해주세요."
+          : "연동 해제에 실패했습니다. 다시 시도해주세요."
       addToast({
-        message:
-          err instanceof Error
-            ? err.message
-            : "연동 해제에 실패했습니다. 다시 시도해주세요.",
+        message,
         color: "red",
         variant: "deep",
         type: "default",

--- a/src/features/project/list/model/projectDetailCta.ts
+++ b/src/features/project/list/model/projectDetailCta.ts
@@ -6,6 +6,7 @@ export type ProjectDetailCtaMode =
   | "apply-blocked-approved"
   | "apply-blocked-part"
   | "apply-blocked-closed"
+  | "other-branch"
   | "no-active-round"
   | "plan-only"
 
@@ -35,8 +36,8 @@ export function resolveProjectDetailCtaMode({
   hasActiveRound,
 }: ResolveCtaParams): ProjectDetailCtaMode {
   if (isOperator) return "recruit-questions"
-  if (!isSameBranch) return "plan-only"
   if (isPm) return "recruit-questions"
+  if (!isSameBranch) return "other-branch"
   if (isApplied && isDraftApplication) return "apply"
   if (isApplied) return "my-application"
   if (isAlreadyApproved) return "apply-blocked-approved"

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -682,6 +682,17 @@ export function ProjectDetailCard({
                     </Button>
                   </>
                 )}
+                {ctaMode === "other-branch" && (
+                  <Button
+                    variant="weak"
+                    color="primary"
+                    className="min-w-32 flex-1 whitespace-nowrap"
+                    disabled={!detail?.applicationFormId}
+                    onClick={() => setIsRecruitQuestionsModalOpen(true)}
+                  >
+                    모집 문항 보기
+                  </Button>
+                )}
               </>
             )}
           </div>

--- a/src/features/settings/ui/ChangeEmailForm.tsx
+++ b/src/features/settings/ui/ChangeEmailForm.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
@@ -42,6 +43,7 @@ export function ChangeEmailForm({
   const [openResendModal, setOpenResendModal] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const addToast = useToastStore((s) => s.addToast)
+  const queryClient = useQueryClient()
 
   const handleSubmit = async () => {
     setIsSubmitting(true)
@@ -49,6 +51,7 @@ export function ChangeEmailForm({
       const token = await handleCodeVerify()
       if (!token) return
       await changeEmail({ newEmail: next, emailVerificationToken: token })
+      await queryClient.invalidateQueries({ queryKey: ["auth", "me"] })
       addToast({
         message: "이메일이 변경되었습니다.",
         color: "primary",


### PR DESCRIPTION
## 📸 작업 내용

> v1.0.0 이후 develop에 누적된 변경사항을 main에 반영합니다.

- 카카오 계정 연동 해제 구현 및 마지막 소셜 연동 대상 에러 메시지 수정 (PR #371)
- 다른 지부 일반 챌린저 대상 프로젝트 상세 페이지에서 '모집 문항 보기' 버튼 렌더링 (PR #372)
- 이메일 변경 후 화면 갱신 안 되는 문제 수정
- 프로젝트 카드 QA 반영 (PR #372)
- `package.json` 버전 1.0.0 bump (PR #370)

## 🖥️ 구현화면

> 각 기능별 PR에서 검수 완료된 변경의 통합 배포로, 별도 캡처는 생략합니다.

## 🔗 연결된 이슈

- Connected: #373
- Closes #373