### PR TITLE
🐛 fix: 프로젝트 수정(/edit) 상단 세그먼트를 프로젝트 설정으로 매핑

### DIFF
--- a/src/shared/config/navigation.ts
+++ b/src/shared/config/navigation.ts
@@ -6,6 +6,7 @@ export interface SideBarMenu {
   id: string
   title: string
   to: string
+  matchPaths?: string[]
 }
 
 export interface SideBarSection {
@@ -35,6 +36,7 @@ export const SIDEBAR_ITEMS: SideBarSection[] = [
         id: "project-management",
         title: "프로젝트 관리",
         to: "/matching/projects/management",
+        matchPaths: ["/matching/projects/edit"],
       },
     ],
   },

--- a/src/shared/config/navigationResolve.test.ts
+++ b/src/shared/config/navigationResolve.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+
+import { filterSectionsByPermission } from "@/components/sidebar/utils"
+import { SIDEBAR_ITEMS } from "@/shared/config/navigation"
+
+import { resolveNavigationFromPathname } from "./navigationResolve"
+
+function resolveIds(pathname: string) {
+  const resolved = resolveNavigationFromPathname(pathname)
+  return resolved && { section: resolved.section.id, menu: resolved.menu.id }
+}
+
+describe("resolveNavigationFromPathname", () => {
+  it("/matching/projects/edit/123은 프로젝트 설정 > 프로젝트 관리로 resolve", () => {
+    expect(resolveIds("/matching/projects/edit/123")).toEqual({
+      section: "project-settings",
+      menu: "project-management",
+    })
+  })
+
+  it("/matching/projects/edit (id 없음)도 프로젝트 설정 > 프로젝트 관리로 resolve", () => {
+    expect(resolveIds("/matching/projects/edit")).toEqual({
+      section: "project-settings",
+      menu: "project-management",
+    })
+  })
+
+  it("[회귀] /matching/projects/new는 프로젝트 설정 > 프로젝트 등록 유지", () => {
+    expect(resolveIds("/matching/projects/new")).toEqual({
+      section: "project-settings",
+      menu: "project-register",
+    })
+  })
+
+  it("[회귀] /matching/projects는 팀 매칭 > 프로젝트 목록 유지", () => {
+    expect(resolveIds("/matching/projects")).toEqual({
+      section: "team-matching",
+      menu: "matching-projects",
+    })
+  })
+
+  it("[회귀] /matching/projects/management는 프로젝트 설정 > 프로젝트 관리 유지", () => {
+    expect(resolveIds("/matching/projects/management")).toEqual({
+      section: "project-settings",
+      menu: "project-management",
+    })
+  })
+
+  it("[회귀] /matching은 팀 매칭 > 공지 유지", () => {
+    expect(resolveIds("/matching")).toEqual({
+      section: "team-matching",
+      menu: "matching-announce",
+    })
+  })
+
+  it("trailing slash는 흡수된다 (/matching/projects/edit/123/)", () => {
+    expect(resolveIds("/matching/projects/edit/123/")).toEqual({
+      section: "project-settings",
+      menu: "project-management",
+    })
+  })
+
+  it("알 수 없는 경로는 null", () => {
+    expect(resolveNavigationFromPathname("/unknown/path")).toBeNull()
+  })
+
+  it("프로젝트 관리 메뉴가 권한으로 제거되면 edit 경로는 별칭을 잃고 팀 매칭으로 fallback", () => {
+    const visibleSections = filterSectionsByPermission(SIDEBAR_ITEMS, {
+      canAccessProjectSettings: true,
+      canWriteProject: true,
+      canAccessProjectManagement: false,
+      canManageMatchingRounds: true,
+    })
+    const resolved = resolveNavigationFromPathname(
+      "/matching/projects/edit/123",
+      visibleSections,
+    )
+    expect(
+      resolved && { section: resolved.section.id, menu: resolved.menu.id },
+    ).toEqual({ section: "team-matching", menu: "matching-projects" })
+  })
+})

--- a/src/shared/config/navigationResolve.ts
+++ b/src/shared/config/navigationResolve.ts
@@ -13,6 +13,19 @@ function normalizePathname(pathname: string): string {
   return pathname
 }
 
+function matchesPath(path: string, target: string): boolean {
+  return path === target || path.startsWith(`${target}/`)
+}
+
+/** menu.to 또는 matchPaths 중 path와 일치하는 경로 문자열을 반환 */
+function getMatchedPath(path: string, menu: SideBarMenu): string | null {
+  if (matchesPath(path, menu.to)) return menu.to
+  for (const alias of menu.matchPaths ?? []) {
+    if (matchesPath(path, alias)) return alias
+  }
+  return null
+}
+
 export function resolveNavigationFromPathname(pathname: string): {
   section: SideBarSection
   menu: SideBarMenu
@@ -38,10 +51,10 @@ export function resolveNavigationFromPathname(
   const source = sections ?? SIDEBAR_ITEMS
   for (const section of source) {
     for (const menu of section.menus) {
-      const hit = path === menu.to || path.startsWith(`${menu.to}/`)
-      if (!hit) continue
-      if (menu.to.length > bestLen) {
-        bestLen = menu.to.length
+      const matchedPath = getMatchedPath(path, menu)
+      if (matchedPath === null) continue
+      if (matchedPath.length > bestLen) {
+        bestLen = matchedPath.length
         picked = { section, menu }
       }
     }


### PR DESCRIPTION
## 📸 작업 내용

> 프로젝트 수정 페이지의 상단 세그먼트/사이드바 오인식 버그를 수정합니다.

- `/matching/projects/edit/$projectId` 진입 시 상단 세그먼트 제목과 사이드바 강조가 **"팀 매칭 > 프로젝트 목록"** 으로 잘못 표시되던 문제를 **"프로젝트 설정 > 프로젝트 관리"** 로 정정
- 원인: `/matching/projects/edit` 경로가 네비게이션 설정에 없어 경로 해석(longest-prefix-match)이 `/matching/projects`(팀 매칭)로 fallback. `/new`는 정확 일치라 정상이었음
- 사이드바에 노출되지 않는 **별칭 경로(`matchPaths`)** 를 도입해, edit 경로를 "프로젝트 관리" 항목에 매핑 (세그먼트 탭과 사이드바 메뉴가 동일한 `section.menus`를 공유하므로 보이는 메뉴를 추가하지 않음)
- 상단 세그먼트 제목과 사이드바 강조는 동일한 경로 해석 로직을 공유하므로 한 번에 함께 정정됨
- `navigationResolve` 단위 테스트 추가(버그 수정·회귀·권한 엣지케이스)

## 🎞️ 주요 코드 설명

### matchPaths 별칭으로 보이지 않는 경로 매핑

\`SideBarMenu\`에 표시에 영향 없는 \`matchPaths\` 필드를 추가하고, \`project-management\` 메뉴에 edit 경로를 등록합니다.

\`\`\`TypeScript
// navigation.ts
{
  id: "project-management",
  title: "프로젝트 관리",
  to: "/matching/projects/management",
  matchPaths: ["/matching/projects/edit"],
}
\`\`\`

경로 해석 시 \`menu.to\` 뿐 아니라 \`matchPaths\`까지 검사하고, 실제로 매칭된 경로 문자열의 길이로 longest-match를 비교합니다.

\`\`\`TypeScript
// navigationResolve.ts
function getMatchedPath(path: string, menu: SideBarMenu): string | null {
  if (matchesPath(path, menu.to)) return menu.to
  for (const alias of menu.matchPaths ?? []) {
    if (matchesPath(path, alias)) return alias
  }
  return null
}
\`\`\`

별칭 \`/matching/projects/edit\`(len 26)가 \`/matching/projects\`(len 18)보다 길어 올바르게 선택되고, \`/matching/projects/new\`(len 24)는 기존대로 "프로젝트 등록"이 유지됩니다.

## 🔗 연결된 이슈

- Connected: #516
- Closes #516