### PR TITLE
🐛 fix: 임시저장 후 등록 시 PENDING_REVIEW 전이 누락 수정 및 검토 요청 버튼 추가

### DIFF
--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -17,6 +17,7 @@ import { TeamMemberModal } from "@/features/project/list/ui/team-member-modal/Te
 import { deleteProject } from "@/features/project/management/api"
 import { invalidateProjectSummaryQueries } from "@/features/project/new/api"
 import { abortProject } from "@/features/project/new/api/projectAbort"
+import { submitProject } from "@/features/project/new/api/projectDraft"
 import { publishProject } from "@/features/project/new/api/projectPublish"
 import MoreVerticalIcon from "@/shared/assets/icon/more/MoreVerticalIcon"
 import { DropdownItem } from "@/shared/ui/dropdown/DropdownItem"
@@ -63,6 +64,7 @@ export function ProjectManagementMoreMenu({
   const queryClient = useQueryClient()
   const [popoverOpen, setPopoverOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
+  const [submitOpen, setSubmitOpen] = useState(false)
   const [publishOpen, setPublishOpen] = useState(false)
   const [abortOpen, setAbortOpen] = useState(false)
   const [applicationOpen, setApplicationOpen] = useState(false)
@@ -153,6 +155,34 @@ export function ProjectManagementMoreMenu({
     },
   })
 
+  const submitMutation = useMutation({
+    mutationFn: () => submitProject(numericProjectId),
+    onSuccess: () => {
+      setSubmitOpen(false)
+      invalidateProjectSummaryQueries(queryClient, numericProjectId)
+      addToast({
+        message: "검토 요청이 완료되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    },
+    onError: (error) => {
+      const serverMessage = isAxiosError(error)
+        ? (error.response?.data as { message?: string } | undefined)?.message
+        : undefined
+      addToast({
+        message:
+          serverMessage ?? "검토 요청에 실패했습니다. 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    },
+  })
+
   const publishMutation = useMutation({
     mutationFn: () => publishProject(numericProjectId),
     onSuccess: () => {
@@ -231,6 +261,13 @@ export function ProjectManagementMoreMenu({
     shouldPreventFocusRestoreRef.current = true
     setPopoverOpen(false)
     setPublishOpen(true)
+  }
+
+  const handleSubmitClick = () => {
+    if (!canEditProject || isPermissionLoading) return
+    shouldPreventFocusRestoreRef.current = true
+    setPopoverOpen(false)
+    setSubmitOpen(true)
   }
 
   const handleApplicationClick = () => {
@@ -318,6 +355,15 @@ export function ProjectManagementMoreMenu({
                   onClick={onClick}
                 />
               ))}
+              {status === "DRAFT" &&
+                (isPermissionLoading || canEditProject) && (
+                  <DropdownItem
+                    label="검토 요청하기"
+                    disabled={isPermissionLoading}
+                    onClick={handleSubmitClick}
+                    className="text-teal-500"
+                  />
+                )}
               {status === "PENDING_REVIEW" &&
                 (isPermissionLoading || canPublishProject) && (
                   <DropdownItem
@@ -388,6 +434,23 @@ export function ProjectManagementMoreMenu({
         onOpenChange={setDeleteOpen}
         onCancel={() => setDeleteOpen(false)}
         onConfirm={() => deleteMutation.mutate()}
+      />
+
+      <CtaModal
+        open={submitOpen}
+        title="검토 요청"
+        content={
+          <>
+            검토를 요청하면 운영진이 검토를 진행합니다. <br /> '{projectName}'을
+            검토 요청하시겠습니까?
+          </>
+        }
+        cancelText="돌아가기"
+        confirmText="검토 요청하기"
+        confirmLoading={submitMutation.isPending}
+        onOpenChange={setSubmitOpen}
+        onCancel={() => setSubmitOpen(false)}
+        onConfirm={() => submitMutation.mutate()}
       />
 
       <CtaModal

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -15,7 +15,10 @@ import { ApplicationDetailModal } from "@/features/application/ui/ApplicationDet
 import { getProjectDetail } from "@/features/project/list/api/matchingProject"
 import { TeamMemberModal } from "@/features/project/list/ui/team-member-modal/TeamMemberModal"
 import { deleteProject } from "@/features/project/management/api"
-import { invalidateProjectSummaryQueries } from "@/features/project/new/api"
+import {
+  invalidateProjectSummaryQueries,
+  projectKeys,
+} from "@/features/project/new/api"
 import { abortProject } from "@/features/project/new/api/projectAbort"
 import { submitProject } from "@/features/project/new/api/projectDraft"
 import { publishProject } from "@/features/project/new/api/projectPublish"
@@ -160,6 +163,9 @@ export function ProjectManagementMoreMenu({
     onSuccess: () => {
       setSubmitOpen(false)
       invalidateProjectSummaryQueries(queryClient, numericProjectId)
+      void queryClient.invalidateQueries({
+        queryKey: [...projectKeys.all, "draft"],
+      })
       addToast({
         message: "검토 요청이 완료되었습니다.",
         color: "primary",

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -369,10 +369,17 @@ function ProjectRegisterPage() {
         await upsertApplicationForm(projectId, body)
       }
       if (isEditMode) {
-        if (gisuId) {
+        const activeGisu = await queryClient.ensureQueryData({
+          queryKey: gisuKeys.active,
+          queryFn: getActiveGisu,
+        })
+        const resolvedGisuId = activeGisu?.gisuId
+          ? Number(activeGisu.gisuId)
+          : undefined
+        if (resolvedGisuId) {
           const draft = await queryClient.ensureQueryData({
-            queryKey: projectKeys.draft(Number(gisuId)),
-            queryFn: () => getMyDraft(Number(gisuId)),
+            queryKey: projectKeys.draft(resolvedGisuId),
+            queryFn: () => getMyDraft(resolvedGisuId),
           })
           const isEditingDraft =
             draft?.status === "DRAFT" &&
@@ -380,7 +387,7 @@ function ProjectRegisterPage() {
           if (isEditingDraft) {
             await submitProject(projectId)
             void queryClient.invalidateQueries({
-              queryKey: projectKeys.draft(Number(gisuId)),
+              queryKey: projectKeys.draft(resolvedGisuId),
             })
           }
         }

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -377,7 +377,12 @@ function ProjectRegisterPage() {
           const isEditingDraft =
             draft?.status === "DRAFT" &&
             Number(draft.id) === Number(editProjectId)
-          if (isEditingDraft) await submitProject(projectId)
+          if (isEditingDraft) {
+            await submitProject(projectId)
+            void queryClient.invalidateQueries({
+              queryKey: projectKeys.draft(Number(gisuId)),
+            })
+          }
         }
         return
       }

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -368,7 +368,19 @@ function ProjectRegisterPage() {
         )
         await upsertApplicationForm(projectId, body)
       }
-      if (isEditMode) return
+      if (isEditMode) {
+        if (gisuId) {
+          const draft = await queryClient.ensureQueryData({
+            queryKey: projectKeys.draft(Number(gisuId)),
+            queryFn: () => getMyDraft(Number(gisuId)),
+          })
+          const isEditingDraft =
+            draft?.status === "DRAFT" &&
+            Number(draft.id) === Number(editProjectId)
+          if (isEditingDraft) await submitProject(projectId)
+        }
+        return
+      }
       const result = await submitProject(projectId)
       if (pmInfo.pm1 && (await resolveCanEditRecruitStep())) {
         await transferOwnership(projectId, {


### PR DESCRIPTION
## 📸 작업 내용

> 임시저장(DRAFT) 프로젝트가 검토 대기(PENDING_REVIEW)로 넘어가지 못하던 문제를 고치고, 관리 화면에서 직접 전환할 수단을 추가했습니다.

- **[fix]** 수정하기(편집 모드)로 진입한 DRAFT도 '등록' 시 `submit`을 호출해 `DRAFT → PENDING_REVIEW`로 전이되도록 수정 (#401)
- **[feat]** 관리 페이지 더보기 메뉴에 'DRAFT → 검토 요청' 버튼 추가 — 가능 상태(DRAFT) + 권한 소유자(EDIT)에게만 노출 (#402, 서버팀 요구사항)
- 비DRAFT(PENDING_REVIEW/IN_PROGRESS) 편집은 기존대로 폼 저장만 수행, 불필요한 submit 호출 없음

## 🎞️ 주요 코드 설명

### 편집 모드 DRAFT 제출 (new.tsx)

```TypeScript
if (isEditMode) {
  if (gisuId) {
    const draft = await queryClient.ensureQueryData({
      queryKey: projectKeys.draft(Number(gisuId)),
      queryFn: () => getMyDraft(Number(gisuId)),
    })
    const isEditingDraft =
      draft?.status === "DRAFT" && Number(draft.id) === Number(editProjectId)
    if (isEditingDraft) await submitProject(projectId)
  }
  return
}
```

- 편집 모드라도 대상이 본인 DRAFT면 `submit` 호출. `getMyDraft`로 클릭 시점 상태를 확인하고, int64 문자열 직렬화를 고려해 id는 `Number()`로 정규화 비교.

### 검토 요청 버튼 (ProjectManagementMoreMenu.tsx)

```TypeScript
{status === "DRAFT" &&
  (isPermissionLoading || canEditProject) && (
    <DropdownItem
      label="검토 요청하기"
      disabled={isPermissionLoading}
      onClick={handleSubmitClick}
      className="text-teal-500"
    />
  )}
```

- 기존 '공개하기' 패턴을 그대로 따른 mutation + 확인 모달. 서버 `submit`의 `@CheckAccess(EDIT)` + DRAFT 검증과 노출 조건이 일치하며, 실패 시 서버 메시지(예: `PROJECT-0011`)를 그대로 노출.

## 🔗 연결된 이슈

- Connected: #401, #402
- Closes #401
- Closes #402