### PR TITLE
🐛 fix: 학교 회장단 지원 현황 지부 전체 조회·숫자만 노출 및 기본 지부 보정

### DIFF
--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -35,7 +35,6 @@ const EMPTY_SET = new Set<string>()
 
 interface ApplicationPageDataOptions {
   enabled?: boolean
-  schoolName?: string
 }
 
 // 매칭 라운드 목록에서 현재 활성 차수 번호 계산
@@ -220,7 +219,6 @@ export function useAdminPageData(
   options: ApplicationPageDataOptions = {},
 ) {
   const enabled = options.enabled ?? true
-  const schoolName = options.schoolName
   const gisuQuery = useActiveGisuId({ enabled })
   const gisuId = gisuQuery.data ?? 0
 
@@ -259,33 +257,10 @@ export function useAdminPageData(
     enabled: enabled && gisuId > 0,
   })
 
-  const projects = useMemo(() => {
-    const content = projectsQuery.data?.content ?? []
-    // SCHOOL_PRESIDENT: 본인 학교 소속 PM의 프로젝트만 표시
-    if (!schoolName) return content
-    return content.filter((p) => p.productOwner.schoolName === schoolName)
-  }, [projectsQuery.data, schoolName])
-
-  // 각 프로젝트의 지원자 목록 조회 (테이블 + 학교별 통계용)
-  const applicantsQuery = useQuery({
-    queryKey: [
-      ...applicationKeys.all,
-      "admin-applicants",
-      gisuId,
-      chapterId,
-      projects.map((p) => p.id),
-    ],
-    queryFn: async () => {
-      const results = await Promise.all(
-        projects.map(async (p) => {
-          const applicants = await getProjectApplications(Number(p.id))
-          return { projectId: p.id, applicants }
-        }),
-      )
-      return new Map(results.map((r) => [String(r.projectId), r.applicants]))
-    },
-    enabled: enabled && projects.length > 0,
-  })
+  const projects = useMemo(
+    () => projectsQuery.data?.content ?? [],
+    [projectsQuery.data],
+  )
 
   // 전체 학교 목록 조회 (schoolId -> schoolName 매핑용)
   const schoolsQuery = useQuery({
@@ -327,11 +302,8 @@ export function useAdminPageData(
 
   // 서버 데이터 -> 프론트 타입 변환 (테이블용)
   const transformed: ProjectApplication[] = useMemo(
-    () =>
-      projects.map((p) =>
-        toProjectApplication(p, applicantsQuery.data?.get(String(p.id)) ?? []),
-      ),
-    [projects, applicantsQuery.data],
+    () => projects.map((p) => toProjectApplication(p, [])),
+    [projects],
   )
 
   // 통계: summary 기반
@@ -471,7 +443,7 @@ export function useAdminPageData(
     stats,
     currentRound,
     activeRound,
-    dataUpdatedAt: applicantsQuery.dataUpdatedAt || projectsQuery.dataUpdatedAt,
+    dataUpdatedAt: projectsQuery.dataUpdatedAt,
     chapters,
     isLoading:
       enabled &&
@@ -479,7 +451,6 @@ export function useAdminPageData(
         chaptersQuery.isLoading ||
         roundsQuery.isLoading ||
         projectsQuery.isLoading ||
-        applicantsQuery.isLoading ||
         chapterStatsQuery.isLoading ||
         chaptersWithSchoolsQuery.isLoading),
     isError:

--- a/src/features/application/ui/ApplicationTableSection.tsx
+++ b/src/features/application/ui/ApplicationTableSection.tsx
@@ -73,6 +73,7 @@ interface ApplicationTableSectionProps {
   hidePendingStatus?: boolean
   /** 지원자 펼치기 버튼 숨김 (SCHOOL_PRESIDENT 등 열람 제한 역할) */
   hideExpand?: boolean
+  disableProjectModal?: boolean
   className?: string
 }
 
@@ -87,6 +88,7 @@ export function ApplicationTableSection({
   disableFormPanel = false,
   hidePendingStatus = false,
   hideExpand = false,
+  disableProjectModal = false,
   className,
 }: ApplicationTableSectionProps) {
   const [searchQuery, setSearchQuery] = useState("")
@@ -314,10 +316,14 @@ export function ApplicationTableSection({
                 onToggleExpand={
                   hideExpand ? undefined : () => toggleExpand(project.id)
                 }
-                onProjectClick={() => {
-                  setSelectedProject(project)
-                  setDetailModalOpen(true)
-                }}
+                onProjectClick={
+                  disableProjectModal
+                    ? undefined
+                    : () => {
+                        setSelectedProject(project)
+                        setDetailModalOpen(true)
+                      }
+                }
                 hideExpandButton={hideExpand}
               />
 

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import { useLayoutEffect, useMemo, useRef, useState } from "react"
 
@@ -24,6 +25,8 @@ import {
   isSchoolLeadership,
   isSuperAdmin,
 } from "@/features/auth/model/identity"
+import { getChaptersWithSchools } from "@/features/challenger/api/organization"
+import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
 import { ProjectTitleCard } from "@/shared/ui/ProjectTitleCard"
 import { SegmentButton } from "@/shared/ui/segment-button/SegmentButton"
 import { CHAPTERS } from "@/shared/ui/segment/ChapterSelector"
@@ -46,6 +49,13 @@ function MatchingApplicationsPage() {
     () => chaptersQuery.data?.chapters ?? [],
     [chaptersQuery.data],
   )
+
+  const gisuId = useActiveGisuId().data ?? 0
+  const chaptersWithSchoolsQuery = useQuery({
+    queryKey: ["chapters-with-schools", gisuId],
+    queryFn: () => getChaptersWithSchools(String(gisuId)),
+    enabled: gisuId > 0 && schoolLeadership,
+  })
 
   // challenger records에서 지부명 추출 (어드민 포함 모든 역할)
   const userChapter = getViewerBranch(me)
@@ -83,24 +93,39 @@ function MatchingApplicationsPage() {
   // challenger records에 지부 정보가 없는 경우 chapters API로 폴백 (페인트 전 적용)
   const hasAutoSelected = useRef(false)
   useLayoutEffect(() => {
-    if (hasAutoSelected.current || !me || chapters.length === 0) return
-    if (!isChapterPresident(me)) return
-    if (CHAPTERS.includes(userChapter as (typeof CHAPTERS)[number])) return // 이미 records로 처리됨
-    const myChapterId = me.roles?.find(
-      (r) => r.roleType === "CHAPTER_PRESIDENT",
-    )?.organizationId
-    if (!myChapterId) return
-    const myChapter = chapters.find((c) => c.id === myChapterId)
-    if (myChapter) {
-      setSelectedChapter(myChapter.name)
-      ownChapter.current = myChapter.name
-      hasAutoSelected.current = true
+    if (hasAutoSelected.current || !me) return
+    if (isChapterPresident(me)) {
+      if (chapters.length === 0) return
+      if (CHAPTERS.includes(userChapter as (typeof CHAPTERS)[number])) return // 이미 records로 처리됨
+      const myChapterId = me.roles?.find(
+        (r) => r.roleType === "CHAPTER_PRESIDENT",
+      )?.organizationId
+      if (!myChapterId) return
+      const myChapter = chapters.find((c) => c.id === myChapterId)
+      if (myChapter) {
+        setSelectedChapter(myChapter.name)
+        ownChapter.current = myChapter.name
+        hasAutoSelected.current = true
+      }
+      return
     }
-  }, [me, chapters, userChapter])
+    if (isSchoolLeadership(me)) {
+      const myChapter = chaptersWithSchoolsQuery.data?.chapters.find((c) =>
+        c.schools.some((s) => s.schoolId === String(me.schoolId)),
+      )
+      if (
+        myChapter &&
+        CHAPTERS.includes(myChapter.chapterName as (typeof CHAPTERS)[number])
+      ) {
+        setSelectedChapter(myChapter.chapterName)
+        ownChapter.current = myChapter.chapterName
+        hasAutoSelected.current = true
+      }
+    }
+  }, [me, chapters, userChapter, chaptersWithSchoolsQuery.data])
 
   const admin = useAdminPageData(selectedChapter, {
     enabled: showAdminSection,
-    schoolName: schoolLeadership ? identity?.schoolName : undefined,
   })
   const adminStats = admin.stats
   const adminProjects = admin.projects
@@ -161,16 +186,8 @@ function MatchingApplicationsPage() {
                     projects={adminProjects}
                     currentRound={admin.currentRound}
                     chapterName={selectedChapter}
-                    disableFormPanel={
-                      isChapterPresident(identity) ||
-                      schoolLeadership ||
-                      isSuperAdmin(identity) ||
-                      isCentralStaff(identity)
-                    }
-                    hideExpand={
-                      isChapterPresident(identity) ||
-                      schoolLeadership
-                    }
+                    hideExpand
+                    disableProjectModal
                   />
                 </div>
               )}


### PR DESCRIPTION
## 📸 작업 내용

> main 핫픽스 — 학교 회장단 지원 현황 조회 버그 수정

- 학교 회장/부회장이 [지원 현황]에서 본인 **학교** 프로젝트만 보이던 문제 수정 → 소속 **지부 전체** 프로젝트 조회
- 지부장·학교 회장단·총괄단(운영진 admin 뷰)은 지원자 개인정보 없이 **숫자(통계)만** 조회하도록, 지원자 목록 조회 API 호출 자체를 제거
- 챌린저 이력이 없는 학교 회장단의 기본 지부가 잘못 고정되던 부수 버그 보정

## 🎞️ 주요 코드 설명

### 지부 전체 조회 + 숫자만 노출

```TypeScript
// useAdminPageData: 본인 학교 필터 제거 → 지부 전체 프로젝트
const projects = useMemo(
  () => projectsQuery.data?.content ?? [],
  [projectsQuery.data],
)

// 지원자 목록(개인정보 포함) 미조회 → 빈 배열로 변환, 통계는 지부 단위 집계 API로만 구성
const transformed = useMemo(
  () => projects.map((p) => toProjectApplication(p, [])),
  [projects],
)
```

- 프로젝트별 파트 카운트는 프로젝트 목록의 정원(partQuotas) 기반, 현황 통계는 지부 단위 집계 응답 기반이라 지원자 목록 없이도 숫자가 그대로 유지됩니다.
- `ApplicationTableSection`에 `disableProjectModal`을 추가해 admin 뷰에서 펼치기·상세 모달을 비활성화(빈 지원자 노출 방지)합니다.

### 학교 회장단 기본 지부 보정

```TypeScript
if (isSchoolLeadership(me)) {
  const myChapter = chaptersWithSchoolsQuery.data?.chapters.find((c) =>
    c.schools.some((s) => s.schoolId === String(me.schoolId)),
  )
  if (myChapter && CHAPTERS.includes(myChapter.chapterName as (typeof CHAPTERS)[number])) {
    setSelectedChapter(myChapter.chapterName)
    ownChapter.current = myChapter.chapterName
    hasAutoSelected.current = true
  }
}
```

- 챌린저 이력 대신 본인 `schoolId`가 속한 지부로 기본 지부를 결정해, 이력이 없거나 지부명이 매칭되지 않는 학교 회장단도 정상 조회됩니다.

## 🔗 연결된 이슈

- Connected: #477
- Closes #477