### PR TITLE
Bug: 2차 지원 현황이 보이지 않음

### DIFF
--- a/src/features/matching/hooks/useMatchingStatusData.ts
+++ b/src/features/matching/hooks/useMatchingStatusData.ts
@@ -371,6 +371,7 @@ export function useMatchingStatusData(chapterName?: string) {
       roundsQuery.isLoading ||
       projectsQuery.isLoading ||
       applicantsQuery.isLoading ||
+      membersQuery.isLoading ||
       chapterStatsQuery.isLoading ||
       chaptersWithSchoolsQuery.isLoading,
     isError:

--- a/src/features/matching/hooks/useMatchingStatusData.ts
+++ b/src/features/matching/hooks/useMatchingStatusData.ts
@@ -370,8 +370,9 @@ export function useMatchingStatusData(chapterName?: string) {
       chaptersQuery.isLoading ||
       roundsQuery.isLoading ||
       projectsQuery.isLoading ||
-      applicantsQuery.isLoading ||
-      membersQuery.isLoading ||
+      (projects.length > 0 &&
+        ((applicantsQuery.data === undefined && !applicantsQuery.isError) ||
+          (membersQuery.data === undefined && !membersQuery.isError))) ||
       chapterStatsQuery.isLoading ||
       chaptersWithSchoolsQuery.isLoading,
     isError:

--- a/src/features/matching/model/matchingStatusMapper.test.ts
+++ b/src/features/matching/model/matchingStatusMapper.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest"
+
+import { toMatchingPartDataList } from "./matchingStatusMapper"
+
+import type { ManagedProjectSummaryResponse } from "@/features/application/model/apiTypes"
+import type { ProjectMembersResponse } from "@/features/project/list/api/matchingProject"
+
+const baseProject: ManagedProjectSummaryResponse = {
+  id: "1",
+  name: "테스트 프로젝트",
+  description: "설명",
+  thumbnailImageUrl: "",
+  status: "IN_PROGRESS",
+  productOwner: {
+    memberId: "100",
+    nickname: "닉네임",
+    name: "이름",
+    schoolName: "가천대",
+  },
+  partQuotas: [
+    { part: "WEB", quota: "3", currentCount: "0", status: "RECRUITING" },
+    { part: "SPRINGBOOT", quota: "2", currentCount: "0", status: "RECRUITING" },
+    { part: "DESIGN", quota: "1", currentCount: "0", status: "RECRUITING" },
+  ],
+  partQuotaStatus: "RECRUITING",
+}
+
+const makeMembers = (
+  partGroups: ProjectMembersResponse["partGroups"],
+): Map<string, ProjectMembersResponse> =>
+  new Map([
+    [
+      "1",
+      {
+        projectId: "1",
+        productOwner: {
+          memberId: "100",
+          nickname: "닉네임",
+          name: "이름",
+          schoolName: "가천대",
+          matchedRoundInfo: null,
+        },
+        coProductOwners: [],
+        partGroups,
+      },
+    ],
+  ])
+
+describe("toMatchingPartDataList - 지원자/멤버 없을 때", () => {
+  it("지원자도 멤버도 없어도 Web 탭에 프로젝트가 포함된다", () => {
+    const result = toMatchingPartDataList([baseProject], new Map(), new Map())
+    const webPart = result.find((p) => p.partName === "Web")
+    expect(webPart).toBeDefined()
+    expect(webPart?.projects).toHaveLength(1)
+  })
+
+  it("Frontend 행이 WEB quota(3) 수만큼 빈 슬롯(type: none)을 가진다", () => {
+    const result = toMatchingPartDataList([baseProject], new Map(), new Map())
+    const project = result.find((p) => p.partName === "Web")?.projects[0]
+    const feRow = project?.roleRows.find((r) => r.role === "Frontend")
+    const noneBlocks = feRow?.blocks.filter((b) => b.type === "none")
+    expect(noneBlocks).toHaveLength(3)
+  })
+
+  it("Design 행이 DESIGN quota(1) 수만큼 빈 슬롯을 가진다", () => {
+    const result = toMatchingPartDataList([baseProject], new Map(), new Map())
+    const project = result.find((p) => p.partName === "Web")?.projects[0]
+    const designRow = project?.roleRows.find((r) => r.role === "Design")
+    const noneBlocks = designRow?.blocks.filter((b) => b.type === "none")
+    expect(noneBlocks).toHaveLength(1)
+  })
+
+  it("Backend 행이 SPRINGBOOT quota(2) 수만큼 빈 슬롯을 가진다", () => {
+    const result = toMatchingPartDataList([baseProject], new Map(), new Map())
+    const project = result.find((p) => p.partName === "Web")?.projects[0]
+    const beRow = project?.roleRows.find((r) => r.role === "Backend")
+    const noneBlocks = beRow?.blocks.filter((b) => b.type === "none")
+    expect(noneBlocks).toHaveLength(2)
+  })
+})
+
+describe("toMatchingPartDataList - 탭 분류", () => {
+  it("WEB quota가 0이면 Web 탭에 포함되지 않는다", () => {
+    const project: ManagedProjectSummaryResponse = {
+      ...baseProject,
+      partQuotas: [
+        { part: "DESIGN", quota: "1", currentCount: "0", status: "RECRUITING" },
+        {
+          part: "SPRINGBOOT",
+          quota: "2",
+          currentCount: "0",
+          status: "RECRUITING",
+        },
+      ],
+    }
+    const result = toMatchingPartDataList([project], new Map(), new Map())
+    expect(result.find((p) => p.partName === "Web")).toBeUndefined()
+  })
+
+  it("IOS quota가 있으면 iOS 탭에 포함된다", () => {
+    const project: ManagedProjectSummaryResponse = {
+      ...baseProject,
+      partQuotas: [
+        { part: "IOS", quota: "2", currentCount: "0", status: "RECRUITING" },
+        {
+          part: "SPRINGBOOT",
+          quota: "2",
+          currentCount: "0",
+          status: "RECRUITING",
+        },
+      ],
+    }
+    const result = toMatchingPartDataList([project], new Map(), new Map())
+    expect(result.find((p) => p.partName === "iOS")).toBeDefined()
+  })
+
+  it("프로젝트가 없으면 빈 배열을 반환한다", () => {
+    expect(toMatchingPartDataList([], new Map(), new Map())).toEqual([])
+  })
+})
+
+describe("toMatchingPartDataList - 멤버 배정 시", () => {
+  it("WEB 1명 배정 시 빈 슬롯이 quota(3) - 1 = 2개가 된다", () => {
+    const members = makeMembers([
+      {
+        part: "WEB",
+        members: [
+          {
+            memberId: "200",
+            nickname: "닉2",
+            name: "이름2",
+            schoolName: "가천대",
+            matchedRoundInfo: { phase: "FIRST" },
+          },
+        ],
+      },
+    ])
+    const result = toMatchingPartDataList([baseProject], new Map(), members)
+    const feRow = result
+      .find((p) => p.partName === "Web")
+      ?.projects[0]?.roleRows.find((r) => r.role === "Frontend")
+    expect(feRow?.blocks.filter((b) => b.type === "none")).toHaveLength(2)
+    expect(
+      feRow?.blocks.filter((b) => b.type === "round1" || b.type === "filled"),
+    ).toHaveLength(1)
+  })
+
+  it("quota만큼 전부 배정되면 빈 슬롯이 0개다", () => {
+    const members = makeMembers([
+      {
+        part: "WEB",
+        members: [
+          {
+            memberId: "1",
+            nickname: "a",
+            name: "a",
+            schoolName: "a",
+            matchedRoundInfo: { phase: "FIRST" },
+          },
+          {
+            memberId: "2",
+            nickname: "b",
+            name: "b",
+            schoolName: "b",
+            matchedRoundInfo: { phase: "SECOND" },
+          },
+          {
+            memberId: "3",
+            nickname: "c",
+            name: "c",
+            schoolName: "c",
+            matchedRoundInfo: { phase: "THIRD" },
+          },
+        ],
+      },
+    ])
+    const result = toMatchingPartDataList([baseProject], new Map(), members)
+    const feRow = result
+      .find((p) => p.partName === "Web")
+      ?.projects[0]?.roleRows.find((r) => r.role === "Frontend")
+    expect(feRow?.blocks.filter((b) => b.type === "none")).toHaveLength(0)
+  })
+})

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -6,6 +6,7 @@ import { useResourcePermissionsBatch } from "@/features/auth/hooks/useResourcePe
 import {
   isAnyOperator,
   isCentralCore,
+  isCentralStaff,
   isChapterPresident,
   isCurrentTermPm,
   isSchoolStaff,
@@ -164,11 +165,16 @@ export function ProjectManagementPage() {
   const projects: MatchingProject[] = useMemo(
     () =>
       (managedQuery.data ?? [])
-        .filter((project) => project.status !== "DRAFT")
+        .filter(
+          (project) =>
+            isSuperAdmin(me) ||
+            isCentralStaff(me) ||
+            project.status !== "DRAFT",
+        )
         .map((project) =>
           toMatchingProject(project, managedQuery.dataUpdatedAt),
         ),
-    [managedQuery.data, managedQuery.dataUpdatedAt],
+    [managedQuery.data, managedQuery.dataUpdatedAt, me],
   )
 
   const selectedChapterInfo = useMemo(() => {

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -162,20 +162,16 @@ export function ProjectManagementPage() {
     enabled: useGroupedView && !!gisuId,
   })
 
-  const projects: MatchingProject[] = useMemo(
-    () =>
-      (managedQuery.data ?? [])
-        .filter(
-          (project) =>
-            isSuperAdmin(me) ||
-            isCentralStaff(me) ||
-            project.status !== "DRAFT",
-        )
-        .map((project) =>
-          toMatchingProject(project, managedQuery.dataUpdatedAt),
-        ),
-    [managedQuery.data, managedQuery.dataUpdatedAt, me],
-  )
+  const projects: MatchingProject[] = useMemo(() => {
+    const hasFullAccess = isSuperAdmin(me) || isCentralStaff(me)
+    const list = managedQuery.data ?? []
+    const filtered = hasFullAccess
+      ? list
+      : list.filter((project) => project.status !== "DRAFT")
+    return filtered.map((project) =>
+      toMatchingProject(project, managedQuery.dataUpdatedAt),
+    )
+  }, [managedQuery.data, managedQuery.dataUpdatedAt, me])
 
   const selectedChapterInfo = useMemo(() => {
     if (!useGroupedView) return undefined

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -6,7 +6,6 @@ import { useResourcePermissionsBatch } from "@/features/auth/hooks/useResourcePe
 import {
   isAnyOperator,
   isCentralCore,
-  isCentralStaff,
   isChapterPresident,
   isCurrentTermPm,
   isSchoolStaff,
@@ -163,7 +162,7 @@ export function ProjectManagementPage() {
   })
 
   const projects: MatchingProject[] = useMemo(() => {
-    const hasFullAccess = isSuperAdmin(me) || isCentralStaff(me)
+    const hasFullAccess = isCentralCore(me)
     const list = managedQuery.data ?? []
     const filtered = hasFullAccess
       ? list

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -125,9 +125,11 @@ function MatchingApplicationsPage() {
     }
   }, [me, chapters, userChapter, chaptersWithSchoolsQuery.data])
 
-  // 차수 제한 대상: 지부장·교내 회장/부회장·Plan 챌린저
+  // 차수 제한 대상: 지부장·교내 회장/부회장·Plan 챌린저 (최고관리자·중앙 총괄단 제외)
   const isRoundRestrictedRole =
-    isChapterPresident(identity) || schoolLeadership || hasPmRole
+    (isChapterPresident(identity) || schoolLeadership || hasPmRole) &&
+    !isSuperAdmin(identity) &&
+    !isCentralStaff(identity)
 
   const admin = useAdminPageData(selectedChapter, {
     enabled: showAdminSection,
@@ -254,7 +256,9 @@ function MatchingApplicationsPage() {
                       )}
                       schoolIdToName={challenger.schoolIdToName}
                       currentRound={challenger.currentRound}
-                      decisionDeadlineByRound={challenger.decisionDeadlineByRound}
+                      decisionDeadlineByRound={
+                        challenger.decisionDeadlineByRound
+                      }
                     />
                   </div>
                 ))

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -18,12 +18,11 @@ import { ensureMe } from "@/features/auth/lib/ensureMe"
 import {
   getViewerBranch,
   isAnyOperator,
-  isCentralStaff,
+  isCentralCore,
   isChapterPresident,
   isCurrentTermPm,
   isOperator,
   isSchoolLeadership,
-  isSuperAdmin,
 } from "@/features/auth/model/identity"
 import { getChaptersWithSchools } from "@/features/challenger/api/organization"
 import { useIsMatchingPeriod } from "@/features/project/new/hooks/useIsMatchingPeriod"
@@ -82,11 +81,9 @@ function MatchingApplicationsPage() {
     canViewPmApplications: hasPmRole,
     canViewOwnApplications,
   })
-  // 지부장·학교 회장: 본인 지부만 조회 가능 (SUPER_ADMIN/중앙 운영진 제외)
+  // 지부장·학교 회장: 본인 지부만 조회 가능 (SUPER_ADMIN/중앙 총괄단 제외)
   const isRestrictedToChapter =
-    (isChapterPresident(me) || isSchoolLeadership(me)) &&
-    !isSuperAdmin(me) &&
-    !isCentralStaff(me)
+    (isChapterPresident(me) || isSchoolLeadership(me)) && !isCentralCore(me)
   const showAdminSection = activeView === "admin"
   const showPmSection = activeView === "pm"
   const showOwnApplications = activeView === "others"
@@ -128,8 +125,7 @@ function MatchingApplicationsPage() {
   // 차수 제한 대상: 지부장·교내 회장/부회장·Plan 챌린저 (최고관리자·중앙 총괄단 제외)
   const isRoundRestrictedRole =
     (isChapterPresident(identity) || schoolLeadership || hasPmRole) &&
-    !isSuperAdmin(identity) &&
-    !isCentralStaff(identity)
+    !isCentralCore(identity)
 
   const admin = useAdminPageData(selectedChapter, {
     enabled: showAdminSection,


### PR DESCRIPTION
## 📸 작업 내용

- 매칭 현황 페이지에서 isLoading 판단 플래그에 membersQuery.isLoading추가 
   (멤버 조회가 완료되기 전에 로딩이 끝난 것으로 판단되는 문제 방지)
- 최고 관리자, 중앙 총괄단 프로젝트 초안부터 조회 가능

## 🎞️ 주요 코드 설명

<!-- 코드 설명, 없다면 생략해도 됩니다! -->

> 설명이 필요한 코드 위주로 작성해주세요

### 주제1

```TypeScript
// 여기에 코드를 작성해주세요
```

- 대충 코드에 대한 내용

### 주제2

```TypeScript
// 여기에 코드를 작성해주세요
```

- 대충 코드에 대한 내용

## 🖥️ 구현화면

> localhost 캡쳐 사진을 첨부해 주세요.

|           A 기능            |           B 기능            |
| :-------------------------: | :-------------------------: |
| <img src = "" width ="250"> | <img src = "" width ="250"> |

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #이슈번호

## 📚 참고자료

<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

## 💬 기타 더 이야기해볼 점

<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
