### PR TITLE
Task: 권한별 분기 재정립

### DIFF
--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -9,6 +9,7 @@ import {
   isChapterPresident,
   isCurrentTermPm,
   isSchoolStaff,
+  isSuperAdmin,
 } from "@/features/auth/model/identity"
 import { getChaptersWithSchools } from "@/features/challenger/api/organization"
 import { projectKeys } from "@/features/project/new/api/queryKeys"
@@ -184,10 +185,11 @@ export function ProjectManagementPage() {
     selectedChapterId !== undefined && Number.isFinite(selectedChapterId)
       ? selectedChapterId
       : undefined
-  const isMatchingPeriod = useIsMatchingPeriod({
+  const rawIsMatchingPeriod = useIsMatchingPeriod({
     ...(useGroupedView ? { chapterId: matchingPeriodChapterId } : {}),
     enabled: hasAccess,
   })
+  const isMatchingPeriod = isSuperAdmin(me) ? false : rawIsMatchingPeriod
 
   const filteredProjects: MatchingProject[] = useMemo(() => {
     if (!useGroupedView) return projects

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -26,6 +26,7 @@ import {
   isSuperAdmin,
 } from "@/features/auth/model/identity"
 import { getChaptersWithSchools } from "@/features/challenger/api/organization"
+import { useIsMatchingPeriod } from "@/features/project/new/hooks/useIsMatchingPeriod"
 import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
 import { ProjectTitleCard } from "@/shared/ui/ProjectTitleCard"
 import { SegmentButton } from "@/shared/ui/segment-button/SegmentButton"
@@ -124,15 +125,28 @@ function MatchingApplicationsPage() {
     }
   }, [me, chapters, userChapter, chaptersWithSchoolsQuery.data])
 
+  // 차수 제한 대상: 지부장·교내 회장/부회장·Plan 챌린저
+  const isRoundRestrictedRole =
+    isChapterPresident(identity) || schoolLeadership || hasPmRole
+
   const admin = useAdminPageData(selectedChapter, {
     enabled: showAdminSection,
   })
   const adminStats = admin.stats
   const adminProjects = admin.projects
 
+  // 지부장·교내 회장/부회장: admin.activeRound가 있으면 차수 진행 중 → 조회 잠금
+  const isAdminRoundLocked =
+    isRoundRestrictedRole && admin.activeRound !== undefined
+
   const challenger = useChallengerPageData({ enabled: showPmSection })
   const pmProjects = challenger.projects
   const availablePerRound = challenger.availablePerRound
+
+  // Plan 챌린저: 매칭 기간 중이면 조회 잠금
+  const isPmMatchingPeriod = useIsMatchingPeriod({
+    enabled: showPmSection && hasPmRole,
+  })
 
   return (
     <section className="flex w-full flex-col">
@@ -174,6 +188,12 @@ function MatchingApplicationsPage() {
                     데이터를 불러오는 중...
                   </p>
                 </div>
+              ) : isAdminRoundLocked ? (
+                <div className="flex items-center justify-center py-20">
+                  <p className="text-body-2-regular text-teal-gray-400">
+                    매칭 차수가 진행 중입니다. 차수 종료 후 조회할 수 있습니다.
+                  </p>
+                </div>
               ) : (
                 <div className="flex flex-col gap-14.25">
                   <ApplicationStatsSection
@@ -186,7 +206,6 @@ function MatchingApplicationsPage() {
                     projects={adminProjects}
                     currentRound={admin.currentRound}
                     chapterName={selectedChapter}
-                    hideExpand
                     disableProjectModal
                   />
                 </div>
@@ -200,6 +219,12 @@ function MatchingApplicationsPage() {
                 <div className="flex items-center justify-center py-20">
                   <p className="text-body-2-regular text-teal-gray-400">
                     데이터를 불러오는 중...
+                  </p>
+                </div>
+              ) : isPmMatchingPeriod ? (
+                <div className="flex items-center justify-center py-20">
+                  <p className="text-body-2-regular text-teal-gray-400">
+                    매칭 차수가 진행 중입니다. 차수 종료 후 조회할 수 있습니다.
                   </p>
                 </div>
               ) : pmProjects.length === 0 ? (


### PR DESCRIPTION
## 📸 작업 내용

> 작업한 내용을 두괄식으로 작성해주세요

- 지원서 조회 권한 적용: 지부장·교내 회장/부회장·Plan 챌린저는 매칭 차수 접수 기간 중 지원 현황 조회를 제한하고, 
   차수 종료 후에만 조회 가능하도록 처리
- 최고관리자(SUPER_ADMIN)의 프로젝트 수정 제한 해제( 매칭 기간 중에도 수정 가능하도록 예외 처리)

## 🎞️ 주요 코드 설명

> 설명이 필요한 코드 위주로 작성해주세요

### 지원서 조회 차수 종료 후 잠금 해제 (admin 뷰)

```TypeScript
// 차수 제한 대상: 지부장·교내 회장/부회장·Plan 챌린저
const isRoundRestrictedRole =
  isChapterPresident(identity) || schoolLeadership || hasPmRole

// admin.activeRound가 있으면 차수 진행 중 → 조회 잠금
const isAdminRoundLocked = isRoundRestrictedRole && admin.activeRound !== undefined
```

- admin.activeRound는 현재 startsAt ≤ 지금 ≤ endsAt인 차수가 있을 때만 값이 존재하고, 차수 종료 후에는 undefined가 됨
- 제한 대상 역할 + 차수 진행 중일 때만 잠금 메시지를 표시하고, 그 외에는 정상 조회 가능

### 지원서 조회 차수 종료 후 잠금 해제 (PM 뷰)

```TypeScript
// Plan 챌린저: 매칭 기간 중이면 조회 잠금
const isPmMatchingPeriod = useIsMatchingPeriod({
  enabled: showPmSection && hasPmRole,
})
```

- useIsMatchingPeriod가 본인 지부 기준으로 매칭 접수 기간 여부를 판별
- 매칭 기간 중에는 잠금 메시지 표시, 종료 후에는 PM 뷰 정상 노출


## 🖥️ 구현화면

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #486 