### PR TITLE
✨ feat: 매칭 기간 중 운영진 모집 정원 수정 허용

### DIFF
--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -552,7 +552,10 @@ export function ProjectDetailCard({
             >
               기획 보기
             </Button>
-            {showEditCta && (!isMatchingPeriod || resolvedCanManageProject) ? (
+            {showEditCta &&
+            (!isMatchingPeriod ||
+              resolvedEditPermissionLoading ||
+              resolvedCanManageProject) ? (
               shouldShowEditCta ? (
                 <Button
                   className="min-w-36 flex-1 whitespace-nowrap"

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -76,6 +76,7 @@ interface ProjectDetailCardProps {
   hideMyApplication?: boolean
   /** 매칭 기간 중 수정하기 버튼 숨김 */
   isMatchingPeriod?: boolean
+  canManageProject?: boolean
 }
 
 function ProjectDetailCardSkeleton() {
@@ -184,6 +185,7 @@ export function ProjectDetailCard({
   viewOnly = false,
   hideMyApplication = false,
   isMatchingPeriod = false,
+  canManageProject,
 }: ProjectDetailCardProps) {
   const projectId = Number(projectIdProp)
   const navigate = useNavigate()
@@ -216,6 +218,8 @@ export function ProjectDetailCard({
   )
   const resolvedCanEditProject =
     canEditProject ?? projectPermissionsQuery.canEdit
+  const resolvedCanManageProject =
+    canManageProject ?? projectPermissionsQuery.canManage
   const resolvedEditPermissionLoading =
     editPermissionLoading ??
     (shouldQueryEditPermission && projectPermissionsQuery.isPending)
@@ -548,7 +552,7 @@ export function ProjectDetailCard({
             >
               기획 보기
             </Button>
-            {showEditCta && !isMatchingPeriod ? (
+            {showEditCta && (!isMatchingPeriod || resolvedCanManageProject) ? (
               shouldShowEditCta ? (
                 <Button
                   className="min-w-36 flex-1 whitespace-nowrap"

--- a/src/features/project/management/ui/ProjectManagementCard.tsx
+++ b/src/features/project/management/ui/ProjectManagementCard.tsx
@@ -146,6 +146,7 @@ export function ProjectManagementCard({
                 projectId={projectId}
                 showEditCta
                 canEditProject={canEditProject}
+                canManageProject={canPublishProject}
                 editPermissionLoading={isPermissionLoading}
                 isMatchingPeriod={isMatchingPeriod}
               />

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -281,7 +281,7 @@ export function ProjectManagementMoreMenu({
 
   const handleEditClick = () => {
     if (!canEditProject || isPermissionLoading) return
-    if (status === "IN_PROGRESS" && isMatchingPeriod) {
+    if (status === "IN_PROGRESS" && isMatchingPeriod && !canPublishProject) {
       setPopoverOpen(false)
       addToast({
         message: "매칭 기간 중에는 수정이 불가능 합니다!",
@@ -335,7 +335,7 @@ export function ProjectManagementMoreMenu({
         label: "프로젝트 수정하기",
         onClick: handleEditClick,
         disabled: isPermissionLoading,
-        visuallyDisabled: isMatchingPeriod,
+        visuallyDisabled: isMatchingPeriod && !canPublishProject,
       })
     }
   } else {

--- a/src/features/project/new/ui/ProjectRegisterPage.tsx
+++ b/src/features/project/new/ui/ProjectRegisterPage.tsx
@@ -221,7 +221,7 @@ export function ProjectRegisterPage(props: ProjectRegisterPageProps) {
   const isMatchingGateLoading =
     isEditMode &&
     isInProgress &&
-    (!matchingRoundsQuery.isSuccess || isMatchingPeriodActive)
+    (matchingRoundsQuery.isLoading || isMatchingPeriodActive)
 
   useEffect(() => {
     if (detailQuery.data) {

--- a/src/features/project/new/ui/ProjectRegisterPage.tsx
+++ b/src/features/project/new/ui/ProjectRegisterPage.tsx
@@ -205,6 +205,24 @@ export function ProjectRegisterPage(props: ProjectRegisterPageProps) {
     return project?.status === "IN_PROGRESS"
   }, [isEditMode, editProjectId, managedQuery.data])
 
+  const isMatchingPeriodActive = useMemo(() => {
+    if (!isEditMode || !isInProgress) return false
+    if (!matchingRoundsQuery.isSuccess) return false
+    return isWithinMatchingPeriod(matchingRoundsQuery.data, new Date())
+  }, [
+    isEditMode,
+    isInProgress,
+    matchingRoundsQuery.isSuccess,
+    matchingRoundsQuery.data,
+  ])
+
+  const isQuotaOnlyMode = isMatchingPeriodActive && canManageProject
+
+  const isMatchingGateLoading =
+    isEditMode &&
+    isInProgress &&
+    (!matchingRoundsQuery.isSuccess || isMatchingPeriodActive)
+
   useEffect(() => {
     if (detailQuery.data) {
       hydrateProjectDetailIntoStore(detailQuery.data)
@@ -229,9 +247,9 @@ export function ProjectRegisterPage(props: ProjectRegisterPageProps) {
   }, [isEditMode, detailQuery.isError, detailQuery.error, addToast, navigate])
 
   useEffect(() => {
-    if (!isEditMode || !isInProgress) return
-    if (!matchingRoundsQuery.isSuccess) return
-    if (!isWithinMatchingPeriod(matchingRoundsQuery.data, new Date())) return
+    if (!isMatchingPeriodActive) return
+    if (projectPermissionsQuery.isPending) return
+    if (canManageProject) return
     addToast({
       message: "매칭 기간 중에는 수정이 불가능 합니다!",
       color: "red",
@@ -241,13 +259,16 @@ export function ProjectRegisterPage(props: ProjectRegisterPageProps) {
     })
     navigate({ to: "/matching/projects/management", replace: true })
   }, [
-    isEditMode,
-    isInProgress,
-    matchingRoundsQuery.isSuccess,
-    matchingRoundsQuery.data,
+    isMatchingPeriodActive,
+    projectPermissionsQuery.isPending,
+    canManageProject,
     addToast,
     navigate,
   ])
+
+  useEffect(() => {
+    if (isQuotaOnlyMode) setStep(2)
+  }, [isQuotaOnlyMode])
 
   useEffect(() => {
     if (isEditMode) return
@@ -412,6 +433,10 @@ export function ProjectRegisterPage(props: ProjectRegisterPageProps) {
 
   const handleStepChange = async (targetStep: number) => {
     if (targetStep === step) return
+    if (isQuotaOnlyMode && targetStep !== 2) {
+      triggerStepTooltip(targetStep)
+      return
+    }
     if (!canEditRecruitStep && targetStep === 2) {
       triggerStepTooltip(2)
       return
@@ -449,6 +474,10 @@ export function ProjectRegisterPage(props: ProjectRegisterPageProps) {
 
   const handleRegister = () => {
     submitMutation.mutate()
+  }
+
+  const handleQuotaOnlyLeave = () => {
+    navigate({ to: "/matching/projects/management", replace: true })
   }
 
   const handleSaveAndLeave = async () => {
@@ -507,39 +536,52 @@ export function ProjectRegisterPage(props: ProjectRegisterPageProps) {
         <Stepper
           step={step}
           onStepChange={handleStepChange}
-          disabledSteps={!canEditRecruitStep ? [2] : []}
+          disabledSteps={
+            isQuotaOnlyMode ? [1, 3] : !canEditRecruitStep ? [2] : []
+          }
           disabledTooltips={
-            !canEditRecruitStep
+            isQuotaOnlyMode
               ? {
-                  2: "기술 스택 및 파트별 TO는 운영진이 수기로 조정합니다.",
-                  3: "기본 정보를 입력한 뒤 작성할 수 있습니다.",
+                  1: "매칭 기간 중에는 모집 정원만 수정할 수 있습니다.",
+                  3: "매칭 기간 중에는 모집 정원만 수정할 수 있습니다.",
                 }
-              : {
-                  2: "기본 정보를 입력한 뒤 작성할 수 있습니다.",
-                  3: "기본 정보를 입력한 뒤 작성할 수 있습니다.",
-                }
+              : !canEditRecruitStep
+                ? {
+                    2: "기술 스택 및 파트별 TO는 운영진이 수기로 조정합니다.",
+                    3: "기본 정보를 입력한 뒤 작성할 수 있습니다.",
+                  }
+                : {
+                    2: "기본 정보를 입력한 뒤 작성할 수 있습니다.",
+                    3: "기본 정보를 입력한 뒤 작성할 수 있습니다.",
+                  }
           }
           openTooltipStep={tooltipTriggerStep}
         />
-        {step === 1 && (
-          <BasicInfoForm
-            ref={basicInfoRef}
-            canCreateProject={canCreateProject}
-            createPermissionLoading={isCreatePermissionLoading}
-            isEditMode={isEditMode}
-            onNext={handleBasicInfoNext}
-          />
-        )}
+        {step === 1 &&
+          (isMatchingGateLoading ? (
+            <p className="text-body-2-regular text-teal-gray-400 py-20 text-center">
+              데이터를 불러오는 중...
+            </p>
+          ) : (
+            <BasicInfoForm
+              ref={basicInfoRef}
+              canCreateProject={canCreateProject}
+              createPermissionLoading={isCreatePermissionLoading}
+              isEditMode={isEditMode}
+              onNext={handleBasicInfoNext}
+            />
+          ))}
         {step === 2 && (
           <RecruitInfoForm
             ref={recruitInfoRef}
             readOnly={!canEditRecruitStep}
+            quotaOnlyMode={isQuotaOnlyMode}
             canUpdatePartQuotasOverride={
               isEditMode ? undefined : canManageRecruitInfoByRole
             }
             isHydrated={isEditMode ? detailQuery.isSuccess : true}
-            onPrev={() => moveToStep(1)}
-            onNext={() => moveToStep(3)}
+            onPrev={isQuotaOnlyMode ? handleQuotaOnlyLeave : () => moveToStep(1)}
+            onNext={isQuotaOnlyMode ? handleQuotaOnlyLeave : () => moveToStep(3)}
           />
         )}
         {step === 3 && (

--- a/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
+++ b/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
@@ -48,6 +48,7 @@ interface RecruitInfoFormProps {
   readOnly?: boolean
   isHydrated?: boolean
   canUpdatePartQuotasOverride?: boolean
+  quotaOnlyMode?: boolean
 }
 
 function buildSummaryText(
@@ -74,6 +75,7 @@ export const RecruitInfoForm = forwardRef<
     readOnly = false,
     isHydrated = true,
     canUpdatePartQuotasOverride,
+    quotaOnlyMode = false,
   },
   ref,
 ) {
@@ -217,7 +219,9 @@ export const RecruitInfoForm = forwardRef<
     const ok = await savePartQuotas(true)
     if (!ok) return
     addToast({
-      message: "작성한 내용이 저장되었습니다.",
+      message: quotaOnlyMode
+        ? "모집 정원이 변경되었습니다."
+        : "작성한 내용이 저장되었습니다.",
       color: "primary",
       variant: "deep",
       type: "default",
@@ -307,7 +311,7 @@ export const RecruitInfoForm = forwardRef<
         </div>
       </div>
       <div className="flex items-center justify-between gap-3">
-        {!readOnly ? (
+        {!readOnly && !quotaOnlyMode ? (
           <Button
             type="button"
             variant="weak"
@@ -323,7 +327,7 @@ export const RecruitInfoForm = forwardRef<
         )}
         <div className="flex items-center justify-end gap-4">
           <Button type="button" variant="weak" color="neutral" onClick={onPrev}>
-            이전
+            {quotaOnlyMode ? "돌아가기" : "이전"}
           </Button>
           <Button
             type="button"
@@ -332,7 +336,7 @@ export const RecruitInfoForm = forwardRef<
             disabled={isSaving}
             onClick={() => void handleNext()}
           >
-            다음
+            {quotaOnlyMode ? "변경" : "다음"}
           </Button>
         </div>
       </div>

--- a/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
+++ b/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
@@ -97,7 +97,6 @@ export const RecruitInfoForm = forwardRef<
     projectPermissionsQuery.isPending
   const isReadOnly =
     readOnly || isPartQuotaPermissionLoading || !canUpdatePartQuotas
-  const isStackLocked = isReadOnly || quotaOnlyMode
 
   const [isSaving, setIsSaving] = useState(false)
   const [hasSavedOnce, setHasSavedOnce] = useState(false)
@@ -282,7 +281,7 @@ export const RecruitInfoForm = forwardRef<
                   value={roleStates[key].stack}
                   className="max-w-full flex-wrap"
                   onValueChange={(v) =>
-                    isStackLocked
+                    isReadOnly
                       ? undefined
                       : updateStack(key, v as RoleStack | undefined)
                   }
@@ -291,7 +290,7 @@ export const RecruitInfoForm = forwardRef<
                     <OptionButton
                       key={stack}
                       value={stack}
-                      disabled={isStackLocked || roleStates[key].count === 0}
+                      disabled={isReadOnly || roleStates[key].count === 0}
                     >
                       {stack}
                     </OptionButton>

--- a/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
+++ b/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
@@ -97,6 +97,7 @@ export const RecruitInfoForm = forwardRef<
     projectPermissionsQuery.isPending
   const isReadOnly =
     readOnly || isPartQuotaPermissionLoading || !canUpdatePartQuotas
+  const isStackLocked = isReadOnly || quotaOnlyMode
 
   const [isSaving, setIsSaving] = useState(false)
   const [hasSavedOnce, setHasSavedOnce] = useState(false)
@@ -281,7 +282,7 @@ export const RecruitInfoForm = forwardRef<
                   value={roleStates[key].stack}
                   className="max-w-full flex-wrap"
                   onValueChange={(v) =>
-                    isReadOnly
+                    isStackLocked
                       ? undefined
                       : updateStack(key, v as RoleStack | undefined)
                   }
@@ -290,7 +291,7 @@ export const RecruitInfoForm = forwardRef<
                     <OptionButton
                       key={stack}
                       value={stack}
-                      disabled={isReadOnly || roleStates[key].count === 0}
+                      disabled={isStackLocked || roleStates[key].count === 0}
                     >
                       {stack}
                     </OptionButton>

--- a/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
+++ b/src/features/project/new/ui/recruit-info/RecruitInfoForm.tsx
@@ -199,6 +199,7 @@ export const RecruitInfoForm = forwardRef<
 
   const handleNext = async () => {
     if (isReadOnly) {
+      if (quotaOnlyMode) return
       onNext()
       return
     }
@@ -333,7 +334,7 @@ export const RecruitInfoForm = forwardRef<
             type="button"
             variant="fill"
             color="primary"
-            disabled={isSaving}
+            disabled={isSaving || (quotaOnlyMode && isReadOnly)}
             onClick={() => void handleNext()}
           >
             {quotaOnlyMode ? "변경" : "다음"}


### PR DESCRIPTION
## 📸 작업 내용

> 매칭 기간 중 공개(IN_PROGRESS) 프로젝트의 모집 정원을 관리 권한 보유 운영진이 수정할 수 있도록 정원 전용 수정 모드를 추가했습니다.

- 기존에는 매칭 기간 중 공개 프로젝트 수정이 전면 차단되었으나, 관리 권한자에 한해 모집 정원만 수정할 수 있는 경로를 열었습니다.
- 관리 메뉴와 상세 모달의 '프로젝트 수정하기'를 매칭 기간 중에도 관리 권한자에게만 활성화합니다.
- 수정 화면 진입 시 모집 정보(2단계)로 바로 이동하고, 기본 정보(1단계)·지원 문항(3단계)은 잠급니다.
- 2단계 CTA를 '다음' 대신 '변경'으로 노출하고, 저장 시 모집 정원만 반영한 뒤 관리 페이지로 복귀합니다.
- 관리 권한이 없는 사용자는 기존과 동일하게 매칭 기간 중 수정 진입이 차단됩니다.
- 권한 판정 로딩 중 폼 깜빡임을 막는 로더와, 정원을 모두 비운 상태에서 빠져나갈 수 있는 '돌아가기' 버튼을 추가했습니다.

## 🎞️ 주요 코드 설명

> 정원 전용 모드는 단일 플래그로 진입 허용·단계 잠금·CTA 전환을 일괄 제어합니다.

### 정원 전용 모드 판정

```TypeScript
const isMatchingPeriodActive =
  isEditMode &&
  isInProgress &&
  matchingRoundsQuery.isSuccess &&
  isWithinMatchingPeriod(matchingRoundsQuery.data, new Date())

const isQuotaOnlyMode = isMatchingPeriodActive && canManageProject
```

- 매칭 기간 활성 + 공개 상태 + 관리 권한이 모두 충족될 때만 정원 전용 모드가 켜집니다.
- 관리 권한이 없으면 매칭 기간 중 수정 화면 진입 시 관리 페이지로 되돌립니다(권한 판정 로딩 중에는 대기).

## 🖥️ 구현화면

> 매칭 차수 활성 + 공개 프로젝트 + 관리 권한 계정 조건에서의 로컬 캡처를 추후 첨부합니다.

|          정원 전용 수정 모드          |
| :-----------------------------------: |
|      <img src = "" width ="250">      |

## 🔗 연결된 이슈

- Connected: #496
- Closes #496