### PR TITLE
🐛 fix: 매칭 프로젝트 지원 CTA helper·버튼 일관성 정정

### DIFF
--- a/src/features/auth/model/identity.ts
+++ b/src/features/auth/model/identity.ts
@@ -166,8 +166,5 @@ export function getLatestChallengerRecord(
 export function getCurrentChallengerPart(
   me: MemberInfoResponse | undefined,
 ): Part | undefined {
-  return (
-    me?.currentGisuMemberInfo?.challenger?.part ??
-    getLatestChallengerRecord(me)?.part
-  )
+  return me?.currentGisuMemberInfo?.challenger?.part
 }

--- a/src/features/auth/model/identity.ts
+++ b/src/features/auth/model/identity.ts
@@ -1,6 +1,7 @@
 import type { MemberInfoResponse } from "@/features/auth/api/me"
 import type {
   ChallengerInfoResponse,
+  Part,
   RoleType,
 } from "@/features/challenger/model/types"
 
@@ -160,4 +161,13 @@ export function getLatestChallengerRecord(
   const records = me?.challengerRecords
   if (!records?.length) return undefined
   return [...records].sort((a, b) => Number(b.gisuId) - Number(a.gisuId))[0]
+}
+
+export function getCurrentChallengerPart(
+  me: MemberInfoResponse | undefined,
+): Part | undefined {
+  return (
+    me?.currentGisuMemberInfo?.challenger?.part ??
+    getLatestChallengerRecord(me)?.part
+  )
 }

--- a/src/features/project/list/model/projectDetailCta.test.ts
+++ b/src/features/project/list/model/projectDetailCta.test.ts
@@ -5,6 +5,8 @@ import {
   resolveProjectDetailCtaMode,
   selectCurrentApplicationForProject,
   selectIsAlreadyApproved,
+  selectIsPartIneligible,
+  selectIsPartRecruitClosed,
 } from "./projectDetailCta"
 
 const applicable = {
@@ -181,6 +183,106 @@ describe("resolveProjectDetailCtaMode", () => {
         isPartRecruitClosed: true,
       }),
     ).toBe("my-application")
+  })
+})
+
+describe("파트 적격/마감 판정 (dev 실데이터 기반, Web 계정)", () => {
+  const projects: Record<
+    string,
+    { part: string; currentCount: string; quota: string; status: string }[]
+  > = {
+    "13-중앙대1": [
+      { part: "WEB", currentCount: "3", quota: "3", status: "COMPLETED" },
+      {
+        part: "SPRINGBOOT",
+        currentCount: "3",
+        quota: "3",
+        status: "COMPLETED",
+      },
+      { part: "DESIGN", currentCount: "0", quota: "1", status: "RECRUITING" },
+    ],
+    "14-중앙대2": [
+      { part: "DESIGN", currentCount: "1", quota: "2", status: "RECRUITING" },
+      { part: "WEB", currentCount: "4", quota: "4", status: "COMPLETED" },
+      {
+        part: "SPRINGBOOT",
+        currentCount: "4",
+        quota: "4",
+        status: "COMPLETED",
+      },
+    ],
+    "15-한성대1": [
+      { part: "DESIGN", currentCount: "1", quota: "20", status: "RECRUITING" },
+      { part: "WEB", currentCount: "20", quota: "20", status: "COMPLETED" },
+      { part: "NODEJS", currentCount: "20", quota: "20", status: "COMPLETED" },
+    ],
+    "16-중앙대3": [
+      { part: "DESIGN", currentCount: "0", quota: "2", status: "RECRUITING" },
+      { part: "ANDROID", currentCount: "4", quota: "4", status: "COMPLETED" },
+      { part: "NODEJS", currentCount: "4", quota: "4", status: "COMPLETED" },
+    ],
+    "17-중앙대4": [
+      { part: "DESIGN", currentCount: "0", quota: "2", status: "RECRUITING" },
+      { part: "IOS", currentCount: "3", quota: "3", status: "COMPLETED" },
+      {
+        part: "SPRINGBOOT",
+        currentCount: "4",
+        quota: "4",
+        status: "COMPLETED",
+      },
+    ],
+    "23-가천대": [
+      { part: "DESIGN", currentCount: "0", quota: "1", status: "RECRUITING" },
+      { part: "WEB", currentCount: "0", quota: "1", status: "RECRUITING" },
+      {
+        part: "SPRINGBOOT",
+        currentCount: "0",
+        quota: "1",
+        status: "RECRUITING",
+      },
+    ],
+    "37-가천대": [
+      { part: "IOS", currentCount: "0", quota: "1", status: "RECRUITING" },
+      {
+        part: "SPRINGBOOT",
+        currentCount: "0",
+        quota: "2",
+        status: "RECRUITING",
+      },
+    ],
+  }
+
+  const ctaForWeb = (key: string) =>
+    resolveProjectDetailCtaMode({
+      ...ctaParams,
+      isPartIneligible: selectIsPartIneligible(projects[key], "WEB"),
+      isPartRecruitClosed: selectIsPartRecruitClosed(projects[key], "WEB"),
+      hasActiveRound: true,
+    })
+
+  it("WEB 정원이 마감(COMPLETED)된 프로젝트는 apply-blocked-closed", () => {
+    expect(ctaForWeb("13-중앙대1")).toBe("apply-blocked-closed")
+    expect(ctaForWeb("14-중앙대2")).toBe("apply-blocked-closed")
+    expect(ctaForWeb("15-한성대1")).toBe("apply-blocked-closed")
+  })
+
+  it("WEB 파트를 아예 모집하지 않는 프로젝트는 apply-blocked-part", () => {
+    expect(ctaForWeb("16-중앙대3")).toBe("apply-blocked-part")
+    expect(ctaForWeb("17-중앙대4")).toBe("apply-blocked-part")
+    expect(ctaForWeb("37-가천대")).toBe("apply-blocked-part")
+  })
+
+  it("WEB 파트를 모집 중(RECRUITING)인 프로젝트는 apply(지원 가능)", () => {
+    expect(ctaForWeb("23-가천대")).toBe("apply")
+  })
+
+  it("내 파트를 알 수 없으면(undefined) 파트 사유로 막지 않는다", () => {
+    expect(selectIsPartIneligible(projects["16-중앙대3"], undefined)).toBe(
+      false,
+    )
+    expect(selectIsPartRecruitClosed(projects["14-중앙대2"], undefined)).toBe(
+      false,
+    )
   })
 })
 

--- a/src/features/project/list/model/projectDetailCta.test.ts
+++ b/src/features/project/list/model/projectDetailCta.test.ts
@@ -187,10 +187,7 @@ describe("resolveProjectDetailCtaMode", () => {
 })
 
 describe("파트 적격/마감 판정 (dev 실데이터 기반, Web 계정)", () => {
-  const projects: Record<
-    string,
-    { part: string; currentCount: string; quota: string; status: string }[]
-  > = {
+  const projects = {
     "13-중앙대1": [
       { part: "WEB", currentCount: "3", quota: "3", status: "COMPLETED" },
       {
@@ -250,9 +247,12 @@ describe("파트 적격/마감 판정 (dev 실데이터 기반, Web 계정)", ()
         status: "RECRUITING",
       },
     ],
-  }
+  } satisfies Record<
+    string,
+    { part: string; currentCount: string; quota: string; status: string }[]
+  >
 
-  const ctaForWeb = (key: string) =>
+  const ctaForWeb = (key: keyof typeof projects) =>
     resolveProjectDetailCtaMode({
       ...ctaParams,
       isPartIneligible: selectIsPartIneligible(projects[key], "WEB"),

--- a/src/features/project/list/model/projectDetailCta.test.ts
+++ b/src/features/project/list/model/projectDetailCta.test.ts
@@ -9,6 +9,8 @@ import {
   selectIsPartRecruitClosed,
 } from "./projectDetailCta"
 
+import type { PartQuotaStatus, ProjectPart } from "../api/matchingProject"
+
 const applicable = {
   isPmReadonly: false,
   isDetailLoading: false,
@@ -249,7 +251,12 @@ describe("파트 적격/마감 판정 (dev 실데이터 기반, Web 계정)", ()
     ],
   } satisfies Record<
     string,
-    { part: string; currentCount: string; quota: string; status: string }[]
+    {
+      part: ProjectPart
+      currentCount: string
+      quota: string
+      status: PartQuotaStatus
+    }[]
   >
 
   const ctaForWeb = (key: keyof typeof projects) =>

--- a/src/features/project/list/model/projectDetailCta.ts
+++ b/src/features/project/list/model/projectDetailCta.ts
@@ -1,3 +1,5 @@
+import type { ProjectDetail } from "../api/matchingProject"
+
 export type ProjectDetailCtaMode =
   | "recruit-questions"
   | "my-application"
@@ -48,10 +50,10 @@ export function resolveProjectDetailCtaMode({
   return "apply"
 }
 
-type PartQuotaForCta = {
-  part: string
-  status: string
-}
+type PartQuotaForCta = Pick<
+  ProjectDetail["partQuotas"][number],
+  "part" | "status"
+>
 
 export function selectIsPartIneligible(
   partQuotas: PartQuotaForCta[],

--- a/src/features/project/list/model/projectDetailCta.ts
+++ b/src/features/project/list/model/projectDetailCta.ts
@@ -48,6 +48,27 @@ export function resolveProjectDetailCtaMode({
   return "apply"
 }
 
+type PartQuotaForCta = {
+  part: string
+  status: string
+}
+
+export function selectIsPartIneligible(
+  partQuotas: PartQuotaForCta[],
+  myPart: string | undefined,
+): boolean {
+  if (myPart == null) return false
+  return !partQuotas.some((q) => q.part === myPart)
+}
+
+export function selectIsPartRecruitClosed(
+  partQuotas: PartQuotaForCta[],
+  myPart: string | undefined,
+): boolean {
+  if (myPart == null) return false
+  return partQuotas.some((q) => q.part === myPart && q.status === "COMPLETED")
+}
+
 interface ApplyButtonDisabledParams {
   isPmReadonly: boolean
   isDetailLoading: boolean

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import { useToastStore } from "@/components/toast/useToastStore"
 import { useResourcePermission } from "@/features/auth/hooks/useResourcePermission"
 import {
+  getCurrentChallengerPart,
   getLatestChallengerRecord,
   isCurrentTermPm,
   isOperator,
@@ -44,6 +45,8 @@ import {
   resolveProjectDetailCtaMode,
   selectCurrentApplicationForProject,
   selectIsAlreadyApproved,
+  selectIsPartIneligible,
+  selectIsPartRecruitClosed,
 } from "../model/projectDetailCta"
 import { ApplyFormSkeleton } from "./apply-modal/ApplyFormSkeleton"
 import { MyApplicationModal } from "./apply-modal/MyApplicationModal"
@@ -289,14 +292,14 @@ export function ProjectDetailCard({
     [applicationForm],
   )
 
-  const latestChallengerPart = useMemo(() => {
-    return getLatestChallengerRecord(me)?.part
+  const myMatchingPart = useMemo(() => {
+    return getCurrentChallengerPart(me)
   }, [me])
 
   const visibleSections = useMemo(() => {
     if (userIsOperator || userIsPm) return sections
-    return filterApplicationSectionsByPart(sections, latestChallengerPart)
-  }, [sections, userIsOperator, userIsPm, latestChallengerPart])
+    return filterApplicationSectionsByPart(sections, myMatchingPart)
+  }, [sections, userIsOperator, userIsPm, myMatchingPart])
 
   useEffect(() => {
     if (!formError) return
@@ -391,16 +394,12 @@ export function ProjectDetailCard({
   const isPartIneligible =
     isChallengerView &&
     detail != null &&
-    latestChallengerPart != null &&
-    !detail.partQuotas.some((q) => q.part === latestChallengerPart)
+    selectIsPartIneligible(detail.partQuotas, myMatchingPart)
 
   const isPartRecruitClosed =
     isChallengerView &&
     detail != null &&
-    latestChallengerPart != null &&
-    detail.partQuotas.some(
-      (q) => q.part === latestChallengerPart && q.status === "COMPLETED",
-    )
+    selectIsPartRecruitClosed(detail.partQuotas, myMatchingPart)
 
   const hasActiveRoundForCtaMode: boolean | undefined =
     isChallengerView && !isActiveMatchingRoundLoading
@@ -708,29 +707,21 @@ export function ProjectDetailCard({
                 {(ctaMode === "apply-blocked-other" ||
                   ctaMode === "apply-blocked-part" ||
                   ctaMode === "apply-blocked-closed") && (
-                  <>
-                    <Button
-                      variant="weak"
-                      color="primary"
-                      className="min-w-32 flex-1 whitespace-nowrap"
-                      disabled={!detail?.applicationFormId}
-                      onClick={() => {
-                        trackEvent("project_questions_click", {
-                          project_id: projectId,
-                          cta_mode: ctaMode,
-                        })
-                        setIsRecruitQuestionsModalOpen(true)
-                      }}
-                    >
-                      모집 문항 보기
-                    </Button>
-                    <Button
-                      className="min-w-28 flex-1 whitespace-nowrap"
-                      disabled
-                    >
-                      지원하기
-                    </Button>
-                  </>
+                  <Button
+                    variant="weak"
+                    color="primary"
+                    className="min-w-32 flex-1 whitespace-nowrap"
+                    disabled={!detail?.applicationFormId}
+                    onClick={() => {
+                      trackEvent("project_questions_click", {
+                        project_id: projectId,
+                        cta_mode: ctaMode,
+                      })
+                      setIsRecruitQuestionsModalOpen(true)
+                    }}
+                  >
+                    모집 문항 보기
+                  </Button>
                 )}
                 {ctaMode === "no-active-round" && (
                   <Button
@@ -798,7 +789,7 @@ export function ProjectDetailCard({
             <div className="mt-2 flex w-full items-center justify-center gap-1">
               <CheckIcon className="text-teal-gray-500 h-4 w-4 shrink-0" />
               <p className="text-caption-2-regular text-teal-gray-500 text-center">
-                모집이 마감된 파트라 지원할 수 없습니다.
+                해당 파트는 모집이 마감되었습니다.
               </p>
             </div>
           )}


### PR DESCRIPTION
## 📸 작업 내용

- 지원 불가 프로젝트(파트 부적격 / 정원 마감 / 타 프로젝트 지원 중)에서 비활성 `지원하기` 버튼을 제거하고 `모집 문항 보기`만 노출 — `모집 문항 보기`와 `지원하기`가 동시에 표시되지 않도록 정리
- 파트 적격/마감 판정 기준을 현재 기수 파트(`currentGisuMemberInfo.challenger.part`)로 정정 — 과거 기수 이력 파트를 참조하던 문제로 다중 기수 계정에서 helper가 일관되지 않던 것을 해결
- 정원 마감 안내 문구를 "해당 파트는 모집이 마감되었습니다"로 수정
- 파트 적격/마감 판정을 순수 함수로 추출하고 단위 테스트 추가

## 🎞️ 주요 코드 설명

### 파트 판정 순수 함수 추출

```TypeScript
export function selectIsPartIneligible(
  partQuotas: PartQuotaForCta[],
  myPart: string | undefined,
): boolean {
  if (myPart == null) return false
  return !partQuotas.some((q) => q.part === myPart)
}

export function selectIsPartRecruitClosed(
  partQuotas: PartQuotaForCta[],
  myPart: string | undefined,
): boolean {
  if (myPart == null) return false
  return partQuotas.some((q) => q.part === myPart && q.status === "COMPLETED")
}
```

- 파트 적격/마감 판정을 컴포넌트에서 분리해 테스트 가능하게 만들고, 응답 `partQuotas`와 본인 파트의 정확한 일치 기준으로 판정 (정원 마감은 `status === "COMPLETED"` 기준)

## 🔗 연결된 이슈

- Connected: #458
- Closes #458