### PR TITLE
✨ feat: 기본 공지 audience 필터링 추가

### DIFF
--- a/src/features/notice/model/defaultNotices.test.ts
+++ b/src/features/notice/model/defaultNotices.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest"
+
+import { canViewDefaultNotice } from "./defaultNotices"
+
+import type { MemberInfoResponse } from "@/features/auth/api/me"
+import type {
+  ChallengerInfoResponse,
+  ChallengerRoleResponse,
+  Part,
+  RoleType,
+} from "@/features/challenger/model/types"
+
+function makeMe({
+  part,
+  roleTypes = ["CHALLENGER"],
+  isAdmin = roleTypes.some((roleType) => roleType !== "CHALLENGER"),
+}: {
+  part?: Part
+  roleTypes?: RoleType[]
+  isAdmin?: boolean
+} = {}): MemberInfoResponse {
+  const roles: ChallengerRoleResponse[] = roleTypes.map((roleType) => ({
+    challengerRoleId: "0",
+    challengerId: "0",
+    roleType,
+    organizationType: "CHAPTER",
+    organizationId: "0",
+    gisuId: "10",
+    gisu: "10",
+  }))
+
+  const challengerRecords: ChallengerInfoResponse[] = part
+    ? [
+        {
+          challengerId: "0",
+          memberId: "0",
+          gisuId: "10",
+          gisu: "10",
+          chapterId: "0",
+          chapterName: "테스트 지부",
+          part,
+          challengerStatus: "ACTIVE",
+          name: "테스트",
+          nickname: "테스트",
+          email: null,
+          schoolId: "0",
+          schoolName: "테스트 학교",
+        },
+      ]
+    : []
+
+  return {
+    id: "0",
+    name: "테스트",
+    nickname: "테스트",
+    email: "test@test.com",
+    schoolId: "0",
+    schoolName: "테스트 학교",
+    profileImageLink: null,
+    status: "ACTIVE",
+    hasLocalCredential: false,
+    currentGisuMemberInfo: {
+      gisuId: "10",
+      generation: "10",
+      challenger: part
+        ? {
+            challengerId: "0",
+            part,
+            challengerStatus: "ACTIVE",
+          }
+        : null,
+      isAdmin,
+      roleTypes,
+    },
+    roles,
+    challengerRecords,
+  }
+}
+
+describe("canViewDefaultNotice", () => {
+  it("all은 모든 사용자가 볼 수 있다", () => {
+    expect(canViewDefaultNotice("all", makeMe({ part: "WEB" }))).toBe(true)
+  })
+
+  it("pm은 일반 챌린저를 제외한다", () => {
+    expect(canViewDefaultNotice("pm", makeMe({ part: "WEB" }))).toBe(false)
+  })
+
+  it("pm은 플랜 챌린저가 볼 수 있다", () => {
+    expect(canViewDefaultNotice("pm", makeMe({ part: "PLAN" }))).toBe(true)
+  })
+
+  it("operator는 플랜 챌린저를 제외한다", () => {
+    expect(canViewDefaultNotice("operator", makeMe({ part: "PLAN" }))).toBe(
+      false,
+    )
+  })
+
+  it("operator는 운영진이 볼 수 있다", () => {
+    expect(
+      canViewDefaultNotice(
+        "operator",
+        makeMe({ roleTypes: ["CHAPTER_PRESIDENT"] }),
+      ),
+    ).toBe(true)
+  })
+
+  it("일반 챌린저라도 ADMIN 파트면 pm과 operator를 볼 수 있다", () => {
+    const me = makeMe({ part: "ADMIN", isAdmin: false })
+
+    expect(canViewDefaultNotice("pm", me)).toBe(true)
+    expect(canViewDefaultNotice("operator", me)).toBe(true)
+  })
+})

--- a/src/features/notice/model/defaultNotices.test.ts
+++ b/src/features/notice/model/defaultNotices.test.ts
@@ -100,7 +100,7 @@ describe("canViewDefaultNotice", () => {
     expect(
       canViewDefaultNotice(
         "operator",
-        makeMe({ roleTypes: ["CHAPTER_PRESIDENT"] }),
+        makeMe({ roleTypes: ["CHAPTER_PRESIDENT"], isAdmin: false }),
       ),
     ).toBe(true)
   })

--- a/src/features/notice/model/defaultNotices.ts
+++ b/src/features/notice/model/defaultNotices.ts
@@ -1,0 +1,220 @@
+import { isAnyOperator, isCurrentTermPm } from "@/features/auth/model/identity"
+
+import type { MemberInfoResponse } from "@/features/auth/api/me"
+
+import type { NoticeItem } from "../ui/NoticeCardList"
+
+export type DefaultNoticeAudience = "all" | "pm" | "operator"
+
+export type DefaultNoticeItem = NoticeItem & {
+  audience: DefaultNoticeAudience
+}
+
+export function canViewDefaultNotice(
+  audience: DefaultNoticeAudience,
+  me: MemberInfoResponse | undefined,
+) {
+  if (audience === "all") return true
+
+  const isAdmin = Boolean(me?.currentGisuMemberInfo?.isAdmin)
+  const isAdminPart = me?.currentGisuMemberInfo?.challenger?.part === "ADMIN"
+  const isPm = isCurrentTermPm(me)
+  const isOperator = isAnyOperator(me)
+
+  if (audience === "pm") {
+    return isPm || isOperator || isAdmin || isAdminPart
+  }
+
+  return isOperator || isAdmin || isAdminPart
+}
+
+export const DEFAULT_PROJECT_SETTING_NOTICES: DefaultNoticeItem[] = [
+  {
+    id: "default-project-menu",
+    title: "[PM] 플랜 챌린저인데 프로젝트 등록 메뉴가 보이지 않아요.",
+    date: "2026.06.18",
+    chip: "필독",
+    audience: "pm",
+  },
+  {
+    id: "default-project-status",
+    title: "[운영진] 프로젝트 상태는 어떻게 구분되나요?",
+    date: "2026.06.18",
+    chip: "필독",
+    audience: "operator",
+  },
+  {
+    id: "default-project-abort",
+    title:
+      "[운영진] 실수로 프로젝트를 중단 처리했어요. 다시 공개로 되돌릴 수 있나요?",
+    date: "2026.06.18",
+    chip: "필독",
+    audience: "operator",
+  },
+  {
+    id: "default-project-publish",
+    title: "[지부장] 반드시 매칭 시작 전까지 프로젝트를 공개 처리해야 하나요?",
+    date: "2026.06.18",
+    chip: "필독",
+    audience: "operator",
+  },
+  {
+    id: "default-project-edit",
+    title: "[PM, 지부장] 프로젝트 정보는 언제든지 수정할 수 있나요?",
+    date: "2026.06.18",
+    chip: "필독",
+    audience: "pm",
+  },
+  {
+    id: "default-project-application-form",
+    title: "[PM, 지부장] 지원 폼을 변경하면 기존 지원서는 어떻게 표시되나요?",
+    date: "2026.06.18",
+    chip: "필독",
+    audience: "pm",
+  },
+]
+
+export const DEFAULT_PROJECT_SETTING_CONTENTS: Record<string, string> = {
+  "default-project-menu": `**프로젝트 등록 메뉴는 이번 기수 플랜 챌린저에게만 표시돼요.**
+
+UMC 앱에서 플랜 챌린저로 표시되는데도 메뉴가 보이지 않는다면 프로덕트팀에 문의해주세요.`,
+  "default-project-status": `**프로젝트는 아래 상태를 가져요.**
+
+1. **초안**
+PM이 본인의 프로젝트를 등록하는 과정이에요. 본인만 볼 수 있어요.
+
+2. **검토 대기**
+지부장이나 중앙운영사무국에서 파트별 TO를 등록하고 공개 처리하기 전까지의 상태예요. 이 상태에서는 프로젝트 목록에서 다른 챌린저가 볼 수 없어요.
+
+3. **공개**
+운영진이 승인한 이후 지원서를 받을 수 있는 상태예요. 프로젝트 목록에서 조회할 수 있고, 매칭 기간이면 지원서를 제출할 수 있어요.
+
+4. **종료**
+데모데이까지 모두 완료한 상태예요. 이 시점부터 프로젝트 관련 정보 변경은 운영진이 더 이상 개입할 수 없고 PO만 개입할 수 있어요.
+
+5. **중단**
+데모데이까지 프로젝트를 완수하지 못하고 팀이 와해된 경우예요. 프로젝트 목록에서 더 이상 조회할 수 없고 지원도 불가능해요. 중단된 프로젝트는 다시 다른 상태로 변경할 수 없으므로 유의해주세요.
+
+**상태 변경 규칙은 아래와 같아요.**
+
+- 초안 → 검토 대기 : 플랜 챌린저가 프로젝트 등록을 완료하면 자동으로 진행돼요.
+- 검토 대기 → 공개 : 각 지부장 및 중앙운영사무국 총괄단만 가능해요. 공개하려면 각 파트별 TO를 설정해야 해요.
+- 공개 → 종료 : 데모데이가 끝나고 기수가 종료되면 자동으로 변경돼요.
+- 중단 처리 : 중앙운영사무국 총괄단만 가능해요.`,
+  "default-project-abort": `**불가능해요. 프로젝트 중단 처리는 프로젝트를 제명시키는 작업이에요.**
+
+프로젝트 멤버, 연관 지원서 등 여러 데이터에 비가역적인 작업이 수행돼요. 프로덕트팀에 문의해도 복구를 도와드릴 수 없어요.
+
+아직 매칭 기간이 시작되지 않았다면 프로젝트를 삭제한 뒤 다시 생성해주세요.`,
+  "default-project-publish": `**아니요. 프로젝트 공개 처리와 매칭 차수는 관계 없어요.**
+
+단, 프로젝트를 공개 처리하기 전까지는 챌린저가 프로젝트를 조회하거나 지원할 수 없으므로 주의해주세요.`,
+  "default-project-edit": `**시기에 따라 달라요.**
+
+- 매칭 기간이 시작되면 프로젝트 이름, 설명 같은 기본 정보부터 지원 폼까지 전부 수정이 제한돼요.
+
+- 매칭 기간이 아닐 때는 PO가 지원 폼이나 프로젝트 정보를 변경할 수 있어요.`,
+  "default-project-application-form": `**질문을 변경해도 각 지원서는 응답한 시점의 질문과 응답으로 표시돼요.**
+
+예를 들어 1차 매칭 때 질문이 "나이를 입력해주세요"였고, 2차 매칭 때 "태어난 연도를 입력해주세요"로 변경된 경우 각 차수별 지원서는 아래처럼 확인할 수 있어요.
+
+- 1차 매칭 지원자 : Q. "나이를 입력해주세요" A. 26살
+- 2차 매칭 지원자 : Q. "태어난 연도를 입력해주세요" A. 2001년
+
+객관식 유형에서 보기를 변경하는 경우에도 지원자가 응답한 값 기준으로 표시돼요.`,
+}
+
+export const DEFAULT_TEAM_MATCHING_NOTICES: DefaultNoticeItem[] = [
+  {
+    id: "default-matching-application-count",
+    title: "[공통] 지원 현황의 학교별 인원 수가 실제와 달라 보여요.",
+    date: "2026.06.18",
+    chip: "필독",
+    audience: "all",
+  },
+  {
+    id: "default-matching-application-deadline",
+    title: "[공통] 지원서 제출 및 철회는 언제까지 가능한가요?",
+    date: "2026.06.18",
+    chip: "필독",
+    audience: "all",
+  },
+  {
+    id: "default-matching-review-deadline",
+    title:
+      "[PM] 접수된 지원서는 언제 확인하고 언제까지 합/불을 결정해야 하나요?",
+    date: "2026.06.18",
+    chip: "필독",
+    audience: "pm",
+  },
+  {
+    id: "default-matching-reject-limit",
+    title: "[PM] 지원서를 불합격 처리할 수 없어요.",
+    date: "2026.06.18",
+    chip: "필독",
+    audience: "pm",
+  },
+  {
+    id: "default-matching-round-warning",
+    title: "[지부장] 매칭 기간 설정 시 경고문이 계속 떠요.",
+    date: "2026.06.18",
+    chip: "필독",
+    audience: "operator",
+  },
+  {
+    id: "default-matching-round-edit",
+    title: "[지부장] 매칭 차수는 언제든지 바꿀 수 있나요?",
+    date: "2026.06.18",
+    chip: "필독",
+    audience: "operator",
+  },
+]
+
+export const DEFAULT_TEAM_MATCHING_CONTENTS: Record<string, string> = {
+  "default-matching-application-count": `**해당 인원은 "지원 가능한 인원"을 기준으로 산출돼요.**
+
+기수 내 챌린저 중 플랜 파트와 프로젝트를 하지 않는 운영진을 제외한 값이에요.`,
+  "default-matching-application-deadline": `**지원서 제출 및 철회는 각 매칭 차수 종료 시점까지 가능해요.**
+
+각 지부장이 설정한 값에 따라 종료 시점이 59분 00초일 수도, 59분 59초일 수도 있으니 미리 제출하는 것을 추천드려요.
+
+- 같은 매칭 차수 내 중복 지원은 불가능해요.
+- 다른 프로젝트에 지원하고 싶다면 기존 지원서를 철회한 뒤 새로운 프로젝트에 지원해주세요.
+- 각 매칭 차수가 끝나기 전까지는 운영진이나 플랜 챌린저도 지원자가 어디에 지원했는지 확인할 수 없어요.
+- 운영 관리를 위해 학교별, 프로젝트별 지원자 수만 표시돼요.
+
+**단, 철회한 지원서는 복구가 어려우니 신중하게 결정해주세요.**`,
+  "default-matching-review-deadline": `**지원서는 각 매칭 차수별로 관리돼요.**
+
+챌린저가 마음 편히 철회할 수 있도록, 내 프로젝트에 접수된 지원서는 매칭 차수 종료 시점 이후부터 확인할 수 있어요.
+
+- 합격/불합격 처리는 종료 시점 이후 결정 마감 기한까지 가능해요.
+- 결정 마감 기한까지 합격/불합격 여부가 정해지지 않은 지원서는 시스템에서 임의로 합격 또는 불합격 처리돼요.
+- 임의 처리 시에는 매칭 규정에 명시된 TO 대비 지원자 수에 따른 최소 선발 인원을 보장해요.`,
+  "default-matching-reject-limit": `**매칭 규정에 따른 최소 선발 인원이 보장되지 않은 경우 불합격 처리가 불가능해요.**
+
+TO 대비 지원자 수에 따른 최소 선발 인원을 합격시킨 뒤 나머지 지원서를 불합격 처리해주세요. 참고로 TO는 각 지원 차수별로 별도로 산정돼요.
+
+예를 들어 내 프로젝트에 배정된 SpringBoot 파트 TO가 4명이고 5명이 지원한 경우, TO의 100% 이상이 지원했으므로 TO의 50%인 2명 이상을 합격시켜야 해요.
+
+**예시**
+
+- 합/불 결정을 하지 않으면 시스템에서 랜덤으로 2명을 합격시키고 나머지는 불합격 처리해요.
+- 1명만 합격 처리한 경우에는 최소 선발 인원 2명을 보장하기 위해 1명을 랜덤으로 추가 합격시키고 나머지는 불합격 처리해요.`,
+  "default-matching-round-warning": `**매칭 차수는 10기 중앙운영사무국에서 아래와 같이 공지했어요.**
+
+- 1차 매칭 : 00:00 ~ 23:59
+- 2차 매칭 : 1차 익일 12:05 ~ 23:59
+- 3차 매칭 : 2차 익일 12:05 ~ 종료 23:59
+
+중앙운영사무국과 논의 후 지부별로 상이한 매칭 기간을 적용하는 경우에만 다른 값을 적용해주세요.
+
+**아래 사항을 반드시 고려해야 해요.**
+
+- N차 매칭에 접수된 지원서는 N차 매칭의 지원서 결정 마감 기한까지만 PM 챌린저가 합격 및 불합격 여부를 결정할 수 있어요.
+- 지원서 결정 마감 기한은 웹사이트 기준으로 1차는 2차 매칭 시작 5분 전, 2차는 3차 매칭 시작 5분 전, 3차는 3차 매칭 종료 12시간 이후예요.
+- 1차 종료와 2차 시작 사이, 2차 종료와 3차 시작 사이는 최소 5분 이상이어야 해요.`,
+  "default-matching-round-edit": `**아니요. 매칭 차수는 1차 매칭이 시작되면 변경할 수 없어요.**
+
+불가피하게 변경이 필요한 경우 프로덕트팀으로 문의해주세요.`,
+}

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -26,6 +26,11 @@ import {
   type NoticeItem,
 } from "@/features/notice"
 import { deleteNotice, getNotices } from "@/features/notice/api/noticeApi"
+import {
+  canViewDefaultNotice,
+  DEFAULT_TEAM_MATCHING_CONTENTS,
+  DEFAULT_TEAM_MATCHING_NOTICES,
+} from "@/features/notice/model/defaultNotices"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import { Button } from "@/shared/ui/Button"
 import { MarkdownRenderer } from "@/shared/ui/MarkdownRenderer"
@@ -41,29 +46,6 @@ interface AnnounceSearch {
 const DEFAULT_PAGE = 1
 const NOTICE_PAGE_SIZE = 10
 const NOTICE_COMPLETION_STORAGE_KEY = "notice:completion-target"
-
-const DEFAULT_MATCHING_NOTICES: NoticeItem[] = [
-  {
-    id: "default-matching-1",
-    title: "[프로덕트 팀이 작성한 FAQ예요]",
-    date: "2003.03.16",
-    chip: "필독",
-  },
-]
-
-const DEFAULT_MATCHING_CONTENTS: Record<string, string> = {
-  "default-matching-1": `1. **여러 프로젝트에 동시에 지원할 수 있나요?**
-동일한 매칭 차수 내에는 하나의 프로젝트에만 지원할 수 있어요. 차수가 바뀌면 다른 프로젝트에 새로 지원할 수 있어요.
-
-2. **같은 프로젝트에 여러 차수에 걸쳐 지원할 수 있나요?**
-네, 가능해요. 1차에 지원했다가 불합격하더라도 2차, 3차에 동일한 프로젝트에 다시 지원할 수 있어요.
-
-3. **지원 폼 제출 후 수정이 가능한가요? 지원을 취소할 수 있나요?**
-이미 제출한 지원 폼의 수정은 불가능해요. 단, 해당 매칭 차수가 종료되기 전까지는 지원 취소가 가능해요. 지원 취소 후 동일한 프로젝트에 지원 폼을 새롭게 제출할 수 있어요.
-
-4. **합/불 결과는 언제, 어디서 확인할 수 있나요?**
-매칭 차수가 종료된 후, 웹사이트의 내 지원 현황 페이지에서 확인할 수 있어요. 차수가 진행되는 동안에는 결과가 공개되지 않아요.`,
-}
 
 type PendingNotice = {
   id: string
@@ -208,8 +190,16 @@ function TeamMatchingAnnouncePage() {
   const canEdit = hasPermission("EDIT")
   const canDelete = hasPermission("DELETE")
 
+  const defaultMatchingNotices = useMemo(
+    () =>
+      DEFAULT_TEAM_MATCHING_NOTICES.filter((notice) =>
+        canViewDefaultNotice(notice.audience, identity),
+      ),
+    [identity],
+  )
+
   const notices = useMemo(() => {
-    if (!noticesData) return page === 1 ? DEFAULT_MATCHING_NOTICES : []
+    if (!noticesData) return page === 1 ? defaultMatchingNotices : []
 
     const mappedNotices: NoticeItem[] = noticesData.content.map((item) => ({
       id: String(item.id),
@@ -219,16 +209,14 @@ function TeamMatchingAnnouncePage() {
     }))
 
     const combined =
-      page === 1
-        ? [...DEFAULT_MATCHING_NOTICES, ...mappedNotices]
-        : mappedNotices
+      page === 1 ? [...defaultMatchingNotices, ...mappedNotices] : mappedNotices
 
     return [...combined].sort((a, b) => {
       if (a.chip === "필독" && b.chip !== "필독") return -1
       if (a.chip !== "필독" && b.chip === "필독") return 1
       return 0
     })
-  }, [noticesData, page])
+  }, [defaultMatchingNotices, noticesData, page])
 
   const totalPages = noticesData?.totalPages || 1
   const safePage = Math.min(Math.max(1, page), totalPages)
@@ -368,7 +356,7 @@ function TeamMatchingAnnouncePage() {
               onDeleteNotice={handleNoticeDeleteClick}
               onEditNotice={handleNoticeEditClick}
               renderContent={(noticeId) => {
-                const defaultContent = DEFAULT_MATCHING_CONTENTS[noticeId]
+                const defaultContent = DEFAULT_TEAM_MATCHING_CONTENTS[noticeId]
                 if (defaultContent !== undefined) {
                   return (
                     <div className="flex flex-col gap-4">

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -25,6 +25,11 @@ import {
   type NoticeItem,
 } from "@/features/notice"
 import { deleteNotice, getNotices } from "@/features/notice/api/noticeApi"
+import {
+  canViewDefaultNotice,
+  DEFAULT_PROJECT_SETTING_CONTENTS,
+  DEFAULT_PROJECT_SETTING_NOTICES,
+} from "@/features/notice/model/defaultNotices"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import { Button } from "@/shared/ui/Button"
 import { MarkdownRenderer } from "@/shared/ui/MarkdownRenderer"
@@ -40,39 +45,6 @@ interface AnnounceSearch {
 const DEFAULT_PAGE = 1
 const NOTICE_PAGE_SIZE = 10
 const NOTICE_COMPLETION_STORAGE_KEY = "notice:completion-target"
-
-const DEFAULT_PROJECT_NOTICES: NoticeItem[] = [
-  {
-    id: "default-project-1",
-    title: "[프로덕트 팀이 작성한 FAQ예요]",
-    date: "2003.03.16",
-    chip: "필독",
-  },
-  {
-    id: "default-project-2",
-    title: "필독!!",
-    date: "2003.03.16",
-    chip: "필독",
-  },
-]
-
-const DEFAULT_PROJECT_CONTENTS: Record<string, string> = {
-  "default-project-1": `1. **프로젝트 등록 후 수정이 가능한가요? 매칭 진행 중에도 지원 폼 문항을 수정할 수 있나요?**
-매칭이 진행되는 동안에는 프로젝트 정보와 지원 폼 문항 수정이 제한돼요. 차수가 끝나고 다음 차수가 시작되기 전 사이 기간에는 자유롭게 수정할 수 있어요.
-
-2. **지원 폼 문항을 수정하면 어떻게 되나요?**
-Plan 챌린저가 문항을 수정하면 차수에 따라 지원자에게 보이는 문항이 달라지고 Plan 챌린저 또한 차수별로 서로 다른 문항 구성의 지원서를 검토하게 돼요. 매칭이 진행되는 동안에는 지원 폼 문항을 수정할 수 없다는 점 유의해 주세요!
-
-3. **지원자 합/불 처리는 언제부터 가능한가요? 한 번 불합격 처리한 지원자를 다시 합격으로 바꿀 수 있나요?**
-지원자 합/불 처리는 해당 차수가 종료된 후부터 다음 차수가 시작되기 전까지 가능해요. 이 기간 안에는 합/불 상태를 자유롭게 변경할 수 있어요. 단, 다음 차수가 시작되면 결정을 번복할 수 없어요.
-
-4. **지원자가 아무도 없는 파트는 어떻게 처리되나요?**
-1차, 2차, 3차 매칭을 거쳐도 TO가 채워지지 않은 파트는 랜덤으로 팀원이 배정될 예정이에요.`,
-  "default-project-2": `**본 공지사항을 숙지하지 않아 발생하는 불이익에 대해서는 프로덕트 팀이 책임지지 않으니 반드시 확인 부탁드립니다.**
-
-1. 각 PM들은 다음 매칭 차수 시작 5분 전까지 지원서 합/불 결정을 완료해야 합니다.
-2. 기획-개발자 3차 매칭은 종료 후 12시간 내에 지원서 합/불 결정을 완료해야 합니다.`,
-}
 
 type PendingNotice = {
   id: string
@@ -217,8 +189,16 @@ function ProjectSettingsAnnouncePage() {
   const canEdit = hasPermission("EDIT")
   const canDelete = hasPermission("DELETE")
 
+  const defaultProjectNotices = useMemo(
+    () =>
+      DEFAULT_PROJECT_SETTING_NOTICES.filter((notice) =>
+        canViewDefaultNotice(notice.audience, identity),
+      ),
+    [identity],
+  )
+
   const notices = useMemo(() => {
-    if (!noticesData) return page === 1 ? DEFAULT_PROJECT_NOTICES : []
+    if (!noticesData) return page === 1 ? defaultProjectNotices : []
 
     const mappedNotices: NoticeItem[] = noticesData.content.map((item) => ({
       id: String(item.id),
@@ -228,16 +208,14 @@ function ProjectSettingsAnnouncePage() {
     }))
 
     const combined =
-      page === 1
-        ? [...DEFAULT_PROJECT_NOTICES, ...mappedNotices]
-        : mappedNotices
+      page === 1 ? [...defaultProjectNotices, ...mappedNotices] : mappedNotices
 
     return [...combined].sort((a, b) => {
       if (a.chip === "필독" && b.chip !== "필독") return -1
       if (a.chip !== "필독" && b.chip === "필독") return 1
       return 0
     })
-  }, [noticesData, page])
+  }, [defaultProjectNotices, noticesData, page])
 
   const totalPages = noticesData?.totalPages || 1
   const safePage = Math.min(Math.max(1, page), totalPages)
@@ -375,7 +353,8 @@ function ProjectSettingsAnnouncePage() {
               onDeleteNotice={handleNoticeDeleteClick}
               onEditNotice={handleNoticeEditClick}
               renderContent={(noticeId) => {
-                const defaultContent = DEFAULT_PROJECT_CONTENTS[noticeId]
+                const defaultContent =
+                  DEFAULT_PROJECT_SETTING_CONTENTS[noticeId]
                 if (defaultContent !== undefined) {
                   return (
                     <div className="flex flex-col gap-4">


### PR DESCRIPTION
## 📸 작업 내용

- 프로젝트 설정 공지와 팀 매칭 공지의 기본 FAQ를 notice model 상수로 분리했습니다.
- 기본 공지별 audience를 `all`, `pm`, `operator`로 정의하고 사용자 역할에 따라 노출되도록 필터링했습니다.
- 기본 공지 제목에 `[공통]`, `[PM]`, `[운영진]`, `[지부장]` 대상 표시를 추가했습니다.
- audience 필터링 기준을 검증하는 단위 테스트를 추가했습니다.

## 🎞️ 주요 코드 설명

### 기본 공지 audience 필터

```TypeScript
canViewDefaultNotice(notice.audience, identity)
```

- 일반 챌린저는 공통 공지만 볼 수 있도록 제한했습니다.
- PM은 PM 대상 공지를 볼 수 있고, 운영진 및 ADMIN 파트 예외는 운영진 대상 공지도 볼 수 있도록 처리했습니다.

## 구현 화면
<img width="949" height="852" alt="스크린샷 2026-06-18 오후 5 40 03" src="https://github.com/user-attachments/assets/9cafadc6-5a63-4fca-a197-6760e07379e8" />
<img width="936" height="810" alt="스크린샷 2026-06-18 오후 5 40 21" src="https://github.com/user-attachments/assets/9d2c3102-86da-437f-af25-0866481c83b2" />


## 🔗 연결된 이슈

- Connected: #472
- Closes #472