### PR TITLE
🐛 fix: 헤더 매칭 active 상태 수정 + Footer dark variant 추가

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -2,6 +2,7 @@ import InstagramLogo from "@/shared/assets/icon/logo/InstagramLogo"
 import KakaoLogo from "@/shared/assets/icon/logo/KakaoLogo"
 import UmcLogo from "@/shared/assets/icon/logo/UmcLogo"
 import UmcLogoFilled from "@/shared/assets/icon/logo/UmcLogoFilled"
+import { cn } from "@/shared/lib/utils"
 
 const TEAM_ROWS = [
   { role: "Lead", members: { group_1: ["리버/이재원", "우연/추연우"] } },
@@ -17,32 +18,72 @@ const TEAM_ROWS = [
     role: "Mobile",
     members: {
       group_1: ["PM 제용/정의찬", "Design 삼이/이희원", "Design 시안/우자영"],
-      group_2: ["FE 원/김동민", "FE 도도/김도연", "FE 소피/이예지"],
-      group_3: ["FE 도리/김도연", "FE 어핫차/박유수"],
+      group_2: ["iOS 원/김동민", "iOS 도도/김도연", "iOS 소피/이예지"],
+      group_3: ["Android 도리/김도연", "Android 어헛차/박유수"],
     },
   },
   {
     role: "Server",
     members: {
-      group_1: ["하늘/박경운", "와나/강하나", "커너/박성현"],
-      group_2: ["세니/박세은", "박박지현/박지현", "스읍/이예은"],
-      group_3: ["라미/권도희", "이람/박승범"],
+      group_1: ["하늘/박경운", "갈래/김민서", "와나/강하나"],
+      group_2: ["우디/박성현", "세니/박세은", "박박지현/박지현"],
+      group_3: ["스읍/이예은", "라미/권도희", "이람/박승범"],
     },
   },
 ]
 
-export default function Footer() {
+const VARIANT_STYLES = {
+  light: {
+    bg: "bg-teal-gray-100",
+    logoFilledVariant: "dark" as const,
+    logoFilledColor: "text-teal-gray-300",
+    primary: "text-teal-gray-400",
+    secondary: "text-teal-gray-400",
+    logoColor: "text-teal-gray-400",
+    linkHover: "hover:text-gray-500",
+  },
+  dark: {
+    bg: "bg-teal-gray-400",
+    logoFilledVariant: "light" as const,
+    logoFilledColor: "text-teal-gray-100",
+    primary: "text-white",
+    secondary: "text-teal-gray-100",
+    logoColor: "text-teal-gray-100",
+    linkHover: "hover:text-teal-gray-50",
+  },
+}
+
+interface FooterProps {
+  variant?: "light" | "dark"
+}
+
+export default function Footer({ variant = "light" }: FooterProps) {
+  const s = VARIANT_STYLES[variant]
+
   return (
-    <footer className="bg-teal-gray-100 max-bp1:px-9 max-bp1:py-10 flex flex-col items-center gap-2.5 self-stretch py-16 pr-14 pl-15">
+    <footer
+      className={cn(
+        "max-bp1:px-9 max-bp1:py-10 flex flex-col items-center gap-2.5 self-stretch py-16 pr-14 pl-15",
+        s.bg,
+      )}
+    >
       <div className="flex flex-col items-start gap-6 self-stretch">
         <div className="flex w-full justify-between gap-4 max-[930px]:flex-col">
           <div className="flex min-w-0 items-center gap-4">
-            <UmcLogoFilled className="text-teal-gray-300 h-5.5 w-auto shrink-0" />
-            <span className="text-heading-7-semibold text-teal-gray-400">
+            <UmcLogoFilled
+              variant={s.logoFilledVariant}
+              className={cn("h-5.5 w-auto shrink-0", s.logoFilledColor)}
+            />
+            <span className={cn("text-heading-7-semibold", s.primary)}>
               University Make us Challenge
             </span>
           </div>
-          <div className="text-teal-gray-400 flex flex-col items-center justify-center gap-2 pt-1 whitespace-nowrap max-[930px]:items-start">
+          <div
+            className={cn(
+              "flex flex-col items-center justify-center gap-2 pt-1 whitespace-nowrap max-[930px]:items-start",
+              s.primary,
+            )}
+          >
             <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
               <nav
                 aria-label="약관 및 정책"
@@ -52,7 +93,10 @@ export default function Footer() {
                   href="https://makeus-challenge.notion.site/300b57f4596b8018a2dfd38784478715"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-body-3-regular transition-colors hover:text-gray-500 hover:underline"
+                  className={cn(
+                    "text-body-3-regular transition-colors hover:underline",
+                    s.linkHover,
+                  )}
                 >
                   서비스이용약관
                 </a>
@@ -60,7 +104,10 @@ export default function Footer() {
                   href="https://makeus-challenge.notion.site/300b57f4596b803f8c94dd4f4fb71960"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-body-3-regular transition-colors hover:text-gray-500 hover:underline"
+                  className={cn(
+                    "text-body-3-regular transition-colors hover:underline",
+                    s.linkHover,
+                  )}
                 >
                   개인정보처리방침
                 </a>
@@ -75,15 +122,15 @@ export default function Footer() {
         <section aria-labelledby="footer-team-heading" className="w-full">
           <h2
             id="footer-team-heading"
-            className="text-subtitle-4-semibold text-teal-gray-400"
+            className={cn("text-subtitle-4-semibold", s.secondary)}
           >
-            UMC Product
+            UMC PRODUCT
           </h2>
           <dl className="mt-4 flex flex-col gap-1.75">
             {TEAM_ROWS.map(({ role, members }) => (
               <div
                 key={role}
-                className="text-teal-gray-400 flex items-baseline gap-2.25"
+                className={cn("flex items-baseline gap-2.25", s.secondary)}
               >
                 <dt className="flex gap-2.25">
                   <span className="text-body-3-medium w-10 shrink-0">
@@ -126,21 +173,29 @@ export default function Footer() {
           className="max-bp1:flex-col max-bp1:items-center flex w-full flex-wrap items-center gap-x-6 gap-y-3"
         >
           <div className="flex items-center gap-1.75">
-            <UmcLogo className="text-teal-gray-400 h-3 w-auto" />
+            <UmcLogo className={cn("h-3 w-auto", s.logoColor)} />
             <a
               href="https://apps.apple.com/kr/app/umc/id6759412446"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-body-3-medium text-teal-gray-400 transition-colors hover:text-gray-500 hover:underline"
+              className={cn(
+                "text-body-3-medium transition-colors hover:underline",
+                s.secondary,
+                s.linkHover,
+              )}
             >
               iOS
             </a>
-            <span className="text-body-3-medium text-teal-gray-400">/</span>
+            <span className={cn("text-body-3-medium", s.secondary)}>/</span>
             <a
               href="https://play.google.com/store/apps/details?id=com.umc.product&hl=en"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-body-3-medium text-teal-gray-400 transition-colors hover:text-gray-500 hover:underline"
+              className={cn(
+                "text-body-3-medium transition-colors hover:underline",
+                s.secondary,
+                s.linkHover,
+              )}
             >
               Android
             </a>
@@ -148,7 +203,11 @@ export default function Footer() {
               href="https://tech.university.neordinary.com/"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-body-3-medium text-teal-gray-400 flex items-center gap-1.75 transition-colors hover:text-gray-500"
+              className={cn(
+                "text-body-3-medium flex items-center gap-1.75 transition-colors",
+                s.secondary,
+                s.linkHover,
+              )}
             >
               <UmcLogo className="ml-4 h-3 w-auto" />
               <span className="hover:underline">Product Tech</span>
@@ -159,7 +218,11 @@ export default function Footer() {
               href="https://www.instagram.com/uni_makeus_challenge/?hl=en"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-body-3-medium text-teal-gray-400 flex items-center gap-1.75 transition-colors hover:text-gray-500"
+              className={cn(
+                "text-body-3-medium flex items-center gap-1.75 transition-colors",
+                s.secondary,
+                s.linkHover,
+              )}
             >
               <InstagramLogo className="size-4" />
               <span className="hover:underline">Instagram</span>
@@ -168,7 +231,11 @@ export default function Footer() {
               href="https://pf.kakao.com/_MDxhqX/chat"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-body-3-medium text-teal-gray-400 flex items-center gap-1.75 transition-colors hover:text-gray-500"
+              className={cn(
+                "text-body-3-medium flex items-center gap-1.75 transition-colors",
+                s.secondary,
+                s.linkHover,
+              )}
             >
               <KakaoLogo className="size-4" />
               <span className="hover:underline">Kakao</span>

--- a/src/components/header/headerNavPolicy.ts
+++ b/src/components/header/headerNavPolicy.ts
@@ -33,5 +33,5 @@ export function isHeaderNavItemActive(pathname: string, item: HeaderNavItem) {
     return pathname === "/intro"
   }
 
-  return pathname.startsWith(basePath)
+  return pathname === basePath || pathname.startsWith(basePath + "/")
 }

--- a/src/components/header/headerNavPolicy.ts
+++ b/src/components/header/headerNavPolicy.ts
@@ -4,12 +4,17 @@ export const RECRUITING_DISABLED_MESSAGE =
 export type HeaderNavItem = {
   label: string
   to: string
+  activeBasePath?: string
   disabled?: boolean
 }
 
 export const HEADER_NAV_ITEMS: HeaderNavItem[] = [
   { label: "소개", to: "/intro" },
-  { label: "데모데이 매칭", to: "/matching/projects" },
+  {
+    label: "데모데이 매칭",
+    to: "/matching/projects",
+    activeBasePath: "/matching",
+  },
   { label: "리크루팅", to: "/recruiting", disabled: true },
 ]
 
@@ -22,9 +27,11 @@ export function getDisabledNavMessage(label: string) {
 }
 
 export function isHeaderNavItemActive(pathname: string, item: HeaderNavItem) {
-  if (item.to === "/intro") {
+  const basePath = item.activeBasePath ?? item.to
+
+  if (basePath === "/intro") {
     return pathname === "/intro"
   }
 
-  return pathname.startsWith(item.to)
+  return pathname.startsWith(basePath)
 }

--- a/src/features/intro/ui/components/LandingHeader.tsx
+++ b/src/features/intro/ui/components/LandingHeader.tsx
@@ -7,7 +7,7 @@ import {
   RECRUITING_DISABLED_MESSAGE,
 } from "@/components/header/headerNavPolicy"
 import { useToastStore } from "@/components/toast/useToastStore"
-import UmcLogoFilled from "@/shared/assets/icon/logo/UmcLogoFilled"
+import UmcLogo from "@/shared/assets/icon/logo/UmcLogo"
 import { cn } from "@/shared/lib/utils"
 
 export function LandingHeader() {
@@ -67,9 +67,9 @@ export function LandingHeader() {
         }}
       />
 
-      <div className="relative flex h-full w-full max-w-[1440px] items-center justify-between">
+      <div className="relative flex h-full w-full max-w-360 items-center justify-between">
         <div className="flex h-full w-55 items-center justify-start pl-12.5">
-          <UmcLogoFilled className="h-5.5 w-18.5 text-white" aria-label="UMC" />
+          <UmcLogo className="h-5.5 w-18.5 text-white" aria-label="UMC" />
         </div>
 
         <nav

--- a/src/routes/test/footer.tsx
+++ b/src/routes/test/footer.tsx
@@ -8,13 +8,34 @@ export const Route = createFileRoute("/test/footer")({
 
 function FooterTestPage() {
   return (
-    <div className="flex min-h-screen flex-col">
-      <div className="flex flex-1 items-center justify-center">
-        <p className="text-teal-gray-400 text-body-2-regular">
-          페이지 컨텐츠 영역
-        </p>
-      </div>
-      <Footer />
+    <div className="flex min-h-screen flex-col gap-0">
+      <section className="flex flex-col">
+        <div className="bg-teal-gray-50 border-teal-gray-100 flex items-center border-b px-6 py-3">
+          <span className="text-label-1-medium text-teal-gray-500">
+            variant="light"
+          </span>
+        </div>
+        <div className="bg-teal-gray-50 flex min-h-40 items-center justify-center">
+          <p className="text-body-2-regular text-teal-gray-300">
+            페이지 컨텐츠 영역
+          </p>
+        </div>
+        <Footer variant="light" />
+      </section>
+
+      <section className="flex flex-col">
+        <div className="bg-teal-gray-50 border-teal-gray-100 flex items-center border-b px-6 py-3">
+          <span className="text-label-1-medium text-teal-gray-500">
+            variant="dark"
+          </span>
+        </div>
+        <div className="bg-teal-gray-50 flex min-h-40 items-center justify-center">
+          <p className="text-body-2-regular text-teal-gray-300">
+            페이지 컨텐츠 영역
+          </p>
+        </div>
+        <Footer variant="dark" />
+      </section>
     </div>
   )
 }

--- a/src/routes/test/header.tsx
+++ b/src/routes/test/header.tsx
@@ -26,7 +26,7 @@ export const Route = createFileRoute("/test/header")({
 
 function HeaderTestPage() {
   const [activePathname, setActivePathname] = useState(
-    PATHNAME_OPTIONS[1].value,
+    PATHNAME_OPTIONS[1]?.value ?? PATHNAME_OPTIONS[0]!.value,
   )
   const isReady = useHeaderPreviewUser()
 

--- a/src/routes/test/header.tsx
+++ b/src/routes/test/header.tsx
@@ -6,6 +6,7 @@ import Header from "@/components/header/Header"
 import { MatchingSegmentRegion } from "@/components/sidebar/MatchingSegmentRegion"
 import SideBar from "@/components/sidebar/SideBar"
 import { useAuthStore } from "@/features/auth/store/authStore"
+import { cn } from "@/shared/lib/utils"
 
 import type { MemberInfoResponse } from "@/features/auth/api/me"
 
@@ -62,11 +63,12 @@ function HeaderTestPage() {
                       key={value}
                       type="button"
                       onClick={() => setActivePathname(value)}
-                      className={`text-body-3-medium rounded-full border px-3 py-1.5 transition-colors ${
+                      className={cn(
+                        "text-body-3-medium rounded-full border px-3 py-1.5 transition-colors",
                         activePathname === value
                           ? "border-teal-600 bg-teal-600 text-white"
-                          : "border-teal-gray-200 text-teal-gray-500 hover:border-teal-gray-300 bg-white"
-                      }`}
+                          : "border-teal-gray-200 text-teal-gray-500 hover:border-teal-gray-300 bg-white",
+                      )}
                     >
                       {label}
                     </button>

--- a/src/routes/test/header.tsx
+++ b/src/routes/test/header.tsx
@@ -9,35 +9,73 @@ import { useAuthStore } from "@/features/auth/store/authStore"
 
 import type { MemberInfoResponse } from "@/features/auth/api/me"
 
-const HEADER_PREVIEW_PATHNAME = "/matching/projects/management"
+const PATHNAME_OPTIONS = [
+  { label: "소개", value: "/intro" },
+  { label: "데모데이 매칭 / 프로젝트 목록", value: "/matching/projects" },
+  { label: "데모데이 매칭 / 관리", value: "/matching/projects/management" },
+  { label: "데모데이 매칭 / 라운드", value: "/matching/rounds" },
+  { label: "데모데이 매칭 / 지원 현황", value: "/matching/status" },
+  { label: "데모데이 매칭 / 지원서 목록", value: "/matching/applications" },
+  { label: "기타 (active 없음)", value: "/other" },
+]
 
 export const Route = createFileRoute("/test/header")({
   component: HeaderTestPage,
 })
 
 function HeaderTestPage() {
+  const [activePathname, setActivePathname] = useState(
+    PATHNAME_OPTIONS[1].value,
+  )
   const isReady = useHeaderPreviewUser()
 
   if (!isReady) return null
 
   return (
     <main className="h-full min-h-screen w-full">
-      <Header activePathname={HEADER_PREVIEW_PATHNAME} />
+      <Header activePathname={activePathname} />
       <div className="flex w-full">
-        <SideBar activePathname={HEADER_PREVIEW_PATHNAME} />
+        <SideBar activePathname={activePathname} />
         <div className="flex min-w-0 flex-1 flex-col">
           <div className="bp2:px-8.5 bp2:pt-14.5 px-4 pt-6">
-            <MatchingSegmentRegion activePathname={HEADER_PREVIEW_PATHNAME} />
+            <MatchingSegmentRegion activePathname={activePathname} />
           </div>
-          <div className="bp2:px-8.5 bp2:pt-8 flex min-h-screen min-w-0 flex-1 flex-col px-4 pt-6">
-            <section className="border-teal-gray-100 flex flex-col gap-3 rounded-lg border bg-white p-6">
-              <h1 className="text-heading-6-semibold text-teal-gray-900">
-                Header Test Page
-              </h1>
-              <p className="text-body-2-regular text-teal-gray-500">
-                실제 매칭 workflow 레이아웃과 같은 Header, SideBar, Segment
-                조합에서 반응형 상태를 확인합니다.
-              </p>
+          <div className="bp2:px-8.5 bp2:pt-8 flex min-w-0 flex-1 flex-col px-4 pt-6">
+            <section className="border-teal-gray-100 flex flex-col gap-4 rounded-lg border bg-white p-6">
+              <div>
+                <h1 className="text-heading-6-semibold text-teal-gray-900">
+                  Header / SideBar / Segment 테스트
+                </h1>
+                <p className="text-body-2-regular text-teal-gray-500 mt-1">
+                  pathname을 전환하며 헤더 active 상태와 사이드바·세그먼트를
+                  확인합니다.
+                </p>
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <span className="text-label-1-medium text-teal-gray-600">
+                  pathname 선택
+                </span>
+                <div className="flex flex-wrap gap-2">
+                  {PATHNAME_OPTIONS.map(({ label, value }) => (
+                    <button
+                      key={value}
+                      type="button"
+                      onClick={() => setActivePathname(value)}
+                      className={`text-body-3-medium rounded-full border px-3 py-1.5 transition-colors ${
+                        activePathname === value
+                          ? "border-teal-600 bg-teal-600 text-white"
+                          : "border-teal-gray-200 text-teal-gray-500 hover:border-teal-gray-300 bg-white"
+                      }`}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+                <p className="text-body-3-regular text-teal-gray-400 font-mono">
+                  {activePathname}
+                </p>
+              </div>
             </section>
           </div>
         </div>

--- a/src/shared/assets/icon/logo/UmcLogoFilled.tsx
+++ b/src/shared/assets/icon/logo/UmcLogoFilled.tsx
@@ -1,64 +1,115 @@
 import type { SVGProps } from "react"
-const UmcLogoFilled = (props: SVGProps<SVGSVGElement>) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    fill="none"
-    viewBox="0 0 64 20"
-    {...props}
-  >
-    <g filter="url(#UMCLogoFilled_svg__a)">
-      <path
-        fill="currentColor"
-        d="M18.602 0H.979A.99.99 0 0 0 0 1v9c0 5.522 4.384 10 9.79 10 5.407 0 9.79-4.478 9.79-10V1a.99.99 0 0 0-.978-1"
-      />
-      <path
-        fill="currentColor"
-        fillOpacity={0.4}
-        d="M18.602 0H.979A.99.99 0 0 0 0 1v9c0 5.522 4.384 10 9.79 10 5.407 0 9.79-4.478 9.79-10V1a.99.99 0 0 0-.978-1"
-      />
-      <path
-        fill="currentColor"
-        d="M40.63 0c-4.867 0-8.812 3.028-8.812 8 0-4.972-3.946-8-8.812-8a.99.99 0 0 0-.979 1v18c0 .552.439 1 .98 1h17.622a.99.99 0 0 0 .98-1V1a.99.99 0 0 0-.98-1"
-      />
-      <path
-        fill="currentColor"
-        fillOpacity={0.4}
-        d="M40.63 0c-4.867 0-8.812 3.028-8.812 8 0-4.972-3.946-8-8.812-8a.99.99 0 0 0-.979 1v18c0 .552.439 1 .98 1h17.622a.99.99 0 0 0 .98-1V1a.99.99 0 0 0-.98-1"
-      />
-      <path
-        fill="currentColor"
-        d="M63.637 19V1a.99.99 0 0 0-.98-1h-8.81c-5.407 0-9.791 4.478-9.791 10s4.384 10 9.79 10h8.811a.99.99 0 0 0 .98-1"
-      />
-      <path
-        fill="currentColor"
-        fillOpacity={0.4}
-        d="M63.637 19V1a.99.99 0 0 0-.98-1h-8.81c-5.407 0-9.791 4.478-9.791 10s4.384 10 9.79 10h8.811a.99.99 0 0 0 .98-1"
-      />
-    </g>
-    <defs>
-      <filter
-        id="UMCLogoFilled_svg__a"
-        width={63.637}
-        height={24}
-        x={0}
-        y={-4}
-        colorInterpolationFilters="sRGB"
-        filterUnits="userSpaceOnUse"
+
+interface UmcLogoFilledProps extends SVGProps<SVGSVGElement> {
+  variant?: "light" | "dark"
+}
+
+const UmcLogoFilled = ({ variant = "dark", ...props }: UmcLogoFilledProps) => {
+  if (variant === "light") {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 64 20"
+        {...props}
       >
-        <feFlood floodOpacity={0} result="BackgroundImageFix" />
-        <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
-        <feColorMatrix
-          in="SourceAlpha"
-          result="hardAlpha"
-          values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+        <g fill="#fff" filter="url(#UMCLogoFilled_light__a)">
+          <path d="M18.602 0H.979A.99.99 0 0 0 0 1v9c0 5.522 4.384 10 9.79 10 5.407 0 9.79-4.478 9.79-10V1a.99.99 0 0 0-.978-1M40.63 0c-4.866 0-8.812 3.028-8.812 8 0-4.972-3.945-8-8.811-8a.99.99 0 0 0-.98 1v18c0 .552.44 1 .98 1H40.63a.99.99 0 0 0 .979-1V1a.99.99 0 0 0-.98-1M63.636 19V1a.99.99 0 0 0-.98-1h-8.81c-5.407 0-9.79 4.478-9.79 10s4.383 10 9.79 10h8.81a.99.99 0 0 0 .98-1" />
+        </g>
+        <defs>
+          <filter
+            id="UMCLogoFilled_light__a"
+            width={63.636}
+            height={24}
+            x={0}
+            y={-4}
+            colorInterpolationFilters="sRGB"
+            filterUnits="userSpaceOnUse"
+          >
+            <feFlood floodOpacity={0} result="BackgroundImageFix" />
+            <feBlend
+              in="SourceGraphic"
+              in2="BackgroundImageFix"
+              result="shape"
+            />
+            <feColorMatrix
+              in="SourceAlpha"
+              result="hardAlpha"
+              values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            />
+            <feOffset dy={-4} />
+            <feGaussianBlur stdDeviation={2} />
+            <feComposite in2="hardAlpha" k2={-1} k3={1} operator="arithmetic" />
+            <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0" />
+            <feBlend in2="shape" result="effect1_innerShadow_7243_208411" />
+          </filter>
+        </defs>
+      </svg>
+    )
+  }
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 64 20"
+      {...props}
+    >
+      <g filter="url(#UMCLogoFilled_dark__a)">
+        <path
+          fill="currentColor"
+          d="M18.602 0H.979A.99.99 0 0 0 0 1v9c0 5.522 4.384 10 9.79 10 5.407 0 9.79-4.478 9.79-10V1a.99.99 0 0 0-.978-1"
         />
-        <feOffset dy={-4} />
-        <feGaussianBlur stdDeviation={2} />
-        <feComposite in2="hardAlpha" k2={-1} k3={1} operator="arithmetic" />
-        <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.06 0" />
-        <feBlend in2="shape" result="effect1_innerShadow_7289_1596" />
-      </filter>
-    </defs>
-  </svg>
-)
+        <path
+          fill="currentColor"
+          fillOpacity={0.4}
+          d="M18.602 0H.979A.99.99 0 0 0 0 1v9c0 5.522 4.384 10 9.79 10 5.407 0 9.79-4.478 9.79-10V1a.99.99 0 0 0-.978-1"
+        />
+        <path
+          fill="currentColor"
+          d="M40.63 0c-4.867 0-8.812 3.028-8.812 8 0-4.972-3.946-8-8.812-8a.99.99 0 0 0-.979 1v18c0 .552.439 1 .98 1h17.622a.99.99 0 0 0 .98-1V1a.99.99 0 0 0-.98-1"
+        />
+        <path
+          fill="currentColor"
+          fillOpacity={0.4}
+          d="M40.63 0c-4.867 0-8.812 3.028-8.812 8 0-4.972-3.946-8-8.812-8a.99.99 0 0 0-.979 1v18c0 .552.439 1 .98 1h17.622a.99.99 0 0 0 .98-1V1a.99.99 0 0 0-.98-1"
+        />
+        <path
+          fill="currentColor"
+          d="M63.637 19V1a.99.99 0 0 0-.98-1h-8.81c-5.407 0-9.791 4.478-9.791 10s4.384 10 9.79 10h8.811a.99.99 0 0 0 .98-1"
+        />
+        <path
+          fill="currentColor"
+          fillOpacity={0.4}
+          d="M63.637 19V1a.99.99 0 0 0-.98-1h-8.81c-5.407 0-9.791 4.478-9.791 10s4.384 10 9.79 10h8.811a.99.99 0 0 0 .98-1"
+        />
+      </g>
+      <defs>
+        <filter
+          id="UMCLogoFilled_dark__a"
+          width={63.637}
+          height={24}
+          x={0}
+          y={-4}
+          colorInterpolationFilters="sRGB"
+          filterUnits="userSpaceOnUse"
+        >
+          <feFlood floodOpacity={0} result="BackgroundImageFix" />
+          <feBlend in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+          <feColorMatrix
+            in="SourceAlpha"
+            result="hardAlpha"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+          />
+          <feOffset dy={-4} />
+          <feGaussianBlur stdDeviation={2} />
+          <feComposite in2="hardAlpha" k2={-1} k3={1} operator="arithmetic" />
+          <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.06 0" />
+          <feBlend in2="shape" result="effect1_innerShadow_7289_1596" />
+        </filter>
+      </defs>
+    </svg>
+  )
+}
+
 export default UmcLogoFilled

--- a/src/shared/assets/icon/logo/UmcLogoFilled.tsx
+++ b/src/shared/assets/icon/logo/UmcLogoFilled.tsx
@@ -13,7 +13,7 @@ const UmcLogoFilled = ({ variant = "dark", ...props }: UmcLogoFilledProps) => {
         viewBox="0 0 64 20"
         {...props}
       >
-        <g fill="#fff" filter="url(#UMCLogoFilled_light__a)">
+        <g fill="currentColor" filter="url(#UMCLogoFilled_light__a)">
           <path d="M18.602 0H.979A.99.99 0 0 0 0 1v9c0 5.522 4.384 10 9.79 10 5.407 0 9.79-4.478 9.79-10V1a.99.99 0 0 0-.978-1M40.63 0c-4.866 0-8.812 3.028-8.812 8 0-4.972-3.945-8-8.811-8a.99.99 0 0 0-.98 1v18c0 .552.44 1 .98 1H40.63a.99.99 0 0 0 .979-1V1a.99.99 0 0 0-.98-1M63.636 19V1a.99.99 0 0 0-.98-1h-8.81c-5.407 0-9.79 4.478-9.79 10s4.383 10 9.79 10h8.81a.99.99 0 0 0 .98-1" />
         </g>
         <defs>


### PR DESCRIPTION
## 📸 작업 내용

- `/matching` 하위 경로(`/matching/rounds`, `/matching/status` 등) 진입 시 헤더 '데모데이 매칭' 메뉴가 active 되지 않던 버그를 수정했습니다.
- `UmcLogoFilled` 컴포넌트에 `variant` prop(light/dark)을 추가해 기존 `UmClogoLightFilled.tsx`를 병합하고 단일 파일로 통합했습니다.
- `Footer` 컴포넌트에 `dark` variant를 추가했습니다 (bg `teal-gray-400`, 주요 텍스트 `white`, 나머지 `teal-gray-100`).
- `footer`·`header` 테스트 페이지를 보강했습니다.

## 🎞️ 주요 코드 설명

### activeBasePath — 네비게이션 목적지와 active 판단 기준 분리

```typescript
// headerNavPolicy.ts
export type HeaderNavItem = {
  label: string
  to: string
  activeBasePath?: string  // active 판단 기준 경로 (없으면 to 그대로 사용)
  disabled?: boolean
}

export const HEADER_NAV_ITEMS: HeaderNavItem[] = [
  { label: "소개", to: "/intro" },
  { label: "데모데이 매칭", to: "/matching/projects", activeBasePath: "/matching" },
  { label: "리크루팅", to: "/recruiting", disabled: true },
]

export function isHeaderNavItemActive(pathname: string, item: HeaderNavItem) {
  const basePath = item.activeBasePath ?? item.to
  if (basePath === "/intro") return pathname === "/intro"
  return pathname.startsWith(basePath)
}
```

- `to`는 클릭 시 이동할 경로, `activeBasePath`는 active 하이라이트 범위를 별도로 지정

### VARIANT_STYLES — Footer 색상 토큰 일괄 관리

```typescript
const VARIANT_STYLES = {
  light: { bg: "bg-teal-gray-100", primary: "text-teal-gray-400", ... },
  dark:  { bg: "bg-teal-gray-400", primary: "text-white", secondary: "text-teal-gray-100", ... },
}
```

- variant별 색상 객체를 컴포넌트 상단에서 선언해 JSX 내 조건 분기 없이 `s.primary` 형태로 적용

## 🖥️ 구현화면

> `/test/footer`, `/test/header` 테스트 페이지에서 확인 가능합니다.

## 🔗 연결된 이슈

- Connected: #393, #394, #395
- Closes #393
- Closes #394
- Closes #395