### PR TITLE
Task/프로젝트 관리 권한별 메뉴 분기

### DIFF
--- a/src/features/auth/hooks/useOAuthLinking.ts
+++ b/src/features/auth/hooks/useOAuthLinking.ts
@@ -30,6 +30,7 @@ export function useOAuthLinking() {
   const addToast = useToastStore((s) => s.addToast)
   const queryClient = useQueryClient()
   const [isLinking, setIsLinking] = useState(false)
+  const [isUnlinkBlockedOpen, setIsUnlinkBlockedOpen] = useState(false)
 
   const handleGoogleLink = async () => {
     if (isLinking) return
@@ -162,12 +163,12 @@ export function useOAuthLinking() {
       const errorCode = isAxiosError(err)
         ? (err.response?.data as { code?: string } | undefined)?.code
         : undefined
-      const message =
-        errorCode === "AUTHENTICATION-0016"
-          ? "비밀번호가 없는 계정은 마지막 소셜 연동을 해제할 수 없어요.\n비밀번호를 먼저 설정해주세요."
-          : "연동 해제에 실패했습니다. 다시 시도해주세요."
+      if (errorCode === "AUTHENTICATION-0016") {
+        setIsUnlinkBlockedOpen(true)
+        return
+      }
       addToast({
-        message,
+        message: "연동 해제에 실패했습니다. 다시 시도해주세요.",
         color: "red",
         variant: "deep",
         type: "default",
@@ -181,5 +182,7 @@ export function useOAuthLinking() {
     handleAppleLink,
     handleKakaoLink,
     handleUnlink,
+    isUnlinkBlockedOpen,
+    setIsUnlinkBlockedOpen,
   }
 }

--- a/src/features/project/management/ui/ProjectManagementCard.tsx
+++ b/src/features/project/management/ui/ProjectManagementCard.tsx
@@ -71,7 +71,7 @@ export function ProjectManagementCard({
           />
         </div>
 
-        <div className="bp2:items-end flex min-w-0 flex-1 flex-col items-stretch gap-4">
+        <div className="bp2:self-start bp2:pt-[9px] flex min-w-0 flex-1 flex-col items-stretch gap-4">
           <div className="flex min-w-0 flex-col items-start gap-2 self-stretch">
             <div className="flex min-w-0 items-start justify-between gap-3 self-stretch">
               <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -288,17 +288,6 @@ export function ProjectManagementMoreMenu({
     })
   }
 
-  const handleEditMatchingPeriodClick = () => {
-    setPopoverOpen(false)
-    addToast({
-      message: "매칭 기간 중에는 프로젝트를 수정할 수 없습니다.",
-      color: "red",
-      variant: "deep",
-      type: "default",
-      duration: 3000,
-    })
-  }
-
   const handleTeamViewClick = () => {
     shouldPreventFocusRestoreRef.current = true
     setPopoverOpen(false)
@@ -309,7 +298,6 @@ export function ProjectManagementMoreMenu({
     label: string
     onClick: () => void
     disabled?: boolean
-    className?: string
   }[] = []
 
   if (status === "PENDING_REVIEW") {
@@ -321,26 +309,17 @@ export function ProjectManagementMoreMenu({
       })
     }
   } else if (status === "IN_PROGRESS") {
-    if (isMatchingPeriod) {
-      menuItems.push({
-        label: "지원 현황 확인하기",
-        onClick: handleApplicationClick,
-      })
-      menuItems.push({ label: "팀원 구성 보기", onClick: handleTeamViewClick })
+    menuItems.push({
+      label: "지원 현황 확인하기",
+      onClick: handleApplicationClick,
+    })
+    menuItems.push({ label: "팀원 구성 보기", onClick: handleTeamViewClick })
+    if (isPermissionLoading || canEditProject) {
       menuItems.push({
         label: "프로젝트 수정하기",
-        onClick: handleEditMatchingPeriodClick,
-        className:
-          "text-teal-gray-300 cursor-not-allowed hover:bg-white hover:shadow-none",
+        onClick: handleEditClick,
+        disabled: isMatchingPeriod || isPermissionLoading,
       })
-    } else {
-      if (isPermissionLoading || canEditProject) {
-        menuItems.push({
-          label: "프로젝트 수정하기",
-          onClick: handleEditClick,
-          disabled: isPermissionLoading,
-        })
-      }
     }
   } else {
     menuItems.push({
@@ -348,7 +327,7 @@ export function ProjectManagementMoreMenu({
       onClick: handleApplicationClick,
     })
     menuItems.push({ label: "팀원 구성 보기", onClick: handleTeamViewClick })
-    if (!isMatchingPeriod && (isPermissionLoading || canEditProject)) {
+    if (isPermissionLoading || canEditProject) {
       menuItems.push({
         label: "프로젝트 수정하기",
         onClick: handleEditClick,
@@ -384,13 +363,12 @@ export function ProjectManagementMoreMenu({
             </span>
 
             <div className="flex w-full flex-col">
-              {menuItems.map(({ label, onClick, disabled, className }) => (
+              {menuItems.map(({ label, onClick, disabled }) => (
                 <DropdownItem
                   key={label}
                   label={label}
                   disabled={disabled}
                   onClick={onClick}
-                  className={className}
                 />
               ))}
               {status === "DRAFT" &&

--- a/src/features/settings/ui/AccountSettingsPage.tsx
+++ b/src/features/settings/ui/AccountSettingsPage.tsx
@@ -55,8 +55,14 @@ export function AccountSettingsPage() {
   const queryClient = useQueryClient()
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-  const { handleGoogleLink, handleAppleLink, handleKakaoLink, handleUnlink } =
-    useOAuthLinking()
+  const {
+    handleGoogleLink,
+    handleAppleLink,
+    handleKakaoLink,
+    handleUnlink,
+    isUnlinkBlockedOpen,
+    setIsUnlinkBlockedOpen,
+  } = useOAuthLinking()
 
   const linkedMap = new Map(
     oauths.map((o) => [PROVIDER_TO_SOCIAL[o.provider], o.memberOAuthId]),
@@ -375,6 +381,22 @@ export function AccountSettingsPage() {
           void handleUnlink(unlinkTarget.id, unlinkTarget.social)
           setUnlinkTarget(null)
         }}
+      />
+
+      <CtaModal
+        open={isUnlinkBlockedOpen}
+        variant="error"
+        title="계정을 해제할 수 없습니다"
+        content={
+          <>
+            가입한 서비스의 계정은 연동 해제할 수 없습니다.
+            <br />
+            다른 계정을 추가 연동한 후 다시 시도해주세요.
+          </>
+        }
+        confirmText="확인"
+        onOpenChange={setIsUnlinkBlockedOpen}
+        onConfirm={() => setIsUnlinkBlockedOpen(false)}
       />
 
       <CtaModal

--- a/src/features/settings/ui/AccountSettingsPage.tsx
+++ b/src/features/settings/ui/AccountSettingsPage.tsx
@@ -356,7 +356,7 @@ export function AccountSettingsPage() {
       <CtaModal
         open={unlinkTarget !== null}
         variant="error"
-        title={`${unlinkTarget?.social === "kakao" ? "카카오" : unlinkTarget?.social === "apple" ? "애플" : "구글"} 계정 연동을 해제하시겠습니까?`}
+        title={`${unlinkTarget?.social === "kakao" ? "카카오" : unlinkTarget?.social === "apple" ? "Apple" : "Google"} 계정 연동을 해제하시겠습니까?`}
         content={
           <>
             계정 연동을 해제하더라도 기존 데이터는 안전하게 유지됩니다.


### PR DESCRIPTION
## 📸 작업 내용
- 프로젝트 카드 UI 개선
- 계정 설정 페이지 소셜 표기 통일
- 매칭 기간 시 프로젝트 메뉴 수정하기 disabled 처리
- 유일한 소셜 연동의 경우, 안내 모달 띄우기

## 🎞️ 주요 코드 설명

## 🖥️ 구현화면

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #397 