### PR TITLE
🐛 fix: 지원서 목록 지원자 이름 표시 수정

### DIFF
--- a/src/features/application/model/mappers.ts
+++ b/src/features/application/model/mappers.ts
@@ -87,6 +87,17 @@ export function toRoundNumber(phase: MatchingRoundPhaseView): number {
   return PHASE_MAP[phase] ?? 1
 }
 
+function toMemberDisplayName(member: {
+  nickname?: string | null
+  name?: string | null
+}): string {
+  if (member.nickname && member.name) {
+    return `${member.nickname}/${member.name}`
+  }
+
+  return member.nickname ?? member.name ?? ""
+}
+
 // 날짜 문자열 -> { date, time } 변환
 export function toDateTimePair(
   isoString: string | null,
@@ -130,7 +141,7 @@ export function toApplicantDetail(
     id: String(res.applicationId),
     round: toRoundNumber(res.matchingRound.phase),
     role: toFrontRole(res.applicant.part),
-    name: res.applicant.nickname || res.applicant.name,
+    name: toMemberDisplayName(res.applicant),
     university: res.applicant.schoolName,
     status: toFrontStatus(res.status),
     processedAt: toDateTimePair(res.statusChangedAt),


### PR DESCRIPTION
## 📸 작업 내용

- 지원서 목록에서 지원자 이름을 `닉네임/이름` 형식으로 표시하도록 수정했습니다.
- 닉네임 또는 이름 중 일부 값만 있을 때는 기존처럼 존재하는 값만 표시되도록 fallback을 유지했습니다.

## 🖥️ 구현화면

| 지원서 목록 |
| :---: |
| <img src = "" width ="250"> |

## 🔗 연결된 이슈

- Connected: #494
- Closes #494