### PR TITLE
🐛 fix: 소개 페이지·푸터 팀 멤버 표기 정합성 수정

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -17,9 +17,13 @@ const TEAM_ROWS = [
   {
     role: "Mobile",
     members: {
-      group_1: ["PM 제용/정의찬", "Design 삼이/이희원", "Design 시안/우자영"],
-      group_2: ["iOS 원/김동민", "iOS 도도/김도연", "iOS 소피/이예지"],
-      group_3: ["Android 도리/김도연", "Android 어헛차/박유수"],
+      group_1: ["PM 제옹/정의찬", "Design 삼이/이희원", "Design 시안/우자영"],
+      group_2: ["iOS 원/김동민", "iOS 소피/이예지"],
+      group_3: [
+        "Android 조나단/조경석",
+        "Android 도리/김도연",
+        "Android 어헛차/박유수",
+      ],
     },
   },
   {

--- a/src/features/intro/ui/sections/ProductTeamMembersSection.tsx
+++ b/src/features/intro/ui/sections/ProductTeamMembersSection.tsx
@@ -75,7 +75,7 @@ const MOBILE_CARD: TeamCardData = {
       role: "Android",
       members: [
         { nickname: "조나단", name: "조경석" },
-        { nickname: "어핫차", name: "박유수" },
+        { nickname: "어헛차", name: "박유수" },
         { nickname: "도리", name: "김도연" },
       ],
     },
@@ -94,7 +94,7 @@ const SERVER_CARD: TeamCardData = {
         { nickname: "세니", name: "박세은", breakAfter: true },
         { nickname: "스읍", name: "이예은" },
         { nickname: "갈래", name: "김민서" },
-        { nickname: "커너", name: "박성현" },
+        { nickname: "우디", name: "박성현" },
         { nickname: "라미", name: "권도희" },
         { nickname: "이람", name: "박승범" },
       ],


### PR DESCRIPTION
## 📸 작업 내용

PR #410 리뷰(#3420287458)에서 지적된 소개 페이지(`ProductTeamMembersSection`)와 푸터(`Footer`) 간 팀 멤버 표기 불일치를, 팀 확정값으로 양쪽 통일했습니다.

- 소개 페이지: `어핫차 → 어헛차`(박유수), `커너 → 우디`(박성현)
- 푸터: `제용 → 제옹`(정의찬), iOS `도도/김도연` 중복 제거(김도연은 Android `도리`만 유지), Android 맨 앞에 `조나단/조경석` 추가

확정 기준(팀 결정): 정의찬=제옹, 박유수=어헛차, 박성현=우디, 김도연=Android 도리 단독, 조경석=조나단(Android).

## 🔗 연결된 이슈

- Connected: #413, #408
- Closes #413