### PR TITLE
🐛 fix: 지원 관련 모달 타이틀 카드에 프로젝트 로고 표시

### DIFF
--- a/src/features/application/ui/MyApplicationMoreMenu.tsx
+++ b/src/features/application/ui/MyApplicationMoreMenu.tsx
@@ -91,6 +91,20 @@ export function MyApplicationMoreMenu({
     item.matchingRound.id != null &&
     Number(item.matchingRound.id) === Number(activeMatchingRound.id)
 
+  // /me/applications 응답에는 logoImageUrl이 없어, 모달이 열릴 때만 상세를 조회해 로고를 보완한다
+  const projectDetailQuery = useQuery({
+    queryKey: ["projectDetail", Number(item.projectId)],
+    queryFn: () => getProjectDetail(Number(item.projectId)),
+    enabled: formOpen,
+    staleTime: 60 * 1000,
+  })
+
+  const modalData = useMemo<MatchingProject>(() => {
+    const base = toModalData(item)
+    const logoUrl = projectDetailQuery.data?.logoImageUrl
+    return logoUrl ? { ...base, logoImage: { src: logoUrl } } : base
+  }, [item, projectDetailQuery.data])
+
   const cancelMutation = useMutation({
     mutationFn: () =>
       cancelApplication(Number(item.projectId), Number(item.applicationId)),
@@ -203,7 +217,7 @@ export function MyApplicationMoreMenu({
           <Modal.Overlay tone="deep" />
           <Modal.Content>
             <MyApplicationModal
-              data={toModalData(item)}
+              data={modalData}
               projectId={Number(item.projectId)}
               applicationId={Number(item.applicationId)}
               isRoundOpen={isRoundOpen}

--- a/src/features/project/list/ui/apply-modal/ApplyProjectTitleCard.test.tsx
+++ b/src/features/project/list/ui/apply-modal/ApplyProjectTitleCard.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { ApplyProjectTitleCard } from "./ApplyProjectTitleCard"
+
+describe("ApplyProjectTitleCard", () => {
+  it("logoSrc가 있으면 프로젝트 로고 이미지를 렌더한다", () => {
+    render(
+      <ApplyProjectTitleCard
+        projectName="테스트 프로젝트"
+        logoSrc="https://example.com/logo.png"
+      />,
+    )
+
+    const img = screen.getByAltText("project logo")
+    expect(img).toBeInTheDocument()
+    expect(img).toHaveAttribute("src", "https://example.com/logo.png")
+  })
+
+  it("logoSrc가 없으면 이미지 대신 fallback을 렌더한다", () => {
+    render(<ApplyProjectTitleCard projectName="테스트 프로젝트" />)
+
+    expect(screen.queryByAltText("project logo")).not.toBeInTheDocument()
+  })
+})

--- a/src/features/project/list/ui/apply-modal/ApplyProjectTitleCard.tsx
+++ b/src/features/project/list/ui/apply-modal/ApplyProjectTitleCard.tsx
@@ -1,7 +1,9 @@
+import { ProjectLogo } from "@/shared/assets/icon/logo/ProjectLogo"
 import { cn } from "@/shared/lib/utils"
 
 interface ApplyProjectTitleCardProps {
   projectName: string
+  logoSrc?: string
   challengerName?: string
   challengerUniversity?: string
   subtitle?: string
@@ -30,6 +32,7 @@ export const TRAPEZOID_CLIP_PATH = [
 
 export function ApplyProjectTitleCard({
   projectName,
+  logoSrc,
   challengerName,
   challengerUniversity,
   subtitle,
@@ -50,7 +53,7 @@ export function ApplyProjectTitleCard({
         className="flex h-15 w-fit max-w-[calc(100%-1rem)] min-w-69.5 shrink-0 items-center gap-3.5 bg-teal-100 bg-linear-to-r py-2.5 pr-14 pl-4"
         style={{ clipPath: TRAPEZOID_CLIP_PATH }}
       >
-        <div className="bg-teal-gray-200 size-8 shrink-0 rounded-lg" />
+        <ProjectLogo src={logoSrc} size={32} />
         <div className="flex min-w-0 flex-col">
           <span className="text-subtitle-4-semibold text-teal-gray-800 truncate">
             {projectName}

--- a/src/features/project/list/ui/apply-modal/MyApplicationModal.tsx
+++ b/src/features/project/list/ui/apply-modal/MyApplicationModal.tsx
@@ -108,6 +108,7 @@ export function MyApplicationModal({
       <div className="flex w-full">
         <ApplyProjectTitleCard
           projectName={data.title}
+          logoSrc={data.logoImage?.src}
           subtitle={data.authorSchoolLine}
         />
       </div>

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -707,6 +707,7 @@ export const ProjectApplyModal = forwardRef<
         <div className="flex w-full">
           <ApplyProjectTitleCard
             projectName={data.title}
+            logoSrc={data.logoImage?.src}
             subtitle={data.authorSchoolLine}
           />
         </div>

--- a/src/features/project/list/ui/apply-modal/RecruitQuestionsViewModal.tsx
+++ b/src/features/project/list/ui/apply-modal/RecruitQuestionsViewModal.tsx
@@ -50,6 +50,7 @@ export function RecruitQuestionsViewModal({
       <div className="flex w-full">
         <ApplyProjectTitleCard
           projectName={data.title}
+          logoSrc={data.logoImage?.src}
           subtitle={data.authorSchoolLine}
         />
       </div>


### PR DESCRIPTION
## 📸 작업 내용

- **지원 관련 모달의 타이틀 카드에서 프로젝트 로고가 placeholder(회색 박스)만 노출되던 버그 수정.**
- 원인: `ApplyProjectTitleCard`가 로고 자리에 하드코딩된 `<div>`만 그리고 로고 prop 자체가 없었음. 로고 데이터(`logoImageUrl`)는 들어오는데 사용되지 않음.
- 공용 컴포넌트라 **모집 문항 보기 + 지원하기 + 내 지원서 보기** 모달 전부 영향.

## 🎞️ 주요 코드 설명

- `ApplyProjectTitleCard`에 `logoSrc?: string` 추가 → placeholder div를 `<ProjectLogo src={logoSrc} size={32} />`로 교체 (src 있으면 `<img>`, 없으면 UmcLogo fallback).
- 호출처에서 로고 URL 전달:
  - `RecruitQuestionsViewModal` / `ProjectApplyModal` / `MyApplicationModal`(ProjectDetailCard 경유): `logoSrc={data.logoImage?.src}` (상세 데이터에 logoImage 존재).
  - **`MyApplicationMoreMenu`("내 지원서 보기") 경유 `MyApplicationModal`**: `/v1/projects/me/applications` 응답에 `logoImageUrl`이 없어, 모달이 열릴 때 `getProjectDetail(projectId)`로 상세를 조회해 `logoImage`를 주입(백엔드 변경 없이 우회). `GET /v1/projects/{projectId}`(`ProjectDetailResponse`)는 `logoImageUrl`을 반환함을 서버 소스로 확인.
- 회귀 테스트(`ApplyProjectTitleCard.test.tsx`): logoSrc 있으면 `<img>`, 없으면 fallback.

## 🖥️ 구현화면

- 모집 문항 보기 / 지원 / 내 지원서 보기(상세·더보기 메뉴 경유 모두): 프로젝트 로고 표시 복구 — 동덕여자대학교 회장 김가은 제보.

## 🔗 연결된 이슈

- Connected: #424
- Closes #424
