### PR TITLE
🐛 fix: 지원·매칭 현황 통계 카드 표시 버그 수정 및 데드코드 정리

### DIFF
--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -427,12 +427,6 @@ export function useAdminPageData(
         ? Math.round((appliedCount / partial.totalMembers) * 100)
         : 0
 
-    // 도넛 차트 총원을 필터링된 schoolMatchingStatistics 기준으로 보정
-    // roundApplicationStatistics.availableMemberCount는 전체 기준이므로 지부/학교 필터링 반영 안 됨
-    for (const r of partial.rounds) {
-      r.total = partial.totalMembers
-    }
-
     // 학교별 지원자 수 집계 (roundSchoolRankings 전 차수 합산, 챕터 소속 학교만)
     const schoolApplicantCounts = new Map<string, number>()
     for (const ranking of chapterStatsQuery.data.summary.roundSchoolRankings ??

--- a/src/features/application/model/mappers.ts
+++ b/src/features/application/model/mappers.ts
@@ -186,31 +186,13 @@ export function summaryToStats(
   summary: ChapterStatisticsResponse["summary"],
   projectIdToName: Map<string, string>,
   filterRound?: number, // 미지정 시 전 차수 합산, 0 = 완료된 차수 없음, N = N차까지 표시
-  variant: "application" | "matching" = "application",
 ): Omit<ApplicationStats, "universities"> {
-  // 차수별 매칭 완료 수 (projectRoundStatistics에서 합산)
-  const matchedByPhase = new Map<string, number>()
-  if (variant === "matching") {
-    for (const p of summary.projectRoundStatistics) {
-      for (const r of p.matchingRounds) {
-        const phase = r.matchingRound.phase
-        matchedByPhase.set(
-          phase,
-          (matchedByPhase.get(phase) ?? 0) + Number(r.matchedMemberCount),
-        )
-      }
-    }
-  }
-
-  // 차수별 지원/매칭 현황 (완료 차수 + 1차 최소 표시)
+  // 차수별 지원 현황 (완료 차수 + 1차 최소 표시)
   // filterRound=0(1차 진행 중)이어도 r.total(availableMemberCount)이 표시되도록 최소 1차 포함
   const rounds = summary.roundApplicationStatistics
     .map((r) => ({
       round: toRoundNumber(r.matchingRound.phase),
-      applied:
-        variant === "matching"
-          ? (matchedByPhase.get(r.matchingRound.phase) ?? 0)
-          : Number(r.appliedMemberCount),
+      applied: Number(r.appliedMemberCount),
       total: Number(r.availableMemberCount),
     }))
     .filter(
@@ -231,32 +213,27 @@ export function summaryToStats(
   const completionRate =
     totalMembers > 0 ? Math.round((completedCount / totalMembers) * 100) : 0
 
-  // 프로젝트별 차수별 지원/매칭 현황 (완료된 차수만)
-  const projectRoundField =
-    variant === "matching" ? "matchedMemberCount" : "appliedMemberCount"
+  // 프로젝트별 차수별 지원 현황 (완료된 차수만)
   const projectRounds: ProjectRoundData[] = summary.projectRoundStatistics.map(
     (p) => ({
       name: projectIdToName.get(String(p.projectId)) ?? String(p.projectId),
       rounds: [
         filterRound === undefined || filterRound >= 1
           ? Number(
-              p.matchingRounds.find((r) => r.matchingRound.phase === "FIRST")?.[
-                projectRoundField
-              ] ?? 0,
+              p.matchingRounds.find((r) => r.matchingRound.phase === "FIRST")
+                ?.appliedMemberCount ?? 0,
             )
           : 0,
         filterRound === undefined || filterRound >= 2
           ? Number(
-              p.matchingRounds.find(
-                (r) => r.matchingRound.phase === "SECOND",
-              )?.[projectRoundField] ?? 0,
+              p.matchingRounds.find((r) => r.matchingRound.phase === "SECOND")
+                ?.appliedMemberCount ?? 0,
             )
           : 0,
         filterRound === undefined || filterRound >= 3
           ? Number(
-              p.matchingRounds.find((r) => r.matchingRound.phase === "THIRD")?.[
-                projectRoundField
-              ] ?? 0,
+              p.matchingRounds.find((r) => r.matchingRound.phase === "THIRD")
+                ?.appliedMemberCount ?? 0,
             )
           : 0,
       ],
@@ -269,19 +246,19 @@ export function summaryToStats(
     2: "SECOND",
     3: "THIRD",
   }
-  const countField =
-    variant === "matching" ? "matchedMemberCount" : "appliedMemberCount"
   const topProjects: TopProject[] = summary.projectRoundStatistics
     .map((p) => {
       let count = 0
       if (filterRound === undefined) {
-        count = p.matchingRounds.reduce((s, r) => s + Number(r[countField]), 0)
+        count = p.matchingRounds.reduce(
+          (s, r) => s + Number(r.appliedMemberCount),
+          0,
+        )
       } else if (filterRound > 0) {
         const targetPhase = phaseMap[filterRound]
         count = Number(
-          p.matchingRounds.find((r) => r.matchingRound.phase === targetPhase)?.[
-            countField
-          ] ?? 0,
+          p.matchingRounds.find((r) => r.matchingRound.phase === targetPhase)
+            ?.appliedMemberCount ?? 0,
         )
       }
       return {

--- a/src/features/application/ui/ApplicationStatsSection.tsx
+++ b/src/features/application/ui/ApplicationStatsSection.tsx
@@ -163,7 +163,9 @@ export function ApplicationStatsSection({
                           : "text-body-3-medium text-teal-gray-600",
                       )}
                     >
-                      <span className="w-4.5">{r.round}차</span>
+                      <span className="min-w-5 whitespace-nowrap">
+                        {r.round}차
+                      </span>
                       <span className="whitespace-nowrap">
                         {labels.roundSuffix}
                       </span>

--- a/src/features/application/ui/ChallengerStatsSection.tsx
+++ b/src/features/application/ui/ChallengerStatsSection.tsx
@@ -97,7 +97,9 @@ export function ChallengerStatsSection({
               {stats.rounds.map((r) => (
                 <div key={r.round} className="flex items-center gap-7">
                   <div className="text-body-3-medium text-teal-gray-600 flex items-center gap-0.75 leading-normal">
-                    <span className="w-4.5">{r.round}차</span>
+                    <span className="min-w-5 whitespace-nowrap">
+                      {r.round}차
+                    </span>
                     <span className="whitespace-nowrap">지원</span>
                   </div>
                   <div className="flex w-20 items-center justify-end gap-2 leading-[1.4]">

--- a/src/features/matching/model/matchingStatsMapper.test.ts
+++ b/src/features/matching/model/matchingStatsMapper.test.ts
@@ -53,7 +53,7 @@ describe("matchingResponseToStats", () => {
       schoolIdToName,
     )
 
-    expect(stats.rounds).toEqual([{ round: 1, applied: 3, total: 5 }])
+    expect(stats.rounds).toEqual([{ round: 1, applied: 3, total: 4 }])
   })
 
   it("학교별 집계로 총원/완료/완료율을 계산한다 (unclassified는 학교 집계에 이미 포함)", () => {

--- a/src/features/matching/model/matchingStatsMapper.ts
+++ b/src/features/matching/model/matchingStatsMapper.ts
@@ -38,12 +38,12 @@ export function matchingResponseToStats(
   const completionRate =
     totalMembers > 0 ? Math.round((completedCount / totalMembers) * 100) : 0
 
-  // 차수별 매칭 (matched > 0인 차수만, 도넛 분모는 지부 총원으로 보정)
+  // 차수별 매칭 (matched > 0인 차수만, 분모는 차수별 지원 가능 인원)
   const rounds = response.roundMatchingStatistics
     .map((r) => ({
       round: toRoundNumber(r.matchingRound.phase),
       applied: Number(r.matchedMemberCount),
-      total: totalMembers,
+      total: Number(r.availableMemberCount),
     }))
     .filter((r) => r.applied > 0)
     .sort((a, b) => a.round - b.round)


### PR DESCRIPTION
## 📸 작업 내용

> '지원 현황'·'매칭 현황' 통계 카드의 표시 버그 2건과 데드코드를 정리했습니다.

- **차수별 분모 정정**: 차수별 요약의 분모가 매 차수 동일한 '총원'으로 표시되던 것을 각 차수의 '지원 가능 인원'으로 정정 (예: `1차 16/1500`, `2차 4/1491`, `3차 20/1490`)
  - 매칭 현황: 응답의 차수별 `availableMemberCount`(지원 가능 인원) 필드를 분모로 사용
  - 지원 현황(운영진 뷰): 차수별 분모를 총원으로 덮어쓰던 보정 로직 제거
- **차수 라벨 줄바꿈 수정**: 활성 차수('N차')가 굵은 글씨로 강조될 때 고정폭을 넘쳐 '2'/'차' 두 줄로 깨지던 것을 `min-w-5 whitespace-nowrap`으로 해결 (폰트·굵기·정렬 등 타이포그래피는 기존과 동일하게 유지)
- **데드코드 제거**: `summaryToStats`의 호출되지 않는 `variant === "matching"` 분기 제거 (지원 현황 전용으로 단순화)

## 🎞️ 주요 코드 설명

### 차수별 분모를 '지원 가능 인원'으로

```TypeScript
// 매칭 현황 매퍼 (matchingStatsMapper.ts)
applied: Number(r.matchedMemberCount),
total: Number(r.availableMemberCount), // 기존 totalMembers(총원) → 차수별 지원 가능 인원
```

- 1차는 총원과 우연히 일치하지만, 2차부터 누적 매칭 인원이 빠지며 분모가 줄어드는 것이 정상 동작입니다.

## 🖥️ 구현화면

> 로컬(5173)에서 차수별 분모가 차수마다 다르게 표시되고, 활성 차수 라벨이 한 줄로 유지됨을 확인했습니다.

|              지원 현황 차수별 분모               |              매칭 현황 차수별 분모               |
| :---------------------------------------------: | :---------------------------------------------: |
|     `1차 16/1500 · 2차 4/1491 · 3차 20/1490`     |      `1차 9/1500 · 2차 1/1491 · 3차 3/1490`      |

## 🔗 연결된 이슈

- Connected: #527, #529, #530
- Closes #527
- Closes #529
- Closes #530