### PR TITLE
fix: 프로젝트 멤버 수동 배정 시 Frontend 하위 파트 고정 오류 수정

### DIFF
--- a/src/features/matching/model/matchingStatusMapper.ts
+++ b/src/features/matching/model/matchingStatusMapper.ts
@@ -65,20 +65,22 @@ function getNeededParts(
   const subParts = ROLE_TO_PARTS[role] ?? []
   const neededParts: Part[] = []
 
+  const filledCounts = new Map<string, number>()
+  if (members) {
+    for (const group of members.partGroups) {
+      filledCounts.set(group.part, group.members.length)
+    }
+  } else {
+    for (const app of approvedAppByMemberId.values()) {
+      const p = app.applicant.part
+      filledCounts.set(p, (filledCounts.get(p) ?? 0) + 1)
+    }
+  }
+
   for (const part of subParts) {
     const partQuota =
       Number(partQuotas.find((q) => q.part === part)?.quota) || 0
-
-    let filledCount = 0
-    if (members) {
-      const group = members.partGroups.find((g) => g.part === part)
-      filledCount = group ? group.members.length : 0
-    } else {
-      filledCount = Array.from(approvedAppByMemberId.values()).filter(
-        (app) => app.applicant.part === part,
-      ).length
-    }
-
+    const filledCount = filledCounts.get(part) ?? 0
     const needed = Math.max(0, partQuota - filledCount)
     for (let i = 0; i < needed; i++) {
       neededParts.push(part as Part)

--- a/src/features/matching/model/matchingStatusMapper.ts
+++ b/src/features/matching/model/matchingStatusMapper.ts
@@ -6,6 +6,7 @@ import type {
   ManagedProjectSummaryResponse,
   ProjectApplicantResponse,
 } from "@/features/application/model/apiTypes"
+import type { Part } from "@/features/challenger/model/types"
 import type { ProjectMembersResponse } from "@/features/project/list/api/matchingProject"
 
 import type {
@@ -46,6 +47,44 @@ const PART_TO_ROLE: Record<string, string> = {
   IOS: "Frontend",
   SPRINGBOOT: "Backend",
   NODEJS: "Backend",
+}
+
+const ROLE_TO_PARTS: Record<string, string[]> = {
+  Design: ["DESIGN"],
+  Frontend: ["WEB", "ANDROID", "IOS"],
+  Backend: ["SPRINGBOOT", "NODEJS"],
+}
+
+// 각 역할에 대해 아직 채워지지 않은 파트별 남은 슬롯 수 계산
+function getNeededParts(
+  role: string,
+  partQuotas: ManagedProjectSummaryResponse["partQuotas"],
+  approvedAppByMemberId: Map<string, ProjectApplicantResponse>,
+  members: ProjectMembersResponse | undefined,
+): Part[] {
+  const subParts = ROLE_TO_PARTS[role] ?? []
+  const neededParts: Part[] = []
+
+  for (const part of subParts) {
+    const partQuota =
+      Number(partQuotas.find((q) => q.part === part)?.quota) || 0
+
+    let filledCount = 0
+    if (members) {
+      const group = members.partGroups.find((g) => g.part === part)
+      filledCount = group ? group.members.length : 0
+    } else {
+      filledCount = Array.from(approvedAppByMemberId.values()).filter(
+        (app) => app.applicant.part === part,
+      ).length
+    }
+
+    const needed = Math.max(0, partQuota - filledCount)
+    for (let i = 0; i < needed; i++) {
+      neededParts.push(part as Part)
+    }
+  }
+  return neededParts
 }
 
 // 섹션 헤더용 FE 플랫폼 분류
@@ -95,6 +134,7 @@ function toMatchingProject(
                 String(app.applicationId),
               ),
               memberId: String(member.memberId),
+              part: group.part as Part,
             }
           : member.matchedRoundInfo
             ? {
@@ -103,6 +143,7 @@ function toMatchingProject(
                   displayName,
                 ),
                 memberId: String(member.memberId),
+                part: group.part as Part,
               }
             : {
                 // matchedRoundInfo 미제공: 배정 차수 알 수 없음 → 랜덤 매칭으로 표기
@@ -111,6 +152,7 @@ function toMatchingProject(
                 name: displayName,
                 tagVariant: "random" as const,
                 memberId: String(member.memberId),
+                part: group.part as Part,
               }
         const list = blocksByRole.get(role) ?? []
         list.push(block)
@@ -131,6 +173,7 @@ function toMatchingProject(
           String(app.applicationId),
         ),
         memberId: app.applicant.memberId,
+        part: app.applicant.part as Part,
       }
       const list = blocksByRole.get(role) ?? []
       list.push(block)
@@ -157,9 +200,18 @@ function toMatchingProject(
       0,
       Math.min(quota, totalSlots) - filledBlocks.length,
     )
+    const neededParts = getNeededParts(
+      "Design",
+      project.partQuotas,
+      approvedAppByMemberId,
+      members,
+    )
     const emptyBlocks: MatchingBlockData[] = Array.from(
       { length: emptyCount },
-      () => ({ type: "none" }),
+      (_, index) => ({
+        type: "none",
+        part: neededParts[index] as Part,
+      }),
     )
     return {
       role: "Design",
@@ -179,9 +231,18 @@ function toMatchingProject(
     )
 
     const emptyCount = Math.max(0, quota - filledBlocks.length)
+    const neededParts = getNeededParts(
+      role,
+      project.partQuotas,
+      approvedAppByMemberId,
+      members,
+    )
     const emptyBlocks: MatchingBlockData[] = Array.from(
       { length: emptyCount },
-      () => ({ type: "none" }),
+      (_, index) => ({
+        type: "none",
+        part: neededParts[index] as Part,
+      }),
     )
     const blockedCount = totalSlots - filledBlocks.length - emptyCount
     const blockedBlocks: MatchingBlockData[] = Array.from(

--- a/src/features/matching/ui/MatchingResultRow.tsx
+++ b/src/features/matching/ui/MatchingResultRow.tsx
@@ -37,6 +37,7 @@ export interface MatchingBlockData {
   tagVariant?: NumberTagVariant
   applicantId?: string
   memberId?: string
+  part?: Part
 }
 
 export interface MatchingRoleRow {
@@ -89,6 +90,7 @@ export function MatchingResultRow({
     rowIdx: number
     blockIdx: number
     role: string
+    part?: Part
   } | null>(null)
   const [manualUnmatchTarget, setManualUnmatchTarget] = useState<{
     memberId: string
@@ -184,7 +186,7 @@ export function MatchingResultRow({
         idx === rowIdx ? { ...row, blocks: newBlocks } : row,
       ),
     )
-  }, [roleRows])
+  }, [roleRows, projectId])
 
   // 블록 배열을 colsPerRow 단위로 청크 분할
   const chunkedRows = localRoleRows.map((row) => {
@@ -298,6 +300,7 @@ export function MatchingResultRow({
                                   rowIdx,
                                   blockIdx: flatOffset + blockIdx,
                                   role: row.role,
+                                  part: block.part,
                                 })
                             : undefined
                         }
@@ -442,9 +445,10 @@ export function MatchingResultRow({
           challengerUniversity={challengerUniversity}
           role={assignTarget?.role ?? ""}
           part={
-            assignTarget
+            assignTarget?.part ??
+            (assignTarget
               ? roleToPart(assignTarget.role, backendPart)
-              : undefined
+              : undefined)
           }
           gisuId={gisuId}
           chapterId={chapterId}
@@ -465,6 +469,7 @@ export function MatchingResultRow({
               name: challenger.nickname,
               tagVariant: "random" as NumberTagVariant,
               memberId: String(challenger.id),
+              part: assignTarget.part,
             }
             setLocalRoleRows((prev) =>
               prev.map((row, rIdx) =>
@@ -481,7 +486,8 @@ export function MatchingResultRow({
               ),
             )
             // 서버 API 호출 - 실패 시 throw해서 AssignmentModal에서 완료 모달 미표시
-            const part = roleToPart(assignTarget.role, backendPart)
+            const part =
+              assignTarget.part ?? roleToPart(assignTarget.role, backendPart)
             await assignMutation.mutateAsync({
               memberId: String(challenger.id),
               part,

--- a/src/features/matching/ui/MatchingResultRow.tsx
+++ b/src/features/matching/ui/MatchingResultRow.tsx
@@ -445,10 +445,10 @@ export function MatchingResultRow({
           challengerUniversity={challengerUniversity}
           role={assignTarget?.role ?? ""}
           part={
-            assignTarget?.part ??
-            (assignTarget
-              ? roleToPart(assignTarget.role, backendPart)
-              : undefined)
+            assignTarget
+              ? (assignTarget.part ??
+                roleToPart(assignTarget.role, backendPart))
+              : undefined
           }
           gisuId={gisuId}
           chapterId={chapterId}


### PR DESCRIPTION
## 📸 작업 내용

프로젝트 멤버 수동 배정 시 Frontend 역할군 내의 하위 파트가 WEB으로 고정되는 문제를 해결하고, 각 빈 슬롯이 가리키는 정확한 하위 파트(WEB, ANDROID, IOS)로 멤버가 매칭 및 검색될 수 있도록 개선했습니다.

- Frontend 역할군의 매칭 슬롯이 WEB, ANDROID, IOS 중 실제 필요 파트를 가리키도록 `getNeededParts` 로직 추가
- `MatchingBlockData` 및 `assignTarget` 상태에 `part` 필드를 지정하여 선택한 슬롯의 정확한 하위 파트가 전달되도록 개선
- 수동 배정 등록 및 검색용 API 호출 시 올바른 파트 파라미터가 들어가도록 매핑
- `getNeededParts` 헬퍼 함수를 순수 함수로 분리하여 모듈화(리팩토링)하고, `part` 데이터 주입 시 안전하게 기본값으로 대피할 수 있는 방어 코드(Fallback) 구현

## 🎞️ 주요 코드 설명

### 1. 매칭 빈 슬롯의 정확한 하위 파트 계산을 위한 `getNeededParts` 추가 및 모듈화

```TypeScript
// 각 역할에 대해 아직 채워지지 않은 파트별 남은 슬롯 수 계산
function getNeededParts(
  role: string,
  partQuotas: ManagedProjectSummaryResponse["partQuotas"],
  approvedAppByMemberId: Map<string, ProjectApplicantResponse>,
  members: ProjectMembersResponse | undefined,
): Part[] {
  const subParts = ROLE_TO_PARTS[role] ?? []
  const neededParts: Part[] = []

  for (const part of subParts) {
    const partQuota =
      Number(partQuotas.find((q) => q.part === part)?.quota) || 0

    let filledCount = 0
    if (members) {
      const group = members.partGroups.find((g) => g.part === part)
      filledCount = group ? group.members.length : 0
    } else {
      filledCount = Array.from(approvedAppByMemberId.values()).filter(
        (app) => app.applicant.part === part,
      ).length
    }

    const needed = Math.max(0, partQuota - filledCount)
    for (let i = 0; i < needed; i++) {
      neededParts.push(part as Part)
    }
  }
  return neededParts
}
```

- 각 역할군(Design, Frontend, Backend)별 세부 파트 리스트(`Design: DESIGN`, `Frontend: WEB, ANDROID, IOS`, `Backend: SPRINGBOOT, NODEJS`)를 순회하면서, 할당된 Quota와 현재 매칭되어 있는 멤버 수를 대조합니다.
- 아직 채워지지 않은 파트별 남은 슬롯의 리스트를 만들어 `emptyBlocks` 구성 시 정확한 `part` 정보를 바인딩합니다.

### 2. 컴포넌트 레벨에서의 `part` 주입 및 방어 코드 구축

```TypeScript
// src/features/matching/ui/MatchingResultRow.tsx
<AssignmentModal
  open={assignTarget !== null}
  onOpenChange={(open) => {
    if (!open) setAssignTarget(null)
  }}
  projectName={projectName}
  challengerName={challengerName}
  challengerUniversity={challengerUniversity}
  role={assignTarget?.role ?? ""}
  part={
    assignTarget?.part ??
    (assignTarget
      ? roleToPart(assignTarget.role, backendPart)
      : undefined)
  }
  ...
```

- 선택된 매칭 블록의 구체적인 `part` 정보를 Modal 컴포넌트에 주입하도록 수정했습니다.
- 혹시라도 `assignTarget.part`가 계산되지 않았거나 정의되지 않은 경우를 대비하여 `roleToPart(role, backendPart)`를 활용해 타입 세이프하게 동작을 백업하는 방어 코드를 구현했습니다.

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #505 
