### PR TITLE
✨ feat: 소개 페이지(/intro) 공개 및 미인증 루트 진입 시 소개 랜딩 노출

### DIFF
--- a/src/components/header/headerNavPolicy.ts
+++ b/src/components/header/headerNavPolicy.ts
@@ -13,9 +13,6 @@ export const HEADER_NAV_ITEMS: HeaderNavItem[] = [
   {
     label: "소개",
     to: "/intro",
-    disabled: true,
-    disabledMessage:
-      "소개 페이지는 준비 중입니다. 더 나은 UMC 웹사이트로 찾아뵙겠습니다!",
   },
   {
     label: "데모데이 매칭",

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -6,6 +6,7 @@ import {
   isCurrentTermPm,
   isOperator,
 } from "@/features/auth/model/identity"
+import { useAuthStore } from "@/features/auth/store/authStore"
 import { type Chapter, CHAPTERS } from "@/features/notice"
 
 function isChapter(value: unknown): value is Chapter {
@@ -16,6 +17,10 @@ function isChapter(value: unknown): value is Chapter {
 
 export const Route = createFileRoute("/")({
   beforeLoad: async ({ context }) => {
+    if (!useAuthStore.getState().isAuthed) {
+      throw redirect({ to: "/intro" })
+    }
+
     const me = await ensureMe(context.queryClient)
 
     if (isOperator(me)) {


### PR DESCRIPTION
## 📸 작업 내용

> 준비 중으로 막혀 있던 소개 페이지를 공개하고, 미인증 사용자의 루트 진입 동선을 소개 랜딩으로 연결합니다.

- 헤더 "소개" 메뉴의 차단(`disabled`)을 해제해 데스크톱·모바일 양쪽에서 `/intro`로 정상 라우팅되도록 변경
- 루트(`/`) 진입 시 미인증 사용자는 `/intro`로 리다이렉트, 인증 사용자는 기존 권한별 분기(운영진/PM/일반) 유지
- 보호 라우트의 로그인 복귀(`returnTo`) 흐름은 변경 없이 그대로 유지

## 🎞️ 주요 코드 설명

### 루트 진입 미인증 가드

```TypeScript
beforeLoad: async ({ context }) => {
  if (!useAuthStore.getState().isAuthed) {
    throw redirect({ to: "/intro" })
  }

  const me = await ensureMe(context.queryClient)
  // ...기존 권한별 분기 유지
}
```

- `ensureMe` 호출 전에 인증 상태를 먼저 확인해, 미인증이면 로그인 대신 소개 랜딩으로 보냅니다.
- `returnTo`는 보호 라우트의 `ensureMe(queryClient, returnTo)`에서 처리되며 이 경로는 `/`를 거치지 않으므로 영향이 없습니다.

### 헤더 소개 메뉴 차단 해제

```TypeScript
{
  label: "소개",
  to: "/intro",
}
```

- `disabled` / `disabledMessage`를 제거해 클릭 시 안내 토스트 대신 `/intro`로 이동합니다.
- "리크루팅" 항목은 여전히 준비 중이라 차단 정책을 유지합니다.

## 🔗 연결된 이슈

- Closes #442