### PR TITLE
🐛 fix: 매칭 현황 총원을 라운드 가시성과 무관하게 표시

### DIFF
--- a/src/features/matching/hooks/useMatchingStatusData.ts
+++ b/src/features/matching/hooks/useMatchingStatusData.ts
@@ -348,7 +348,8 @@ export function useMatchingStatusData(chapterName?: string) {
       roundsQuery.isLoading ||
       projectsQuery.isLoading ||
       applicantsQuery.isLoading ||
-      chapterStatsQuery.isLoading,
+      chapterStatsQuery.isLoading ||
+      chaptersWithSchoolsQuery.isLoading,
     isError:
       gisuQuery.isError || chaptersQuery.isError || projectsQuery.isError,
     error:

--- a/src/features/matching/hooks/useMatchingStatusData.ts
+++ b/src/features/matching/hooks/useMatchingStatusData.ts
@@ -243,23 +243,35 @@ export function useMatchingStatusData(chapterName?: string) {
   }
 
   const stats: ApplicationStats = useMemo(() => {
-    // s2 이전: 아무 정보도 표시하지 않음
-    if (!chapterStatsQuery.data || visibleUpToRound === 0) return emptyStats
+    if (!chapterStatsQuery.data) return emptyStats
+
+    const summary = chapterStatsQuery.data.summary
+    // 총원·학교별 분포는 지부 모집단 기준 (라운드 가시성과 무관)
+    const chapterSchoolStats = chapterName
+      ? summary.schoolMatchingStatistics.filter((s) =>
+          (chapterSchoolIds ?? new Set()).has(String(s.schoolId)),
+        )
+      : summary.schoolMatchingStatistics
+    const totalMembers = chapterSchoolStats.reduce(
+      (sum, s) => sum + Number(s.totalMemberCount),
+      0,
+    )
+
+    // s2 이전: 차수별 매칭 결과는 숨기되 지부 총원은 표시
+    if (visibleUpToRound === 0) {
+      return { ...emptyStats, totalMembers, pendingCount: totalMembers }
+    }
 
     // 해당 챕터 소속 학교 + 프로젝트만 필터링 (로딩 중엔 빈 Set으로 필터링해 flicker 방지)
     const filteredSummary = chapterName
       ? {
-          ...chapterStatsQuery.data.summary,
-          schoolMatchingStatistics:
-            chapterStatsQuery.data.summary.schoolMatchingStatistics.filter(
-              (s) => (chapterSchoolIds ?? new Set()).has(String(s.schoolId)),
-            ),
-          projectRoundStatistics:
-            chapterStatsQuery.data.summary.projectRoundStatistics.filter((p) =>
-              projectIdToName.has(String(p.projectId)),
-            ),
+          ...summary,
+          schoolMatchingStatistics: chapterSchoolStats,
+          projectRoundStatistics: summary.projectRoundStatistics.filter((p) =>
+            projectIdToName.has(String(p.projectId)),
+          ),
         }
-      : chapterStatsQuery.data.summary
+      : summary
 
     // visibleUpToRound 차수까지의 결과만 표시
     // Top4는 d3 이후에도 1차 기준


### PR DESCRIPTION
## 📸 작업 내용

- **매칭 현황의 총원이 0명으로 표시되던 버그 수정.**
- 원인: `useMatchingStatusData`의 stats 계산에서 `visibleUpToRound === 0`(2차 결과 공개 전)이면 `emptyStats`(`totalMembers: 0`)를 통째로 반환 → 라운드 결과뿐 아니라 **지부 총원까지 0**이 됨.
- 총원·학교별 분포는 시점과 무관한 지부 모집단 값이므로, `schoolMatchingStatistics`에서 라운드 가시성과 무관하게 산출하도록 분리. 차수별 매칭 결과(rounds/완료/도넛/top/projectRounds)만 2차 전까지 숨김 유지.

## 🎞️ 주요 코드 설명

- 가드를 `if (!chapterStatsQuery.data) return emptyStats`로 좁히고, 지부 총원(`totalMembers`)을 먼저 계산.
- `visibleUpToRound === 0`이면 `{ ...emptyStats, totalMembers, pendingCount: totalMembers }` 반환(총원만 표시, 전원 대기).
- 이후 경로의 `filteredSummary`는 동일 `chapterSchoolStats`를 재사용해 동작 불변.

## 🔌 API 검증

- `schoolMatchingStatistics[].totalMemberCount`는 gisu(지부) eligible 멤버를 학교별로 집계한 값으로 **라운드/시간에 의존하지 않음** → 총원을 라운드 가드로 0 처리하던 것이 잘못.

## 🖥️ 구현화면

- 매칭 현황 총원: 1차 지원 기간/2차 공개 전에도 지부 총원 표시 — 동덕여자대학교 회장 김가은 제보. (실제 1차 기간 데이터로 검증 권장)

## 🔗 연결된 이슈

- Connected: 없음
