### PR TITLE
🎨 style: 프로젝트 중단 메뉴 라벨 조정

### DIFF
--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -412,7 +412,7 @@ export function ProjectManagementMoreMenu({
               {status === "IN_PROGRESS" &&
                 (isPermissionLoading || canPublishProject) && (
                   <DropdownItem
-                    label="매칭 중단 (복구 불가)"
+                    label="중단 (복구 불가)"
                     disabled={isPermissionLoading}
                     onClick={handleAbortClick}
                     className="text-error-500"


### PR DESCRIPTION
## 📸 작업 내용

- 프로젝트 관리 더보기 메뉴의 중단 액션 라벨을 `매칭 중단 (복구 불가)`에서 `중단 (복구 불가)`로 조정
- 기존 클릭 동작, 권한 조건, 비활성화 조건은 그대로 유지

## 🔗 연결된 이슈

- Connected: #492
- Closes #492
