### PR TITLE
✨ feat: 로그인 returnTo 리다이렉트 및 프로젝트 관리 매칭 기간 지부 기준 수정

### DIFF
--- a/src/features/auth/lib/ensureMe.ts
+++ b/src/features/auth/lib/ensureMe.ts
@@ -1,15 +1,20 @@
 import { redirect } from "@tanstack/react-router"
 
 import { getMyInfo, type MemberInfoResponse } from "@/features/auth/api/me"
+import { buildLoginRedirectSearch } from "@/features/auth/lib/loginRedirect"
 import { useAuthStore } from "@/features/auth/store/authStore"
 
 import type { QueryClient } from "@tanstack/react-query"
 
 export async function ensureMe(
   queryClient: QueryClient,
+  returnTo?: string,
 ): Promise<MemberInfoResponse> {
   if (!useAuthStore.getState().isAuthed) {
-    throw redirect({ to: "/login" })
+    throw redirect({
+      to: "/login",
+      search: buildLoginRedirectSearch(returnTo),
+    })
   }
 
   try {
@@ -19,6 +24,9 @@ export async function ensureMe(
       staleTime: 1000 * 60 * 5,
     })
   } catch {
-    throw redirect({ to: "/login" })
+    throw redirect({
+      to: "/login",
+      search: buildLoginRedirectSearch(returnTo),
+    })
   }
 }

--- a/src/features/auth/lib/kakaoSignIn.ts
+++ b/src/features/auth/lib/kakaoSignIn.ts
@@ -1,3 +1,5 @@
+import { rememberLoginReturnTo } from "./loginRedirect"
+
 const KAKAO_REDIRECT_PATH = "/oauth/kakao/callback"
 const KAKAO_STATE_STORAGE_KEY = "kakao_oauth_state"
 const KAKAO_LINK_INTENT_KEY = "kakao_link_intent"
@@ -34,7 +36,7 @@ export function consumeKakaoLinkIntent(): boolean {
   return intent === "link"
 }
 
-export function startKakaoSignIn(): void {
+export function startKakaoSignIn(returnTo?: string): void {
   const appKey = import.meta.env.VITE_KAKAO_APP_KEY as string | undefined
 
   if (!appKey) {
@@ -50,6 +52,7 @@ export function startKakaoSignIn(): void {
 
   const state = generateSecureState()
   sessionStorage.setItem(KAKAO_STATE_STORAGE_KEY, state)
+  rememberLoginReturnTo(returnTo)
 
   window.Kakao.Auth.authorize({
     redirectUri: getKakaoRedirectUri(),

--- a/src/features/auth/lib/loginRedirect.ts
+++ b/src/features/auth/lib/loginRedirect.ts
@@ -1,0 +1,59 @@
+const LOGIN_RETURN_TO_STORAGE_KEY = "login_return_to"
+const DEFAULT_LOGIN_SUCCESS_PATH = "/matching/projects"
+
+export function normalizeReturnTo(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  if (!trimmed.startsWith("/") || trimmed.startsWith("//")) return undefined
+
+  try {
+    const url = new URL(trimmed, "https://umc.local")
+    if (url.origin !== "https://umc.local") return undefined
+    return `${url.pathname}${url.search}${url.hash}`
+  } catch {
+    return undefined
+  }
+}
+
+export function buildLoginRedirectSearch(returnTo?: unknown): {
+  returnTo?: string
+} {
+  const normalized = normalizeReturnTo(returnTo)
+  return normalized ? { returnTo: normalized } : {}
+}
+
+export function rememberLoginReturnTo(returnTo?: unknown): void {
+  if (typeof window === "undefined") return
+  const normalized = normalizeReturnTo(returnTo)
+  if (normalized) {
+    sessionStorage.setItem(LOGIN_RETURN_TO_STORAGE_KEY, normalized)
+    return
+  }
+  sessionStorage.removeItem(LOGIN_RETURN_TO_STORAGE_KEY)
+}
+
+export function readLoginReturnTo(): string | undefined {
+  if (typeof window === "undefined") return undefined
+  return normalizeReturnTo(
+    sessionStorage.getItem(LOGIN_RETURN_TO_STORAGE_KEY) ?? undefined,
+  )
+}
+
+export function clearLoginReturnTo(): void {
+  if (typeof window === "undefined") return
+  sessionStorage.removeItem(LOGIN_RETURN_TO_STORAGE_KEY)
+}
+
+export function resolveLoginSuccessPath(returnTo?: unknown): string {
+  const normalized = normalizeReturnTo(returnTo)
+  const stored = readLoginReturnTo()
+  clearLoginReturnTo()
+  return normalized ?? stored ?? DEFAULT_LOGIN_SUCCESS_PATH
+}
+
+export function getCurrentReturnTo(): string | undefined {
+  if (typeof window === "undefined") return undefined
+  return normalizeReturnTo(
+    `${window.location.pathname}${window.location.search}${window.location.hash}`,
+  )
+}

--- a/src/features/auth/lib/logout.ts
+++ b/src/features/auth/lib/logout.ts
@@ -1,6 +1,8 @@
+import { clearLoginReturnTo } from "@/features/auth/lib/loginRedirect"
 import { useAuthStore } from "@/features/auth/store/authStore"
 
 export function logout() {
+  clearLoginReturnTo()
   useAuthStore.getState().clear()
   window.location.href = "/login"
 }

--- a/src/features/auth/model/identity.test.ts
+++ b/src/features/auth/model/identity.test.ts
@@ -6,6 +6,7 @@ import {
   canManageProjects,
   getProjectPmSearchScope,
   isAnyOperator,
+  isCentralCore,
   isProjectRegistrationQuotaLimited,
   isSchoolLeadership,
 } from "./identity"
@@ -95,6 +96,19 @@ describe("isAnyOperator", () => {
   })
   it("일반 챌린저는 false", () => {
     expect(isAnyOperator(makeMe(["CHALLENGER"]))).toBe(false)
+  })
+})
+
+describe("isCentralCore", () => {
+  it("슈퍼어드민·총괄·부총괄은 true", () => {
+    expect(isCentralCore(makeMe(["SUPER_ADMIN"]))).toBe(true)
+    expect(isCentralCore(makeMe(["CENTRAL_PRESIDENT"]))).toBe(true)
+    expect(isCentralCore(makeMe(["CENTRAL_VICE_PRESIDENT"]))).toBe(true)
+  })
+
+  it("중앙 운영국원·교육국원은 false", () => {
+    expect(isCentralCore(makeMe(["CENTRAL_OPERATING_TEAM_MEMBER"]))).toBe(false)
+    expect(isCentralCore(makeMe(["CENTRAL_EDUCATION_TEAM_MEMBER"]))).toBe(false)
   })
 })
 

--- a/src/features/auth/model/identity.ts
+++ b/src/features/auth/model/identity.ts
@@ -54,6 +54,10 @@ export function isCentralStaff(me: MemberInfoResponse | undefined): boolean {
   return hasAnyRoleType(me, CENTRAL_ROLE_TYPES)
 }
 
+export function isCentralCore(me: MemberInfoResponse | undefined): boolean {
+  return hasAnyRoleType(me, CENTRAL_CORE_ROLE_TYPES)
+}
+
 export function isChapterPresident(
   me: MemberInfoResponse | undefined,
 ): boolean {

--- a/src/features/project/list/model/matchingProject.mock.ts
+++ b/src/features/project/list/model/matchingProject.mock.ts
@@ -84,7 +84,7 @@ const RAW_MOCK_PROJECTS: MatchingProjectMock[] = [
     description:
       "프로젝트 한 줄 소개가 여기에 표시됩니다. 초과 내용 ... 처리 없이 설명 전문이 표시됩니다. 본문 내용 공백 포함 200자 이내 약 4줄 표시됩니다. 프로젝트 한 줄 소개가 여기에 표시됩니다. 초과 내용 ... 처리 없이 설명 전문이 표시됩니다. 본문 내용 공백 포함 200자 이내 약 4줄 표시됩니다. 프로젝트 한줄 소개가 여기에 표시됩니다. 초과 내용 ... 처리 없이 설명 전문이 표시됩",
     authorSchoolLine: "닉네임/이름 · 한양대 ERICA",
-    externalLink: "https://issac.app",
+    externalLink: "https://example.com",
     coverImage: {
       src: "https://picsum.photos/seed/umc-matching-1/696/368",
       alt: "프로젝트 대표 이미지",

--- a/src/features/project/management/ui/ProjectManagementCard.tsx
+++ b/src/features/project/management/ui/ProjectManagementCard.tsx
@@ -12,7 +12,6 @@ import { Modal } from "@/shared/ui/Modal"
 import { ProjectThumbnail } from "@/shared/ui/ProjectThumbnail"
 
 import { isRecruitDone } from "../../list/model/matchingProject"
-import { useIsMatchingPeriod } from "../../new/hooks/useIsMatchingPeriod"
 import { ProjectManagementMoreMenu } from "./ProjectManagementMoreMenu"
 
 import type { MatchingProject } from "../../list/model/matchingProject"
@@ -23,6 +22,7 @@ interface ProjectManagementCardProps {
   canEditProject: boolean
   canPublishProject: boolean
   isPermissionLoading: boolean
+  isMatchingPeriod: boolean
 }
 
 export function ProjectManagementCard({
@@ -31,8 +31,8 @@ export function ProjectManagementCard({
   canEditProject,
   canPublishProject,
   isPermissionLoading,
+  isMatchingPeriod,
 }: ProjectManagementCardProps) {
-  const isMatchingPeriod = useIsMatchingPeriod()
   const cover = data.coverImage
   const [open, setOpen] = useState(false)
   const projectId = Number(data.id)

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -5,14 +5,14 @@ import { useMemo, useState } from "react"
 import { useResourcePermissionsBatch } from "@/features/auth/hooks/useResourcePermissionsBatch"
 import {
   isAnyOperator,
-  isCentralStaff,
+  isCentralCore,
   isChapterPresident,
   isCurrentTermPm,
   isSchoolStaff,
-  isSuperAdmin,
 } from "@/features/auth/model/identity"
 import { getChaptersWithSchools } from "@/features/challenger/api/organization"
 import { gisuKeys, projectKeys } from "@/features/project/new/api/queryKeys"
+import { useIsMatchingPeriod } from "@/features/project/new/hooks/useIsMatchingPeriod"
 import { getActiveGisu } from "@/shared/api/gisu"
 import { withImageCacheKey } from "@/shared/lib/withImageCacheKey"
 import { EmptyState } from "@/shared/ui/EmptyState"
@@ -131,7 +131,7 @@ export function ProjectManagementPage() {
   const isAdminScope = isAnyOperator(me)
   const isPm = isCurrentTermPm(me)
   const hasAccess = isAdminScope || isPm
-  const useGroupedView = isCentralStaff(me) || isSuperAdmin(me)
+  const useGroupedView = isCentralCore(me)
 
   const descriptionText = useGroupedView
     ? "전체 지부의 프로젝트 정보를 확인하고 수정할 수 있습니다. 팀 매칭 진행 중에는 수정이 제한됩니다."
@@ -171,14 +171,34 @@ export function ProjectManagementPage() {
     [managedQuery.data, managedQuery.dataUpdatedAt],
   )
 
+  const selectedChapterInfo = useMemo(() => {
+    if (!useGroupedView) return undefined
+    return chaptersQuery.data?.chapters.find(
+      (chapter) => chapter.chapterName === selectedChapter,
+    )
+  }, [useGroupedView, chaptersQuery.data, selectedChapter])
+
+  const selectedChapterId = selectedChapterInfo?.chapterId
+    ? Number(selectedChapterInfo.chapterId)
+    : undefined
+  const matchingPeriodChapterId =
+    selectedChapterId !== undefined && Number.isFinite(selectedChapterId)
+      ? selectedChapterId
+      : undefined
+  const isMatchingPeriod = useIsMatchingPeriod({
+    chapterId: matchingPeriodChapterId,
+    enabled:
+      hasAccess && (!useGroupedView || matchingPeriodChapterId !== undefined),
+  })
+
   const filteredProjects: MatchingProject[] = useMemo(() => {
     if (!useGroupedView) return projects
-    const chapters = chaptersQuery.data?.chapters ?? []
-    const chapter = chapters.find((c) => c.chapterName === selectedChapter)
-    if (!chapter) return projects
-    const schoolNames = new Set(chapter.schools.map((s) => s.schoolName))
+    if (!selectedChapterInfo) return []
+    const schoolNames = new Set(
+      selectedChapterInfo.schools.map((s) => s.schoolName),
+    )
     return projects.filter((p) => schoolNames.has(p.school))
-  }, [useGroupedView, projects, chaptersQuery.data, selectedChapter])
+  }, [useGroupedView, projects, selectedChapterInfo])
 
   const partGroups = useMemo(() => {
     if (!useGroupedView) return new Map<string, MatchingProject[]>()
@@ -220,6 +240,8 @@ export function ProjectManagementPage() {
 
   const isProjectPermissionLoading =
     permissionProjectIds.length > 0 && projectPermissionsQuery.isPending
+  const isProjectListLoading =
+    managedQuery.isLoading || (useGroupedView && chaptersQuery.isLoading)
 
   const getProjectActionPermissions = (project: MatchingProject) => {
     const projectId = toValidProjectId(project)
@@ -276,7 +298,7 @@ export function ProjectManagementPage() {
               />
             </div>
           )}
-          {managedQuery.isLoading ? (
+          {isProjectListLoading ? (
             <p className="text-body-2-regular text-teal-gray-400 py-10 text-center">
               데이터를 불러오는 중...
             </p>
@@ -293,6 +315,7 @@ export function ProjectManagementPage() {
                           key={project.id}
                           data={project}
                           isPermissionLoading={isProjectPermissionLoading}
+                          isMatchingPeriod={isMatchingPeriod}
                           {...permissions}
                         />
                       )
@@ -309,6 +332,7 @@ export function ProjectManagementPage() {
                       key={project.id}
                       data={project}
                       isPermissionLoading={isProjectPermissionLoading}
+                      isMatchingPeriod={isMatchingPeriod}
                       {...permissions}
                     />
                   )
@@ -329,6 +353,7 @@ export function ProjectManagementPage() {
                     key={project.id}
                     data={project}
                     isPermissionLoading={isProjectPermissionLoading}
+                    isMatchingPeriod={isMatchingPeriod}
                     {...permissions}
                   />
                 )

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -186,9 +186,8 @@ export function ProjectManagementPage() {
       ? selectedChapterId
       : undefined
   const isMatchingPeriod = useIsMatchingPeriod({
-    chapterId: matchingPeriodChapterId,
-    enabled:
-      hasAccess && (!useGroupedView || matchingPeriodChapterId !== undefined),
+    ...(useGroupedView ? { chapterId: matchingPeriodChapterId } : {}),
+    enabled: hasAccess,
   })
 
   const filteredProjects: MatchingProject[] = useMemo(() => {

--- a/src/features/project/new/hooks/useIsMatchingPeriod.test.tsx
+++ b/src/features/project/new/hooks/useIsMatchingPeriod.test.tsx
@@ -1,0 +1,127 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { getMatchingRounds } from "@/features/application/api/applicationApi"
+import { useMe } from "@/features/auth/hooks/useMe"
+
+import { useIsMatchingPeriod } from "./useIsMatchingPeriod"
+
+import type { ReactNode } from "react"
+
+import type { MemberInfoResponse } from "@/features/auth/api/me"
+
+vi.mock("@/features/application/api/applicationApi", () => ({
+  getMatchingRounds: vi.fn(),
+}))
+
+vi.mock("@/features/auth/hooks/useMe", () => ({
+  useMe: vi.fn(),
+}))
+
+const mockedGetMatchingRounds = vi.mocked(getMatchingRounds)
+const mockedUseMe = vi.mocked(useMe)
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+function makeMe(chapterId?: string): MemberInfoResponse {
+  return {
+    id: "1",
+    name: "테스터",
+    nickname: "테스터",
+    email: "tester@example.com",
+    schoolId: "1",
+    schoolName: "테스트대학교",
+    profileImageLink: null,
+    status: "ACTIVE",
+    hasLocalCredential: false,
+    roles: [],
+    challengerRecords: chapterId
+      ? [
+          {
+            challengerId: "1",
+            gisuId: "1",
+            gisu: "8",
+            chapterId,
+            chapterName: "Selenium",
+            memberId: "1",
+            part: "PLAN",
+            challengerStatus: "ACTIVE",
+            name: "테스터",
+            nickname: "테스터",
+            email: "tester@example.com",
+            schoolId: "1",
+            schoolName: "테스트대학교",
+          },
+        ]
+      : [],
+  }
+}
+
+describe("useIsMatchingPeriod", () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("chapterId를 넘기면 사용자 지부 대신 전달된 지부로 매칭 차수를 조회한다", async () => {
+    mockedUseMe.mockReturnValue({
+      data: makeMe("10"),
+    } as ReturnType<typeof useMe>)
+    mockedGetMatchingRounds.mockResolvedValue([])
+
+    const { result } = renderHook(
+      () => useIsMatchingPeriod({ chapterId: 20 }),
+      {
+        wrapper: createWrapper(),
+      },
+    )
+
+    await waitFor(() => {
+      expect(mockedGetMatchingRounds).toHaveBeenCalledWith(20)
+    })
+    expect(mockedGetMatchingRounds).not.toHaveBeenCalledWith(10)
+    expect(result.current).toBe(false)
+  })
+
+  it("chapterId가 없으면 사용자 최신 챌린저 기록의 지부로 매칭 차수를 조회한다", async () => {
+    mockedUseMe.mockReturnValue({
+      data: makeMe("10"),
+    } as ReturnType<typeof useMe>)
+    mockedGetMatchingRounds.mockResolvedValue([])
+
+    renderHook(() => useIsMatchingPeriod(), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(mockedGetMatchingRounds).toHaveBeenCalledWith(10)
+    })
+  })
+
+  it("대상 지부가 없으면 매칭 차수를 조회하지 않고 false를 반환한다", () => {
+    mockedUseMe.mockReturnValue({
+      data: makeMe(),
+    } as ReturnType<typeof useMe>)
+
+    const { result } = renderHook(() => useIsMatchingPeriod(), {
+      wrapper: createWrapper(),
+    })
+
+    expect(mockedGetMatchingRounds).not.toHaveBeenCalled()
+    expect(result.current).toBe(false)
+  })
+})

--- a/src/features/project/new/hooks/useIsMatchingPeriod.ts
+++ b/src/features/project/new/hooks/useIsMatchingPeriod.ts
@@ -14,16 +14,23 @@ import {
 const MAX_TIMER_DELAY_MS = 24 * 60 * 60 * 1000
 const BOUNDARY_PASS_MS = 50
 
-export function useIsMatchingPeriod() {
+interface UseIsMatchingPeriodOptions {
+  chapterId?: number
+  enabled?: boolean
+}
+
+export function useIsMatchingPeriod(options?: UseIsMatchingPeriodOptions) {
   const { data: me } = useMe()
-  const chapterId = getLatestChallengerRecord(me)?.chapterId
+  const fallbackChapterId = getLatestChallengerRecord(me)?.chapterId
     ? Number(getLatestChallengerRecord(me)!.chapterId)
     : undefined
+  const chapterId = options?.chapterId ?? fallbackChapterId
+  const enabled = options?.enabled ?? true
 
   const { data: rounds, isSuccess } = useQuery({
     queryKey: applicationKeys.matchingRounds(chapterId),
     queryFn: () => getMatchingRounds(chapterId),
-    enabled: chapterId !== undefined,
+    enabled: enabled && chapterId !== undefined,
   })
 
   const [now, setNow] = useState(() => new Date())

--- a/src/features/project/new/hooks/useIsMatchingPeriod.ts
+++ b/src/features/project/new/hooks/useIsMatchingPeriod.ts
@@ -24,8 +24,9 @@ export function useIsMatchingPeriod(options?: UseIsMatchingPeriodOptions) {
   const fallbackChapterId = getLatestChallengerRecord(me)?.chapterId
     ? Number(getLatestChallengerRecord(me)!.chapterId)
     : undefined
-  const chapterId = options?.chapterId ?? fallbackChapterId
-  const enabled = options?.enabled ?? true
+  const chapterId =
+    options && "chapterId" in options ? options.chapterId : fallbackChapterId
+  const enabled = (options?.enabled ?? true) && chapterId !== undefined
 
   const { data: rounds, isSuccess } = useQuery({
     queryKey: applicationKeys.matchingRounds(chapterId),

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -328,11 +328,9 @@ export const BasicInfoForm = forwardRef<
   useEffect(() => {
     if (!basicDraftFields) return
     const { title, description, externalLink } = basicDraftFields
-    if (title) setValue("title", title, { shouldDirty: false })
-    if (description)
-      setValue("description", description, { shouldDirty: false })
-    if (externalLink)
-      setValue("externalLink", externalLink, { shouldDirty: false })
+    setValue("title", title, { shouldDirty: false })
+    setValue("description", description, { shouldDirty: false })
+    setValue("externalLink", externalLink, { shouldDirty: false })
   }, [basicDraftFields, setValue])
 
   useEffect(() => {

--- a/src/features/settings/ui/AccountSettingsPage.tsx
+++ b/src/features/settings/ui/AccountSettingsPage.tsx
@@ -11,6 +11,7 @@ import {
   isGooglePopupCancelled,
   signInWithGoogle,
 } from "@/features/auth/lib/googleSignIn"
+import { clearLoginReturnTo } from "@/features/auth/lib/loginRedirect"
 import { toRoleTag } from "@/features/auth/model/mappers"
 import { useAuthStore } from "@/features/auth/store/authStore"
 import { uploadFileFlow } from "@/features/project/new/api/storage"
@@ -113,6 +114,7 @@ export function AccountSettingsPage() {
     }
     try {
       await deleteMember({ googleAccessToken })
+      clearLoginReturnTo()
       useAuthStore.getState().clear()
       addToast({
         message: "계정이 삭제되어 로그아웃되었습니다.",

--- a/src/routes/admin/route.tsx
+++ b/src/routes/admin/route.tsx
@@ -14,8 +14,8 @@ import { useViewModeStore } from "@/shared/view-mode"
 import { projectViewMe } from "@/shared/view-mode/projectViewMe"
 
 export const Route = createFileRoute("/admin")({
-  beforeLoad: async ({ context }) => {
-    const me = await ensureMe(context.queryClient)
+  beforeLoad: async ({ context, location }) => {
+    const me = await ensureMe(context.queryClient, location.href)
     const viewMe = projectViewMe(me, useViewModeStore.getState().mode)
     if (!isOperator(viewMe)) throw redirect({ to: "/" })
   },

--- a/src/routes/challenger-verification.tsx
+++ b/src/routes/challenger-verification.tsx
@@ -4,8 +4,8 @@ import { ensureMe } from "@/features/auth/lib/ensureMe"
 import { ChallengerVerification } from "@/features/challenger/ui/ChallengerVerification"
 
 export const Route = createFileRoute("/challenger-verification")({
-  beforeLoad: async ({ context }) => {
-    await ensureMe(context.queryClient)
+  beforeLoad: async ({ context, location }) => {
+    await ensureMe(context.queryClient, location.href)
   },
   component: ChallengerVerification,
 })

--- a/src/routes/login/default.tsx
+++ b/src/routes/login/default.tsx
@@ -18,6 +18,11 @@ import {
 } from "@/features/auth/lib/googleSignIn"
 import { handleLoginResponse } from "@/features/auth/lib/handleLoginResponse"
 import { startKakaoSignIn } from "@/features/auth/lib/kakaoSignIn"
+import {
+  normalizeReturnTo,
+  rememberLoginReturnTo,
+  resolveLoginSuccessPath,
+} from "@/features/auth/lib/loginRedirect"
 import { useAuthStore } from "@/features/auth/store/authStore"
 import {
   Divider,
@@ -33,10 +38,14 @@ import { TextButton } from "@/shared/ui/button/TextButton"
 import { Checkbox } from "@/shared/ui/input/checkbox/Checkbox"
 
 export const Route = createFileRoute("/login/default")({
+  validateSearch: (search: Record<string, unknown>): { returnTo?: string } => ({
+    returnTo: normalizeReturnTo(search.returnTo),
+  }),
   component: DefaultLoginPage,
 })
 
 function DefaultLoginPage() {
+  const { returnTo } = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
   const addToast = useToastStore((s) => s.addToast)
   const [email, setEmail] = useState("")
@@ -60,11 +69,12 @@ function DefaultLoginPage() {
 
   const handleAppleSignIn = async () => {
     try {
+      rememberLoginReturnTo(returnTo)
       const { authorizationCode } = await signInWithApple()
       const res = await loginWithApple({ authorizationCode })
       const result = handleLoginResponse(res, isKeepLoggedIn)
       if (result === "LOGIN_SUCCESS") {
-        await navigate({ to: "/" })
+        await navigate({ to: resolveLoginSuccessPath(returnTo) })
       } else {
         await navigate({ to: "/signup/oauth" })
       }
@@ -76,11 +86,12 @@ function DefaultLoginPage() {
 
   const handleGoogleSignIn = async () => {
     try {
+      rememberLoginReturnTo(returnTo)
       const { accessToken } = await signInWithGoogle()
       const res = await loginWithGoogle({ accessToken })
       const result = handleLoginResponse(res, isKeepLoggedIn)
       if (result === "LOGIN_SUCCESS") {
-        await navigate({ to: "/" })
+        await navigate({ to: resolveLoginSuccessPath(returnTo) })
       } else {
         await navigate({ to: "/signup/oauth" })
       }
@@ -93,7 +104,7 @@ function DefaultLoginPage() {
   const handleKakaoSignIn = () => {
     try {
       sessionStorage.setItem("kakao_keep_logged_in", String(isKeepLoggedIn))
-      startKakaoSignIn()
+      startKakaoSignIn(returnTo)
     } catch (error) {
       console.error("[Kakao Sign-In]", error)
       showToast("Kakao 로그인에 실패했습니다. 다시 시도해주세요.", "red")
@@ -113,6 +124,7 @@ function DefaultLoginPage() {
     setLoginError("")
 
     try {
+      rememberLoginReturnTo(returnTo)
       const res = await loginWithEmail({ email, password, clientType: "WEB" })
       useAuthStore.getState().setTokens(
         {
@@ -122,7 +134,7 @@ function DefaultLoginPage() {
         },
         isKeepLoggedIn,
       )
-      await navigate({ to: "/" })
+      await navigate({ to: resolveLoginSuccessPath(returnTo) })
     } catch (error) {
       if (axios.isAxiosError(error)) {
         setLoginError("이메일 또는 비밀번호가 올바르지 않습니다")

--- a/src/routes/login/index.tsx
+++ b/src/routes/login/index.tsx
@@ -17,6 +17,11 @@ import {
 import { handleLoginResponse } from "@/features/auth/lib/handleLoginResponse"
 import { startKakaoSignIn } from "@/features/auth/lib/kakaoSignIn"
 import {
+  normalizeReturnTo,
+  rememberLoginReturnTo,
+  resolveLoginSuccessPath,
+} from "@/features/auth/lib/loginRedirect"
+import {
   Divider,
   LoginButton,
   // SmallDivider,
@@ -26,10 +31,14 @@ import { Button } from "@/shared/ui/Button"
 import { TextButton } from "@/shared/ui/button/TextButton"
 
 export const Route = createFileRoute("/login/")({
+  validateSearch: (search: Record<string, unknown>): { returnTo?: string } => ({
+    returnTo: normalizeReturnTo(search.returnTo),
+  }),
   component: SocialLoginPage,
 })
 
 function SocialLoginPage() {
+  const { returnTo } = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
   const addToast = useToastStore((s) => s.addToast)
 
@@ -45,11 +54,12 @@ function SocialLoginPage() {
 
   const handleAppleSignIn = async () => {
     try {
+      rememberLoginReturnTo(returnTo)
       const { authorizationCode } = await signInWithApple()
       const res = await loginWithApple({ authorizationCode })
       const result = handleLoginResponse(res)
       if (result === "LOGIN_SUCCESS") {
-        await navigate({ to: "/" })
+        await navigate({ to: resolveLoginSuccessPath(returnTo) })
       } else {
         await navigate({ to: "/signup/oauth" })
       }
@@ -61,11 +71,12 @@ function SocialLoginPage() {
 
   const handleGoogleSignIn = async () => {
     try {
+      rememberLoginReturnTo(returnTo)
       const { accessToken } = await signInWithGoogle()
       const res = await loginWithGoogle({ accessToken })
       const result = handleLoginResponse(res)
       if (result === "LOGIN_SUCCESS") {
-        await navigate({ to: "/" })
+        await navigate({ to: resolveLoginSuccessPath(returnTo) })
       } else {
         await navigate({ to: "/signup/oauth" })
       }
@@ -77,7 +88,7 @@ function SocialLoginPage() {
 
   const handleKakaoSignIn = () => {
     try {
-      startKakaoSignIn()
+      startKakaoSignIn(returnTo)
     } catch (error) {
       console.error("[Kakao Sign-In]", error)
       showToast("Kakao 로그인에 실패했습니다. 다시 시도해주세요.", "red")
@@ -110,7 +121,12 @@ function SocialLoginPage() {
               variant={"weak"}
               color={"primary"}
               className="h-12.5 w-90 rounded-[10px] px-4 py-1 text-[16px]"
-              onClick={() => navigate({ to: "/login/default" })}
+              onClick={() =>
+                navigate({
+                  to: "/login/default",
+                  search: returnTo ? { returnTo } : {},
+                })
+              }
             >
               UMC 계정 로그인
             </Button>

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -29,8 +29,8 @@ import { CHAPTERS } from "@/shared/ui/segment/ChapterSelector"
 import { useViewMe } from "@/shared/view-mode/useViewMe"
 
 export const Route = createFileRoute("/matching/applications")({
-  beforeLoad: async ({ context }) => {
-    await ensureMe(context.queryClient)
+  beforeLoad: async ({ context, location }) => {
+    await ensureMe(context.queryClient, location.href)
   },
   component: MatchingApplicationsPage,
 })

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -124,8 +124,8 @@ export const Route = createFileRoute("/matching/")({
       page: parsePage(search.page),
     }
   },
-  beforeLoad: async ({ search, context }) => {
-    const me = await ensureMe(context.queryClient)
+  beforeLoad: async ({ search, context, location }) => {
+    const me = await ensureMe(context.queryClient, location.href)
     const viewMe = projectViewMe(me, useViewModeStore.getState().mode)
     const isFullAccess = isSuperAdmin(viewMe) || isCentralStaff(viewMe)
     if (isFullAccess) return

--- a/src/routes/matching/notice-publish.tsx
+++ b/src/routes/matching/notice-publish.tsx
@@ -16,8 +16,8 @@ interface NoticePublishSearch {
 }
 
 export const Route = createFileRoute("/matching/notice-publish")({
-  beforeLoad: async ({ context }) => {
-    const me = await ensureMe(context.queryClient)
+  beforeLoad: async ({ context, location }) => {
+    const me = await ensureMe(context.queryClient, location.href)
     const viewMe = projectViewMe(me, useViewModeStore.getState().mode)
     if (!isOperator(viewMe)) throw redirect({ to: "/" })
   },

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -133,8 +133,8 @@ export const Route = createFileRoute("/matching/projects/announce/")({
       page: parsePage(search.page),
     }
   },
-  beforeLoad: async ({ search, context }) => {
-    const me = await ensureMe(context.queryClient)
+  beforeLoad: async ({ search, context, location }) => {
+    const me = await ensureMe(context.queryClient, location.href)
     const viewMe = projectViewMe(me, useViewModeStore.getState().mode)
     const isFullAccess = isSuperAdmin(viewMe) || isCentralStaff(viewMe)
     if (isFullAccess) return

--- a/src/routes/matching/projects/announce/notice-publish.tsx
+++ b/src/routes/matching/projects/announce/notice-publish.tsx
@@ -20,8 +20,8 @@ interface NoticePublishSearch {
 export const Route = createFileRoute(
   "/matching/projects/announce/notice-publish",
 )({
-  beforeLoad: async ({ context }) => {
-    const me = await ensureMe(context.queryClient)
+  beforeLoad: async ({ context, location }) => {
+    const me = await ensureMe(context.queryClient, location.href)
     const viewMe = projectViewMe(me, useViewModeStore.getState().mode)
     if (!isOperator(viewMe)) throw redirect({ to: "/" })
   },

--- a/src/routes/matching/projects/management.tsx
+++ b/src/routes/matching/projects/management.tsx
@@ -13,8 +13,8 @@ export const Route = createFileRoute("/matching/projects/management")({
     search: Record<string, unknown>,
   ): { notice?: "duplicate" } =>
     search.notice === "duplicate" ? { notice: "duplicate" } : {},
-  beforeLoad: async ({ context }) => {
-    const me = await ensureMe(context.queryClient)
+  beforeLoad: async ({ context, location }) => {
+    const me = await ensureMe(context.queryClient, location.href)
     const viewMe = projectViewMe(me, useViewModeStore.getState().mode)
     if (!canManageProjects(viewMe)) throw redirect({ to: "/matching/projects" })
   },

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -59,8 +59,8 @@ import { projectViewMe } from "@/shared/view-mode/projectViewMe"
 import type { BasicInfoFormHandle } from "@/features/project/new/ui/basic-info/BasicInfoForm"
 
 export const Route = createFileRoute("/matching/projects/new")({
-  beforeLoad: async ({ context, search }) => {
-    const me = await ensureMe(context.queryClient)
+  beforeLoad: async ({ context, search, location }) => {
+    const me = await ensureMe(context.queryClient, location.href)
     const viewMe = projectViewMe(me, useViewModeStore.getState().mode)
 
     if (!canManageProjects(viewMe)) {

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -45,8 +45,8 @@ import { projectViewMe } from "@/shared/view-mode/projectViewMe"
 import type { AxiosError } from "axios"
 
 export const Route = createFileRoute("/matching/rounds")({
-  beforeLoad: async ({ context }) => {
-    const me = await ensureMe(context.queryClient)
+  beforeLoad: async ({ context, location }) => {
+    const me = await ensureMe(context.queryClient, location.href)
     const viewMe = projectViewMe(me, useViewModeStore.getState().mode)
     if (!canManageMatchingRounds(viewMe)) throw redirect({ to: "/" })
   },

--- a/src/routes/matching/route.tsx
+++ b/src/routes/matching/route.tsx
@@ -7,8 +7,8 @@ import SideBar from "@/components/sidebar/SideBar"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
 
 export const Route = createFileRoute("/matching")({
-  beforeLoad: async ({ context }) => {
-    await ensureMe(context.queryClient)
+  beforeLoad: async ({ context, location }) => {
+    await ensureMe(context.queryClient, location.href)
   },
   component: MatchingLayout,
 })

--- a/src/routes/matching/status.tsx
+++ b/src/routes/matching/status.tsx
@@ -19,8 +19,8 @@ import { SegmentButton } from "@/shared/ui/segment-button/SegmentButton"
 import { type Chapter, CHAPTERS } from "@/shared/ui/segment/ChapterSelector"
 
 export const Route = createFileRoute("/matching/status")({
-  beforeLoad: async ({ context }) => {
-    await ensureMe(context.queryClient)
+  beforeLoad: async ({ context, location }) => {
+    await ensureMe(context.queryClient, location.href)
   },
   component: MatchingStatusPage,
 })

--- a/src/routes/oauth/kakao/callback.tsx
+++ b/src/routes/oauth/kakao/callback.tsx
@@ -12,6 +12,7 @@ import {
   consumeKakaoState,
   getKakaoRedirectUri,
 } from "@/features/auth/lib/kakaoSignIn"
+import { resolveLoginSuccessPath } from "@/features/auth/lib/loginRedirect"
 
 export const Route = createFileRoute("/oauth/kakao/callback")({
   component: KakaoCallbackPage,
@@ -126,7 +127,7 @@ function KakaoCallbackPage() {
         // 일반 로그인 플로우
         const result = handleLoginResponse(res, keepLoggedIn)
         if (result === "LOGIN_SUCCESS") {
-          void navigate({ to: "/" })
+          void navigate({ to: resolveLoginSuccessPath() })
         } else {
           void navigate({ to: "/signup/oauth" })
         }

--- a/src/routes/settings/route.tsx
+++ b/src/routes/settings/route.tsx
@@ -4,8 +4,8 @@ import Header from "@/components/header/Header"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
 
 export const Route = createFileRoute("/settings")({
-  beforeLoad: async ({ context }) => {
-    await ensureMe(context.queryClient)
+  beforeLoad: async ({ context, location }) => {
+    await ensureMe(context.queryClient, location.href)
   },
   component: SettingsLayout,
 })

--- a/src/shared/lib/axios.ts
+++ b/src/shared/lib/axios.ts
@@ -1,5 +1,9 @@
 import axios, { AxiosError } from "axios"
 
+import {
+  buildLoginRedirectSearch,
+  getCurrentReturnTo,
+} from "@/features/auth/lib/loginRedirect"
 import { useAuthStore } from "@/features/auth/store/authStore"
 
 import type { AxiosRequestConfig } from "axios"
@@ -71,7 +75,10 @@ api.interceptors.response.use(
     const refreshToken = useAuthStore.getState().refreshToken
     if (!refreshToken) {
       useAuthStore.getState().clear()
-      window.location.href = "/login"
+      const search = new URLSearchParams(
+        buildLoginRedirectSearch(getCurrentReturnTo()),
+      )
+      window.location.href = search.size > 0 ? `/login?${search}` : "/login"
       return Promise.reject(error)
     }
 
@@ -115,7 +122,10 @@ api.interceptors.response.use(
     } catch (refreshError) {
       rejectQueue(refreshError)
       useAuthStore.getState().clear()
-      window.location.href = "/login"
+      const search = new URLSearchParams(
+        buildLoginRedirectSearch(getCurrentReturnTo()),
+      )
+      window.location.href = search.size > 0 ? `/login?${search}` : "/login"
       return Promise.reject(refreshError)
     } finally {
       isRefreshing = false


### PR DESCRIPTION
## 📸 작업 내용

- 로그인이 필요한 페이지에 비인증 접근 시, 로그인 성공 후 원래 페이지로 자동 복귀하는 returnTo 리다이렉트 구현
- 프로젝트 관리 화면에서 중앙 코어 권한자의 지부 탭 선택 시 선택 지부 기준으로 매칭 기간 조회하도록 수정
- 서버의 Central Core 정의에 맞춰 프론트 권한 분기를 SUPER_ADMIN, CENTRAL_PRESIDENT, CENTRAL_VICE_PRESIDENT 기준으로 정렬
- 프로젝트 기본 정보 폼에서 링크 필드 초기화 보정

## 🎞️ 주요 코드 설명

### loginRedirect 유틸 및 returnTo 플로우

`src/features/auth/lib/loginRedirect.ts`를 신규 작성해 returnTo 경로 정규화·sessionStorage 저장/복원·`resolveLoginSuccessPath` 로직을 분리했습니다.

`ensureMe`에 `returnTo` 파라미터를 추가해 미인증 시 `/login?returnTo=<현재경로>`로 리다이렉트하고, 로그인/소셜 콜백에서 `resolveLoginSuccessPath(returnTo)`로 원래 경로로 복귀합니다. axios 인터셉터에서 토큰 만료 시에도 현재 경로를 `returnTo`로 보존합니다.

### 선택 지부 기준 매칭 기간 조회

프로젝트 관리 카드 내부에서 매칭 차수를 조회하던 흐름을 ProjectManagementPage 레벨로 올려, 카드 렌더링 여부와 무관하게 선택된 지부 ID 기준으로 `/project/matching-rounds` 요청이 발생하도록 변경했습니다.

## 🖥️ 구현화면

캡처 없음. returnTo 동작은 보호된 경로 직접 접근 후 로그인 플로우로 확인, 매칭 기간 조회는 Network 탭의 `/api/v1/project/matching-rounds?chapterId={선택지부ID}` 요청으로 검증합니다.

## 🔗 연결된 이슈

- Connected: #382, #385
- Closes #382
- Closes #385