### PR TITLE
🐛 fix: 매칭 현황 전체 프로젝트 표시

### DIFF
--- a/src/features/application/api/applicationApi.ts
+++ b/src/features/application/api/applicationApi.ts
@@ -50,6 +50,9 @@ export async function getAllProjects(
     chapterId?: number
     keyword?: string
     partQuotaStatus?: string
+    statuses?: Array<
+      "DRAFT" | "PENDING_REVIEW" | "IN_PROGRESS" | "COMPLETED" | "ABORTED"
+    >
     page?: number
     size?: number
   },

--- a/src/features/matching/hooks/useMatchingStatusData.ts
+++ b/src/features/matching/hooks/useMatchingStatusData.ts
@@ -101,7 +101,32 @@ export function useMatchingStatusData(chapterName?: string) {
   // 전체 프로젝트 조회 (매칭 결과 시트용)
   const projectsQuery = useQuery({
     queryKey: applicationKeys.matchingParts(gisuId, chapterId),
-    queryFn: () => getAllProjects(gisuId, { chapterId }),
+    queryFn: async () => {
+      const size = 100
+      const firstPage = await getAllProjects(gisuId, {
+        chapterId,
+        page: 0,
+        size,
+        statuses: ["IN_PROGRESS", "COMPLETED"],
+      })
+      const projects = [...firstPage.content]
+      let page = 0
+      let hasNext = firstPage.hasNext
+
+      while (hasNext) {
+        page += 1
+        const nextPage = await getAllProjects(gisuId, {
+          chapterId,
+          page,
+          size,
+          statuses: ["IN_PROGRESS", "COMPLETED"],
+        })
+        projects.push(...nextPage.content)
+        hasNext = nextPage.hasNext
+      }
+
+      return { ...firstPage, content: projects }
+    },
     enabled: gisuId > 0,
   })
 

--- a/src/routes/matching/status.tsx
+++ b/src/routes/matching/status.tsx
@@ -73,9 +73,10 @@ function MatchingStatusPage() {
   } = useMatchingStatusData(selectedChapter)
 
   const DEFAULT_PARTS = ["Web", "iOS", "Android"]
-  const displayParts = matchingParts.length > 0
-    ? matchingParts
-    : DEFAULT_PARTS.map((name) => ({ partName: name, projects: [] }))
+  const displayParts = DEFAULT_PARTS.map((name) => {
+    const part = matchingParts.find((item) => item.partName === name)
+    return part ?? { partName: name, projects: [] }
+  })
   const displayStats = stats
 
   return (

--- a/src/routes/matching/status.tsx
+++ b/src/routes/matching/status.tsx
@@ -73,14 +73,7 @@ function MatchingStatusPage() {
   } = useMatchingStatusData(selectedChapter)
 
   const DEFAULT_PARTS = ["Web", "iOS", "Android"]
-  const hasAnyMatch = matchingParts.some((part) =>
-    part.projects.some((project) =>
-      project.roleRows.some((row) =>
-        row.blocks.some((b) => b.type === "filled" || b.type === "round1"),
-      ),
-    ),
-  )
-  const displayParts = hasAnyMatch
+  const displayParts = matchingParts.length > 0
     ? matchingParts
     : DEFAULT_PARTS.map((name) => ({ partName: name, projects: [] }))
   const displayStats = stats


### PR DESCRIPTION
## 📸 작업 내용

- 매칭 현황 결과 시트에서 매칭된 멤버가 없는 프로젝트도 표시되도록 렌더링 조건을 수정
- 프로젝트 목록 조회 시 `IN_PROGRESS`, `COMPLETED` 상태를 명시하고 모든 페이지의 프로젝트를 합산하도록 보강
- 프로젝트 목록 API 래퍼에 `statuses` 요청 파라미터 타입을 추가

## 🎞️ 주요 코드 설명

### 매칭 결과 시트 표시 기준 변경

`/matching/status` 화면에서 매칭된 블록 존재 여부가 아니라 프로젝트 목록 존재 여부를 기준으로 섹션 데이터를 사용하도록 변경했습니다.

### 프로젝트 목록 조회 보강

매칭 현황용 프로젝트 조회에서 공개/완료 상태를 함께 요청하고, 페이지 응답의 `hasNext`가 끝날 때까지 프로젝트를 누적하도록 수정했습니다.

## 🔗 연결된 이슈

- Connected: #490
- Closes #490
