### PR TITLE
🐛 fix: 학교 회장단 지원 현황 통계를 지부 전체 기준으로 집계

### DIFF
--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -364,7 +364,8 @@ export function useAdminPageData(
 
     // 해당 챕터 소속 학교 + 프로젝트만 필터링 (로딩 중엔 빈 Set으로 필터링해 flicker 방지)
     // 학교 회장단 포함 모든 운영진은 지부 전체 통계를 본다 (지부 현황은 지부 단위 집계, 총원·완료율·학교별 분포 일관)
-    const schoolFilter = (id: string) => (chapterSchoolIds ?? new Set()).has(id)
+    const schoolIds = chapterSchoolIds ?? new Set<string>()
+    const schoolFilter = (id: string) => schoolIds.has(id)
     const filteredSummary = chapterName
       ? {
           ...chapterStatsQuery.data.summary,

--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -312,15 +312,6 @@ export function useAdminPageData(
     return map
   }, [schoolsQuery.data])
 
-  // SCHOOL_PRESIDENT: 본인 학교 schoolId 역매핑
-  const mySchoolId = useMemo(() => {
-    if (!schoolName) return undefined
-    for (const [id, name] of schoolIdToName) {
-      if (name === schoolName) return id
-    }
-    return undefined
-  }, [schoolName, schoolIdToName])
-
   // 매칭 차수 조회 (현재 진행 차수 계산용)
   const roundsQuery = useQuery({
     queryKey: applicationKeys.matchingRounds(chapterId),
@@ -372,10 +363,8 @@ export function useAdminPageData(
     }
 
     // 해당 챕터 소속 학교 + 프로젝트만 필터링 (로딩 중엔 빈 Set으로 필터링해 flicker 방지)
-    // SCHOOL_PRESIDENT: mySchoolId가 있으면 본인 학교만 필터링
-    const schoolFilter = mySchoolId
-      ? (id: string) => id === mySchoolId
-      : (id: string) => (chapterSchoolIds ?? new Set()).has(id)
+    // 학교 회장단 포함 모든 운영진은 지부 전체 통계를 본다 (지부 현황은 지부 단위 집계, 총원·완료율·학교별 분포 일관)
+    const schoolFilter = (id: string) => (chapterSchoolIds ?? new Set()).has(id)
     const filteredSummary = chapterName
       ? {
           ...chapterStatsQuery.data.summary,
@@ -484,7 +473,6 @@ export function useAdminPageData(
     schoolIdToName,
     chapterName,
     chapterSchoolIds,
-    mySchoolId,
     currentRound,
   ])
 


### PR DESCRIPTION
## 📸 작업 내용

- **Admin 지원 현황에서 학교 회장단(SCHOOL_PRESIDENT/회장단)이 볼 때 총원이 지부 전체가 아닌 본인 학교 인원만 표시되던 버그 수정.**
- 원인: `useAdminPageData`의 `schoolFilter`가 `mySchoolId`가 있으면 `schoolMatchingStatistics`를 본인 학교 1개로 필터링 → `summaryToStats`가 그 배열로 총원·완료수·완료율·학교별 분포를 산출해 모두 학교 단위로 축소.
- 총원·완료율 등은 같은 `schoolMatchingStatistics`에서 파생되어 분리할 수 없으므로, 학교 회장단도 **지부 전체 통계**를 보도록 `schoolFilter`를 항상 지부(`chapterSchoolIds`) 기준으로 통일. (지부 현황은 지부 단위 집계이며, 학교 리더십이 지부 현황을 보는 역할 설계와도 일치)

## 🎞️ 주요 코드 설명

- `schoolFilter`를 `mySchoolId` 분기 없이 `chapterSchoolIds` 기준으로 단일화. 이 필터에만 쓰이던 `mySchoolId` 역매핑 제거.
- 본인 학교 PM 프로젝트 테이블 스코핑(`schoolName` 기반, 별개 로직)은 그대로 유지.

## 🔌 API 검증 (서버)

- `GET /v1/projects/statistics?chapterId=` → `summary.schoolMatchingStatistics[].totalMemberCount`는 **학교별 eligible 인원**(`ProjectStatisticsQueryService`가 gisu eligible 멤버를 학교별 grouping). **전 학교 합 = 지부 전체 인원**.
- `Gisu`가 `chapterId`(지부)를 가져 gisu 모집단 = 지부 단위 → 전 학교 합산이 곧 지부 총원.

## 🖥️ 구현화면

- Admin 지원 현황 총원: 지부 전체 기준 — 동덕여자대학교 회장 김가은 제보. (학교 회장단 계정으로 실제 데이터 검증 권장)

## 🔗 연결된 이슈

- Connected: 없음
