### PR TITLE
task: 프로젝트 목록 필터링 상태를 URL Query Param에 연동

### DIFF
--- a/src/features/project/list/index.ts
+++ b/src/features/project/list/index.ts
@@ -12,6 +12,7 @@ export { useMatchingProjectListFilters } from "./model/matchingProjectList"
 export type {
   MatchingProjectListFilterDescriptor,
   MatchingProjectListFilterId,
+  ProjectListSearch,
 } from "./model/matchingProjectList"
 export { FilterDropdown } from "./ui/FilterDropDown"
 export { MatchingProjectCard } from "./ui/MatchingProjectCard"

--- a/src/features/project/list/model/matchingProjectList.ts
+++ b/src/features/project/list/model/matchingProjectList.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
+import { useNavigate, useSearch } from "@tanstack/react-router"
 import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { isOperator } from "@/features/auth/model/identity"
@@ -53,30 +54,45 @@ const FILTER_LAYOUT = {
 } as const
 
 export function useMatchingProjectListFilters() {
+  const search = useSearch({ strict: false }) as Record<string, unknown>
+  const navigate = useNavigate() as unknown as (opts: {
+    search: (prev: Record<string, unknown>) => Record<string, unknown>
+    replace?: boolean
+  }) => Promise<void>
+
   const [openFilterId, setOpenFilterId] = useState<string | null>(null)
-  const [selectedBranch, setSelectedBranch] = useState<string>()
-  const [selectedSchool, setSelectedSchool] = useState<string>()
-  const [selectedParts, setSelectedParts] = useState<ProjectPart[]>([])
-  const [selectedRecruitStatus, setSelectedRecruitStatus] =
-    useState<PartQuotaStatus>()
-  const [searchQuery, setSearchQuery] = useState("")
-  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("")
-  const [page, setPage] = useState(1)
+
+  const selectedBranch = search.branch as string | undefined
+  const selectedSchool = search.school as string | undefined
+
+  const rawParts = search.parts as ProjectPart[] | undefined
+  const selectedParts = useMemo(() => rawParts ?? [], [rawParts])
+
+  const selectedRecruitStatus = search.status as PartQuotaStatus | undefined
+  const page = (search.page ?? 1) as number
+  const keyword = (search.keyword ?? "") as string
+
+  const [searchQuery, setSearchQuery] = useState(keyword)
 
   useEffect(() => {
-    const timer = setTimeout(() => setDebouncedSearchQuery(searchQuery), 300)
+    setSearchQuery(keyword)
+  }, [keyword])
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (searchQuery !== keyword) {
+        void navigate({
+          search: (prev) => ({
+            ...prev,
+            keyword: searchQuery || undefined,
+            page: 1,
+          }),
+          replace: true,
+        })
+      }
+    }, 300)
     return () => clearTimeout(timer)
-  }, [searchQuery])
-
-  useEffect(() => {
-    setPage(1)
-  }, [
-    selectedBranch,
-    selectedSchool,
-    selectedParts,
-    selectedRecruitStatus,
-    debouncedSearchQuery,
-  ])
+  }, [searchQuery, keyword, navigate])
 
   const { me, viewContext } = useViewerIdentity()
   const userIsOperator = isOperator(me)
@@ -130,7 +146,7 @@ export function useMatchingProjectListFilters() {
     queryKey: projectKeys.list({
       gisuId: effectiveGisuId,
       page,
-      keyword: debouncedSearchQuery,
+      keyword: keyword,
       chapterId: selectedBranch,
       schoolId: selectedSchool,
       parts: selectedParts,
@@ -139,7 +155,7 @@ export function useMatchingProjectListFilters() {
     queryFn: () =>
       getMatchingProjects({
         gisuId: effectiveGisuId!,
-        keyword: debouncedSearchQuery || undefined,
+        keyword: keyword || undefined,
         chapterId: selectedBranch ? Number(selectedBranch) : undefined,
         schoolIds: selectedSchool ? [Number(selectedSchool)] : undefined,
         parts: selectedParts.length > 0 ? selectedParts : undefined,
@@ -176,21 +192,56 @@ export function useMatchingProjectListFilters() {
     [selectedRecruitStatus],
   )
 
-  const handlePartSelect = useCallback((value: string) => {
-    setSelectedParts((prev) => {
+  const handlePartSelect = useCallback(
+    (value: string) => {
       const part = value as ProjectPart
-      return prev.includes(part)
-        ? prev.filter((selected) => selected !== part)
-        : [...prev, part]
-    })
-  }, [])
+      void navigate({
+        search: (prev) => {
+          const currentParts = (prev.parts ?? []) as ProjectPart[]
+          const newParts = currentParts.includes(part)
+            ? currentParts.filter((selected) => selected !== part)
+            : [...currentParts, part]
+          return {
+            ...prev,
+            parts: newParts.length > 0 ? newParts : undefined,
+            page: 1,
+          }
+        },
+      })
+    },
+    [navigate],
+  )
 
-  const handleRecruitStatusSelect = useCallback((value: string) => {
-    setSelectedRecruitStatus((prev) => {
+  const handleRecruitStatusSelect = useCallback(
+    (value: string) => {
       const status = value as PartQuotaStatus
-      return prev === status ? undefined : status
-    })
-  }, [])
+      void navigate({
+        search: (prev) => ({
+          ...prev,
+          status: prev.status === status ? undefined : status,
+          page: 1,
+        }),
+      })
+    },
+    [navigate],
+  )
+
+  const setPage = useCallback(
+    (newPage: number | ((prev: number) => number)) => {
+      void navigate({
+        search: (prev) => {
+          const prevPage = typeof prev.page === "number" ? prev.page : 1
+          const nextPage =
+            typeof newPage === "function" ? newPage(prevPage) : newPage
+          return {
+            ...prev,
+            page: nextPage,
+          }
+        },
+      })
+    },
+    [navigate],
+  )
 
   const filterDescriptors: MatchingProjectListFilterDescriptor[] = [
     {
@@ -200,8 +251,14 @@ export function useMatchingProjectListFilters() {
       selectedValue: selectedBranch,
       selectedLabel: selectedBranchLabel,
       onSelect: (value) => {
-        setSelectedBranch((prev) => (prev === value ? undefined : value))
-        setSelectedSchool(undefined)
+        void navigate({
+          search: (prev) => ({
+            ...prev,
+            branch: prev.branch === value ? undefined : value,
+            school: undefined,
+            page: 1,
+          }),
+        })
       },
       ...FILTER_LAYOUT.branch,
     },
@@ -211,8 +268,15 @@ export function useMatchingProjectListFilters() {
       options: schoolOptions,
       selectedValue: selectedSchool,
       selectedLabel: selectedSchoolLabel,
-      onSelect: (value) =>
-        setSelectedSchool((prev) => (prev === value ? undefined : value)),
+      onSelect: (value) => {
+        void navigate({
+          search: (prev) => ({
+            ...prev,
+            school: prev.school === value ? undefined : value,
+            page: 1,
+          }),
+        })
+      },
       ...FILTER_LAYOUT.school,
     },
     {

--- a/src/features/project/list/model/matchingProjectList.ts
+++ b/src/features/project/list/model/matchingProjectList.ts
@@ -39,6 +39,16 @@ export type MatchingProjectListFilterDescriptor = {
   multiSelect?: boolean
 }
 
+export type ProjectListSearch = {
+  mock?: "projects"
+  branch?: string
+  school?: string
+  parts?: ProjectPart[]
+  status?: PartQuotaStatus
+  keyword?: string
+  page?: number
+}
+
 const FILTER_LAYOUT = {
   branch: { className: "w-fit min-w-20", dropdownClassName: "w-[9.5rem]" },
   school: {
@@ -53,30 +63,31 @@ const FILTER_LAYOUT = {
   },
 } as const
 
+const EMPTY_PARTS: ProjectPart[] = []
+
 export function useMatchingProjectListFilters() {
-  const search = useSearch({ strict: false }) as Record<string, unknown>
+  const search = useSearch({ strict: false }) as ProjectListSearch
   const navigate = useNavigate() as unknown as (opts: {
-    search: (prev: Record<string, unknown>) => Record<string, unknown>
+    search: (prev: ProjectListSearch) => ProjectListSearch
     replace?: boolean
   }) => Promise<void>
 
   const [openFilterId, setOpenFilterId] = useState<string | null>(null)
 
-  const selectedBranch = search.branch as string | undefined
-  const selectedSchool = search.school as string | undefined
-
-  const rawParts = search.parts as ProjectPart[] | undefined
-  const selectedParts = useMemo(() => rawParts ?? [], [rawParts])
-
-  const selectedRecruitStatus = search.status as PartQuotaStatus | undefined
-  const page = (search.page ?? 1) as number
-  const keyword = (search.keyword ?? "") as string
+  const selectedBranch = search.branch
+  const selectedSchool = search.school
+  const selectedParts = search.parts ?? EMPTY_PARTS
+  const selectedRecruitStatus = search.status
+  const page = search.page ?? 1
+  const keyword = search.keyword ?? ""
 
   const [searchQuery, setSearchQuery] = useState(keyword)
+  const [prevKeyword, setPrevKeyword] = useState(keyword)
 
-  useEffect(() => {
+  if (keyword !== prevKeyword) {
+    setPrevKeyword(keyword)
     setSearchQuery(keyword)
-  }, [keyword])
+  }
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -197,7 +208,7 @@ export function useMatchingProjectListFilters() {
       const part = value as ProjectPart
       void navigate({
         search: (prev) => {
-          const currentParts = (prev.parts ?? []) as ProjectPart[]
+          const currentParts = prev.parts ?? EMPTY_PARTS
           const newParts = currentParts.includes(part)
             ? currentParts.filter((selected) => selected !== part)
             : [...currentParts, part]
@@ -230,7 +241,7 @@ export function useMatchingProjectListFilters() {
     (newPage: number | ((prev: number) => number)) => {
       void navigate({
         search: (prev) => {
-          const prevPage = typeof prev.page === "number" ? prev.page : 1
+          const prevPage = prev.page ?? 1
           const nextPage =
             typeof newPage === "function" ? newPage(prevPage) : newPage
           return {

--- a/src/routes/matching/projects/index.tsx
+++ b/src/routes/matching/projects/index.tsx
@@ -3,19 +3,22 @@ import { createFileRoute } from "@tanstack/react-router"
 
 import { MatchingProjectsListPage } from "@/features/project/list"
 
-import type {
-  PartQuotaStatus,
-  ProjectPart,
-} from "@/features/project/list/api/matchingProject"
+import type { ProjectListSearch } from "@/features/project/list"
+import type { ProjectPart } from "@/features/project/list/api/matchingProject"
 
-export type ProjectListSearch = {
-  mock?: "projects"
-  branch?: string
-  school?: string
-  parts?: ProjectPart[]
-  status?: PartQuotaStatus
-  keyword?: string
-  page?: number
+const VALID_PARTS = new Set<string>([
+  "PLAN",
+  "DESIGN",
+  "WEB",
+  "ANDROID",
+  "IOS",
+  "NODEJS",
+  "SPRINGBOOT",
+  "ADMIN",
+])
+
+function isProjectPart(value: unknown): value is ProjectPart {
+  return typeof value === "string" && VALID_PARTS.has(value)
 }
 
 function parsePage(value: unknown): number {
@@ -34,12 +37,10 @@ function parsePage(value: unknown): number {
 export const Route = createFileRoute("/matching/projects/")({
   validateSearch: (search: Record<string, unknown>): ProjectListSearch => {
     let parts: ProjectPart[] | undefined
-    if (typeof search.parts === "string") {
-      parts = [search.parts as ProjectPart]
+    if (isProjectPart(search.parts)) {
+      parts = [search.parts]
     } else if (Array.isArray(search.parts)) {
-      parts = search.parts.filter(
-        (p): p is ProjectPart => typeof p === "string",
-      )
+      parts = search.parts.filter(isProjectPart)
     }
 
     return {

--- a/src/routes/matching/projects/index.tsx
+++ b/src/routes/matching/projects/index.tsx
@@ -3,9 +3,58 @@ import { createFileRoute } from "@tanstack/react-router"
 
 import { MatchingProjectsListPage } from "@/features/project/list"
 
+import type {
+  PartQuotaStatus,
+  ProjectPart,
+} from "@/features/project/list/api/matchingProject"
+
+export type ProjectListSearch = {
+  mock?: "projects"
+  branch?: string
+  school?: string
+  parts?: ProjectPart[]
+  status?: PartQuotaStatus
+  keyword?: string
+  page?: number
+}
+
+function parsePage(value: unknown): number {
+  const parsedPage =
+    typeof value === "string"
+      ? Number.parseInt(value, 10)
+      : typeof value === "number"
+        ? value
+        : 1
+
+  return Number.isFinite(parsedPage) && parsedPage > 0
+    ? Math.floor(parsedPage)
+    : 1
+}
+
 export const Route = createFileRoute("/matching/projects/")({
-  validateSearch: (search: Record<string, unknown>): { mock?: "projects" } =>
-    search.mock === "projects" ? { mock: "projects" } : {},
+  validateSearch: (search: Record<string, unknown>): ProjectListSearch => {
+    let parts: ProjectPart[] | undefined
+    if (typeof search.parts === "string") {
+      parts = [search.parts as ProjectPart]
+    } else if (Array.isArray(search.parts)) {
+      parts = search.parts.filter(
+        (p): p is ProjectPart => typeof p === "string",
+      )
+    }
+
+    return {
+      mock: search.mock === "projects" ? "projects" : undefined,
+      branch: typeof search.branch === "string" ? search.branch : undefined,
+      school: typeof search.school === "string" ? search.school : undefined,
+      parts,
+      status:
+        search.status === "RECRUITING" || search.status === "COMPLETED"
+          ? search.status
+          : undefined,
+      keyword: typeof search.keyword === "string" ? search.keyword : undefined,
+      page: parsePage(search.page),
+    }
+  },
   component: MatchingProjectsRoute,
 })
 


### PR DESCRIPTION
## 📸 작업 내용

프로젝트 목록 조회 시 사용되는 필터링 및 검색 상태를 URL Query Parameter에 동기화하였습니다.

- 프로젝트 목록 조회 페이지(`/matching/projects/`)에서 사용되는 지부, 학교, 파트, 모집 상태, 검색어, 페이지 정보를 URL의 Query Param과 연동되도록 로직을 리팩토링했습니다.
- 기존의 React `useState` 상태들을 제거하고, TanStack Router의 `useSearch` 및 `useNavigate` 훅을 결합해 단일 상태 모델로 통일했습니다.
- 검색 입력 필드(`ProjectSearchField`)에는 300ms 디바운스를 적용하였으며, 사용자 검색 시 브라우저 히스토리 오염을 피하기 위해 `replace: true` 옵션을 사용해 URL을 갱신하도록 구성했습니다.
- TypeScript 컴파일 검사 및 ESLint (`no-explicit-any`, perfectionist import spacing, react-hooks/exhaustive-deps) 규칙을 완전히 만족하도록 엄격한 타입 정의 및 캐싱을 설계했습니다.

## 🎞️ 주요 코드 설명

### 1. `/matching/projects/` 경로 내 validateSearch 정의

URL로부터 들어오는 Query Params들을 정적 타입에 매칭하고 유효성을 검사하여 안전하게 파싱하도록 라우트 스키마를 구성했습니다.

```TypeScript
// src/routes/matching/projects/index.tsx
export const Route = createFileRoute("/matching/projects/")({
  validateSearch: (search: Record<string, unknown>): ProjectListSearch => {
    let parts: ProjectPart[] | undefined
    if (typeof search.parts === "string") {
      parts = [search.parts as ProjectPart]
    } else if (Array.isArray(search.parts)) {
      parts = search.parts.filter(
        (p): p is ProjectPart => typeof p === "string",
      )
    }

    return {
      mock: search.mock === "projects" ? "projects" : undefined,
      branch: typeof search.branch === "string" ? search.branch : undefined,
      school: typeof search.school === "string" ? search.school : undefined,
      parts,
      status:
        search.status === "RECRUITING" || search.status === "COMPLETED"
          ? search.status
          : undefined,
      keyword: typeof search.keyword === "string" ? search.keyword : undefined,
      page: parsePage(search.page),
    }
  },
  component: MatchingProjectsRoute,
})
```

### 2. useMatchingProjectListFilters 훅 내 URL 동기화 구조

로컬 변수를 대체해 URL의 상태를 직접 구독(Read)하고, 콜백 및 디바운스 이펙트 내에서 `navigate` 함수를 실행(Write)하여 동기화합니다.

```TypeScript
// src/features/project/list/model/matchingProjectList.ts
export function useMatchingProjectListFilters() {
  const search = useSearch({ strict: false }) as Record<string, unknown>
  const navigate = useNavigate() as unknown as (opts: {
    search: (prev: Record<string, unknown>) => Record<string, unknown>
    replace?: boolean
  }) => Promise<void>

  const [openFilterId, setOpenFilterId] = useState<string | null>(null)

  const selectedBranch = search.branch as string | undefined
  const selectedSchool = search.school as string | undefined
  
  const rawParts = search.parts as ProjectPart[] | undefined
  const selectedParts = useMemo(() => rawParts ?? [], [rawParts])

  const selectedRecruitStatus = search.status as PartQuotaStatus | undefined
  const page = (search.page ?? 1) as number
  const keyword = (search.keyword ?? "") as string

  const [searchQuery, setSearchQuery] = useState(keyword)

  useEffect(() => {
    setSearchQuery(keyword)
  }, [keyword])

  useEffect(() => {
    const timer = setTimeout(() => {
      if (searchQuery !== keyword) {
        void navigate({
          search: (prev) => ({
            ...prev,
            keyword: searchQuery || undefined,
            page: 1,
          }),
          replace: true,
        })
      }
    }, 300)
    return () => clearTimeout(timer)
  }, [searchQuery, keyword, navigate])
  // ...
}
```

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #468 