### PR TITLE
🐛 fix: 복합 권한 계정 지원 CTA 보정

### DIFF
--- a/src/features/auth/model/identity.test.ts
+++ b/src/features/auth/model/identity.test.ts
@@ -186,7 +186,7 @@ describe("isCurrentTermPm", () => {
 })
 
 describe("getCurrentChallengerPart", () => {
-  it("currentGisuMemberInfo의 challenger part를 우선한다", () => {
+  it("currentGisuMemberInfo의 challenger part를 반환한다", () => {
     const me = makeMe(
       ["CHAPTER_PRESIDENT"],
       [

--- a/src/features/auth/model/identity.test.ts
+++ b/src/features/auth/model/identity.test.ts
@@ -4,6 +4,7 @@ import {
   canAccessProjectSettings,
   canManageProjectRecruitInfo,
   canManageProjects,
+  getCurrentChallengerPart,
   getProjectPmSearchScope,
   isAnyOperator,
   isCentralCore,
@@ -181,6 +182,33 @@ describe("isCurrentTermPm", () => {
         }),
       ),
     ).toBe(false)
+  })
+})
+
+describe("getCurrentChallengerPart", () => {
+  it("currentGisuMemberInfo의 challenger part를 우선한다", () => {
+    const me = makeMe(
+      ["CHAPTER_PRESIDENT"],
+      [
+        { gisuId: "9", part: "WEB" },
+        { gisuId: "10", part: "SPRINGBOOT" },
+      ],
+    )
+
+    expect(getCurrentChallengerPart(me)).toBe("SPRINGBOOT")
+  })
+
+  it("currentGisuMemberInfo가 없으면 최신 기록이 있어도 undefined를 반환한다", () => {
+    const me = makeMe(
+      ["CHALLENGER"],
+      [
+        { gisuId: "9", part: "WEB" },
+        { gisuId: "10", part: "IOS" },
+      ],
+      { currentGisuMemberInfo: null },
+    )
+
+    expect(getCurrentChallengerPart(me)).toBeUndefined()
   })
 })
 

--- a/src/features/project/list/model/projectDetailCta.test.ts
+++ b/src/features/project/list/model/projectDetailCta.test.ts
@@ -186,6 +186,101 @@ describe("resolveProjectDetailCtaMode", () => {
       }),
     ).toBe("my-application")
   })
+
+  it("운영진 복합 계정이 admin view이면 모집 문항 보기 모드", () => {
+    expect(
+      resolveProjectDetailCtaMode({
+        ...ctaParams,
+        isOperator: true,
+      }),
+    ).toBe("recruit-questions")
+  })
+
+  it("운영진 복합 계정도 challenger view 기준이면 지원 가능 모드", () => {
+    expect(
+      resolveProjectDetailCtaMode({
+        ...ctaParams,
+        isOperator: false,
+        isPm: false,
+        isPartIneligible: selectIsPartIneligible(
+          [
+            { part: "SPRINGBOOT", status: "RECRUITING" },
+            { part: "WEB", status: "COMPLETED" },
+          ],
+          "SPRINGBOOT",
+        ),
+        isPartRecruitClosed: selectIsPartRecruitClosed(
+          [
+            { part: "SPRINGBOOT", status: "RECRUITING" },
+            { part: "WEB", status: "COMPLETED" },
+          ],
+          "SPRINGBOOT",
+        ),
+      }),
+    ).toBe("apply")
+  })
+})
+
+describe("파트 적격/마감 판정", () => {
+  it("내 파트를 모집하지 않으면 부적격", () => {
+    expect(
+      selectIsPartIneligible(
+        [
+          { part: "WEB", status: "RECRUITING" },
+          { part: "DESIGN", status: "RECRUITING" },
+        ],
+        "SPRINGBOOT",
+      ),
+    ).toBe(true)
+  })
+
+  it("내 파트가 모집 중이면 지원 가능", () => {
+    expect(
+      selectIsPartIneligible(
+        [
+          { part: "SPRINGBOOT", status: "RECRUITING" },
+          { part: "WEB", status: "COMPLETED" },
+        ],
+        "SPRINGBOOT",
+      ),
+    ).toBe(false)
+    expect(
+      selectIsPartRecruitClosed(
+        [
+          { part: "SPRINGBOOT", status: "RECRUITING" },
+          { part: "WEB", status: "COMPLETED" },
+        ],
+        "SPRINGBOOT",
+      ),
+    ).toBe(false)
+  })
+
+  it("내 파트가 마감이면 모집 마감", () => {
+    expect(
+      selectIsPartRecruitClosed(
+        [
+          { part: "SPRINGBOOT", status: "COMPLETED" },
+          { part: "DESIGN", status: "RECRUITING" },
+        ],
+        "SPRINGBOOT",
+      ),
+    ).toBe(true)
+  })
+
+  it("내 파트를 알 수 없으면 파트 사유로 차단하지 않는다", () => {
+    expect(
+      selectIsPartIneligible(
+        [{ part: "WEB", status: "RECRUITING" }],
+        undefined,
+      ),
+    ).toBe(false)
+    expect(
+      selectIsPartRecruitClosed(
+        [{ part: "WEB", status: "COMPLETED" }],
+        undefined,
+      ),
+    ).toBe(false)
+  })
 })
 
 describe("파트 적격/마감 판정 (dev 실데이터 기반, Web 계정)", () => {

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -192,6 +192,10 @@ export function ProjectDetailCard({
   const addToast = useToastStore((s) => s.addToast)
   const userIsOperator = isOperator(me)
   const userIsPm = isCurrentTermPm(me)
+  const isAdminView = viewContext.isAdminView && userIsOperator
+  const isPmView = viewContext.isPmView || (!userIsOperator && userIsPm)
+  const isApplicantView =
+    viewContext.isChallengerView || (!userIsOperator && !userIsPm)
   const shouldQueryEditPermission =
     showEditCta && canEditProject === undefined && Number.isFinite(projectId)
   const projectPermissionsQuery = useProjectPermissions(projectId, {
@@ -201,8 +205,7 @@ export function ProjectDetailCard({
     !showEditCta &&
     Number.isFinite(projectId) &&
     me !== undefined &&
-    !userIsOperator &&
-    !userIsPm
+    isApplicantView
   const applicationWritePermissionQuery = useResourcePermission(
     "PROJECT_APPLICATION",
     projectId,
@@ -249,13 +252,14 @@ export function ProjectDetailCard({
   const { data: myApplications, isError: isMyApplicationsError } = useQuery({
     queryKey: ["myApplications", activeGisuId],
     queryFn: () => getMyApplications(activeGisuId!),
-    enabled: activeGisuId != null && !userIsOperator && !userIsPm,
+    enabled: activeGisuId != null && isApplicantView,
   })
 
   const myChapterId = useMemo(() => {
-    const id = getLatestChallengerRecord(me)?.chapterId
+    const id =
+      viewContext.currentChapterId ?? getLatestChallengerRecord(me)?.chapterId
     return id != null ? Number(id) : null
-  }, [me])
+  }, [me, viewContext.currentChapterId])
 
   const isAlreadyApproved = selectIsAlreadyApproved(myApplications)
 
@@ -297,9 +301,9 @@ export function ProjectDetailCard({
   }, [me])
 
   const visibleSections = useMemo(() => {
-    if (userIsOperator || userIsPm) return sections
+    if (!isApplicantView) return sections
     return filterApplicationSectionsByPart(sections, myMatchingPart)
-  }, [sections, userIsOperator, userIsPm, myMatchingPart])
+  }, [sections, isApplicantView, myMatchingPart])
 
   useEffect(() => {
     if (!formError) return
@@ -339,13 +343,11 @@ export function ProjectDetailCard({
     addToast,
   ])
 
-  const isSameBranch = userIsOperator
+  const isSameBranch = isAdminView
     ? true
     : projectChapterId != null && myChapterId != null
       ? projectChapterId === myChapterId
       : true
-  const isChallengerView =
-    viewContext.isChallengerView || (!userIsOperator && !userIsPm)
 
   const devMatchingRoundId =
     Number(import.meta.env.VITE_DEV_MATCHING_ROUND_ID) || null
@@ -361,7 +363,7 @@ export function ProjectDetailCard({
         return getActiveMatchingRound(myChapterId!)
       },
       enabled:
-        isChallengerView && (myChapterId != null || devMatchingRoundId != null),
+        isApplicantView && (myChapterId != null || devMatchingRoundId != null),
       staleTime: 60 * 1000,
     })
 
@@ -387,27 +389,27 @@ export function ProjectDetailCard({
   }, [myApplications, activeMatchingRound, projectId])
 
   const isApplicationStatusResolving =
-    isChallengerView &&
+    isApplicantView &&
     (myApplications === undefined || activeMatchingRound === undefined) &&
     !isMyApplicationsError
 
   const isPartIneligible =
-    isChallengerView &&
+    isApplicantView &&
     detail != null &&
     selectIsPartIneligible(detail.partQuotas, myMatchingPart)
 
   const isPartRecruitClosed =
-    isChallengerView &&
+    isApplicantView &&
     detail != null &&
     selectIsPartRecruitClosed(detail.partQuotas, myMatchingPart)
 
   const hasActiveRoundForCtaMode: boolean | undefined =
-    isChallengerView && !isActiveMatchingRoundLoading
+    isApplicantView && !isActiveMatchingRoundLoading
       ? activeMatchingRound != null
       : undefined
 
   const ctaMode =
-    viewOnly && !userIsOperator
+    viewOnly && !isAdminView && !isPmView
       ? resolveProjectDetailCtaMode({
           isOperator: false,
           isPm: false,
@@ -420,8 +422,8 @@ export function ProjectDetailCard({
           isPartRecruitClosed,
         })
       : resolveProjectDetailCtaMode({
-          isOperator: userIsOperator,
-          isPm: userIsPm,
+          isOperator: isAdminView,
+          isPm: isPmView,
           isSameBranch,
           isApplied,
           isDraftApplication,
@@ -609,18 +611,18 @@ export function ProjectDetailCard({
                   </Button>
                 )}
                 {ctaMode === "apply" &&
-                  (viewOnly && userIsPm
+                  (viewOnly && isPmView
                     ? true
                     : isApplicationWritePermissionLoading ||
                       canWriteProjectApplication) && (
                     <Button
                       className="min-w-28 flex-1 whitespace-nowrap"
                       isLoading={
-                        !(viewOnly && userIsPm) &&
+                        !(viewOnly && isPmView) &&
                         (isDetailLoading || isApplicationWritePermissionLoading)
                       }
                       disabled={isApplyButtonDisabled({
-                        isPmReadonly: viewOnly && userIsPm,
+                        isPmReadonly: viewOnly && isPmView,
                         isDetailLoading,
                         hasApplicationForm: !!detail?.applicationFormId,
                         isWritePermissionLoading:
@@ -635,7 +637,7 @@ export function ProjectDetailCard({
                           cta_mode: ctaMode,
                           is_draft_application: isDraftApplication,
                         })
-                        if (viewOnly && userIsPm) {
+                        if (viewOnly && isPmView) {
                           if (!detail?.applicationFormId) {
                             addToast({
                               message:
@@ -874,7 +876,7 @@ export function ProjectDetailCard({
                 projectId={projectId}
                 matchingRoundId={Number(activeMatchingRound.id)}
                 sections={visibleSections}
-                canToggleSection={userIsOperator || userIsPm}
+                canToggleSection={!isApplicantView}
                 initialApplicationId={
                   isDraftApplication && myApplicationForProject
                     ? Number(myApplicationForProject.applicationId)

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -611,18 +611,15 @@ export function ProjectDetailCard({
                   </Button>
                 )}
                 {ctaMode === "apply" &&
-                  (viewOnly && isPmView
-                    ? true
-                    : isApplicationWritePermissionLoading ||
-                      canWriteProjectApplication) && (
+                  (isApplicationWritePermissionLoading ||
+                    canWriteProjectApplication) && (
                     <Button
                       className="min-w-28 flex-1 whitespace-nowrap"
                       isLoading={
-                        !(viewOnly && isPmView) &&
                         (isDetailLoading || isApplicationWritePermissionLoading)
                       }
                       disabled={isApplyButtonDisabled({
-                        isPmReadonly: viewOnly && isPmView,
+                        isPmReadonly: false,
                         isDetailLoading,
                         hasApplicationForm: !!detail?.applicationFormId,
                         isWritePermissionLoading:

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -193,7 +193,7 @@ export function ProjectDetailCard({
   const userIsOperator = isOperator(me)
   const userIsPm = isCurrentTermPm(me)
   const isAdminView = viewContext.isAdminView && userIsOperator
-  const isPmView = viewContext.isPmView || (!userIsOperator && userIsPm)
+  const isPmView = viewContext.isPmView
   const isApplicantView =
     viewContext.isChallengerView || (!userIsOperator && !userIsPm)
   const shouldQueryEditPermission =

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -252,7 +252,7 @@ export function ProjectDetailCard({
   const { data: myApplications, isError: isMyApplicationsError } = useQuery({
     queryKey: ["myApplications", activeGisuId],
     queryFn: () => getMyApplications(activeGisuId!),
-    enabled: activeGisuId != null && isApplicantView,
+    enabled: activeGisuId != null && isApplicantView && me != null,
   })
 
   const myChapterId = useMemo(() => {

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -634,26 +634,6 @@ export function ProjectDetailCard({
                           cta_mode: ctaMode,
                           is_draft_application: isDraftApplication,
                         })
-                        if (viewOnly && isPmView) {
-                          if (!detail?.applicationFormId) {
-                            addToast({
-                              message:
-                                "지원 양식이 등록되지 않은 프로젝트입니다.",
-                              color: "red",
-                              variant: "deep",
-                              type: "default",
-                              duration: 3000,
-                            })
-                            return
-                          }
-                          setIsRecruitQuestionsModalOpen(true)
-                          trackEvent("project_questions_click", {
-                            project_id: projectId,
-                            cta_mode: ctaMode,
-                            source: "pm_readonly_apply",
-                          })
-                          return
-                        }
                         if (
                           isApplicationWritePermissionLoading ||
                           !canWriteProjectApplication


### PR DESCRIPTION
## 📸 작업 내용

- 복합 권한 계정이 챌린저 뷰에서 프로젝트 상세를 볼 때 지원자 관점 CTA가 노출되도록 수정
- 지원서 작성 권한, 내 지원서 목록, 활성 매칭 라운드 조회를 현재 뷰 기준으로 정렬
- 현재 기수 파트 기반 문항 필터와 파트 모집 가능/마감 판정 테스트 보강

## 🎞️ 주요 코드 설명

### 현재 뷰 기준 CTA 판정

`ProjectDetailCard`에서 원본 권한과 현재 선택된 뷰를 분리해 `admin`, `pm`, `applicant` 관점별 CTA 계산에 사용합니다.

### 파트 판정 테스트 보강

복합 권한 계정의 admin/challenger view 차이와 파트 모집 가능/마감 케이스를 단위 테스트로 고정했습니다.

## 🔗 연결된 이슈

- Connected: #460
- Closes #460