### PR TITLE
🐛 fix: 프로젝트 목록 필터 드롭다운 overflow 클리핑 이슈 수정

### DIFF
--- a/src/features/project/list/ui/MatchingProjectsListPage.tsx
+++ b/src/features/project/list/ui/MatchingProjectsListPage.tsx
@@ -168,7 +168,10 @@ export function MatchingProjectsListPage({
           />
           <div
             ref={filterAreaRef}
-            className="scrollbar-none bp2:w-auto bp2:overflow-visible bp2:pb-0 flex w-full min-w-0 items-center gap-2 overflow-x-auto pb-1"
+            className={cn(
+              "scrollbar-none bp2:w-auto bp2:overflow-visible bp2:pb-0 flex w-full min-w-0 items-center gap-2 pb-1",
+              openFilterId ? "overflow-visible" : "overflow-x-auto",
+            )}
           >
             {filterDescriptors.map((filter) => (
               <FilterDropdown


### PR DESCRIPTION
## 📸 작업 내용

> 맥북/모바일 환경에서의 필터 드롭다운 보이지 않는 이슈 해결

## 🎞️ 주요 코드 설명

> 설명이 필요한 코드 위주로 작성해주세요

### overflow 상태 분기 처리

```TypeScript
<div
            ref={filterAreaRef}
            className={cn(
              "scrollbar-none bp2:w-auto bp2:overflow-visible bp2:pb-0 flex w-full min-w-0 items-center gap-2 pb-1",
              openFilterId ? "overflow-visible" : "overflow-x-auto",
            )}
          >
```

- 모바일에서 필터 컨테이너의 overflow-x-auto가 CSS 스펙에 의해 overflow-y도 auto로 강제 승격되어 드롭다운이 클리핑되는 문제 수정
- 드롭다운이 열린 동안(openFilterId 존재 시)에만 overflow-visible로 전환하여 가로 스크롤은 유지하면서 드롭다운 패널이 컨테이너 밖으로 노출되도록 처리

## 🖥️ 구현화면

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #452 