### PR TITLE
🐛 fix: 지원률 분모를 지원 가능 인원으로 명확히 표기

### DIFF
--- a/src/features/application/ui/ChallengerStatsSection.tsx
+++ b/src/features/application/ui/ChallengerStatsSection.tsx
@@ -89,6 +89,11 @@ export function ChallengerStatsSection({
           {/* 하단 차수별 breakdown */}
           <div className="bg-stats-breakdown absolute right-7.5 bottom-8 w-44.5 rounded px-3.5 py-3">
             <div className="flex flex-col gap-1.25 text-[12px]">
+              <div className="text-label-4-medium text-teal-gray-400 flex items-center justify-end gap-1 leading-normal">
+                <span className="text-teal-500">지원</span>
+                <span>/</span>
+                <span>지원 가능 인원</span>
+              </div>
               {stats.rounds.map((r) => (
                 <div key={r.round} className="flex items-center gap-7">
                   <div className="text-body-3-medium text-teal-gray-600 flex items-center gap-0.75 leading-normal">


### PR DESCRIPTION
## 📸 작업 내용

- **Challenger 뷰 "매칭 차수별 지원률" breakdown의 분모가 지부 전체 인원으로 오인되던 문제를 라벨 보정으로 해결.**
- 분모 값(`availableMemberCount`)은 의도된 값이므로 그대로 두고, 컬럼 범례(`지원 / 지원 가능 인원`)를 추가해 두 번째 수가 "지원 가능 인원"임을 명확히 함.

## 🔌 API 검증 (서버 origin/develop)

- 분모는 프로젝트 통계 엔드포인트(`GET /v1/projects/{projectId}/statistics`)의 `roundApplicationStatistics[].availableMemberCount`.
- 서버 `ProjectStatisticsQueryService`상 이 값 = `(gisu eligible 인원) − (누적 매칭 인원)`으로 **라운드가 진행될수록 감소하는 "잔여 지원 가능 인원"**. 따라서 고정된 지부 총원과 다른 것이 정상 동작.
- 결정: 분모 의미를 그대로 유지하고 라벨만 보정(제품 의도 확정 결과).

## 🎞️ 주요 코드 설명

- breakdown 상단에 범례 1줄 추가(`지원 / 지원 가능 인원`). 값/계산 로직 변경 없음(라벨 전용).

## 🖥️ 구현화면

- 매칭 차수별 지원률 breakdown: 분모가 "지원 가능 인원"임을 명시 — 동덕여자대학교 회장 김가은 제보. (실제 화면에서 범례 배치 확인 권장)

## 🔗 연결된 이슈

- Connected: 없음
