### PR TITLE
fix: 임시저장(DRAFT)된 프로젝트의 수정/등록 과정 및 캐시 관련 버그 수정

### DIFF
--- a/src/features/project/new/ui/application/ApplicationForm.tsx
+++ b/src/features/project/new/ui/application/ApplicationForm.tsx
@@ -39,6 +39,7 @@ interface ApplicationFormProps {
   onPrev?: () => void
   onNext?: () => void
   isEditMode?: boolean
+  isDraft?: boolean
   readOnly?: boolean
   isHydrated?: boolean
   isSubmitting?: boolean
@@ -54,6 +55,7 @@ export const ApplicationForm = forwardRef<
     onPrev,
     onNext,
     isEditMode = false,
+    isDraft = false,
     readOnly = false,
     isHydrated = true,
     isSubmitting = false,
@@ -387,7 +389,7 @@ export const ApplicationForm = forwardRef<
               disabled={isSubmitting}
               onClick={handleNext}
             >
-              {isEditMode ? "수정 완료" : "등록하기"}
+              {isEditMode && !isDraft ? "수정 완료" : "등록하기"}
             </Button>
           )}
         </div>

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -453,7 +453,7 @@ export const BasicInfoForm = forwardRef<
       setBasicDraftFields({
         title: values.title,
         description: values.description,
-        externalLink: values.externalLink,
+        externalLink: values.externalLink ?? "",
       })
       invalidateProjectSummaryQueries(queryClient, resolvedProjectId)
       reset(values, { keepValues: true, keepDirty: false })

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -417,7 +417,6 @@ export const BasicInfoForm = forwardRef<
         const res = await uploadFileFlow(values.thumbnail, "PROJECT_THUMBNAIL")
         thumbnailFileId = res.fileId ?? null
         thumbnailUrl = res.downloadUrl ?? null
-        setUploaded({ thumbnailFileId, thumbnailUrl })
       }
 
       let logoFileId = uploaded.logoFileId
@@ -426,7 +425,15 @@ export const BasicInfoForm = forwardRef<
         const res = await uploadFileFlow(values.logo, "PROJECT_LOGO")
         logoFileId = res.fileId ?? null
         logoUrl = res.downloadUrl ?? null
-        setUploaded({ logoFileId, logoUrl })
+      }
+
+      if (
+        thumbnailFileId !== uploaded.thumbnailFileId ||
+        thumbnailUrl !== uploaded.thumbnailUrl ||
+        logoFileId !== uploaded.logoFileId ||
+        logoUrl !== uploaded.logoUrl
+      ) {
+        setUploaded({ thumbnailFileId, thumbnailUrl, logoFileId, logoUrl })
       }
 
       await updateProjectDraft(resolvedProjectId, {

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -138,6 +138,9 @@ export const BasicInfoForm = forwardRef<
   const setProjectId = useProjectRegisterStore((s) => s.setProjectId)
   const setBasicInfo = useProjectRegisterStore((s) => s.setBasicInfo)
   const basicDraftFields = useProjectRegisterStore((s) => s.basicDraftFields)
+  const setBasicDraftFields = useProjectRegisterStore(
+    (s) => s.setBasicDraftFields,
+  )
   const addToast = useToastStore((s) => s.addToast)
   const queryClient = useQueryClient()
 
@@ -409,17 +412,21 @@ export const BasicInfoForm = forwardRef<
       }
 
       let thumbnailFileId = uploaded.thumbnailFileId
+      let thumbnailUrl = uploaded.thumbnailUrl
       if (values.thumbnail instanceof File && !thumbnailFileId) {
         const res = await uploadFileFlow(values.thumbnail, "PROJECT_THUMBNAIL")
         thumbnailFileId = res.fileId ?? null
-        setUploaded({ thumbnailFileId })
+        thumbnailUrl = res.downloadUrl ?? null
+        setUploaded({ thumbnailFileId, thumbnailUrl })
       }
 
       let logoFileId = uploaded.logoFileId
+      let logoUrl = uploaded.logoUrl
       if (values.logo instanceof File && !logoFileId) {
         const res = await uploadFileFlow(values.logo, "PROJECT_LOGO")
         logoFileId = res.fileId ?? null
-        setUploaded({ logoFileId })
+        logoUrl = res.downloadUrl ?? null
+        setUploaded({ logoFileId, logoUrl })
       }
 
       await updateProjectDraft(resolvedProjectId, {
@@ -443,6 +450,11 @@ export const BasicInfoForm = forwardRef<
       }
 
       setPmInfo({ isMultiPm, pm1: pm1Member, pm2: pm2Member })
+      setBasicDraftFields({
+        title: values.title,
+        description: values.description,
+        externalLink: values.externalLink,
+      })
       invalidateProjectSummaryQueries(queryClient, resolvedProjectId)
       reset(values, { keepValues: true, keepDirty: false })
       setSavedSnapshot({ pm1: pm1Member, pm2: pm2Member, isMultiPm })

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -378,9 +378,24 @@ function ProjectRegisterPage() {
           : undefined
         if (resolvedGisuId) {
           const draft = await getMyDraft(resolvedGisuId)
-          const isEditingDraft =
+          const isOwnDraft =
             draft?.status === "DRAFT" &&
             Number(draft.id) === Number(editProjectId)
+
+          let isEditingDraft = isOwnDraft
+
+          if (!isEditingDraft) {
+            try {
+              const managed = await getManagedProjects(resolvedGisuId)
+              const currentProject = managed.find(
+                (p) => Number(p.id) === Number(editProjectId),
+              )
+              isEditingDraft = currentProject?.status === "DRAFT"
+            } catch {
+              // ignore
+            }
+          }
+
           if (isEditingDraft) {
             await submitProject(projectId)
             void queryClient.invalidateQueries({

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -400,7 +400,9 @@ function ProjectRegisterPage() {
 
           if (!isEditingDraft) {
             try {
-              const managed = await getManagedProjects(resolvedGisuId)
+              const managed = await getManagedProjects(resolvedGisuId, {
+                size: 200,
+              })
               const currentProject = managed.find(
                 (p) => Number(p.id) === Number(editProjectId),
               )

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -285,6 +285,20 @@ function ProjectRegisterPage() {
     enabled: isEditMode,
   })
 
+  const managedQuery = useQuery({
+    queryKey: projectKeys.managedMe(gisuId ? Number(gisuId) : undefined),
+    queryFn: () => getManagedProjects(Number(gisuId)!, { size: 200 }),
+    enabled: isEditMode && !!gisuId,
+  })
+
+  const isDraft = useMemo(() => {
+    if (!isEditMode || !editProjectId || !managedQuery.data) return false
+    const project = managedQuery.data.find(
+      (p) => Number(p.id) === Number(editProjectId),
+    )
+    return project?.status === "DRAFT"
+  }, [isEditMode, editProjectId, managedQuery.data])
+
   useEffect(() => {
     if (detailQuery.data) {
       hydrateProjectDetailIntoStore(detailQuery.data)
@@ -635,6 +649,7 @@ function ProjectRegisterPage() {
           <ApplicationForm
             ref={applicationFormRef}
             isEditMode={isEditMode}
+            isDraft={isDraft}
             readOnly={isApplicationReadOnly}
             isHydrated={isEditMode ? applicationFormHydrated : true}
             isSubmitting={submitMutation.isPending || isCreatePermissionLoading}
@@ -648,9 +663,9 @@ function ProjectRegisterPage() {
       <CtaModal
         open={showSuccessModal}
         variant="success"
-        title={isEditMode ? "수정 완료" : "등록 완료"}
+        title={isEditMode && !isDraft ? "수정 완료" : "등록 완료"}
         content={
-          isEditMode
+          isEditMode && !isDraft
             ? "프로젝트 수정이 완료되었습니다."
             : "프로젝트 등록이 완료되었습니다."
         }

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -377,10 +377,7 @@ function ProjectRegisterPage() {
           ? Number(activeGisu.gisuId)
           : undefined
         if (resolvedGisuId) {
-          const draft = await queryClient.ensureQueryData({
-            queryKey: projectKeys.draft(resolvedGisuId),
-            queryFn: () => getMyDraft(resolvedGisuId),
-          })
+          const draft = await getMyDraft(resolvedGisuId)
           const isEditingDraft =
             draft?.status === "DRAFT" &&
             Number(draft.id) === Number(editProjectId)
@@ -562,7 +559,8 @@ function ProjectRegisterPage() {
       queryClient.removeQueries({
         queryKey: projectKeys.applicationForm(editProjectId),
       })
-    } else if (gisuId) {
+    }
+    if (gisuId) {
       queryClient.removeQueries({
         queryKey: projectKeys.draft(Number(gisuId)),
       })


### PR DESCRIPTION
## 📸 작업 내용

임시저장(DRAFT)된 프로젝트의 수정/등록 과정 및 캐시 관련 버그 수정

- **캐시 문제 해결**: 기존에 캐시된 드래프트 정보로 인해 프로젝트 제출 여부가 정상 판별되지 않던 문제를 `getMyDraft` API 다이렉트 조회 및 완료 시 캐시 명시적 제거(`removeQueries`)를 통해 해결했습니다.
- **임시저장 탭 이동 시 정보 유실 방지**: 기본 정보 입력 단계에서 탭 이동 시 새로 업로드한 이미지 URL과 텍스트 필드 값들이 보존되도록 상태 저장 로직을 보완했습니다.
- **공동 PM 및 운영진 대리 제출 버그 수정**: 공동 PM(PM2)이나 권한이 있는 운영진이 임시저장 프로젝트를 수정 모드에서 완료할 때 `submitProject` API 호출이 건너뛰어지는 현상을 `getManagedProjects` 목록을 통한 2차 검증(fallback) 조건으로 해결했습니다.
- **문구 및 버튼 UI 일관성 개선**: DRAFT 상태인 프로젝트를 수정 모드로 수정하는 경우, 최종 완료 버튼을 '수정 완료' 대신 '등록하기'로 노출하고 성공 모달 팝업의 문구 또한 '등록 완료'로 통일하여 사용자 경험을 향상시켰습니다.

## 🎞️ 주요 코드 설명

### 1. 공동 PM 및 운영진의 임시저장 프로젝트 제출 교차 검증 (fallback)
[new.tsx](file:///C:/Users/doldo/Desktop/PROJECT/UMC/Product/src/routes/matching/projects/new.tsx#L378-L398)

```TypeScript
const draft = await getMyDraft(resolvedGisuId)
const isOwnDraft =
  draft?.status === "DRAFT" &&
  Number(draft.id) === Number(editProjectId)

let isEditingDraft = isOwnDraft

if (!isEditingDraft) {
  try {
    const managed = await getManagedProjects(resolvedGisuId)
    const currentProject = managed.find(
      (p) => Number(p.id) === Number(editProjectId),
    )
    isEditingDraft = currentProject?.status === "DRAFT"
  } catch {
    // ignore
  }
}

if (isEditingDraft) {
  await submitProject(projectId)
  void queryClient.invalidateQueries({
    queryKey: projectKeys.draft(resolvedGisuId),
  })
}
```
- 본인이 PM1(메인 작성자)이 아니어서 `getMyDraft`가 null 또는 다른 드래프트를 반환하더라도, 본인의 관리 프로젝트 목록(`getManagedProjects`)에서 해당 프로젝트의 상태가 `DRAFT`임을 확인하면 정상적으로 제출 프로세스(`submitProject`)를 거치도록 수정했습니다.

### 2. 기본 정보 탭 이동 시 데이터 유실 방지
[BasicInfoForm.tsx](file:///C:/Users/doldo/Desktop/PROJECT/UMC/Product/src/features/project/new/ui/basic-info/BasicInfoForm.tsx#L410-L460)

```TypeScript
// 이미지 파일 신규 업로드 후 URL 상태에 업데이트
let logoFileId = uploaded.logoFileId
let logoUrl = uploaded.logoUrl
if (values.logo instanceof File && !logoFileId) {
  const res = await uploadFileFlow(values.logo, "PROJECT_LOGO")
  logoFileId = res.fileId ?? null
  logoUrl = res.downloadUrl ?? null
  setUploaded({ logoFileId, logoUrl })
}

// ...

// Zustand 기본 기획 필드 동기화
setBasicDraftFields({
  title: values.title,
  description: values.description,
  externalLink: values.externalLink,
})
```
- 업로드된 이미지 파일의 downloadUrl 상태 보존 및 입력값의 Zustand 동기화를 통해 탭 이동 시 1단계의 데이터가 모두 정상 복구되도록 개선했습니다.

### 3. DRAFT 프로젝트 수정 모드에서의 완료 버튼 분기
[ApplicationForm.tsx](file:///C:/Users/doldo/Desktop/PROJECT/UMC/Product/src/features/project/new/ui/application/ApplicationForm.tsx#L389-L394)

```TypeScript
<Button
  type="button"
  variant="fill"
  color="primary"
  isLoading={isSubmitting}
  disabled={isSubmitting}
  onClick={handleNext}
>
  {isEditMode && !isDraft ? "수정 완료" : "등록하기"}
</Button>
```
- 수정 모드로 진입했더라도 해당 프로젝트가 등록되지 않은 `DRAFT` 상태라면 버튼 명칭을 '등록하기'로 보여주어 유저가 등록 액션을 명확히 인지하게 조치했습니다.

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #430 
