### PR TITLE
task: 내 정보 조회하기 및 활성 기수 정보 캐싱

### DIFF
--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -6,7 +6,7 @@ import {
   getAllSchools,
   getChaptersWithSchools,
 } from "@/features/challenger/api/organization"
-import { getActiveGisu } from "@/shared/api/gisu"
+import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
 
 import {
   getAllProjects,
@@ -66,19 +66,6 @@ function getCurrentRound(rounds: MatchingRoundResponse[]): {
   const fallback =
     completed.length > 0 ? toRound(completed[0]!.phase) : undefined
   return { currentRound: fallback, activeRound: undefined }
-}
-
-// 활성 기수 ID 조회
-export function useActiveGisuId(options: ApplicationPageDataOptions = {}) {
-  const enabled = options.enabled ?? true
-
-  return useQuery({
-    queryKey: ["gisu", "active"],
-    queryFn: getActiveGisu,
-    enabled,
-    staleTime: 5 * 60 * 1000,
-    select: (data) => (data?.gisuId != null ? Number(data.gisuId) : null),
-  })
 }
 
 // PM 챌린저 뷰용 데이터

--- a/src/features/application/ui/MyApplicationView.tsx
+++ b/src/features/application/ui/MyApplicationView.tsx
@@ -2,7 +2,6 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
 
-import { useActiveGisuId } from "@/features/application/hooks/useApplicationPageData"
 import {
   getMyApplications,
   getProjectDetail,
@@ -11,6 +10,7 @@ import {
 import { ProjectDetailCard } from "@/features/project/list/ui/ProjectDetailCard"
 import { ProjectManagementSubTitle } from "@/features/project/management/ui/ProjectManagementSubTitle"
 import { UsabilitySurvey } from "@/features/usability-survey"
+import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
 import { StatusChipTag } from "@/shared/ui/chip/StatusChipTag"
 import { EmptyState } from "@/shared/ui/EmptyState"
 import { Modal } from "@/shared/ui/Modal"

--- a/src/features/auth/hooks/useMe.ts
+++ b/src/features/auth/hooks/useMe.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query"
+import { queryOptions, useQuery } from "@tanstack/react-query"
 
 import { getMyInfo } from "../api/me"
 import { useAuthStore } from "../store/authStore"
@@ -7,12 +7,16 @@ export const authKeys = {
   me: ["auth", "me"] as const,
 } as const
 
+export const meQueryOptions = queryOptions({
+  queryKey: authKeys.me,
+  queryFn: getMyInfo,
+  staleTime: 1000 * 60 * 5,
+})
+
 export function useMe() {
   const isAuthed = useAuthStore((s) => s.isAuthed)
   return useQuery({
-    queryKey: authKeys.me,
-    queryFn: getMyInfo,
-    staleTime: 1000 * 60 * 5,
+    ...meQueryOptions,
     enabled: isAuthed,
   })
 }

--- a/src/features/auth/hooks/useMe.ts
+++ b/src/features/auth/hooks/useMe.ts
@@ -3,10 +3,14 @@ import { useQuery } from "@tanstack/react-query"
 import { getMyInfo } from "../api/me"
 import { useAuthStore } from "../store/authStore"
 
+export const authKeys = {
+  me: ["auth", "me"] as const,
+} as const
+
 export function useMe() {
   const isAuthed = useAuthStore((s) => s.isAuthed)
   return useQuery({
-    queryKey: ["auth", "me"],
+    queryKey: authKeys.me,
     queryFn: getMyInfo,
     staleTime: 1000 * 60 * 5,
     enabled: isAuthed,

--- a/src/features/auth/lib/ensureMe.ts
+++ b/src/features/auth/lib/ensureMe.ts
@@ -1,11 +1,12 @@
 import { redirect } from "@tanstack/react-router"
 
-import { getMyInfo, type MemberInfoResponse } from "@/features/auth/api/me"
-import { authKeys } from "@/features/auth/hooks/useMe"
+import { meQueryOptions } from "@/features/auth/hooks/useMe"
 import { buildLoginRedirectSearch } from "@/features/auth/lib/loginRedirect"
 import { useAuthStore } from "@/features/auth/store/authStore"
 
 import type { QueryClient } from "@tanstack/react-query"
+
+import type { MemberInfoResponse } from "@/features/auth/api/me"
 
 export async function ensureMe(
   queryClient: QueryClient,
@@ -19,11 +20,7 @@ export async function ensureMe(
   }
 
   try {
-    return await queryClient.ensureQueryData({
-      queryKey: authKeys.me,
-      queryFn: getMyInfo,
-      staleTime: 1000 * 60 * 5,
-    })
+    return await queryClient.ensureQueryData(meQueryOptions)
   } catch {
     throw redirect({
       to: "/login",

--- a/src/features/auth/lib/ensureMe.ts
+++ b/src/features/auth/lib/ensureMe.ts
@@ -1,6 +1,7 @@
 import { redirect } from "@tanstack/react-router"
 
 import { getMyInfo, type MemberInfoResponse } from "@/features/auth/api/me"
+import { authKeys } from "@/features/auth/hooks/useMe"
 import { buildLoginRedirectSearch } from "@/features/auth/lib/loginRedirect"
 import { useAuthStore } from "@/features/auth/store/authStore"
 
@@ -19,7 +20,7 @@ export async function ensureMe(
 
   try {
     return await queryClient.ensureQueryData({
-      queryKey: ["auth", "me"],
+      queryKey: authKeys.me,
       queryFn: getMyInfo,
       staleTime: 1000 * 60 * 5,
     })

--- a/src/features/challenger/ui/ChallengerVerification.tsx
+++ b/src/features/challenger/ui/ChallengerVerification.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "@tanstack/react-router"
 import { Info } from "lucide-react"
 import { useState } from "react"
 
+import { authKeys } from "@/features/auth/hooks/useMe"
 import { addChallengerRecordToMember } from "@/features/challenger/api/challengerRecord"
 import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
 import { Button } from "@/shared/ui/Button"
@@ -35,7 +36,7 @@ export function ChallengerVerification() {
   const verifyMutation = useMutation({
     mutationFn: (value: string) => addChallengerRecordToMember(value),
     onSuccess: () => {
-      queryClient.removeQueries({ queryKey: ["auth", "me"] })
+      queryClient.removeQueries({ queryKey: authKeys.me })
       void navigate({ to: "/" })
     },
     onError: () => {

--- a/src/features/matching/hooks/useMatchingStatusData.ts
+++ b/src/features/matching/hooks/useMatchingStatusData.ts
@@ -8,10 +8,7 @@ import {
   getProjectApplications,
 } from "@/features/application/api/applicationApi"
 import { applicationKeys } from "@/features/application/api/applicationKeys"
-import {
-  useActiveGisuId,
-  useChapters,
-} from "@/features/application/hooks/useApplicationPageData"
+import { useChapters } from "@/features/application/hooks/useApplicationPageData"
 import {
   shortenSchoolName,
   summaryToStats,
@@ -22,6 +19,7 @@ import {
   getChaptersWithSchools,
 } from "@/features/challenger/api/organization"
 import { getProjectMembers } from "@/features/project/list/api/matchingProject"
+import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
 import { useViewModeStore } from "@/shared/view-mode"
 
 import { toMatchingPartDataList } from "../model/matchingStatusMapper"

--- a/src/features/project/list/model/matchingProjectList.ts
+++ b/src/features/project/list/model/matchingProjectList.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import { isOperator } from "@/features/auth/model/identity"
 import { getChaptersWithSchools } from "@/features/challenger/api/organization"
 import { projectKeys } from "@/features/project/new/api"
-import { getActiveGisu } from "@/shared/api/gisu"
+import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
 import { formatSchoolName } from "@/shared/lib/formatSchoolName"
 import { useViewerIdentity } from "@/shared/view-mode/useViewerIdentity"
 
@@ -81,10 +81,7 @@ export function useMatchingProjectListFilters() {
   const { me, viewContext } = useViewerIdentity()
   const userIsOperator = isOperator(me)
 
-  const { data: gisuData } = useQuery({
-    queryKey: ["gisu"],
-    queryFn: getActiveGisu,
-  })
+  const { data: gisuData } = useActiveGisu()
 
   const activeGisuId = gisuData?.gisuId ? Number(gisuData.gisuId) : undefined
 

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -19,9 +19,9 @@ import {
 } from "@/features/project/new/api"
 import { UsabilitySurvey } from "@/features/usability-survey"
 import { trackEvent } from "@/shared/analytics"
-import { getActiveGisu } from "@/shared/api/gisu"
 import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
 import { ProjectLogo } from "@/shared/assets/icon/logo/ProjectLogo"
+import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
 import { formatSchoolName } from "@/shared/lib/formatSchoolName"
 import { withImageCacheKey } from "@/shared/lib/withImageCacheKey"
 import { Button } from "@/shared/ui/Button"
@@ -242,11 +242,7 @@ export function ProjectDetailCard({
     staleTime: 5 * 60 * 1000,
   })
 
-  const { data: activeGisuData } = useQuery({
-    queryKey: ["gisu"],
-    queryFn: getActiveGisu,
-    staleTime: 5 * 60 * 1000,
-  })
+  const { data: activeGisuData } = useActiveGisu()
   const activeGisuId = activeGisuData?.gisuId ?? null
 
   const { data: myApplications, isError: isMyApplicationsError } = useQuery({
@@ -616,7 +612,7 @@ export function ProjectDetailCard({
                     <Button
                       className="min-w-28 flex-1 whitespace-nowrap"
                       isLoading={
-                        (isDetailLoading || isApplicationWritePermissionLoading)
+                        isDetailLoading || isApplicationWritePermissionLoading
                       }
                       disabled={isApplyButtonDisabled({
                         isPmReadonly: false,

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod"
+import { useQueryClient } from "@tanstack/react-query"
 import { AxiosError } from "axios"
 import {
   forwardRef,
@@ -17,6 +18,7 @@ import { trackEvent } from "@/shared/analytics"
 import { getActiveGisu } from "@/shared/api/gisu"
 import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
 import WarningTriangleIcon from "@/shared/assets/icon/infomation/WarningTriangleIcon"
+import { gisuKeys } from "@/shared/hooks/useActiveGisu"
 import { Button } from "@/shared/ui/Button"
 import { RecruitStatusChip } from "@/shared/ui/chip/RecruitStatusChip"
 import { FormHeader } from "@/shared/ui/FormHeader"
@@ -196,6 +198,7 @@ export const ProjectApplyModal = forwardRef<
   },
   ref,
 ) {
+  const queryClient = useQueryClient()
   const addToast = useToastStore((s) => s.addToast)
   const isDevMatchingRound = Boolean(import.meta.env.VITE_DEV_MATCHING_ROUND_ID)
   const [sectionEnabled, setSectionEnabled] = useState<Record<string, boolean>>(
@@ -251,7 +254,13 @@ export const ProjectApplyModal = forwardRef<
         setApplicationId(Number(draft.applicationId))
       } catch (err) {
         if (err instanceof AxiosError && err.response?.status === 409) {
-          const gisu = await getActiveGisu().catch(() => null)
+          const gisu = await queryClient
+            .ensureQueryData({
+              queryKey: gisuKeys.active,
+              queryFn: getActiveGisu,
+              staleTime: 5 * 60 * 1000,
+            })
+            .catch(() => null)
           if (gisu) {
             const apps: MyProjectApplicationResponse[] =
               await getMyApplications(Number(gisu.gisuId), "DRAFT").catch(

--- a/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
+++ b/src/features/project/list/ui/apply-modal/ProjectApplyModal.tsx
@@ -15,10 +15,9 @@ import { useToastStore } from "@/components/toast/useToastStore"
 import { useResourcePermission } from "@/features/auth/hooks/useResourcePermission"
 import { uploadFileFlow } from "@/features/project/new/api/storage"
 import { trackEvent } from "@/shared/analytics"
-import { getActiveGisu } from "@/shared/api/gisu"
 import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
 import WarningTriangleIcon from "@/shared/assets/icon/infomation/WarningTriangleIcon"
-import { gisuKeys } from "@/shared/hooks/useActiveGisu"
+import { activeGisuQueryOptions } from "@/shared/hooks/useActiveGisu"
 import { Button } from "@/shared/ui/Button"
 import { RecruitStatusChip } from "@/shared/ui/chip/RecruitStatusChip"
 import { FormHeader } from "@/shared/ui/FormHeader"
@@ -255,11 +254,7 @@ export const ProjectApplyModal = forwardRef<
       } catch (err) {
         if (err instanceof AxiosError && err.response?.status === 409) {
           const gisu = await queryClient
-            .ensureQueryData({
-              queryKey: gisuKeys.active,
-              queryFn: getActiveGisu,
-              staleTime: 5 * 60 * 1000,
-            })
+            .ensureQueryData(activeGisuQueryOptions)
             .catch(() => null)
           if (gisu) {
             const apps: MyProjectApplicationResponse[] =

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -11,9 +11,9 @@ import {
   isSchoolStaff,
 } from "@/features/auth/model/identity"
 import { getChaptersWithSchools } from "@/features/challenger/api/organization"
-import { gisuKeys, projectKeys } from "@/features/project/new/api/queryKeys"
+import { projectKeys } from "@/features/project/new/api/queryKeys"
 import { useIsMatchingPeriod } from "@/features/project/new/hooks/useIsMatchingPeriod"
-import { getActiveGisu } from "@/shared/api/gisu"
+import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
 import { withImageCacheKey } from "@/shared/lib/withImageCacheKey"
 import { EmptyState } from "@/shared/ui/EmptyState"
 import { SegmentButton } from "@/shared/ui/segment-button/SegmentButton"
@@ -142,11 +142,7 @@ export function ProjectManagementPage() {
         ? "내 지부의 프로젝트 정보를 확인합니다."
         : "내 프로젝트 정보를 확인하고 수정할 수 있습니다. 팀 매칭 진행 중에는 수정할 수 없습니다."
 
-  const gisuQuery = useQuery({
-    queryKey: gisuKeys.active,
-    queryFn: getActiveGisu,
-    enabled: hasAccess,
-  })
+  const gisuQuery = useActiveGisu({ enabled: hasAccess })
   const gisuId = gisuQuery.data?.gisuId
     ? Number(gisuQuery.data.gisuId)
     : undefined

--- a/src/features/project/new/api/queryKeys.ts
+++ b/src/features/project/new/api/queryKeys.ts
@@ -31,7 +31,7 @@ export const projectKeys = {
 } as const
 
 export const gisuKeys = {
-  active: ["gisu"] as const,
+  active: ["gisu", "active"] as const,
 } as const
 
 export const memberKeys = {

--- a/src/features/project/new/api/queryKeys.ts
+++ b/src/features/project/new/api/queryKeys.ts
@@ -30,9 +30,7 @@ export const projectKeys = {
     [...projectKeys.all, "members", projectId] as const,
 } as const
 
-export const gisuKeys = {
-  active: ["gisu", "active"] as const,
-} as const
+export { gisuKeys } from "@/shared/hooks/useActiveGisu"
 
 export const memberKeys = {
   search: (keyword: string) => ["member", "search", keyword] as const,

--- a/src/features/project/new/ui/ProjectRegisterPage.tsx
+++ b/src/features/project/new/ui/ProjectRegisterPage.tsx
@@ -29,7 +29,6 @@ import {
   getApplicationForm,
   getMyDraft,
   getProjectDetail,
-  gisuKeys,
   invalidateProjectSummaryQueries,
   projectKeys,
   submitProject,
@@ -41,8 +40,7 @@ import { hydrateDraftIntoStore } from "@/features/project/new/model/draftHydrato
 import { isWithinMatchingPeriod } from "@/features/project/new/model/matchingPeriod"
 import { hydrateProjectDetailIntoStore } from "@/features/project/new/model/projectDetailHydrator"
 import { useProjectRegisterStore } from "@/features/project/new/model/useProjectRegisterStore"
-import { getActiveGisu } from "@/shared/api/gisu"
-import { getMe } from "@/shared/api/me"
+import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
 
 import type { BasicInfoFormHandle } from "@/features/project/new/ui/basic-info/BasicInfoForm"
@@ -159,12 +157,7 @@ export function ProjectRegisterPage(props: ProjectRegisterPageProps) {
     )
   })
 
-  useQuery({ queryKey: ["me"], queryFn: getMe })
-
-  const gisuQuery = useQuery({
-    queryKey: gisuKeys.active,
-    queryFn: getActiveGisu,
-  })
+  const gisuQuery = useActiveGisu()
 
   const gisuId = gisuQuery.data?.gisuId
 

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -1,9 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod"
-import {
-  useInfiniteQuery,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query"
+import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query"
 import { isAxiosError } from "axios"
 import {
   forwardRef,
@@ -33,8 +29,8 @@ import {
   uploadFileFlow,
 } from "@/features/project/new/api"
 import { challengerSearchItemToMemberItem } from "@/features/project/new/api/memberAdapter"
-import { getActiveGisu } from "@/shared/api/gisu"
 import InfoCircleIcon from "@/shared/assets/icon/infomation/InfoCircleIcon"
+import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
 import { formatSchoolName } from "@/shared/lib/formatSchoolName"
 import { Button } from "@/shared/ui/Button"
 import { ImageUploader } from "@/shared/ui/ImageUploader"
@@ -105,11 +101,7 @@ export const BasicInfoForm = forwardRef<
 ) {
   const { me: meData } = useViewerIdentity()
   const isPm = isCurrentTermPm(meData)
-  const activeGisuQuery = useQuery({
-    queryKey: ["gisu"],
-    queryFn: getActiveGisu,
-    staleTime: 5 * 60 * 1000,
-  })
+  const activeGisuQuery = useActiveGisu()
   const activeGisuId = activeGisuQuery.data?.gisuId
 
   const pmSearchScope = useMemo(() => getProjectPmSearchScope(meData), [meData])

--- a/src/features/settings/ui/AccountSettingsPage.tsx
+++ b/src/features/settings/ui/AccountSettingsPage.tsx
@@ -4,7 +4,7 @@ import { useRef, useState } from "react"
 
 import { useToastStore } from "@/components/toast/useToastStore"
 import { deleteMember, updateMemberInfo } from "@/features/auth/api/me"
-import { useMe } from "@/features/auth/hooks/useMe"
+import { authKeys, useMe } from "@/features/auth/hooks/useMe"
 import { useMemberOAuthList } from "@/features/auth/hooks/useMemberOAuthList"
 import { useOAuthLinking } from "@/features/auth/hooks/useOAuthLinking"
 import {
@@ -77,7 +77,7 @@ export function AccountSettingsPage() {
     try {
       const { fileId } = await uploadFileFlow(file, "PROFILE_IMAGE")
       await updateMemberInfo({ profileImageId: fileId })
-      await queryClient.invalidateQueries({ queryKey: ["auth", "me"] })
+      await queryClient.invalidateQueries({ queryKey: authKeys.me })
       addToast({
         message: "프로필 이미지가 변경되었습니다.",
         color: "primary",

--- a/src/features/settings/ui/ChangeEmailForm.tsx
+++ b/src/features/settings/ui/ChangeEmailForm.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { useToastStore } from "@/components/toast/useToastStore"
 import { changeEmail } from "@/features/auth/api/me"
 import { useEmailVerification } from "@/features/auth/hooks/useEmailVerification"
+import { authKeys } from "@/features/auth/hooks/useMe"
 import CircleBang from "@/shared/assets/icon/bang/CircleBang"
 import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
 import { Button } from "@/shared/ui/Button"
@@ -51,7 +52,7 @@ export function ChangeEmailForm({
       const token = await handleCodeVerify()
       if (!token) return
       await changeEmail({ newEmail: next, emailVerificationToken: token })
-      await queryClient.invalidateQueries({ queryKey: ["auth", "me"] })
+      await queryClient.invalidateQueries({ queryKey: authKeys.me })
       addToast({
         message: "이메일이 변경되었습니다.",
         color: "primary",

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -44,6 +44,7 @@ export const Route = createFileRoute("/matching/projects/new")({
         const gisu = await context.queryClient.ensureQueryData({
           queryKey: gisuKeys.active,
           queryFn: getActiveGisu,
+          staleTime: 5 * 60 * 1000,
         })
         const gisuId = gisu?.gisuId ? Number(gisu.gisuId) : undefined
         if (gisuId) {

--- a/src/routes/matching/projects/new.tsx
+++ b/src/routes/matching/projects/new.tsx
@@ -5,9 +5,9 @@ import { ensureMe } from "@/features/auth/lib/ensureMe"
 import { isProjectRegistrationQuotaLimited } from "@/features/auth/model/identity"
 import { hasGrantedPermission } from "@/features/auth/model/resourcePermission"
 import { getManagedProjects } from "@/features/project/management/api"
-import { getMyDraft, gisuKeys, projectKeys } from "@/features/project/new/api"
+import { getMyDraft, projectKeys } from "@/features/project/new/api"
 import { ProjectRegisterPage } from "@/features/project/new/ui/ProjectRegisterPage"
-import { getActiveGisu } from "@/shared/api/gisu"
+import { activeGisuQueryOptions } from "@/shared/hooks/useActiveGisu"
 
 export const Route = createFileRoute("/matching/projects/new")({
   beforeLoad: async ({ context }) => {
@@ -41,11 +41,9 @@ export const Route = createFileRoute("/matching/projects/new")({
 
     if (isProjectRegistrationQuotaLimited(me)) {
       try {
-        const gisu = await context.queryClient.ensureQueryData({
-          queryKey: gisuKeys.active,
-          queryFn: getActiveGisu,
-          staleTime: 5 * 60 * 1000,
-        })
+        const gisu = await context.queryClient.ensureQueryData(
+          activeGisuQueryOptions,
+        )
         const gisuId = gisu?.gisuId ? Number(gisu.gisuId) : undefined
         if (gisuId) {
           const draft = await context.queryClient.ensureQueryData({

--- a/src/routes/test/header.tsx
+++ b/src/routes/test/header.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react"
 import Header from "@/components/header/Header"
 import { MatchingSegmentRegion } from "@/components/sidebar/MatchingSegmentRegion"
 import SideBar from "@/components/sidebar/SideBar"
+import { authKeys } from "@/features/auth/hooks/useMe"
 import { useAuthStore } from "@/features/auth/store/authStore"
 import { cn } from "@/shared/lib/utils"
 
@@ -134,7 +135,7 @@ export function useHeaderPreviewUser() {
 
   useEffect(() => {
     const previousAuthState = useAuthStore.getState()
-    const previousAuthQuery = queryClient.getQueryData(["auth", "me"])
+    const previousAuthQuery = queryClient.getQueryData(authKeys.me)
 
     useAuthStore.setState({
       accessToken: null,
@@ -142,7 +143,7 @@ export function useHeaderPreviewUser() {
       memberId: null,
       isAuthed: false,
     })
-    queryClient.setQueryData(["auth", "me"], HEADER_PREVIEW_USER)
+    queryClient.setQueryData(authKeys.me, HEADER_PREVIEW_USER)
     setIsReady(true)
 
     return () => {
@@ -152,7 +153,7 @@ export function useHeaderPreviewUser() {
         memberId: previousAuthState.memberId,
         isAuthed: previousAuthState.isAuthed,
       })
-      queryClient.setQueryData(["auth", "me"], previousAuthQuery)
+      queryClient.setQueryData(authKeys.me, previousAuthQuery)
     }
   }, [queryClient])
 

--- a/src/shared/hooks/useActiveGisu.ts
+++ b/src/shared/hooks/useActiveGisu.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query"
+import { queryOptions, useQuery } from "@tanstack/react-query"
 
 import { getActiveGisu } from "@/shared/api/gisu"
 
@@ -6,20 +6,22 @@ export const gisuKeys = {
   active: ["gisu", "active"] as const,
 }
 
+export const activeGisuQueryOptions = queryOptions({
+  queryKey: gisuKeys.active,
+  queryFn: getActiveGisu,
+  staleTime: 5 * 60 * 1000,
+})
+
 export function useActiveGisu(options?: { enabled?: boolean }) {
   return useQuery({
-    queryKey: gisuKeys.active,
-    queryFn: getActiveGisu,
-    staleTime: 5 * 60 * 1000,
+    ...activeGisuQueryOptions,
     ...options,
   })
 }
 
 export function useActiveGisuId(options?: { enabled?: boolean }) {
   return useQuery({
-    queryKey: gisuKeys.active,
-    queryFn: getActiveGisu,
-    staleTime: 5 * 60 * 1000,
+    ...activeGisuQueryOptions,
     select: (data) => (data?.gisuId != null ? Number(data.gisuId) : null),
     ...options,
   })

--- a/src/shared/hooks/useActiveGisu.ts
+++ b/src/shared/hooks/useActiveGisu.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { getActiveGisu } from "@/shared/api/gisu"
+
+export const gisuKeys = {
+  active: ["gisu", "active"] as const,
+}
+
+export function useActiveGisu(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: gisuKeys.active,
+    queryFn: getActiveGisu,
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })
+}
+
+export function useActiveGisuId(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: gisuKeys.active,
+    queryFn: getActiveGisu,
+    staleTime: 5 * 60 * 1000,
+    select: (data) => (data?.gisuId != null ? Number(data.gisuId) : null),
+    ...options,
+  })
+}

--- a/src/shared/hooks/useSchoolChapterMap.ts
+++ b/src/shared/hooks/useSchoolChapterMap.ts
@@ -4,14 +4,10 @@ import { useQuery } from "@tanstack/react-query"
 import { useMemo } from "react"
 
 import { getChaptersWithSchools } from "@/features/challenger/api/organization"
-import { getActiveGisu } from "@/shared/api/gisu"
+import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
 
 export function useSchoolChapterMap() {
-  const { data: gisuData } = useQuery({
-    queryKey: ["gisu"],
-    queryFn: getActiveGisu,
-    staleTime: 5 * 60 * 1000,
-  })
+  const { data: gisuData } = useActiveGisu()
 
   const activeGisuId = gisuData?.gisuId ? Number(gisuData.gisuId) : undefined
 


### PR DESCRIPTION
## 📸 작업 내용

> `/api/v2/member/me` 및 `/api/v1/gisu/active` API의 캐싱 구조를 리팩토링하고 쿼리 키 오동작 및 성능 저하 문제를 방지했습니다.

- `/v2/member/me` API의 쿼리 키를 `authKeys.me` (`["auth", "me"]`)로 묶어 중앙에서 제어하도록 개선하고 관련 컴포넌트(useMe, ensureMe, 회원 탈퇴/이메일 변경/프로필 이미지 변경 등)에 일관되게 적용
- `/v1/gisu/active` API에 개별적으로 사용되던 불일치 쿼리 키(`["gisu"]` vs `["gisu", "active"]`)를 `["gisu", "active"]`로 단일화
- 활성 기수 API 조회를 편리하게 사용하고 재사용할 수 있도록 `useActiveGisu`, `useActiveGisuId` 공통 커스텀 훅 정의 및 staleTime(5분) 기본값 지정
- `ProjectRegisterPage` 내 불필요하게 찌꺼기로 남아있던 구버전 `/v1/member/me` API 중복 호출 코드 제거

## 🎞️ 주요 코드 설명

### 1. `useActiveGisu` 훅 및 활성 기수 쿼리 키 중앙화

`src/shared/hooks/useActiveGisu.ts`에 활성 기수 정보를 가져오는 공통 훅을 정의하여 staleTime 및 select 처리를 일원화했습니다.

```TypeScript
// src/shared/hooks/useActiveGisu.ts
import { useQuery } from "@tanstack/react-query"
import { getActiveGisu } from "@/shared/api/gisu"

export const gisuKeys = {
  active: ["gisu", "active"] as const,
}

export function useActiveGisu(options?: { enabled?: boolean }) {
  return useQuery({
    queryKey: gisuKeys.active,
    queryFn: getActiveGisu,
    staleTime: 5 * 60 * 1000,
    ...options,
  })
}

export function useActiveGisuId(options?: { enabled?: boolean }) {
  return useQuery({
    queryKey: gisuKeys.active,
    queryFn: getActiveGisu,
    staleTime: 5 * 60 * 1000,
    select: (data) => (data?.gisuId != null ? Number(data.gisuId) : null),
    ...options,
  })
}
```

### 2. `authKeys.me` 정의 및 일치화

`/api/v2/member/me` 조회의 쿼리 키 관리를 중앙화하여 무효화(`invalidateQueries`) 처리가 누락되는 등의 버그 가능성을 원천적으로 차단했습니다.

```TypeScript
// src/features/auth/hooks/useMe.ts
export const authKeys = {
  me: ["auth", "me"] as const,
} as const
```

## 🔗 연결된 이슈

- Connected: #465 
