### PR TITLE
fix: 지부장/회장단 및 최고관리자 지원현황 조회 권한 수정

### DIFF
--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -22,7 +22,6 @@ import {
   isCurrentTermPm,
   isOperator,
   isSchoolLeadership,
-  isSchoolVicePresident,
   isSuperAdmin,
 } from "@/features/auth/model/identity"
 import { ProjectTitleCard } from "@/shared/ui/ProjectTitleCard"
@@ -41,7 +40,6 @@ function MatchingApplicationsPage() {
   const { data: me } = useMe()
   const { me: identity, viewContext } = useViewerIdentity()
   const schoolLeadership = isSchoolLeadership(identity)
-  const schoolVicePresident = isSchoolVicePresident(identity)
   const addToast = useToastStore((s) => s.addToast)
   const chaptersQuery = useChapters()
   const chapters = useMemo(
@@ -163,8 +161,16 @@ function MatchingApplicationsPage() {
                     projects={adminProjects}
                     currentRound={admin.currentRound}
                     chapterName={selectedChapter}
-                    disableFormPanel={schoolLeadership}
-                    hideExpand={schoolVicePresident}
+                    disableFormPanel={
+                      isChapterPresident(identity) ||
+                      isSchoolLeadership(identity) ||
+                      isSuperAdmin(identity) ||
+                      isCentralStaff(identity)
+                    }
+                    hideExpand={
+                      isChapterPresident(identity) ||
+                      isSchoolLeadership(identity)
+                    }
                   />
                 </div>
               )}

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -163,13 +163,13 @@ function MatchingApplicationsPage() {
                     chapterName={selectedChapter}
                     disableFormPanel={
                       isChapterPresident(identity) ||
-                      isSchoolLeadership(identity) ||
+                      schoolLeadership ||
                       isSuperAdmin(identity) ||
                       isCentralStaff(identity)
                     }
                     hideExpand={
                       isChapterPresident(identity) ||
-                      isSchoolLeadership(identity)
+                      schoolLeadership
                     }
                   />
                 </div>


### PR DESCRIPTION
## 📸 작업 내용

지부장, 교내 회장단, SUPER_ADMIN 및 중앙운영사무국 총괄단의 프로젝트 지원현황 조회 권한을 기획 내용에 부합하도록 수정했습니다.

- **지부장 (`CHAPTER_PRESIDENT`), 교내 회장 (`SCHOOL_PRESIDENT`), 교내 부회장 (`SCHOOL_VICE_PRESIDENT`)**
  - 본인 지부의 지원 현황을 **"숫자만"** 조회할 수 있도록 변경했습니다.
  - 지원자 목록 확장(`hideExpand={true}`) 및 개별 지원서 상세 조회(`disableFormPanel={true}`) 기능을 모두 차단하여 순수 수치 통계만 노출되도록 제한했습니다.
- **SUPER_ADMIN 및 중앙운영사무국 총괄단 (`CENTRAL_PRESIDENT`, `CENTRAL_VICE_PRESIDENT` 등)**
  - 개별 지원서 답변의 원본 내용은 볼 수 없고, 지원자 목록과 현황 정보만 조회할 수 있는 **"현재 교내 회장단 뷰랑 동일"**한 권한을 적용했습니다.
  - 지원자 목록 확장(`hideExpand={false}`)은 허용하되, 개별 지원서 상세 조회(`disableFormPanel={true}`) 권한은 차단하도록 제한했습니다.

## 🎞️ 주요 코드 설명

### 지원현황 페이지에서의 역할별 권한 주입 코드 변경

[applications.tsx](file:///C:/Users/doldo/Desktop/PROJECT/UMC/Product/src/routes/matching/applications.tsx#L161-L174)

```TypeScript
<ApplicationTableSection
  projects={adminProjects}
  currentRound={admin.currentRound}
  chapterName={selectedChapter}
  disableFormPanel={
    isChapterPresident(identity) ||
    isSchoolLeadership(identity) ||
    isSuperAdmin(identity) ||
    isCentralStaff(identity)
  }
  hideExpand={
    isChapterPresident(identity) ||
    isSchoolLeadership(identity)
  }
/>
```

- `isChapterPresident(identity)`와 `isSchoolLeadership(identity)`에게 `hideExpand={true}`를 지정하여 지원자 이름 목록을 펼칠 수 없게 합니다.
- `isChapterPresident(identity)`, `isSchoolLeadership(identity)`, `isSuperAdmin(identity)`, `isCentralStaff(identity)`에게 `disableFormPanel={true}`를 지정하여 지원자 클릭 시 상세 모달 패널로 이동하거나 답변 내용을 조회할 수 없게 차단합니다.

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #470 
