### PR TITLE
🐛 fix: 지원 상세 모달에서의 토스트 메시지 교정

### DIFF
--- a/src/features/application/ui/ApplicationDetailModal.tsx
+++ b/src/features/application/ui/ApplicationDetailModal.tsx
@@ -67,7 +67,7 @@ export function ApplicationDetailModal({
     if (project.applicants.length === 0 && !emptyToastShownRef.current) {
       emptyToastShownRef.current = true
       addToast({
-        message: "아직 지원자한 챌린저가 없습니다.",
+        message: "아직 지원한 챌린저가 없습니다.",
         color: "primary",
         variant: "deep",
         type: "default",


### PR DESCRIPTION
## 📸 작업 내용

> 지원 상세 모달에서의 토스트 메시지 수정
('아직 지원한 챌린저가 없습니다.')

## 🎞️ 주요 코드 설명

## 🖥️ 구현화면

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #450 