### PR TITLE
🐛 fix: 매칭 지원 마감 후 이전 차수 합/불 처리 불가 수정

### DIFF
--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query"
 import { useMemo } from "react"
 
+import { useMe } from "@/features/auth/hooks/useMe"
+import { getLatestChallengerRecord } from "@/features/auth/model/identity"
 import {
   getAllChapters,
   getAllSchools,
@@ -23,6 +25,7 @@ import {
   toProjectApplication,
   toRoundNumber,
 } from "../model/mappers"
+import { buildDecisionDeadlineByRound } from "../model/matchingDecision"
 
 import type { MatchingRoundResponse } from "../model/apiTypes"
 import type {
@@ -74,6 +77,20 @@ export function useChallengerPageData(
   const enabled = options.enabled ?? true
   const gisuQuery = useActiveGisuId({ enabled })
   const gisuId = gisuQuery.data ?? 0
+
+  // PM 본인 지부의 매칭 차수(decisionDeadline) -> 차수별 합/불 결정 마감 잠금용
+  const meQuery = useMe()
+  const pmChapterIdRaw = getLatestChallengerRecord(meQuery.data)?.chapterId
+  const pmChapterId = pmChapterIdRaw ? Number(pmChapterIdRaw) : undefined
+  const roundsQuery = useQuery({
+    queryKey: applicationKeys.matchingRounds(pmChapterId),
+    queryFn: () => getMatchingRounds(pmChapterId),
+    enabled: enabled && pmChapterId !== undefined,
+  })
+  const decisionDeadlineByRound = useMemo(
+    () => buildDecisionDeadlineByRound(roundsQuery.data),
+    [roundsQuery.data],
+  )
 
   const projectsQuery = useQuery({
     queryKey: applicationKeys.managedProjects(gisuId),
@@ -188,6 +205,7 @@ export function useChallengerPageData(
     projects: transformed,
     projectInfo,
     currentRound,
+    decisionDeadlineByRound,
     availablePerRound,
     projectStats: projectStatsQuery.data ?? [],
     schoolIdToName,
@@ -284,6 +302,10 @@ export function useAdminPageData(
   })
   const { currentRound, activeRound } = useMemo(
     () => getCurrentRound(roundsQuery.data ?? []),
+    [roundsQuery.data],
+  )
+  const decisionDeadlineByRound = useMemo(
+    () => buildDecisionDeadlineByRound(roundsQuery.data),
     [roundsQuery.data],
   )
 
@@ -443,6 +465,7 @@ export function useAdminPageData(
     stats,
     currentRound,
     activeRound,
+    decisionDeadlineByRound,
     dataUpdatedAt: projectsQuery.dataUpdatedAt,
     chapters,
     isLoading:

--- a/src/features/application/model/matchingDecision.test.ts
+++ b/src/features/application/model/matchingDecision.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildDecisionDeadlineByRound,
+  isRoundDecisionClosed,
+} from "./matchingDecision"
+
+import type { MatchingRoundResponse } from "./apiTypes"
+
+function makeRound(
+  phase: MatchingRoundResponse["phase"],
+  decisionDeadline: string,
+): MatchingRoundResponse {
+  return {
+    id: "1",
+    name: `${phase} 차수`,
+    description: "",
+    type: "PLAN_DEVELOPER",
+    phase,
+    chapterId: "1",
+    startsAt: "2026-06-01T00:00:00Z",
+    endsAt: "2026-06-05T00:00:00Z",
+    decisionDeadline,
+    autoDecisionExecutedAt: null,
+    autoDecisionExecutedMemberId: null,
+    createdAt: "2026-06-01T00:00:00Z",
+    updatedAt: "2026-06-01T00:00:00Z",
+  }
+}
+
+describe("buildDecisionDeadlineByRound", () => {
+  it("phase를 차수 번호로 매핑해 decisionDeadline(ms)을 담는다", () => {
+    const map = buildDecisionDeadlineByRound([
+      makeRound("FIRST", "2026-06-10T00:00:00Z"),
+      makeRound("SECOND", "2026-06-20T00:00:00Z"),
+      makeRound("THIRD", "2026-06-30T00:00:00Z"),
+    ])
+    expect(map.get(1)).toBe(new Date("2026-06-10T00:00:00Z").getTime())
+    expect(map.get(2)).toBe(new Date("2026-06-20T00:00:00Z").getTime())
+    expect(map.get(3)).toBe(new Date("2026-06-30T00:00:00Z").getTime())
+  })
+
+  it("rounds가 없으면 빈 맵", () => {
+    expect(buildDecisionDeadlineByRound(undefined).size).toBe(0)
+    expect(buildDecisionDeadlineByRound([]).size).toBe(0)
+  })
+
+  it("같은 차수가 중복되면 더 늦은 마감을 채택한다", () => {
+    const map = buildDecisionDeadlineByRound([
+      makeRound("FIRST", "2026-06-10T00:00:00Z"),
+      makeRound("FIRST", "2026-06-15T00:00:00Z"),
+    ])
+    expect(map.get(1)).toBe(new Date("2026-06-15T00:00:00Z").getTime())
+  })
+})
+
+describe("isRoundDecisionClosed", () => {
+  const map = buildDecisionDeadlineByRound([
+    makeRound("FIRST", "2026-06-10T00:00:00Z"),
+    makeRound("SECOND", "2026-06-20T00:00:00Z"),
+  ])
+
+  it("결정 마감 전이면 잠그지 않는다(1차 마감 후 2차 진행 중이어도 1차 결정 가능)", () => {
+    const now = new Date("2026-06-08T00:00:00Z").getTime()
+    expect(isRoundDecisionClosed(1, map, now)).toBe(false)
+  })
+
+  it("결정 마감이 지나면 잠근다", () => {
+    const now = new Date("2026-06-11T00:00:00Z").getTime()
+    expect(isRoundDecisionClosed(1, map, now)).toBe(true)
+    expect(isRoundDecisionClosed(2, map, now)).toBe(false)
+  })
+
+  it("마감 정보가 없는 차수/맵은 잠그지 않는다(서버가 최종 검증)", () => {
+    const now = new Date("2026-06-25T00:00:00Z").getTime()
+    expect(isRoundDecisionClosed(3, map, now)).toBe(false)
+    expect(isRoundDecisionClosed(1, undefined, now)).toBe(false)
+  })
+})

--- a/src/features/application/model/matchingDecision.ts
+++ b/src/features/application/model/matchingDecision.ts
@@ -1,0 +1,29 @@
+import { toRoundNumber } from "./mappers"
+
+import type { MatchingRoundResponse } from "./apiTypes"
+
+// 차수 번호 -> 합/불 결정 마감(decisionDeadline) epoch ms
+// 서버 규칙(APPLY-103): 합/불 결정은 지원 종료(endsAt) 후 ~ 결정 마감(decisionDeadline) 전까지 가능
+export function buildDecisionDeadlineByRound(
+  rounds: MatchingRoundResponse[] | undefined,
+): Map<number, number> {
+  const map = new Map<number, number>()
+  for (const round of rounds ?? []) {
+    const roundNo = toRoundNumber(round.phase)
+    const ms = new Date(round.decisionDeadline).getTime()
+    if (!Number.isFinite(ms)) continue
+    const prev = map.get(roundNo)
+    if (prev === undefined || ms > prev) map.set(roundNo, ms)
+  }
+  return map
+}
+
+// 해당 차수의 결정 마감이 지났으면 true(잠금). 마감 정보가 없으면 잠그지 않는다(서버가 최종 검증).
+export function isRoundDecisionClosed(
+  round: number,
+  deadlineByRound: Map<number, number> | undefined,
+  now: number,
+): boolean {
+  const deadline = deadlineByRound?.get(round)
+  return deadline !== undefined && now > deadline
+}

--- a/src/features/application/ui/ApplicationDetailModal.tsx
+++ b/src/features/application/ui/ApplicationDetailModal.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import { useToastStore } from "@/components/toast/useToastStore"
 import { useResourcePermissionsBatch } from "@/features/auth/hooks/useResourcePermissionsBatch"
 import { Modal } from "@/shared/ui/Modal"
+import { CtaModal } from "@/shared/ui/modal/CtaModal"
 
 import { updateApplicationDecision } from "../api/applicationApi"
 import { applicationKeys } from "../api/applicationKeys"
@@ -38,6 +39,38 @@ function toApplicationId(applicantId: string): number | null {
   return Number.isFinite(id) && id > 0 ? id : null
 }
 
+// 합/불 상태 변경 확인 모달 문구 (대기는 PM 뷰에서 노출되지 않으나 타입 완전성 위해 포함)
+const DECISION_CONFIRM: Record<
+  StatusValue,
+  {
+    title: string
+    confirmText: string
+    variant: "success" | "warning" | "error"
+  }
+> = {
+  pass: {
+    title: "합격 처리할까요?",
+    confirmText: "합격 처리",
+    variant: "success",
+  },
+  fail: {
+    title: "불합격 처리할까요?",
+    confirmText: "불합격 처리",
+    variant: "warning",
+  },
+  pending: {
+    title: "대기로 변경할까요?",
+    confirmText: "변경",
+    variant: "warning",
+  },
+}
+
+const STATUS_LABEL: Record<StatusValue, string> = {
+  pass: "합격",
+  fail: "불합격",
+  pending: "대기",
+}
+
 export function ApplicationDetailModal({
   project,
   chapterName,
@@ -58,6 +91,11 @@ export function ApplicationDetailModal({
   const [statusOverrides, setStatusOverrides] = useState<
     Record<string, StatusValue>
   >({})
+  // 합/불 변경 확인 모달 대기 상태 (확인 시에만 실제 반영)
+  const [pendingDecision, setPendingDecision] = useState<{
+    applicantId: string
+    status: StatusValue
+  } | null>(null)
 
   // 이중 실행 방지용 ref (Strict Mode 대응)
   const emptyToastShownRef = useRef(false)
@@ -201,8 +239,19 @@ export function ApplicationDetailModal({
     )
     if (!applicant) return
     if (!canChangeApplicantStatus(applicant.id, applicant.round)) return
-    setStatusOverrides((prev) => ({ ...prev, [applicant.id]: status }))
-    decisionMutation.mutate({ appId: Number(applicant.id), status })
+    if (applicant.status === status) return
+    // 즉시 반영하지 않고 확인 모달을 띄운다
+    setPendingDecision({ applicantId: applicant.id, status })
+  }
+
+  const handleConfirmDecision = () => {
+    if (!pendingDecision) return
+    const { applicantId, status } = pendingDecision
+    setStatusOverrides((prev) => ({ ...prev, [applicantId]: status }))
+    decisionMutation.mutate(
+      { appId: Number(applicantId), status },
+      { onSettled: () => setPendingDecision(null) },
+    )
   }
 
   const handleClose = () => {
@@ -211,90 +260,137 @@ export function ApplicationDetailModal({
     setRoundFilter([])
     setStatusFilter([])
     setStatusOverrides({})
+    setPendingDecision(null)
   }
 
   const handlePanelClose = () => {
     setSelectedApplicantId(null)
   }
 
+  const pendingApplicant = pendingDecision
+    ? (projectWithOverrides.applicants.find(
+        (a) => a.id === pendingDecision.applicantId,
+      ) ?? null)
+    : null
+  const decisionConfirm = pendingDecision
+    ? DECISION_CONFIRM[pendingDecision.status]
+    : null
+
   return (
-    <Modal.Root
-      open={open}
-      onOpenChange={(next) => (next ? onOpenChange(true) : handleClose())}
-    >
-      <Modal.Portal>
-        <Modal.Overlay tone="deep" />
-        <Modal.Content
-          className="top-20! bottom-7.5! flex h-[calc(100vh-110px)]! translate-y-0! items-start gap-4"
-          aria-describedby={undefined}
-          onOpenAutoFocus={(e) => e.preventDefault()}
-          onEscapeKeyDown={(e) => {
-            // 우측 패널 열려있으면 패널만 닫고, 없으면 전체 닫기
-            if (hasPanel) {
-              e.preventDefault()
-              handlePanelClose()
-            }
-          }}
-          onPointerDownOutside={(e) => {
-            const target = e.target as HTMLElement
-            if (target.closest("[data-status-chip-dropdown]")) {
-              e.preventDefault()
-              return
-            }
-            handleClose()
-          }}
-        >
-          <Modal.Title className="sr-only">
-            {project.projectName} 지원 현황 상세
-          </Modal.Title>
+    <>
+      <Modal.Root
+        open={open}
+        onOpenChange={(next) => (next ? onOpenChange(true) : handleClose())}
+      >
+        <Modal.Portal>
+          <Modal.Overlay tone="deep" />
+          <Modal.Content
+            className="top-20! bottom-7.5! flex h-[calc(100vh-110px)]! translate-y-0! items-start gap-4"
+            aria-describedby={undefined}
+            onOpenAutoFocus={(e) => e.preventDefault()}
+            onEscapeKeyDown={(e) => {
+              // 확인 모달 열려있으면 전체 모달은 그대로 유지
+              if (pendingDecision) {
+                e.preventDefault()
+                return
+              }
+              // 우측 패널 열려있으면 패널만 닫고, 없으면 전체 닫기
+              if (hasPanel) {
+                e.preventDefault()
+                handlePanelClose()
+              }
+            }}
+            onPointerDownOutside={(e) => {
+              // 확인 모달과 상호작용 중에는 전체 모달을 닫지 않는다
+              if (pendingDecision) {
+                e.preventDefault()
+                return
+              }
+              const target = e.target as HTMLElement
+              if (target.closest("[data-status-chip-dropdown]")) {
+                e.preventDefault()
+                return
+              }
+              handleClose()
+            }}
+          >
+            <Modal.Title className="sr-only">
+              {project.projectName} 지원 현황 상세
+            </Modal.Title>
 
-          <div className="flex h-full w-185 shrink-0 overflow-hidden rounded-xl bg-white shadow-xl">
-            <ModalApplicantPanel
-              project={projectWithOverrides}
-              chapterName={chapterName}
-              roundFilter={roundFilter}
-              statusFilter={statusFilter}
-              onRoundFilterChange={setRoundFilter}
-              onStatusFilterChange={setStatusFilter}
-              selectedApplicantId={selectedApplicantId}
-              onApplicantClick={
-                disableFormPanel ? () => {} : setSelectedApplicantId
-              }
-              onStatusChange={handleApplicantStatusChange}
-              onClose={handleClose}
-              currentRound={currentRound}
-              decisionDeadlineByRound={decisionDeadlineByRound}
-              canApproveApplicant={canApproveApplicant}
-              approvePermissionLoading={isApprovePermissionLoading}
-              statusOptions={hidePendingStatus ? ["pass", "fail"] : undefined}
-              className="w-full"
-            />
-          </div>
+            <div className="flex h-full w-185 shrink-0 overflow-hidden rounded-xl bg-white shadow-xl">
+              <ModalApplicantPanel
+                project={projectWithOverrides}
+                chapterName={chapterName}
+                roundFilter={roundFilter}
+                statusFilter={statusFilter}
+                onRoundFilterChange={setRoundFilter}
+                onStatusFilterChange={setStatusFilter}
+                selectedApplicantId={selectedApplicantId}
+                onApplicantClick={
+                  disableFormPanel ? () => {} : setSelectedApplicantId
+                }
+                onStatusChange={handleApplicantStatusChange}
+                onClose={handleClose}
+                currentRound={currentRound}
+                decisionDeadlineByRound={decisionDeadlineByRound}
+                canApproveApplicant={canApproveApplicant}
+                approvePermissionLoading={isApprovePermissionLoading}
+                statusOptions={hidePendingStatus ? ["pass", "fail"] : undefined}
+                className="w-full"
+              />
+            </div>
 
-          {hasPanel && selectedApplicant && (
-            <ModalFormPanel
-              applicant={selectedApplicant}
-              formData={formData}
-              chapterName={chapterName}
-              projectName={project.projectName}
-              challengerName={project.challengerName}
-              challengerUniversity={project.challengerUniversity}
-              onStatusChange={(status) =>
-                handleApplicantStatusChange(selectedApplicant.id, status)
-              }
-              onClose={handlePanelClose}
-              statusDisabled={
-                !canChangeApplicantStatus(
-                  selectedApplicant.id,
-                  selectedApplicant.round,
-                )
-              }
-              hidePendingStatus={hidePendingStatus}
-              className="max-h-[calc(100vh-60px)] shadow-xl"
-            />
-          )}
-        </Modal.Content>
-      </Modal.Portal>
-    </Modal.Root>
+            {hasPanel && selectedApplicant && (
+              <ModalFormPanel
+                applicant={selectedApplicant}
+                formData={formData}
+                chapterName={chapterName}
+                projectName={project.projectName}
+                challengerName={project.challengerName}
+                challengerUniversity={project.challengerUniversity}
+                onStatusChange={(status) =>
+                  handleApplicantStatusChange(selectedApplicant.id, status)
+                }
+                onClose={handlePanelClose}
+                statusDisabled={
+                  !canChangeApplicantStatus(
+                    selectedApplicant.id,
+                    selectedApplicant.round,
+                  )
+                }
+                hidePendingStatus={hidePendingStatus}
+                className="max-h-[calc(100vh-60px)] shadow-xl"
+              />
+            )}
+          </Modal.Content>
+        </Modal.Portal>
+      </Modal.Root>
+
+      {pendingDecision && pendingApplicant && decisionConfirm && (
+        <CtaModal
+          open
+          title={decisionConfirm.title}
+          content={
+            <>
+              {pendingApplicant.name} · {pendingApplicant.university} 지원자를{" "}
+              {STATUS_LABEL[pendingDecision.status]} 처리합니다.
+            </>
+          }
+          cancelText="취소"
+          confirmText={decisionConfirm.confirmText}
+          variant={decisionConfirm.variant}
+          overlayTone="deep"
+          confirmLoading={decisionMutation.isPending}
+          onOpenChange={(next) => {
+            if (!next && !decisionMutation.isPending) setPendingDecision(null)
+          }}
+          onCancel={() => {
+            if (!decisionMutation.isPending) setPendingDecision(null)
+          }}
+          onConfirm={handleConfirmDecision}
+        />
+      )}
+    </>
   )
 }

--- a/src/features/application/ui/ApplicationDetailModal.tsx
+++ b/src/features/application/ui/ApplicationDetailModal.tsx
@@ -10,6 +10,7 @@ import { updateApplicationDecision } from "../api/applicationApi"
 import { applicationKeys } from "../api/applicationKeys"
 import { useApplicationDetail } from "../hooks/useApplications"
 import { toApplicantFormData, toServerStatus } from "../model/mappers"
+import { isRoundDecisionClosed } from "../model/matchingDecision"
 import { ModalApplicantPanel } from "./detail-modal/ModalApplicantPanel"
 import { ModalFormPanel } from "./detail-modal/ModalFormPanel"
 
@@ -22,8 +23,10 @@ interface ApplicationDetailModalProps {
   chapterName: string
   open: boolean
   onOpenChange: (open: boolean) => void
-  /** 현재 활성 차수 (이전 차수의 상태 칩 disabled 처리) */
+  /** 현재 활성 차수 (배정 안내 툴팁 분기용) */
   currentRound?: number
+  /** 차수별 합/불 결정 마감(decisionDeadline) - 마감 지난 차수의 상태 변경 잠금 */
+  decisionDeadlineByRound?: Map<number, number>
   /** APPLY-102 권한 없는 역할(SCHOOL_PRESIDENT 등) - 지원자 행 클릭 시 폼 패널 열리지 않음 */
   disableFormPanel?: boolean
   /** 플랜 챌린저(PM) 뷰: 대기 상태 옵션 숨김 */
@@ -41,6 +44,7 @@ export function ApplicationDetailModal({
   open,
   onOpenChange,
   currentRound,
+  decisionDeadlineByRound,
   disableFormPanel = false,
   hidePendingStatus = false,
 }: ApplicationDetailModalProps) {
@@ -186,7 +190,7 @@ export function ApplicationDetailModal({
   ): boolean =>
     !isApprovePermissionLoading &&
     canApproveApplicant(applicantId) &&
-    !(currentRound != null && applicantRound < currentRound)
+    !isRoundDecisionClosed(applicantRound, decisionDeadlineByRound, Date.now())
 
   const handleApplicantStatusChange = (
     applicantId: string,
@@ -259,6 +263,7 @@ export function ApplicationDetailModal({
               onStatusChange={handleApplicantStatusChange}
               onClose={handleClose}
               currentRound={currentRound}
+              decisionDeadlineByRound={decisionDeadlineByRound}
               canApproveApplicant={canApproveApplicant}
               approvePermissionLoading={isApprovePermissionLoading}
               statusOptions={hidePendingStatus ? ["pass", "fail"] : undefined}

--- a/src/features/application/ui/ApplicationTableSection.tsx
+++ b/src/features/application/ui/ApplicationTableSection.tsx
@@ -63,8 +63,10 @@ interface ApplicationTableSectionProps {
   projects: ProjectApplication[]
   searchPlaceholder?: string
   visibleFilters?: FilterName[]
-  /** 현재 활성 차수 (이전 차수의 상태 칩 disabled 처리) */
+  /** 현재 활성 차수 (배정 안내 툴팁 분기용) */
   currentRound?: number
+  /** 차수별 합/불 결정 마감(decisionDeadline) - 마감 지난 차수의 상태 변경 잠금 */
+  decisionDeadlineByRound?: Map<number, number>
   /** 현재 선택된 챕터 이름 (상세 모달 전달용) */
   chapterName?: string
   /** APPLY-102 단건 상세 권한 없는 역할(SCHOOL_PRESIDENT 등)일 때 true - 모달은 열리지만 폼 패널 비활성 */
@@ -84,6 +86,7 @@ export function ApplicationTableSection({
   searchPlaceholder = "프로젝트 명으로 검색하세요.",
   visibleFilters = DEFAULT_FILTERS,
   currentRound,
+  decisionDeadlineByRound,
   chapterName,
   disableFormPanel = false,
   hidePendingStatus = false,
@@ -372,6 +375,7 @@ export function ApplicationTableSection({
           open={detailModalOpen}
           onOpenChange={setDetailModalOpen}
           currentRound={currentRound}
+          decisionDeadlineByRound={decisionDeadlineByRound}
           disableFormPanel={disableFormPanel}
           hidePendingStatus={hidePendingStatus}
         />

--- a/src/features/application/ui/ChallengerApplicationView.tsx
+++ b/src/features/application/ui/ChallengerApplicationView.tsx
@@ -15,6 +15,7 @@ interface ChallengerApplicationViewProps {
   projectStats?: ProjectStatisticsResponse[]
   schoolIdToName?: Map<string, string>
   currentRound?: number
+  decisionDeadlineByRound?: Map<number, number>
   className?: string
 }
 
@@ -116,6 +117,7 @@ export function ChallengerApplicationView({
   projectStats,
   schoolIdToName,
   currentRound,
+  decisionDeadlineByRound,
   className,
 }: ChallengerApplicationViewProps) {
   const stats = useMemo(
@@ -138,6 +140,7 @@ export function ChallengerApplicationView({
         searchPlaceholder="닉네임/이름으로 검색하세요."
         visibleFilters={["part", "school"]}
         currentRound={currentRound}
+        decisionDeadlineByRound={decisionDeadlineByRound}
         hidePendingStatus
       />
     </div>

--- a/src/features/application/ui/detail-modal/ApplicantRoleSection.tsx
+++ b/src/features/application/ui/detail-modal/ApplicantRoleSection.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/shared/lib/utils"
 import { PartTagChip } from "@/shared/ui/chip/PartTagChip"
 
+import { isRoundDecisionClosed } from "../../model/matchingDecision"
 import { ApplicantRow } from "./ApplicantRow"
 
 import type { ApplicantDetail, Role, StatusValue } from "../../model/types"
@@ -12,7 +13,7 @@ interface ApplicantRoleSectionProps {
   selectedApplicantId: string | null
   onApplicantClick: (id: string) => void
   onStatusChange?: (applicantId: string, status: StatusValue) => void
-  currentRound?: number
+  decisionDeadlineByRound?: Map<number, number>
   canApproveApplicant: (applicantId: string) => boolean
   approvePermissionLoading: boolean
   statusOptions?: StatusValue[]
@@ -26,7 +27,7 @@ export function ApplicantRoleSection({
   selectedApplicantId,
   onApplicantClick,
   onStatusChange,
-  currentRound,
+  decisionDeadlineByRound,
   canApproveApplicant,
   approvePermissionLoading,
   statusOptions,
@@ -76,7 +77,11 @@ export function ApplicantRoleSection({
           const statusDisabled =
             approvePermissionLoading ||
             !canApproveApplicant(applicant.id) ||
-            (currentRound != null && applicant.round < currentRound)
+            isRoundDecisionClosed(
+              applicant.round,
+              decisionDeadlineByRound,
+              Date.now(),
+            )
 
           return (
             <ApplicantRow

--- a/src/features/application/ui/detail-modal/ModalApplicantPanel.tsx
+++ b/src/features/application/ui/detail-modal/ModalApplicantPanel.tsx
@@ -37,6 +37,7 @@ interface ModalApplicantPanelProps {
   onStatusChange?: (applicantId: string, status: StatusValue) => void
   onClose: () => void
   currentRound?: number
+  decisionDeadlineByRound?: Map<number, number>
   canApproveApplicant: (applicantId: string) => boolean
   approvePermissionLoading: boolean
   statusOptions?: StatusValue[]
@@ -55,6 +56,7 @@ export function ModalApplicantPanel({
   onStatusChange,
   onClose,
   currentRound,
+  decisionDeadlineByRound,
   canApproveApplicant,
   approvePermissionLoading,
   statusOptions,
@@ -249,7 +251,7 @@ export function ModalApplicantPanel({
               selectedApplicantId={selectedApplicantId}
               onApplicantClick={onApplicantClick}
               onStatusChange={onStatusChange}
-              currentRound={currentRound}
+              decisionDeadlineByRound={decisionDeadlineByRound}
               canApproveApplicant={canApproveApplicant}
               approvePermissionLoading={approvePermissionLoading}
               statusOptions={statusOptions}
@@ -266,7 +268,7 @@ export function ModalApplicantPanel({
                 selectedApplicantId={selectedApplicantId}
                 onApplicantClick={onApplicantClick}
                 onStatusChange={onStatusChange}
-                currentRound={currentRound}
+                decisionDeadlineByRound={decisionDeadlineByRound}
                 canApproveApplicant={canApproveApplicant}
                 approvePermissionLoading={approvePermissionLoading}
                 statusOptions={statusOptions}

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -234,6 +234,7 @@ function MatchingApplicationsPage() {
                   projectStats={challenger.projectStats}
                   schoolIdToName={challenger.schoolIdToName}
                   currentRound={challenger.currentRound}
+                  decisionDeadlineByRound={challenger.decisionDeadlineByRound}
                 />
               ) : (
                 pmProjects.map((project) => (
@@ -253,6 +254,7 @@ function MatchingApplicationsPage() {
                       )}
                       schoolIdToName={challenger.schoolIdToName}
                       currentRound={challenger.currentRound}
+                      decisionDeadlineByRound={challenger.decisionDeadlineByRound}
                     />
                   </div>
                 ))


### PR DESCRIPTION
## 📸 작업 내용

> 매칭 상세 모달에서 상위 차수가 진행되면 이전 차수 지원자의 합/불 변경이 막히던 문제를 수정했습니다.

- 합/불 상태 변경 잠금 판정을 단일 스칼라 비교(`현재 차수`보다 낮은 차수면 잠금)에서 **차수별 결정 마감(`decisionDeadline`) 비교**로 교체
- 차수 간 결합을 제거해, 상위 차수 진행 여부와 무관하게 각 차수는 **자기 결정 마감 전까지** 합/불 변경 가능 (1·2·3차 대칭 동작)
- 매칭 차수 API 응답에서 차수별 `decisionDeadline` 맵을 구성하는 헬퍼(`matchingDecision.ts`) 추가, 두 페이지 훅(`useChallengerPageData`/`useAdminPageData`)에서 노출
- 잠금 기준 데이터를 상세 모달 트리(`ApplicationTableSection` → `ApplicationDetailModal` → `ModalApplicantPanel` → `ApplicantRoleSection`)로 전달
- 차수별 잠금 판정 단위 테스트 추가
- 안내 툴팁/통계 표시용 `currentRound`는 그대로 유지 (게이트에서만 분리)

## 🎞️ 주요 코드 설명

### 차수별 결정 마감 잠금 헬퍼

```TypeScript
export function isRoundDecisionClosed(
  round: number,
  deadlineByRound: Map<number, number> | undefined,
  now: number,
): boolean {
  const deadline = deadlineByRound?.get(round)
  return deadline !== undefined && now > deadline
}
```

- 해당 차수의 `decisionDeadline`이 지났을 때만 잠금. 마감 정보가 없으면 잠그지 않음(관대).

### 게이트 적용

```TypeScript
const statusDisabled =
  approvePermissionLoading ||
  !canApproveApplicant(applicant.id) ||
  isRoundDecisionClosed(applicant.round, decisionDeadlineByRound, Date.now())
```

- 기존 `applicant.round < currentRound` 비교를 제거하고 차수별 독립 판정으로 변경.

## 🔗 연결된 이슈

- Connected: #498
- Closes #498