### PR TITLE
🔖 chore: v1.1.2 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "umc-product-web-v2",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/header/headerNavPolicy.ts
+++ b/src/components/header/headerNavPolicy.ts
@@ -13,9 +13,6 @@ export const HEADER_NAV_ITEMS: HeaderNavItem[] = [
   {
     label: "소개",
     to: "/intro",
-    disabled: true,
-    disabledMessage:
-      "소개 페이지는 준비 중입니다. 더 나은 UMC 웹사이트로 찾아뵙겠습니다!",
   },
   {
     label: "데모데이 매칭",

--- a/src/features/auth/hooks/useOAuthLinking.ts
+++ b/src/features/auth/hooks/useOAuthLinking.ts
@@ -30,6 +30,7 @@ export function useOAuthLinking() {
   const addToast = useToastStore((s) => s.addToast)
   const queryClient = useQueryClient()
   const [isLinking, setIsLinking] = useState(false)
+  const [isUnlinkBlockedOpen, setIsUnlinkBlockedOpen] = useState(false)
 
   const handleGoogleLink = async () => {
     if (isLinking) return
@@ -162,12 +163,12 @@ export function useOAuthLinking() {
       const errorCode = isAxiosError(err)
         ? (err.response?.data as { code?: string } | undefined)?.code
         : undefined
-      const message =
-        errorCode === "AUTHENTICATION-0016"
-          ? "비밀번호가 없는 계정은 마지막 소셜 연동을 해제할 수 없어요.\n비밀번호를 먼저 설정해주세요."
-          : "연동 해제에 실패했습니다. 다시 시도해주세요."
+      if (errorCode === "AUTHENTICATION-0016") {
+        setIsUnlinkBlockedOpen(true)
+        return
+      }
       addToast({
-        message,
+        message: "연동 해제에 실패했습니다. 다시 시도해주세요.",
         color: "red",
         variant: "deep",
         type: "default",
@@ -181,5 +182,7 @@ export function useOAuthLinking() {
     handleAppleLink,
     handleKakaoLink,
     handleUnlink,
+    isUnlinkBlockedOpen,
+    setIsUnlinkBlockedOpen,
   }
 }

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -86,11 +86,7 @@ function ProjectDetailCardSkeleton() {
               <div className="bg-teal-gray-150 h-6 w-full max-w-52 animate-pulse rounded-md" />
               <div className="bg-teal-gray-150 h-4 w-32 animate-pulse rounded-md" />
             </div>
-            <div className="flex w-full flex-col gap-1.5">
-              <div className="bg-teal-gray-150 h-4 w-full animate-pulse rounded-md" />
-              <div className="bg-teal-gray-150 h-4 w-4/5 animate-pulse rounded-md" />
-              <div className="bg-teal-gray-150 h-4 w-2/3 animate-pulse rounded-md" />
-            </div>
+            <div className="bg-teal-gray-150 h-4 w-full animate-pulse rounded-md" />
           </div>
           <div className="flex w-full flex-col items-start gap-1.5">
             {[0, 1, 2].map((i) => (

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -775,24 +775,36 @@ export function ProjectDetailCard({
             )}
           </div>
           {!viewOnly && ctaMode === "apply-blocked-other" && (
-            <p className="text-caption-2-regular text-error-600 mt-2 w-full text-center">
-              이번 차수에 이미 다른 프로젝트에 지원하여 지원할 수 없습니다.
-            </p>
+            <div className="mt-2 flex w-full items-center justify-center gap-1">
+              <CheckIcon className="text-teal-gray-500 h-4 w-4 shrink-0" />
+              <p className="text-caption-2-regular text-teal-gray-500 text-center">
+                이번 차수에 이미 다른 프로젝트에 지원하여 지원할 수 없습니다.
+              </p>
+            </div>
           )}
           {!viewOnly && ctaMode === "apply-blocked-approved" && (
-            <p className="text-caption-2-regular text-error-600 mt-2 w-full text-center">
-              이미 합격한 챌린저는 추가로 지원할 수 없습니다.
-            </p>
+            <div className="mt-2 flex w-full items-center justify-center gap-1">
+              <CheckIcon className="text-teal-gray-500 h-4 w-4 shrink-0" />
+              <p className="text-caption-2-regular text-teal-gray-500 text-center">
+                이미 합격한 챌린저는 추가로 지원할 수 없습니다.
+              </p>
+            </div>
           )}
           {!viewOnly && ctaMode === "apply-blocked-part" && (
-            <p className="text-caption-2-regular text-error-600 mt-2 w-full text-center">
-              지원 가능한 파트가 아니어서 지원할 수 없습니다.
-            </p>
+            <div className="mt-2 flex w-full items-center justify-center gap-1">
+              <CheckIcon className="text-teal-gray-500 h-4 w-4 shrink-0" />
+              <p className="text-caption-2-regular text-teal-gray-500 text-center">
+                지원 가능한 파트가 아니어서 지원할 수 없습니다.
+              </p>
+            </div>
           )}
           {!viewOnly && ctaMode === "apply-blocked-closed" && (
-            <p className="text-caption-2-regular text-error-600 mt-2 w-full text-center">
-              모집이 마감된 파트라 지원할 수 없습니다.
-            </p>
+            <div className="mt-2 flex w-full items-center justify-center gap-1">
+              <CheckIcon className="text-teal-gray-500 h-4 w-4 shrink-0" />
+              <p className="text-caption-2-regular text-teal-gray-500 text-center">
+                모집이 마감된 파트라 지원할 수 없습니다.
+              </p>
+            </div>
           )}
           {!viewOnly && ctaMode === "no-active-round" && (
             <div className="mt-2 flex w-full items-center justify-center gap-1">

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -736,6 +736,24 @@ export function ProjectDetailCard({
                     </Button>
                   </>
                 )}
+                {ctaMode === "no-active-round" && (
+                  <Button
+                    variant="weak"
+                    color="primary"
+                    className="min-w-32 flex-1 whitespace-nowrap"
+                    isLoading={isDetailLoading}
+                    disabled={!isDetailLoading && !detail?.applicationFormId}
+                    onClick={() => {
+                      trackEvent("project_questions_click", {
+                        project_id: projectId,
+                        cta_mode: ctaMode,
+                      })
+                      setIsRecruitQuestionsModalOpen(true)
+                    }}
+                  >
+                    모집 문항 보기
+                  </Button>
+                )}
                 {ctaMode === "other-branch" && (
                   <Button
                     variant="weak"

--- a/src/features/project/management/ui/ProjectManagementCard.tsx
+++ b/src/features/project/management/ui/ProjectManagementCard.tsx
@@ -71,7 +71,7 @@ export function ProjectManagementCard({
           />
         </div>
 
-        <div className="bp2:items-end flex min-w-0 flex-1 flex-col items-stretch gap-4">
+        <div className="bp2:self-start bp2:pt-[9px] flex min-w-0 flex-1 flex-col items-stretch gap-4">
           <div className="flex min-w-0 flex-col items-start gap-2 self-stretch">
             <div className="flex min-w-0 items-start justify-between gap-3 self-stretch">
               <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -84,9 +84,6 @@ export function ProjectManagementMoreMenu({
     staleTime: 5 * 60 * 1000,
   })
 
-  const isPlanViewDisabled =
-    !projectDetailQuery.isSuccess || !projectDetailQuery.data.externalLink
-
   const applicantsQuery = useQuery({
     queryKey: applicationKeys.applicants(numericProjectId),
     queryFn: () => getProjectApplications(numericProjectId),
@@ -291,11 +288,15 @@ export function ProjectManagementMoreMenu({
     })
   }
 
-  const handlePlanViewClick = () => {
+  const handleEditMatchingPeriodClick = () => {
     setPopoverOpen(false)
-    const externalLink = projectDetailQuery.data?.externalLink
-    if (!externalLink) return
-    window.open(externalLink, "_blank", "noopener,noreferrer")
+    addToast({
+      message: "매칭 기간 중에는 프로젝트를 수정할 수 없습니다.",
+      color: "red",
+      variant: "deep",
+      type: "default",
+      duration: 3000,
+    })
   }
 
   const handleTeamViewClick = () => {
@@ -308,22 +309,52 @@ export function ProjectManagementMoreMenu({
     label: string
     onClick: () => void
     disabled?: boolean
-  }[] = [
-    { label: "지원 현황 확인하기", onClick: handleApplicationClick },
-    {
-      label: "기획 보기",
-      onClick: handlePlanViewClick,
-      disabled: isPlanViewDisabled,
-    },
-    { label: "팀원 구성 보기", onClick: handleTeamViewClick },
-  ]
+    className?: string
+  }[] = []
 
-  if (!isMatchingPeriod && (isPermissionLoading || canEditProject)) {
-    menuItems.splice(2, 0, {
-      label: "프로젝트 수정하기",
-      onClick: handleEditClick,
-      disabled: isPermissionLoading,
+  if (status === "PENDING_REVIEW") {
+    if (isPermissionLoading || canEditProject) {
+      menuItems.push({
+        label: "프로젝트 수정하기",
+        onClick: handleEditClick,
+        disabled: isPermissionLoading,
+      })
+    }
+  } else if (status === "IN_PROGRESS") {
+    if (isMatchingPeriod) {
+      menuItems.push({
+        label: "지원 현황 확인하기",
+        onClick: handleApplicationClick,
+      })
+      menuItems.push({ label: "팀원 구성 보기", onClick: handleTeamViewClick })
+      menuItems.push({
+        label: "프로젝트 수정하기",
+        onClick: handleEditMatchingPeriodClick,
+        className:
+          "text-teal-gray-300 cursor-not-allowed hover:bg-white hover:shadow-none",
+      })
+    } else {
+      if (isPermissionLoading || canEditProject) {
+        menuItems.push({
+          label: "프로젝트 수정하기",
+          onClick: handleEditClick,
+          disabled: isPermissionLoading,
+        })
+      }
+    }
+  } else {
+    menuItems.push({
+      label: "지원 현황 확인하기",
+      onClick: handleApplicationClick,
     })
+    menuItems.push({ label: "팀원 구성 보기", onClick: handleTeamViewClick })
+    if (!isMatchingPeriod && (isPermissionLoading || canEditProject)) {
+      menuItems.push({
+        label: "프로젝트 수정하기",
+        onClick: handleEditClick,
+        disabled: isPermissionLoading,
+      })
+    }
   }
 
   return (
@@ -353,12 +384,13 @@ export function ProjectManagementMoreMenu({
             </span>
 
             <div className="flex w-full flex-col">
-              {menuItems.map(({ label, onClick, disabled }) => (
+              {menuItems.map(({ label, onClick, disabled, className }) => (
                 <DropdownItem
                   key={label}
                   label={label}
                   disabled={disabled}
                   onClick={onClick}
+                  className={className}
                 />
               ))}
               {status === "DRAFT" &&

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -288,17 +288,6 @@ export function ProjectManagementMoreMenu({
     })
   }
 
-  const handleEditMatchingPeriodClick = () => {
-    setPopoverOpen(false)
-    addToast({
-      message: "매칭 기간 중에는 프로젝트를 수정할 수 없습니다.",
-      color: "red",
-      variant: "deep",
-      type: "default",
-      duration: 3000,
-    })
-  }
-
   const handleTeamViewClick = () => {
     shouldPreventFocusRestoreRef.current = true
     setPopoverOpen(false)
@@ -309,7 +298,6 @@ export function ProjectManagementMoreMenu({
     label: string
     onClick: () => void
     disabled?: boolean
-    className?: string
   }[] = []
 
   if (status === "PENDING_REVIEW") {
@@ -321,26 +309,17 @@ export function ProjectManagementMoreMenu({
       })
     }
   } else if (status === "IN_PROGRESS") {
-    if (isMatchingPeriod) {
-      menuItems.push({
-        label: "지원 현황 확인하기",
-        onClick: handleApplicationClick,
-      })
-      menuItems.push({ label: "팀원 구성 보기", onClick: handleTeamViewClick })
+    menuItems.push({
+      label: "지원 현황 확인하기",
+      onClick: handleApplicationClick,
+    })
+    menuItems.push({ label: "팀원 구성 보기", onClick: handleTeamViewClick })
+    if (isPermissionLoading || canEditProject) {
       menuItems.push({
         label: "프로젝트 수정하기",
-        onClick: handleEditMatchingPeriodClick,
-        className:
-          "text-teal-gray-300 cursor-not-allowed hover:bg-white hover:shadow-none",
+        onClick: handleEditClick,
+        disabled: isMatchingPeriod || isPermissionLoading,
       })
-    } else {
-      if (isPermissionLoading || canEditProject) {
-        menuItems.push({
-          label: "프로젝트 수정하기",
-          onClick: handleEditClick,
-          disabled: isPermissionLoading,
-        })
-      }
     }
   } else {
     menuItems.push({
@@ -348,7 +327,7 @@ export function ProjectManagementMoreMenu({
       onClick: handleApplicationClick,
     })
     menuItems.push({ label: "팀원 구성 보기", onClick: handleTeamViewClick })
-    if (!isMatchingPeriod && (isPermissionLoading || canEditProject)) {
+    if (isPermissionLoading || canEditProject) {
       menuItems.push({
         label: "프로젝트 수정하기",
         onClick: handleEditClick,
@@ -384,13 +363,12 @@ export function ProjectManagementMoreMenu({
             </span>
 
             <div className="flex w-full flex-col">
-              {menuItems.map(({ label, onClick, disabled, className }) => (
+              {menuItems.map(({ label, onClick, disabled }) => (
                 <DropdownItem
                   key={label}
                   label={label}
                   disabled={disabled}
                   onClick={onClick}
-                  className={className}
                 />
               ))}
               {status === "DRAFT" &&

--- a/src/features/settings/ui/AccountSettingsPage.tsx
+++ b/src/features/settings/ui/AccountSettingsPage.tsx
@@ -55,8 +55,14 @@ export function AccountSettingsPage() {
   const queryClient = useQueryClient()
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-  const { handleGoogleLink, handleAppleLink, handleKakaoLink, handleUnlink } =
-    useOAuthLinking()
+  const {
+    handleGoogleLink,
+    handleAppleLink,
+    handleKakaoLink,
+    handleUnlink,
+    isUnlinkBlockedOpen,
+    setIsUnlinkBlockedOpen,
+  } = useOAuthLinking()
 
   const linkedMap = new Map(
     oauths.map((o) => [PROVIDER_TO_SOCIAL[o.provider], o.memberOAuthId]),
@@ -375,6 +381,22 @@ export function AccountSettingsPage() {
           void handleUnlink(unlinkTarget.id, unlinkTarget.social)
           setUnlinkTarget(null)
         }}
+      />
+
+      <CtaModal
+        open={isUnlinkBlockedOpen}
+        variant="error"
+        title="계정을 해제할 수 없습니다"
+        content={
+          <>
+            가입한 서비스의 계정은 연동 해제할 수 없습니다.
+            <br />
+            다른 계정을 추가 연동한 후 다시 시도해주세요.
+          </>
+        }
+        confirmText="확인"
+        onOpenChange={setIsUnlinkBlockedOpen}
+        onConfirm={() => setIsUnlinkBlockedOpen(false)}
       />
 
       <CtaModal

--- a/src/features/settings/ui/AccountSettingsPage.tsx
+++ b/src/features/settings/ui/AccountSettingsPage.tsx
@@ -356,7 +356,7 @@ export function AccountSettingsPage() {
       <CtaModal
         open={unlinkTarget !== null}
         variant="error"
-        title={`${unlinkTarget?.social === "kakao" ? "카카오" : unlinkTarget?.social === "apple" ? "애플" : "구글"} 계정 연동을 해제하시겠습니까?`}
+        title={`${unlinkTarget?.social === "kakao" ? "카카오" : unlinkTarget?.social === "apple" ? "Apple" : "Google"} 계정 연동을 해제하시겠습니까?`}
         content={
           <>
             계정 연동을 해제하더라도 기존 데이터는 안전하게 유지됩니다.

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -6,6 +6,7 @@ import {
   isCurrentTermPm,
   isOperator,
 } from "@/features/auth/model/identity"
+import { useAuthStore } from "@/features/auth/store/authStore"
 import { type Chapter, CHAPTERS } from "@/features/notice"
 
 function isChapter(value: unknown): value is Chapter {
@@ -16,6 +17,10 @@ function isChapter(value: unknown): value is Chapter {
 
 export const Route = createFileRoute("/")({
   beforeLoad: async ({ context }) => {
+    if (!useAuthStore.getState().isAuthed) {
+      throw redirect({ to: "/intro" })
+    }
+
     const me = await ensureMe(context.queryClient)
 
     if (isOperator(me)) {


### PR DESCRIPTION
## 📸 작업 내용

> v1.1.2 배포 (develop → main)

### ✨ 기능
- 소개 페이지(`/intro`) 공개: 헤더 "소개" 메뉴 차단 해제 및 라우팅 활성화
- 미인증 사용자 루트(`/`) 진입 시 `/intro` 소개 랜딩으로 리다이렉트

### 🐛 버그 수정
- 프로젝트 관리 카드 더보기 메뉴에서 기획 보기 항목 삭제
- 매칭 기간 전 본인 지부 타 프로젝트 카드 조회 시 모집 문항 보기 버튼 추가
- 프로젝트 카드 내 안내 메시지 UI 통일
- 프로젝트 관리 카드 프로젝트 이름·닉네임 위치 고정
- 매칭 기간에는 프로젝트 수정 메뉴 disabled 처리
- 유일한 소셜 계정 연동인 경우 연동 해제 불가 모달 노출

### 💄 스타일 / 기타
- 프로젝트 상세 카드 스켈레톤 설명 placeholder 1줄로 축소
- 소셜 표기 통일
- 버전 1.1.2로 bump

## 🔗 연결된 이슈

- Closes #442