### PR TITLE
🐛 fix: gtag 명령을 arguments 객체로 push해 GA4 이벤트 전송 복구

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -83,4 +83,10 @@ export default tseslint.config(
       },
     },
   },
+  {
+    files: ["src/shared/analytics/ga.ts"],
+    rules: {
+      "prefer-rest-params": "off",
+    },
+  },
 )

--- a/src/shared/analytics/ga.test.ts
+++ b/src/shared/analytics/ga.test.ts
@@ -31,16 +31,32 @@ describe("ga analytics", () => {
     trackEvent("project_card_click", { project_id: 1 })
 
     expect(document.querySelector("#ga4-script")).not.toBeNull()
-    expect(window.dataLayer).toContainEqual([
+    const commands = (window.dataLayer ?? []).map((entry) =>
+      Array.from(entry as ArrayLike<unknown>),
+    )
+    expect(commands).toContainEqual([
       "config",
       "G-TEST1234",
       { send_page_view: false },
     ])
-    expect(window.dataLayer).toContainEqual([
+    expect(commands).toContainEqual([
       "event",
       "project_card_click",
       { project_id: 1 },
     ])
+  })
+
+  it("gtag 명령을 배열이 아닌 arguments 객체로 push 한다", async () => {
+    vi.stubEnv("VITE_GA_MEASUREMENT_ID", "G-TEST1234")
+    const { trackEvent } = await import("./ga")
+
+    trackEvent("project_card_click", { project_id: 1 })
+
+    const firstCommand = window.dataLayer?.[0]
+    expect(Array.isArray(firstCommand)).toBe(false)
+    expect(Object.prototype.toString.call(firstCommand)).toBe(
+      "[object Arguments]",
+    )
   })
 
   it("api path query와 식별자 segment를 정리한다", async () => {
@@ -55,7 +71,10 @@ describe("ga analytics", () => {
       success: true,
     })
 
-    expect(window.dataLayer).toContainEqual([
+    const commands = (window.dataLayer ?? []).map((entry) =>
+      Array.from(entry as ArrayLike<unknown>),
+    )
+    expect(commands).toContainEqual([
       "event",
       "api_request",
       {

--- a/src/shared/analytics/ga.ts
+++ b/src/shared/analytics/ga.ts
@@ -25,8 +25,8 @@ export function initializeAnalytics() {
   if (!window.dataLayer) window.dataLayer = []
   window.gtag =
     window.gtag ??
-    function gtag(...args: unknown[]) {
-      window.dataLayer?.push(args)
+    function gtag() {
+      window.dataLayer?.push(arguments)
     }
   window.gtag("js", new Date())
   window.gtag("config", measurementId, { send_page_view: false })


### PR DESCRIPTION
## 📸 작업 내용

> GA4 분석 이벤트가 GA로 전송되지 않던 버그를 수정합니다.

- 자체 gtag 래퍼가 `dataLayer` 에 펼친 배열(`["config", ...]`)을 push 해 gtag.js 가 명령을 인식하지 못하던 문제를, 표준대로 `arguments` 객체를 push 하도록 변경
- 그 결과 `config`/`page_view`/커스텀 이벤트가 `/g/collect` 로 정상 전송되고 `client_id` 가 발급됨 (로컬에서 HTTP 204 확인)
- `arguments` 객체로 push 되는지 검증하는 회귀 테스트 추가, 기존 테스트는 `Array.from` 정규화로 보강
- gtag.js 호환을 위해 `arguments` 사용이 필요해 ga.ts 한정 ESLint `prefer-rest-params` 예외 추가

## 🎞️ 주요 코드 설명

### gtag 스텁 전송 방식

```TypeScript
// Before — gtag.js가 인식하지 못하는 펼친 배열
function gtag(...args: unknown[]) {
  window.dataLayer?.push(args)
}

// After — 표준 arguments 객체
function gtag() {
  window.dataLayer?.push(arguments)
}
```

- gtag.js 는 `dataLayer` 에 push 된 항목이 `arguments` 객체일 때만 gtag 명령으로 처리합니다. 일반 배열은 무시되어 어떤 이벤트도 전송되지 않았습니다.

## 🖥️ 구현화면

> UI 변경은 없습니다(분석 전송 로직). 로컬(5173) 검증 결과로 대체합니다.

- 수정 전: `/g/collect` 0건, `client_id` 미발급(TIMEOUT)
- 수정 후: `page_view` collect 전송(HTTP 204), `client_id` 발급, `dataLayer` 항목이 `arguments` 객체
- 정적 검증: `tsc -b` 통과 · Vitest 4/4 통과 · ESLint 통과

## 🔗 연결된 이슈

- Connected: #448
- Closes #448