### PR TITLE
task: API 반복 호출 최적화

### DIFF
--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -125,6 +125,7 @@ export function useChallengerPageData(
       return new Map(results.map((r) => [String(r.projectId), r.applicants]))
     },
     enabled: enabled && projects.length > 0,
+    staleTime: 1000 * 60 * 5,
   })
 
   // 프로젝트별 통계 조회 (차수별 지원률, 학교별 지원자 수)
@@ -141,6 +142,7 @@ export function useChallengerPageData(
       return res.projects
     },
     enabled: enabled && projects.length > 0,
+    staleTime: 1000 * 60 * 5,
   })
 
   const { currentRound } = useMemo(
@@ -315,6 +317,7 @@ export function useAdminPageData(
     queryKey: applicationKeys.chapterStatistics(chapterId ?? 0),
     queryFn: () => getChapterStatistics(chapterId!),
     enabled: enabled && !!chapterId,
+    staleTime: 1000 * 60 * 5,
   })
 
   // projectId -> name 맵 (키를 String으로 통일)

--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -169,6 +169,7 @@ export function useChallengerPageData(
     queryKey: ["schools", "all"],
     queryFn: getAllSchools,
     enabled,
+    staleTime: Infinity,
   })
   const schoolIdToName = useMemo(() => {
     const map = new Map<string, string>()
@@ -231,6 +232,7 @@ export function useChapters(options: ApplicationPageDataOptions = {}) {
     queryKey: applicationKeys.chapters(),
     queryFn: getAllChapters,
     enabled,
+    staleTime: Infinity,
   })
 }
 
@@ -254,6 +256,7 @@ export function useAdminPageData(
     queryKey: ["chapters-with-schools", gisuId],
     queryFn: () => getChaptersWithSchools(String(gisuId)),
     enabled: enabled && gisuId > 0,
+    staleTime: Infinity,
   })
   const chapterSchoolIds = useMemo(() => {
     if (!chapterName || !chaptersWithSchoolsQuery.data) return null
@@ -288,6 +291,7 @@ export function useAdminPageData(
     queryKey: ["schools", "all"],
     queryFn: getAllSchools,
     enabled,
+    staleTime: Infinity,
   })
   const schoolIdToName = useMemo(() => {
     const map = new Map<string, string>()

--- a/src/features/matching/hooks/useMatchingStatusData.ts
+++ b/src/features/matching/hooks/useMatchingStatusData.ts
@@ -89,6 +89,7 @@ export function useMatchingStatusData(chapterName?: string) {
   const schoolsQuery = useQuery({
     queryKey: ["schools", "all"],
     queryFn: getAllSchools,
+    staleTime: Infinity,
   })
   const schoolIdToName = useMemo(() => {
     const map = new Map<string, string>()

--- a/src/features/matching/hooks/useMatchingStatusData.ts
+++ b/src/features/matching/hooks/useMatchingStatusData.ts
@@ -78,6 +78,7 @@ export function useMatchingStatusData(chapterName?: string) {
       return { ...firstPage, content: projects }
     },
     enabled: gisuId > 0,
+    staleTime: 1000 * 60 * 5,
   })
 
   const projects = useMemo(

--- a/src/features/matching/hooks/useMatchingStatusData.ts
+++ b/src/features/matching/hooks/useMatchingStatusData.ts
@@ -104,6 +104,7 @@ export function useMatchingStatusData(chapterName?: string) {
     queryKey: applicationKeys.matchingMatchings(chapterId ?? 0),
     queryFn: () => getMatchingStatistics(chapterId!),
     enabled: !!chapterId,
+    staleTime: 1000 * 60 * 5,
   })
 
   // projectId -> name 맵 (키를 String으로 통일)
@@ -121,6 +122,7 @@ export function useMatchingStatusData(chapterName?: string) {
     ),
     queryFn: () => getProjectMembersBatch(projects.map((p) => Number(p.id))),
     enabled: projects.length > 0,
+    staleTime: 1000 * 60 * 5,
   })
 
   // 전체 프로젝트에 배정된 멤버 ID 수집 (수동 배정 시 중복 필터링용)

--- a/src/features/project/list/model/matchingProjectList.ts
+++ b/src/features/project/list/model/matchingProjectList.ts
@@ -128,6 +128,7 @@ export function useMatchingProjectListFilters() {
     queryKey: ["chaptersWithSchools", activeGisuId],
     queryFn: () => getChaptersWithSchools(String(activeGisuId!)),
     enabled: activeGisuId != null,
+    staleTime: Infinity,
   })
 
   const branchOptions: ProjectFilterOption[] = useMemo(

--- a/src/features/project/list/model/matchingProjectList.ts
+++ b/src/features/project/list/model/matchingProjectList.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query"
+import { keepPreviousData, useQuery } from "@tanstack/react-query"
 import { useNavigate, useSearch } from "@tanstack/react-router"
 import { useCallback, useEffect, useMemo, useState } from "react"
 
@@ -177,6 +177,7 @@ export function useMatchingProjectListFilters() {
         size: MATCHING_PROJECT_PAGE_SIZE,
       }),
     enabled: effectiveGisuId != null,
+    placeholderData: keepPreviousData,
   })
 
   const selectedBranchLabel = useMemo(

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -15,9 +15,9 @@ const isMaintenance = import.meta.env.VITE_MAINTENANCE === "true"
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 0,
+      staleTime: 1000 * 30, // 30초
       retry: 1,
-      refetchOnMount: "always",
+      refetchOnMount: true, // 데이터가 stale할 때만 마운트 시 리페치 수행
     },
   },
 })


### PR DESCRIPTION
## 📸 작업 내용

프로젝트 내 API 호출 효율성 개선 및 쿼리 최적화 작업을 진행했습니다.

- **글로벌 캐싱 옵션 조정**: 마운트 시 무조건 리페치를 수행하던 `refetchOnMount: "always"` 및 `staleTime: 0` 설정을 `staleTime: 30초`, `refetchOnMount: true`로 변경하여 불필요한 연속 API 호출을 방지했습니다.
- **통계성/N+1 대형 쿼리 최적화**: 통계 연산 및 N+1 병렬 호출이 수행되는 무거운 쿼리에 `staleTime: 5분`을 오버라이드하여 데이터 갱신이 불필요한 시점의 중복 호출을 더욱 강력하게 차단했습니다.
- **정적 코드 데이터 캐싱 최적화**: 지부 목록, 전체 학교 목록 등 거의 바뀌지 않는 정적 메타데이터성 쿼리에 `staleTime: Infinity`를 개별 부여하여 세션 동안 캐시를 영구적으로 재사용하도록 개선했습니다.
- **프로젝트 목록 페이지네이션 반복 루프 최적화**: 매칭 결과 시트 조회를 위해 전체 페이지를 비동기 루프로 한 번에 가져오는 대형 프로젝트 조회 쿼리에 `staleTime: 5분`을 추가했습니다.
- **필터링 UX 개선 (keepPreviousData)**: 프로젝트 목록 필터 변경 시 깜빡이는 현상(레이아웃 플리커)을 방지하기 위해 `placeholderData: keepPreviousData`를 도입했습니다.

## 🎞️ 주요 코드 설명

### 1. 글로벌 QueryClient 캐싱 옵션 완화
- **위치**: `src/main.tsx`
- **설명**: 불필요한 무한 리페치를 방지하고자 기본 캐시 신선 시간(staleTime)을 30초로 설정하고 마운트 시에는 캐시가 stale할 때만 새로 고침을 수행하도록 변경했습니다.

```typescript
const queryClient = new QueryClient({
  defaultOptions: {
    queries: {
      staleTime: 1000 * 30, // 30초 동안 캐싱 데이터를 fresh한 상태로 간주
      retry: 1,
      refetchOnMount: true, // 데이터가 stale할 때만 마운트 시 리페치 수행 (기본 동작)
    },
  },
})
```

### 2. 무거운 대형/N+1 쿼리에 개별 `staleTime: 5분` 오버라이드
- **위치**: `useApplicationPageData.ts`, `useMatchingStatusData.ts`
- **설명**: `Promise.all` 기반 병렬 조회 쿼리(`applicantsQuery`) 및 대용량 통계 연산 쿼리(`projectStatsQuery`, `chapterStatsQuery`, `matchingStatsQuery`, `membersQuery`)에 개별 만료 시간인 5분을 지정했습니다.

```typescript
// useApplicationPageData.ts 중 일부
const applicantsQuery = useQuery({
  queryKey: [
    ...applicationKeys.all,
    "managed-applicants",
    gisuId,
    projects.map((p) => p.id),
  ],
  queryFn: async () => {
    const results = await Promise.all(
      projects.map(async (p) => {
        const applicants = await getProjectApplications(Number(p.id))
        return { projectId: p.id, applicants }
      }),
    )
    return new Map(results.map((r) => [String(r.projectId), r.applicants]))
  },
  enabled: enabled && projects.length > 0,
  staleTime: 1000 * 60 * 5, // 5분 캐싱 오버라이드
})
```

### 3. 정적 메타데이터성 데이터 캐싱 강화 (`staleTime: Infinity`)
- **위치**: `useApplicationPageData.ts`, `useMatchingStatusData.ts`, `matchingProjectList.ts`
- **설명**: 한 번 불러온 후 데이터 변경이 매우 드문 지부 정보 및 전체 학교 목록 API의 개별 staleTime을 `Infinity`로 명시했습니다.

```typescript
// 전체 학교 목록 조회 (schoolId -> schoolName 매핑용)
const schoolsQuery = useQuery({
  queryKey: ["schools", "all"],
  queryFn: getAllSchools,
  staleTime: Infinity, // 세션 내내 캐시 재사용
})
```

### 4. 필터링 변경 시 UX 향상 및 레이아웃 플리커 방지
- **위치**: `matchingProjectList.ts`
- **설명**: 검색 필터 변경 등으로 인해 프로젝트 리스트 쿼리 키가 바뀌었을 때 화면이 하얗게 비거나 로딩 스피너로 깜빡이지 않고 이전 페이지를 유지하도록 `placeholderData` 옵션을 설정했습니다.

```typescript
const { data, isLoading, isError } = useQuery({
  queryKey: projectKeys.list({ ... }),
  queryFn: () => getMatchingProjects({ ... }),
  enabled: effectiveGisuId != null,
  placeholderData: keepPreviousData, // 이전 조회 데이터를 유지하여 플리커링 방지
})
```

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #519 
