### PR TITLE
💄 style: 프로젝트 상세 카드 스켈레톤 설명 placeholder 1줄로 축소

### DIFF
--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -86,11 +86,7 @@ function ProjectDetailCardSkeleton() {
               <div className="bg-teal-gray-150 h-6 w-full max-w-52 animate-pulse rounded-md" />
               <div className="bg-teal-gray-150 h-4 w-32 animate-pulse rounded-md" />
             </div>
-            <div className="flex w-full flex-col gap-1.5">
-              <div className="bg-teal-gray-150 h-4 w-full animate-pulse rounded-md" />
-              <div className="bg-teal-gray-150 h-4 w-4/5 animate-pulse rounded-md" />
-              <div className="bg-teal-gray-150 h-4 w-2/3 animate-pulse rounded-md" />
-            </div>
+            <div className="bg-teal-gray-150 h-4 w-full animate-pulse rounded-md" />
           </div>
           <div className="flex w-full flex-col items-start gap-1.5">
             {[0, 1, 2].map((i) => (


### PR DESCRIPTION
## 📸 작업 내용

> 프로젝트 목록에서 카드를 눌렀을 때 표시되는 상세 카드 로딩 스켈레톤의 설명(description) 영역을 간결화했습니다.

- 상세 카드 로딩 스켈레톤의 설명 placeholder를 **3줄 → 1줄**로 축소
- 자식이 하나만 남게 된 세로 스택 래퍼(`flex flex-col gap-1.5`)를 제거하고, 제목 블록과의 간격은 부모의 `gap-2.5`로 그대로 유지
- 파트 모집 현황 placeholder(3행) 등 나머지 스켈레톤 구조는 변경 없음

## 🔗 연결된 이슈

- Connected: #440
- Closes #440