### PR TITLE
🐛 fix: 프로젝트 관리 카드 로고 잘림 해결

### DIFF
--- a/src/shared/assets/icon/logo/ProjectLogo.tsx
+++ b/src/shared/assets/icon/logo/ProjectLogo.tsx
@@ -10,24 +10,29 @@ type ProjectLogoSize = 30 | 32 | 40 | 50
 type ProjectLogoSizeConfig = {
   box: string
   logo: string
+  padding: string
 }
 
 const sizeConfig: Record<ProjectLogoSize, ProjectLogoSizeConfig> = {
   30: {
-    box: "h-[1.875rem] w-[1.875rem] px-[5px]",
+    box: "h-[1.875rem] w-[1.875rem]",
     logo: "h-[6px] w-[20px]",
+    padding: "px-[5px]",
   },
   32: {
-    box: "h-8 w-8 px-[4px]",
+    box: "h-8 w-8",
     logo: "h-[7px] w-[24px]",
+    padding: "px-[4px]",
   },
   40: {
-    box: "h-10 w-10 px-[5px]",
+    box: "h-10 w-10",
     logo: "h-[9px] w-[30px]",
+    padding: "px-[5px]",
   },
   50: {
-    box: "h-[3.125rem] w-[3.125rem] pr-[8.365px] pl-[7.999px]",
+    box: "h-[3.125rem] w-[3.125rem]",
     logo: "h-[10px] w-[33.636px]",
+    padding: "pr-[8.365px] pl-[7.999px]",
   },
 }
 
@@ -40,13 +45,14 @@ export function ProjectLogo({
 }) {
   const [erroredSrc, setErroredSrc] = useState<string | null>(null)
   const showFallback = !src || erroredSrc === src
-  const { box, logo } = sizeConfig[size]
+  const { box, logo, padding } = sizeConfig[size]
 
   return (
     <div
       className={cn(
         "bg-teal-gray-200 flex shrink-0 items-center justify-center overflow-hidden rounded-lg",
         box,
+        showFallback && padding,
       )}
     >
       {showFallback ? (


### PR DESCRIPTION
## 📸 작업 내용

> 프로젝트 관리 카드 로고 잘림 이슈 해결
- 패딩 분리

## 🎞️ 주요 코드 설명

## 🖥️ 구현화면

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #375 