### PR TITLE
🐛 fix: 루트 강제 /intro 리다이렉트 제거 및 권한별 분기 복원

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,7 +1,46 @@
 import { createFileRoute, redirect } from "@tanstack/react-router"
 
+import { ensureMe } from "@/features/auth/lib/ensureMe"
+import {
+  getViewerBranch,
+  isCurrentTermPm,
+  isOperator,
+} from "@/features/auth/model/identity"
+import { type Chapter, CHAPTERS } from "@/features/notice"
+
+function isChapter(value: unknown): value is Chapter {
+  return (
+    typeof value === "string" && (CHAPTERS as readonly string[]).includes(value)
+  )
+}
+
 export const Route = createFileRoute("/")({
-  beforeLoad: () => {
-    throw redirect({ to: "/intro" })
+  beforeLoad: async ({ context }) => {
+    const me = await ensureMe(context.queryClient)
+
+    if (isOperator(me)) {
+      throw redirect({ to: "/matching/projects" })
+    }
+
+    if (isCurrentTermPm(me)) {
+      const pmChapter = getViewerBranch(me)
+      throw redirect({
+        to: "/matching/projects/announce",
+        search: {
+          chapter: isChapter(pmChapter) ? pmChapter : CHAPTERS[0],
+          page: 1,
+        },
+      })
+    }
+
+    const userChapter = getViewerBranch(me)
+    if (isChapter(userChapter)) {
+      throw redirect({
+        to: "/matching",
+        search: { chapter: userChapter, page: 1 },
+      })
+    }
+
+    throw redirect({ to: "/challenger-verification" })
   },
 })


### PR DESCRIPTION
## 📸 작업 내용

> main 배포 후 루트 `/` 접속 시 의도치 않게 `/intro`로 강제 진입하던 회귀를 수정합니다.

- 루트 `/` `beforeLoad`가 무조건 `throw redirect({ to: "/intro" })` 하던 회귀(커밋 `69e44e6`)를 제거
- 배포 직전 정상 동작이던 **권한별 분기 로직** 복원
  - 운영진 → `/matching/projects`
  - PM → `/matching/projects/announce` (본인 지부)
  - 챌린저 → `/matching` (본인 지부)
  - 미인증 → `/challenger-verification`
- `/intro`는 자동 진입점이 사라지고 헤더에서도 `disabled`(준비 중) 상태이므로 **주소창 직접 접근 시에만** 노출 (라우트/페이지 자체는 미변경)

## 🎞️ 주요 코드 설명

### src/routes/index.tsx

```TypeScript
beforeLoad: async ({ context }) => {
  const me = await ensureMe(context.queryClient)
  if (isOperator(me)) throw redirect({ to: "/matching/projects" })
  // ...PM / 챌린저 / 미인증 분기
}
```

- 단일 `redirect({ to: "/intro" })`를 `ensureMe` 기반 권한별 분기로 되돌렸습니다.

## 🖥️ 구현화면

> 로컬 5173 런타임 검증: `/` 접속 시 더 이상 `/intro`로 가지 않고 미인증 분기(`/login`)로 정상 이동함을 확인했습니다.

## 🔗 연결된 이슈

- 긴급 핫픽스 (연결된 이슈 없음)

## 💬 기타 더 이야기해볼 점

- 이 회귀(`69e44e6`)는 **develop에도 동일하게 존재**합니다. 본 PR을 main에 머지한 뒤 develop에도 반드시 반영(백머지 또는 동일 수정)해야 다음 develop→main 배포 시 회귀가 재발하지 않습니다.