### PR TITLE
fix: UI 버그 통합 수정

### DIFF
--- a/src/features/application/ui/ApplicantTableHead.tsx
+++ b/src/features/application/ui/ApplicantTableHead.tsx
@@ -1,3 +1,5 @@
+import { AnimatePresence, motion } from "motion/react"
+
 import CollapseAllIcon from "@/shared/assets/icon/expand-collapse/CollapseAllIcon"
 import ExpandAllIcon from "@/shared/assets/icon/expand-collapse/ExpandAllIcon"
 import { cn } from "@/shared/lib/utils"
@@ -56,11 +58,30 @@ export function ApplicantTableHead({
           onClick={onToggleAll}
           className="shadow-inner-neutral-2 flex size-6.5 shrink-0 items-center justify-center rounded-lg bg-teal-100 transition-colors hover:bg-teal-200"
         >
-          {hasExpanded ? (
-            <CollapseAllIcon width={24} height={24} className="text-teal-700" />
-          ) : (
-            <ExpandAllIcon width={24} height={24} className="text-teal-700" />
-          )}
+          <AnimatePresence mode="wait" initial={false}>
+            <motion.div
+              key={hasExpanded ? "collapse" : "expand"}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.15 }}
+              className="flex items-center justify-center"
+            >
+              {hasExpanded ? (
+                <CollapseAllIcon
+                  width={24}
+                  height={24}
+                  className="text-teal-700"
+                />
+              ) : (
+                <ExpandAllIcon
+                  width={24}
+                  height={24}
+                  className="text-teal-700"
+                />
+              )}
+            </motion.div>
+          </AnimatePresence>
         </button>
       )}
     </div>

--- a/src/features/application/ui/ApplicationDetailModal.tsx
+++ b/src/features/application/ui/ApplicationDetailModal.tsx
@@ -346,9 +346,7 @@ export function ApplicationDetailModal({
                 applicant={selectedApplicant}
                 formData={formData}
                 chapterName={chapterName}
-                projectName={project.projectName}
-                challengerName={project.challengerName}
-                challengerUniversity={project.challengerUniversity}
+                project={project}
                 onStatusChange={(status) =>
                   handleApplicantStatusChange(selectedApplicant.id, status)
                 }

--- a/src/features/application/ui/ApplicationStatsSection.tsx
+++ b/src/features/application/ui/ApplicationStatsSection.tsx
@@ -15,8 +15,6 @@ const ROUND_COLORS = [
   "var(--color-teal-200)",
 ] as const
 
-const ROUND_LABELS = ["1차 지원", "2차 지원", "3차 지원"] as const
-
 interface ApplicationStatsSectionProps {
   stats: ApplicationStats
   dataUpdatedAt?: number
@@ -34,6 +32,7 @@ const VARIANT_LABELS = {
     roundSuffix: "지원",
     top4Suffix: "지원",
     projectSectionTitle: "프로젝트별 지원 현황",
+    legendLabels: ["1차 지원", "2차 지원", "3차 지원"],
   },
   matching: {
     completedLabel: "매칭 완료",
@@ -41,6 +40,7 @@ const VARIANT_LABELS = {
     roundSuffix: "매칭",
     top4Suffix: "완료",
     projectSectionTitle: "프로젝트별 매칭 현황",
+    legendLabels: ["1차 매칭", "2차 매칭", "3차 매칭"],
   },
 } as const
 
@@ -291,7 +291,7 @@ export function ApplicationStatsSection({
             {labels.projectSectionTitle}
           </h3>
           <div className="flex items-center gap-2">
-            {ROUND_LABELS.map((label, i) => (
+            {labels.legendLabels.map((label, i) => (
               <ChartLegendLabel
                 key={label}
                 color={ROUND_COLORS[i]!}

--- a/src/features/application/ui/ProjectRoundBar.tsx
+++ b/src/features/application/ui/ProjectRoundBar.tsx
@@ -45,7 +45,7 @@ export function ProjectRoundBar({
           )
         })}
       </div>
-      <span className="text-body-2-medium text-teal-gray-900 mt-1.25 h-10.5 w-full text-center wrap-break-word">
+      <span className="text-body-2-medium text-teal-gray-900 mt-1.25 line-clamp-2 h-10.5 w-full text-center wrap-break-word break-all">
         {projectName}
       </span>
     </div>

--- a/src/features/application/ui/RankBar.tsx
+++ b/src/features/application/ui/RankBar.tsx
@@ -2,28 +2,31 @@ import { cva } from "class-variance-authority"
 
 import { cn } from "@/shared/lib/utils"
 
-const barVariants = cva("w-full rounded-t-[0.375rem] px-2 pt-2", {
-  variants: {
-    rank: {
-      1: "bg-teal-500",
-      2: "bg-teal-400",
-      3: "bg-teal-300",
-      4: "bg-teal-200",
-      5: "border-b-[0.3125rem] border-teal-200 bg-teal-50",
-    },
-  },
-})
-
-const labelVariants = cva(
-  "text-[0.75rem] font-bold leading-[1.4] tracking-[-0.02em]",
+const barVariants = cva(
+  "w-full rounded-t-[0.375rem] px-2 pt-2 overflow-hidden",
   {
     variants: {
       rank: {
-        1: "text-white",
-        2: "text-teal-600",
-        3: "text-teal-500",
-        4: "text-teal-500",
-        5: "text-teal-500",
+        1: "bg-teal-500",
+        2: "bg-teal-400",
+        3: "bg-teal-300",
+        4: "bg-teal-200",
+        5: "border-b-[0.3125rem] border-teal-200 bg-teal-50",
+      },
+    },
+  },
+)
+
+const labelVariants = cva(
+  "text-[0.75rem] font-bold leading-[1.4] tracking-[-0.02em] break-all",
+  {
+    variants: {
+      rank: {
+        1: "text-white line-clamp-3",
+        2: "text-teal-600 line-clamp-3",
+        3: "text-teal-500 line-clamp-2",
+        4: "text-teal-500 line-clamp-2",
+        5: "text-teal-500 line-clamp-2",
       },
     },
   },

--- a/src/features/application/ui/detail-modal/ModalFormPanel.tsx
+++ b/src/features/application/ui/detail-modal/ModalFormPanel.tsx
@@ -11,7 +11,7 @@ import type { ApplicantFormData, FormField } from "../../model/types"
 import type { ApplicantDetail, StatusValue } from "../../model/types"
 
 const ROLE_LABEL: Record<string, string> = {
-  plan: "PM",
+  plan: "Plan",
   design: "Design",
   web: "Web",
   ios: "iOS",
@@ -242,7 +242,7 @@ export function ModalFormPanel({
           {/* 역할 정보 (우) */}
           <div className="ml-auto flex items-center gap-3">
             <span className="text-body-2-medium text-teal-gray-700">
-              {roleLabel.toUpperCase()}
+              {roleLabel}
             </span>
             <span className="text-caption-2-regular text-teal-gray-500">
               0/1

--- a/src/features/application/ui/detail-modal/ModalFormPanel.tsx
+++ b/src/features/application/ui/detail-modal/ModalFormPanel.tsx
@@ -90,9 +90,12 @@ interface ModalFormPanelProps {
   applicant: ApplicantDetail
   formData: ApplicantFormData | null
   chapterName: string
-  projectName: string
-  challengerName: string
-  challengerUniversity: string
+  project: {
+    projectName: string
+    challengerName: string
+    challengerUniversity: string
+    thumbnailUrl?: string
+  }
   variant?: "application" | "matching"
   onStatusChange?: (status: StatusValue) => void
   onUnmatch?: () => void
@@ -106,9 +109,7 @@ export function ModalFormPanel({
   applicant,
   formData,
   chapterName,
-  projectName,
-  challengerName,
-  challengerUniversity,
+  project,
   variant = "application",
   onStatusChange,
   onUnmatch,
@@ -230,9 +231,10 @@ export function ModalFormPanel({
         <div className="relative flex h-15 items-end px-4 py-4.5">
           {/* 프로젝트 카드 (좌) */}
           <ProjectTitleCard
-            projectName={projectName}
-            challengerName={challengerName}
-            challengerUniversity={challengerUniversity}
+            projectName={project.projectName}
+            challengerName={project.challengerName}
+            challengerUniversity={project.challengerUniversity}
+            thumbnailUrl={project.thumbnailUrl}
             size="sm"
             className="absolute top-0 left-0 w-full"
           />

--- a/src/features/application/ui/detail-modal/ModalFormPanel.tsx
+++ b/src/features/application/ui/detail-modal/ModalFormPanel.tsx
@@ -177,22 +177,19 @@ export function ModalFormPanel({
                   variant="segmented"
                   value={statusDisabled ? "" : applicant.status}
                   onValueChange={(v) => onStatusChange?.(v as StatusValue)}
-                  className={cn(
-                    "w-60",
-                    statusDisabled && "pointer-events-none",
-                  )}
+                  className={cn(statusDisabled && "pointer-events-none")}
                 >
                   <OptionButton
                     value="pass"
                     disabled={statusDisabled}
-                    className="h-7.5 gap-0.5 font-normal!"
+                    className="h-7.5 w-20 gap-0.5 font-normal!"
                   >
                     합격
                   </OptionButton>
                   <OptionButton
                     value="fail"
                     disabled={statusDisabled}
-                    className="h-7.5 gap-0.5 font-normal!"
+                    className="h-7.5 w-20 gap-0.5 font-normal!"
                   >
                     불합격
                   </OptionButton>
@@ -200,7 +197,7 @@ export function ModalFormPanel({
                     <OptionButton
                       value="pending"
                       disabled={statusDisabled}
-                      className="h-7.5 gap-0.5 font-normal!"
+                      className="h-7.5 w-20 gap-0.5 font-normal!"
                     >
                       대기
                     </OptionButton>

--- a/src/features/matching/model/matchingStatusMapper.ts
+++ b/src/features/matching/model/matchingStatusMapper.ts
@@ -290,6 +290,7 @@ function toMatchingProject(
       project.partQuotaStatus === "RECRUITING" ? "recruiting" : "completed",
     currentCount,
     totalCount,
+    thumbnailUrl: project.thumbnailImageUrl || undefined,
   }
 }
 

--- a/src/features/matching/model/matchingStatusTypes.ts
+++ b/src/features/matching/model/matchingStatusTypes.ts
@@ -10,6 +10,7 @@ export interface MatchingProjectData {
   status: "recruiting" | "completed"
   currentCount?: number
   totalCount?: number
+  thumbnailUrl?: string
 }
 
 export interface MatchingPartData {

--- a/src/features/matching/ui/MatchingDetailModal.tsx
+++ b/src/features/matching/ui/MatchingDetailModal.tsx
@@ -14,9 +14,12 @@ interface MatchingDetailModalProps {
   projectId?: string
   memberId?: string
   chapterName: string
-  projectName: string
-  challengerName: string
-  challengerUniversity: string
+  project: {
+    projectName: string
+    challengerName: string
+    challengerUniversity: string
+    thumbnailUrl?: string
+  }
   open: boolean
   onOpenChange: (open: boolean) => void
   isEditable?: boolean
@@ -27,9 +30,7 @@ export function MatchingDetailModal({
   applicantId,
   projectId,
   chapterName,
-  projectName,
-  challengerName,
-  challengerUniversity,
+  project,
   open,
   onOpenChange,
   isEditable = false,
@@ -94,9 +95,7 @@ export function MatchingDetailModal({
             applicant={applicant}
             formData={formData}
             chapterName={chapterName}
-            projectName={projectName}
-            challengerName={challengerName}
-            challengerUniversity={challengerUniversity}
+            project={project}
             variant="matching"
             onUnmatch={isEditable ? handleUnmatch : undefined}
             onClose={handleClose}

--- a/src/features/matching/ui/MatchingResultRow.tsx
+++ b/src/features/matching/ui/MatchingResultRow.tsx
@@ -62,6 +62,7 @@ interface MatchingResultRowProps {
   assignedMemberIds?: Set<string>
   chapterName?: string
   className?: string
+  thumbnailUrl?: string
 }
 
 export function MatchingResultRow({
@@ -80,6 +81,7 @@ export function MatchingResultRow({
   assignedMemberIds,
   chapterName,
   className,
+  thumbnailUrl,
 }: MatchingResultRowProps) {
   const [selectedApplicantId, setSelectedApplicantId] = useState<string | null>(
     null,
@@ -390,9 +392,12 @@ export function MatchingResultRow({
         projectId={projectId}
         memberId={selectedMemberId ?? undefined}
         chapterName={chapterName ?? ""}
-        projectName={projectName}
-        challengerName={challengerName}
-        challengerUniversity={challengerUniversity}
+        project={{
+          projectName,
+          challengerName,
+          challengerUniversity,
+          thumbnailUrl,
+        }}
         open={selectedApplicantId !== null}
         onOpenChange={(open) => {
           if (!open) {

--- a/src/routes/matching/status.tsx
+++ b/src/routes/matching/status.tsx
@@ -151,6 +151,7 @@ function MatchingStatusPage() {
                               chapterId={chapterId}
                               assignedMemberIds={assignedMemberIds}
                               chapterName={selectedChapter}
+                              thumbnailUrl={project.thumbnailUrl}
                             />
                           ))}
                         </>


### PR DESCRIPTION
## 📸 작업 내용

- RankBar.tsx 프로젝트명 랭크별 `line-clamp` 처리 및 넘침 방지
- 파트 지원서 합격/불합격 세그먼트 버튼 너비 고정(`w-20`) 및 우측 정렬
- 지원서 상세 패널에서 프로젝트 정보 프로프 그룹화(`project`) 및 썸네일 누락 노출 버그 수정
- 파트 표시명 형식 PM -> Plan 변경 및 대소문자 혼용 표기화
- ApplicantTableHead.tsx 접기/펼치기 토글 버튼 디졸브 애니메이션 전환 적용
- ProjectRoundBar.tsx 하단 프로젝트명 `line-clamp-2` 및 `break-all` 적용

## 🎞️ 주요 코드 설명

### 1. 프로젝트명 랭크별 말줄임 및 가로/세로 넘침 대응

RankBar.tsx에서 순위별로 다르게 텍스트 줄 수를 적용하고 넘침을 보정했습니다.

```TypeScript
const labelVariants = cva(
  "text-[0.75rem] font-bold leading-[1.4] tracking-[-0.02em] break-all",
  {
    variants: {
      rank: {
        1: "text-white line-clamp-3",
        2: "text-teal-600 line-clamp-3",
        3: "text-teal-500 line-clamp-2",
        4: "text-teal-500 line-clamp-2",
        5: "text-teal-500 line-clamp-2",
      },
    },
  },
)
```

- 공백 없는 긴 문자로 인해 가로 영역을 벗어나는 문제를 `break-all`로 보정했습니다.
- 낮은 막대 그래프일 때 텍스트가 바깥으로 튀어나가지 않도록 막대에 `overflow-hidden`을 주었습니다.

### 2. 프로젝트 정보 프로프 통합 및 썸네일 노출 버그 수정

ModalFormPanel.tsx와 관련된 여러 곳의 prop drilling을 줄이기 위해 프로젝트 메타데이터를 객체 형태로 통합하고 썸네일 API 필드(`thumbnailImageUrl`)를 연계했습니다.

```TypeScript
interface ModalFormPanelProps {
  applicant: ApplicantDetail
  formData: ApplicantFormData | null
  chapterName: string
  project: {
    projectName: string
    challengerName: string
    challengerUniversity: string
    thumbnailUrl?: string
  }
  variant?: "application" | "matching"
  // ...
}
```

- `ProjectApplication`과 `MatchingProjectData`에 `thumbnailUrl` 매핑 구조를 정상화하고 이를 객체 단일 prop으로 넘기도록 리팩토링했습니다.

### 3. 모두 접기/펼치기 토글 버튼 디졸브(Dissolve) 애니메이션 추가

ApplicantTableHead.tsx의 아이콘 전환을 부드럽게 만들기 위해 `motion/react`를 활용하였습니다.

```TypeScript
<AnimatePresence mode="wait" initial={false}>
  <motion.div
    key={hasExpanded ? "collapse" : "expand"}
    initial={{ opacity: 0 }}
    animate={{ opacity: 1 }}
    exit={{ opacity: 0 }}
    transition={{ duration: 0.15 }}
    className="flex items-center justify-center"
  >
    {hasExpanded ? (
      <CollapseAllIcon width={24} height={24} className="text-teal-700" />
    ) : (
      <ExpandAllIcon width={24} height={24} className="text-teal-700" />
    )}
  </motion.div>
</AnimatePresence>
```

- `AnimatePresence`와 `motion.div`를 사용하여 0.15초 동안 아이콘이 서로 디졸브(cross-fade)되며 전환되도록 연출했습니다.

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #507 