### PR TITLE
🐛 fix: 지원현황 제한 오류 수정

### DIFF
--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -186,12 +186,6 @@ function MatchingApplicationsPage() {
                     데이터를 불러오는 중...
                   </p>
                 </div>
-              ) : isAdminRoundLocked ? (
-                <div className="flex items-center justify-center py-20">
-                  <p className="text-body-2-regular text-teal-gray-400">
-                    매칭 차수가 진행 중입니다. 차수 종료 후 조회할 수 있습니다.
-                  </p>
-                </div>
               ) : (
                 <div className="flex flex-col gap-14.25">
                   <ApplicationStatsSection
@@ -200,12 +194,21 @@ function MatchingApplicationsPage() {
                     currentRound={admin.currentRound}
                     activeRound={admin.activeRound}
                   />
-                  <ApplicationTableSection
-                    projects={adminProjects}
-                    currentRound={admin.currentRound}
-                    chapterName={selectedChapter}
-                    disableProjectModal
-                  />
+                  {isAdminRoundLocked ? (
+                    <div className="flex items-center justify-center py-20">
+                      <p className="text-body-2-regular text-teal-gray-400">
+                        매칭 차수가 진행 중입니다. 차수 종료 후 조회할 수
+                        있습니다.
+                      </p>
+                    </div>
+                  ) : (
+                    <ApplicationTableSection
+                      projects={adminProjects}
+                      currentRound={admin.currentRound}
+                      chapterName={selectedChapter}
+                      disableProjectModal
+                    />
+                  )}
                 </div>
               )}
             </div>


### PR DESCRIPTION
## 📸 작업 내용

> 지원 현황 UI 제한 수정

- 매칭 차수 진행 중 지원 통계(ApplicationStatsSection)까지 함께 잠기던 문제를 수정. 
지부장·교내 회장/부회장은 차수 진행 중에도 통계는 조회 가능하고, 지원서 목록만 차수 종료 후 열리도록 권한 분기 복원


## 🎞️ 주요 코드 설명

### 지원 통계 · 지원서 목록 잠금 분리

```TypeScript
) : (
  <div className="flex flex-col gap-14.25">
    <ApplicationStatsSection ... /> {/* 항상 노출 */}
    {isAdminRoundLocked ? (
      <p>매칭 차수가 진행 중입니다. 차수 종료 후 조회할 수 있습니다.</p>
    ) : (
      <ApplicationTableSection ... /> {/* 차수 종료 후 노출 */}
    )}
  </div>
)}
```

- 기존에는 isAdminRoundLocked이면 통계·지원서 목록을 통째로 막았으나, 
권한 표상 지원 통계는 차수 진행 중에도 조회 가능해야 하므로 잠금 위치를 지원서 목록 단위로 내림

## 🖥️ 구현화면

## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #508 

## 💬 기타 더 이야기해볼 점

<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
