### PR TITLE
🐛 fix: 푸터 하단 링크 정렬 보정 및 Product Blog 라벨 수정

### DIFF
--- a/src/components/footer/Footer.tsx
+++ b/src/components/footer/Footer.tsx
@@ -183,20 +183,22 @@ export default function Footer({ variant = "light" }: FooterProps) {
               target="_blank"
               rel="noopener noreferrer"
               className={cn(
-                "text-body-3-medium transition-colors hover:underline",
+                "text-body-3-medium pt-0.5 transition-colors hover:underline",
                 s.secondary,
                 s.linkHover,
               )}
             >
               iOS
             </a>
-            <span className={cn("text-body-3-medium", s.secondary)}>/</span>
+            <span className={cn("text-body-3-medium pt-0.5", s.secondary)}>
+              /
+            </span>
             <a
               href="https://play.google.com/store/apps/details?id=com.umc.product&hl=en"
               target="_blank"
               rel="noopener noreferrer"
               className={cn(
-                "text-body-3-medium transition-colors hover:underline",
+                "text-body-3-medium pt-0.5 transition-colors hover:underline",
                 s.secondary,
                 s.linkHover,
               )}
@@ -214,7 +216,7 @@ export default function Footer({ variant = "light" }: FooterProps) {
               )}
             >
               <UmcLogo className="ml-4 h-3 w-auto" />
-              <span className="hover:underline">Product Tech</span>
+              <span className="pt-0.5 hover:underline">Product Blog</span>
             </a>
           </div>
           <div className="flex items-center gap-6">


### PR DESCRIPTION
## 📸 작업 내용

- 푸터 하단 링크 행(iOS / Android, 구분자 `/`, 블로그 링크)에 `pt-0.5`를 추가해 로고 대비 텍스트 수직 정렬을 미세 보정했습니다.
- 블로그 링크 라벨을 `Product Tech` → `Product Blog`로 수정했습니다.

## 🖥️ 구현화면

- 푸터 하단 링크 정렬·라벨 변경 (UI 미세 조정)

## 🔗 연결된 이슈

- Connected: 없음
