### PR TITLE
🐛 fix: 지원 현황 프로젝트 배너를 로고 이미지로 대체

### DIFF
--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -248,7 +248,9 @@ export function useChallengerPageData(
         projectsQuery.isLoading ||
         applicantsQuery.isLoading ||
         projectStatsQuery.isLoading ||
-        logoQuery.isLoading ||
+        (projects.length > 0 &&
+          logoQuery.data === undefined &&
+          !logoQuery.isError) ||
         isMeLoading ||
         (chapterId !== undefined &&
           roundsQuery.data === undefined &&

--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -8,6 +8,7 @@ import {
   getAllSchools,
   getChaptersWithSchools,
 } from "@/features/challenger/api/organization"
+import { getProjectDetail } from "@/features/project/list/api/matchingProject"
 import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
 
 import {
@@ -179,13 +180,45 @@ export function useChallengerPageData(
     return map
   }, [schoolsQuery.data])
 
+  // 프로젝트별 로고 조회 (managed API는 logoImageUrl 미포함)
+  const logoQuery = useQuery({
+    queryKey: [
+      ...applicationKeys.all,
+      "project-logos",
+      projects.map((p) => p.id),
+    ],
+    queryFn: async () => {
+      const results = await Promise.allSettled(
+        projects.map(async (p) => {
+          const detail = await getProjectDetail(Number(p.id))
+          return {
+            projectId: String(p.id),
+            logoUrl: detail.logoImageUrl ?? undefined,
+          }
+        }),
+      )
+      return new Map(
+        results.flatMap((r) =>
+          r.status === "fulfilled"
+            ? [[r.value.projectId, r.value.logoUrl]]
+            : [],
+        ),
+      )
+    },
+    enabled: enabled && projects.length > 0,
+  })
+
   // 서버 데이터 -> 프론트 타입으로 변환
   const transformed: ProjectApplication[] = useMemo(
     () =>
-      projects.map((p) =>
-        toProjectApplication(p, applicantsQuery.data?.get(String(p.id)) ?? []),
-      ),
-    [projects, applicantsQuery.data],
+      projects.map((p) => ({
+        ...toProjectApplication(
+          p,
+          applicantsQuery.data?.get(String(p.id)) ?? [],
+        ),
+        logoUrl: logoQuery.data?.get(String(p.id)),
+      })),
+    [projects, applicantsQuery.data, logoQuery.data],
   )
 
   // PM 프로젝트 정보 (프로젝트 카드용)
@@ -215,6 +248,7 @@ export function useChallengerPageData(
         projectsQuery.isLoading ||
         applicantsQuery.isLoading ||
         projectStatsQuery.isLoading ||
+        logoQuery.isLoading ||
         isMeLoading ||
         (chapterId !== undefined &&
           roundsQuery.data === undefined &&

--- a/src/features/application/model/types.ts
+++ b/src/features/application/model/types.ts
@@ -89,6 +89,7 @@ export interface ProjectApplication {
   challengerName: string
   challengerUniversity: string
   thumbnailUrl?: string
+  logoUrl?: string
   statusLabel: string
   designCount: AssignmentCount
   feCount: AssignmentCount

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -244,7 +244,7 @@ function MatchingApplicationsPage() {
                       projectName={project.projectName}
                       challengerName={project.challengerName}
                       challengerUniversity={project.challengerUniversity}
-                      thumbnailUrl={project.thumbnailUrl}
+                      thumbnailUrl={project.logoUrl}
                       size="lg"
                     />
                     <ChallengerApplicationView


### PR DESCRIPTION
## 📸 작업 내용

> PM 지원현황 페이지의 프로젝트 카드에 배너 이미지 대신 로고 이미지를 표시하도록 변경

- ProjectTitleCard에 전달하던 thumbnailUrl(배너)을 logoUrl(로고)로 교체
- managed projects API가 logoImageUrl을 미포함하여 getProjectDetail로 별도 조회

## 🎞️ 주요 코드 설명

> 설명이 필요한 코드 위주로 작성해주세요

### 프로젝트 로고 별도 조회

```TypeScript
const logoQuery = useQuery({
  queryKey: [...applicationKeys.all, "project-logos", projects.map((p) => p.id)],
  queryFn: async () => {
    const results = await Promise.allSettled(
      projects.map(async (p) => {
        const detail = await getProjectDetail(Number(p.id))
        return { projectId: String(p.id), logoUrl: detail.logoImageUrl ?? undefined }
      }),
    )
    return new Map(
      results.flatMap((r) =>
        r.status === "fulfilled" ? [[r.value.projectId, r.value.logoUrl]] : [],
      ),
    )
  },
  enabled: enabled && projects.length > 0,
})
```

- /v1/projects/me/managed 응답에 logoImageUrl이 없어 프로젝트별로 상세 API를 추가 호출
- logoQuery.isLoading을 isLoading에 포함해 로고 로딩 전 깜빡임 방지


## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #511 
