### PR TITLE
fix: me 응답 정규화 fallback 보강

### DIFF
--- a/src/features/auth/api/me.test.ts
+++ b/src/features/auth/api/me.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+
+import { computeAvailableViewModes } from "@/shared/view-mode/availableViewModes"
+import { getProjectViewContext } from "@/shared/view-mode/projectViewContext"
+
+import { normalizeMemberInfo } from "./me"
+
+describe("normalizeMemberInfo", () => {
+  it("기존 me 응답의 roles와 challengerRecords를 보존하고 currentGisuMemberInfo를 보강한다", () => {
+    const me = normalizeMemberInfo({
+      id: "2916",
+      name: "송민서",
+      nickname: "소온",
+      email: "minseosong5@gmail.com",
+      schoolId: "12",
+      schoolName: "동아대학교",
+      profileImageLink: null,
+      status: "ACTIVE",
+      roles: [
+        {
+          id: "185",
+          challengerId: "751",
+          roleType: "SCHOOL_PRESIDENT",
+          organizationType: "SCHOOL",
+          organizationId: "12",
+          responsiblePart: undefined,
+          gisuId: "5",
+          gisu: "10",
+        },
+      ],
+      challengerRecords: [
+        {
+          challengerId: "751",
+          memberId: "2916",
+          gisuId: "5",
+          gisu: "10",
+          chapterId: "31",
+          chapterName: "Platinum",
+          part: "SPRINGBOOT",
+          challengerStatus: null,
+          name: "송민서",
+          nickname: "소온",
+          email: null,
+          schoolId: "12",
+          schoolName: "동아대학교",
+        },
+      ],
+    })
+
+    expect(me.roles).toHaveLength(1)
+    expect(me.roles[0]?.roleType).toBe("SCHOOL_PRESIDENT")
+    expect(me.challengerRecords).toHaveLength(1)
+    expect(me.currentGisuMemberInfo).toMatchObject({
+      gisuId: "5",
+      generation: "10",
+      challenger: {
+        challengerId: "751",
+        part: "SPRINGBOOT",
+        challengerStatus: "ACTIVE",
+      },
+      isAdmin: true,
+      roleTypes: ["SCHOOL_PRESIDENT"],
+    })
+    expect(computeAvailableViewModes(me)).toEqual(["admin", "others"])
+    expect(getProjectViewContext(me, "others")).toMatchObject({
+      isChallengerView: true,
+      currentPart: "SPRINGBOOT",
+      currentChapterId: "31",
+    })
+  })
+})

--- a/src/features/auth/api/me.ts
+++ b/src/features/auth/api/me.ts
@@ -4,7 +4,9 @@ import type {
   ChallengerInfoResponse,
   ChallengerPointInfo,
   ChallengerRoleResponse,
+  ChallengerStatus,
   Part,
+  RoleType,
 } from "@/features/challenger/model/types"
 import type { ApiResponse } from "@/shared/lib/apiResponse"
 
@@ -60,6 +62,18 @@ interface V2HistoryItem {
   [key: string]: unknown
 }
 
+type LegacyChallengerRecord = Omit<
+  ChallengerInfoResponse,
+  "challengerStatus"
+> & {
+  challengerStatus?: ChallengerStatus | null
+}
+
+type LegacyRoleResponse = Omit<ChallengerRoleResponse, "challengerRoleId"> & {
+  challengerRoleId?: string | number
+  id?: string | number
+}
+
 interface MemberInfoV2Raw {
   hasLocalCredential?: boolean
   profile?: MemberProfileInfo | null
@@ -76,64 +90,157 @@ interface MemberInfoV2Raw {
     isAdmin?: boolean
     roleTypes?: string[]
   } | null
+  challengerRecords?: LegacyChallengerRecord[]
+  roles?: LegacyRoleResponse[]
   [key: string]: unknown
+}
+
+function toStringId(value: unknown): string {
+  if (typeof value === "string") return value
+  if (typeof value === "number" && Number.isFinite(value)) return String(value)
+  return ""
+}
+
+function getLatestRecord(
+  records: ChallengerInfoResponse[],
+): ChallengerInfoResponse | undefined {
+  return [...records].sort((a, b) => {
+    const generationDiff = Number(b.gisu) - Number(a.gisu)
+    if (Number.isFinite(generationDiff) && generationDiff !== 0) {
+      return generationDiff
+    }
+    return Number(b.gisuId) - Number(a.gisuId)
+  })[0]
+}
+
+function normalizeChallengerStatus(
+  status: ChallengerStatus | null | undefined,
+): ChallengerStatus {
+  return status ?? "ACTIVE"
+}
+
+function normalizeChallengerRecords(
+  raw: MemberInfoV2Raw,
+): ChallengerInfoResponse[] {
+  if (raw.challengerHistory?.length) {
+    return raw.challengerHistory.map((h) => ({
+      ...(h as unknown as ChallengerInfoResponse),
+      challengerId: String(h.challengerId),
+      gisuId: String(h.gisuId),
+      gisu: String(h.generation),
+      chapterId: String(h.chapterId),
+      memberId: "",
+      name: "",
+      nickname: "",
+      email: null,
+      schoolId: "",
+      schoolName: "",
+    }))
+  }
+
+  return (raw.challengerRecords ?? []).map((record) => ({
+    ...record,
+    challengerId: toStringId(record.challengerId),
+    memberId: toStringId(record.memberId),
+    gisuId: toStringId(record.gisuId),
+    gisu: toStringId(record.gisu),
+    chapterId: toStringId(record.chapterId),
+    schoolId: toStringId(record.schoolId),
+    challengerStatus: normalizeChallengerStatus(record.challengerStatus),
+  }))
+}
+
+function normalizeCurrentGisuMemberInfo(
+  raw: MemberInfoV2Raw,
+  records: ChallengerInfoResponse[],
+): CurrentGisuMemberInfo | null {
+  if (raw.currentGisuMemberInfo) {
+    return {
+      ...raw.currentGisuMemberInfo,
+      gisuId: String(raw.currentGisuMemberInfo.gisuId),
+      generation: String(raw.currentGisuMemberInfo.generation),
+      challenger: raw.currentGisuMemberInfo.challenger
+        ? {
+            ...raw.currentGisuMemberInfo.challenger,
+            challengerId: String(
+              raw.currentGisuMemberInfo.challenger.challengerId,
+            ),
+            part: raw.currentGisuMemberInfo.challenger.part,
+          }
+        : null,
+    }
+  }
+
+  const currentRecord = getLatestRecord(records)
+  if (!currentRecord) return null
+
+  const roleTypes = (raw.roles ?? [])
+    .filter((role) => role.gisuId === currentRecord.gisuId)
+    .map((role) => role.roleType)
+
+  return {
+    gisuId: currentRecord.gisuId,
+    generation: currentRecord.gisu,
+    challenger: {
+      challengerId: currentRecord.challengerId,
+      part: currentRecord.part,
+      challengerStatus: normalizeChallengerStatus(
+        currentRecord.challengerStatus,
+      ),
+    },
+    isAdmin: roleTypes.some((roleType) => roleType !== "CHALLENGER"),
+    roleTypes,
+  }
+}
+
+function normalizeRoles(
+  raw: MemberInfoV2Raw,
+  currentGisu: CurrentGisuMemberInfo | null,
+  records: ChallengerInfoResponse[],
+): ChallengerRoleResponse[] {
+  if (raw.roles?.length) {
+    return raw.roles.map((role) => ({
+      ...role,
+      challengerRoleId: toStringId(role.challengerRoleId ?? role.id),
+      challengerId: toStringId(role.challengerId),
+      organizationId: toStringId(role.organizationId),
+      gisuId: toStringId(role.gisuId),
+      gisu: toStringId(role.gisu),
+    }))
+  }
+
+  const currentHistory = records.find((h) => h.gisuId === currentGisu?.gisuId)
+
+  return (currentGisu?.roleTypes ?? []).map((rt) => ({
+    roleType: rt as RoleType,
+    organizationId: String(currentHistory?.chapterId ?? ""),
+    challengerRoleId: "",
+    challengerId: String(currentHistory?.challengerId ?? ""),
+    organizationType: "CHAPTER",
+    gisuId: String(currentGisu?.gisuId ?? ""),
+    gisu: String(currentGisu?.generation ?? ""),
+  }))
+}
+
+export function normalizeMemberInfo(raw: MemberInfoV2Raw): MemberInfoResponse {
+  const challengerRecords = normalizeChallengerRecords(raw)
+  const currentGisuMemberInfo = normalizeCurrentGisuMemberInfo(
+    raw,
+    challengerRecords,
+  )
+  const roles = normalizeRoles(raw, currentGisuMemberInfo, challengerRecords)
+
+  return {
+    ...(raw as unknown as MemberInfoResponse),
+    currentGisuMemberInfo,
+    challengerRecords,
+    roles,
+  }
 }
 
 export async function getMyInfo(): Promise<MemberInfoResponse> {
   const { data } = await api.get<ApiResponse<MemberInfoV2Raw>>("/v2/member/me")
-  const raw = data.result
-  const history = raw.challengerHistory ?? []
-  const currentGisu = raw.currentGisuMemberInfo
-
-  // 현재 기수 history 항목 → CHAPTER_PRESIDENT의 organizationId(chapterId) 추출용
-  const currentHistory = history.find((h) => h.gisuId === currentGisu?.gisuId)
-
-  const challengerRecords: ChallengerInfoResponse[] = history.map((h) => ({
-    ...(h as unknown as ChallengerInfoResponse),
-    challengerId: String(h.challengerId),
-    gisuId: String(h.gisuId),
-    gisu: String(h.generation), // generation(기수 번호) → gisu(표시용)
-    chapterId: String(h.chapterId),
-    memberId: "",
-    name: "",
-    nickname: "",
-    email: null,
-    schoolId: "",
-    schoolName: "",
-  }))
-
-  // 현재 기수 roleTypes 기준, chapterId를 organizationId로 사용
-  const roles: ChallengerRoleResponse[] = (currentGisu?.roleTypes ?? []).map(
-    (rt) => ({
-      roleType: rt as ChallengerRoleResponse["roleType"],
-      organizationId: String(currentHistory?.chapterId ?? ""),
-      challengerRoleId: "",
-      challengerId: String(currentHistory?.challengerId ?? ""),
-      organizationType: "CHAPTER" as ChallengerRoleResponse["organizationType"],
-      gisuId: String(currentGisu?.gisuId ?? ""),
-      gisu: String(currentGisu?.generation ?? ""),
-    }),
-  )
-
-  return {
-    ...(raw as unknown as MemberInfoResponse),
-    currentGisuMemberInfo: currentGisu
-      ? {
-          ...currentGisu,
-          gisuId: String(currentGisu.gisuId),
-          generation: String(currentGisu.generation),
-          challenger: currentGisu.challenger
-            ? {
-                ...currentGisu.challenger,
-                challengerId: String(currentGisu.challenger.challengerId),
-                part: currentGisu.challenger.part,
-              }
-            : null,
-        }
-      : null,
-    challengerRecords,
-    roles,
-  }
+  return normalizeMemberInfo(data.result)
 }
 
 export async function updateMemberInfo(body: {


### PR DESCRIPTION
## 작업 내용

- 기존 `/api/v2/member/me` 응답 형태에서 `roles`와 `challengerRecords`를 보존하도록 정규화 로직을 보강했습니다.
- `currentGisuMemberInfo`가 없는 경우 챌린저 기록과 역할 정보로 현재 기수 정보를 보강하도록 fallback을 추가했습니다.
- 운영 권한과 챌린저 기록을 함께 가진 사용자가 관리자 관점과 챌린저 관점을 모두 유지하는 회귀 테스트를 추가했습니다.

## 주요 코드 설명

### me 응답 정규화 fallback

- `challengerHistory`가 있으면 기존 변환 흐름을 유지합니다.
- `challengerHistory`가 없고 `challengerRecords`가 있으면 해당 기록을 보존하면서 ID 타입과 `challengerStatus`를 정규화합니다.
- `currentGisuMemberInfo`가 없으면 최신 챌린저 기록과 같은 기수의 역할 정보로 현재 기수 컨텍스트를 구성합니다.

### 회귀 테스트

- `roles`와 `challengerRecords`만 포함된 me 응답을 기준으로 정규화 결과를 검증했습니다.
- 혼합 역할 사용자의 사용 가능 뷰 모드가 `admin`, `others`로 유지되는지 확인했습니다.
- 챌린저 관점에서 현재 파트와 지부 정보가 유지되는지 확인했습니다.

## 연결된 이슈

- Connected: #479
- Closes #479

## 검증

- `pnpm build`
- `pnpm exec vitest run src/features/auth/api/me.test.ts src/shared/view-mode/projectViewContext.test.ts src/shared/view-mode/availableViewModes.test.ts src/features/project/list/model/projectDetailCta.test.ts`
- `pnpm exec eslint src/features/auth/api/me.ts src/features/auth/api/me.test.ts`