### PR TITLE
fix: PM 지원서 결정 시 활성 차수 판단 오류 수정

### DIFF
--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query"
 import { useMemo } from "react"
 
+import { useMe } from "@/features/auth/hooks/useMe"
+import { getLatestChallengerRecord } from "@/features/auth/model/identity"
 import {
   getAllChapters,
   getAllSchools,
@@ -75,10 +77,23 @@ export function useChallengerPageData(
   const gisuQuery = useActiveGisuId({ enabled })
   const gisuId = gisuQuery.data ?? 0
 
+  const { data: me } = useMe()
+  const chapterId = useMemo(() => {
+    const record = getLatestChallengerRecord(me)
+    return record?.chapterId ? Number(record.chapterId) : undefined
+  }, [me])
+
   const projectsQuery = useQuery({
     queryKey: applicationKeys.managedProjects(gisuId),
     queryFn: () => getManagedProjects(gisuId),
     enabled: enabled && gisuId > 0,
+  })
+
+  // 매칭 차수 조회 (현재 진행 차수 계산용)
+  const roundsQuery = useQuery({
+    queryKey: applicationKeys.matchingRounds(chapterId),
+    queryFn: () => getMatchingRounds(chapterId),
+    enabled: enabled && chapterId !== undefined,
   })
 
   // 프로젝트 목록이 로드되면 각 프로젝트의 지원자 목록도 함께 조회
@@ -122,17 +137,10 @@ export function useChallengerPageData(
     enabled: enabled && projects.length > 0,
   })
 
-  // 현재 차수: 서버 통계에 존재하는 가장 높은 차수
-  const currentRound = useMemo(() => {
-    const firstStat = (projectStatsQuery.data ?? [])[0]
-    if (!firstStat) return undefined
-    let max = 0
-    for (const r of firstStat.roundApplicationStatistics) {
-      const n = toRoundNumber(r.matchingRound.phase)
-      if (n > max) max = n
-    }
-    return max || undefined
-  }, [projectStatsQuery.data])
+  const { currentRound } = useMemo(
+    () => getCurrentRound(roundsQuery.data ?? []),
+    [roundsQuery.data],
+  )
 
   // 차수별 지원 가용 인원 (서버 roundApplicationStatistics 직접 사용)
   const availablePerRound = useMemo(() => {
@@ -196,7 +204,8 @@ export function useChallengerPageData(
       (gisuQuery.isLoading ||
         projectsQuery.isLoading ||
         applicantsQuery.isLoading ||
-        projectStatsQuery.isLoading),
+        projectStatsQuery.isLoading ||
+        roundsQuery.isLoading),
     isError: enabled && (gisuQuery.isError || projectsQuery.isError),
     error: gisuQuery.error ?? projectsQuery.error ?? applicantsQuery.error,
   }

--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -77,7 +77,7 @@ export function useChallengerPageData(
   const gisuQuery = useActiveGisuId({ enabled })
   const gisuId = gisuQuery.data ?? 0
 
-  const { data: me } = useMe()
+  const { data: me, isLoading: isMeLoading } = useMe()
   const chapterId = useMemo(() => {
     const record = getLatestChallengerRecord(me)
     return record?.chapterId ? Number(record.chapterId) : undefined
@@ -205,7 +205,10 @@ export function useChallengerPageData(
         projectsQuery.isLoading ||
         applicantsQuery.isLoading ||
         projectStatsQuery.isLoading ||
-        roundsQuery.isLoading),
+        isMeLoading ||
+        (chapterId !== undefined &&
+          roundsQuery.data === undefined &&
+          !roundsQuery.isError)),
     isError: enabled && (gisuQuery.isError || projectsQuery.isError),
     error: gisuQuery.error ?? projectsQuery.error ?? applicantsQuery.error,
   }

--- a/src/features/application/model/mappers.ts
+++ b/src/features/application/model/mappers.ts
@@ -163,7 +163,7 @@ export function toProjectApplication(
     thumbnailUrl: project.thumbnailImageUrl || undefined,
     statusLabel,
     designCount: getQuotaCount(project.partQuotas, "DESIGN"),
-    feCount: getQuotaCount(project.partQuotas, "WEB", "IOS", "ANDROID"),
+    feCount: getQuotaCount(project.partQuotas, "WEB"),
     beCount: getQuotaCount(project.partQuotas, "SPRINGBOOT", "NODEJS"),
     applicants: applicants.map(toApplicantDetail),
   }

--- a/src/features/application/model/mappers.ts
+++ b/src/features/application/model/mappers.ts
@@ -163,7 +163,7 @@ export function toProjectApplication(
     thumbnailUrl: project.thumbnailImageUrl || undefined,
     statusLabel,
     designCount: getQuotaCount(project.partQuotas, "DESIGN"),
-    feCount: getQuotaCount(project.partQuotas, "WEB"),
+    feCount: getQuotaCount(project.partQuotas, "WEB", "IOS", "ANDROID"),
     beCount: getQuotaCount(project.partQuotas, "SPRINGBOOT", "NODEJS"),
     applicants: applicants.map(toApplicantDetail),
   }


### PR DESCRIPTION
## 📸 작업 내용

- UMC 매칭 시스템에서 Plan 챌린저(PM)가 본인 프로젝트의 지원서들에 대해 합격/불합격 상태를 변경(승인/반려/대기)할 수 없던 심각한 오작동 버그를 수정했습니다.
- **원인**: `useChallengerPageData` 훅에서 현재 진행 차수(`currentRound`)를 계산할 때, 단순히 누적 프로젝트 통계에서 최댓값(phase max)을 추출함에 따라 항상 3차로 오판하는 로직이 원인이었습니다. 이로 인해 1차/2차 매칭 기간 도중에도 지원자들의 라운드(1 또는 2)가 현재 차수(3)보다 이전인 것으로 오인하여 UI 상태 변경이 `disabled` 처리되었습니다.
- **해결**: 로그인한 사용자의 정보를 받아와 소속 지부(`chapterId`)를 구한 후, 실제 매칭 차수 목록 조회 API(`getMatchingRounds`) 및 현재 활성 차수 계산 함수(`getCurrentRound`)를 통해 실제 활성화된 차수를 평가하도록 수정했습니다.

## 🎞️ 주요 코드 설명

### useChallengerPageData 훅의 활성 차수 계산 로직 개선

- 기존에는 `projectStatsQuery.data`에서 가장 높은 차수 단계를 가져오는 폴백 방식을 취하고 있어 항상 `3`으로 고정되었습니다.
- 변경 후에는 로그인한 PM 본인의 지부 `chapterId`를 바탕으로 매칭 라운드 정보(`roundsQuery`)를 동적으로 가져온 뒤, `getCurrentRound`를 호출하여 서버 시간 기준의 정확한 현재 진행 중인 차수를 판별하도록 교정했습니다.

```TypeScript
// src/features/application/hooks/useApplicationPageData.ts
export function useChallengerPageData(
  options: ApplicationPageDataOptions = {},
) {
  const enabled = options.enabled ?? true
  const gisuQuery = useActiveGisuId({ enabled })
  const gisuId = gisuQuery.data ?? 0

  const { data: me } = useMe()
  const chapterId = useMemo(() => {
    const record = getLatestChallengerRecord(me)
    return record?.chapterId ? Number(record.chapterId) : undefined
  }, [me])

  const projectsQuery = useQuery({
    queryKey: applicationKeys.managedProjects(gisuId),
    queryFn: () => getManagedProjects(gisuId),
    enabled: enabled && gisuId > 0,
  })

  // 매칭 차수 조회 (현재 진행 차수 계산용)
  const roundsQuery = useQuery({
    queryKey: applicationKeys.matchingRounds(chapterId),
    queryFn: () => getMatchingRounds(chapterId),
    enabled: enabled && chapterId !== undefined,
  })

  // ... (중략)

  const { currentRound } = useMemo(
    () => getCurrentRound(roundsQuery.data ?? []),
    [roundsQuery.data],
  )
  
  // ... (중략)
  
  return {
    // ...
    isLoading:
      enabled &&
      (gisuQuery.isLoading ||
        projectsQuery.isLoading ||
        applicantsQuery.isLoading ||
        projectStatsQuery.isLoading ||
        roundsQuery.isLoading),
  }
}
```

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #487 
