### PR TITLE
⚡️ perf: 소개 페이지 GPU 부하 완화

### DIFF
--- a/src/features/intro/ui/IntroPage.tsx
+++ b/src/features/intro/ui/IntroPage.tsx
@@ -1,5 +1,3 @@
-import { motion } from "motion/react"
-
 import { LANDING_BACKGROUND, LANDING_BACKGROUND_HEIGHT } from "../constants"
 import { LandingHeader } from "./components/LandingHeader"
 import { LightStripTexture } from "./components/LightStripTexture"
@@ -20,6 +18,34 @@ const LANDING_BACKGROUND_MASK = `linear-gradient(to right, transparent, #000 ${L
 
 const LIGHT_OVERLAY_FADE = 120
 const LIGHT_OVERLAY_MASK = `linear-gradient(to right, transparent, #000 ${LIGHT_OVERLAY_FADE}px, #000 calc(100% - ${LIGHT_OVERLAY_FADE}px), transparent)`
+
+function StaticGlow({
+  left,
+  top,
+  size,
+  opacity = 0.3,
+}: {
+  left: number
+  top: number
+  size: number
+  opacity?: number
+}) {
+  return (
+    <div
+      className="pointer-events-none absolute rounded-full"
+      style={{
+        left,
+        top,
+        width: size,
+        height: size,
+        opacity,
+        background:
+          "radial-gradient(circle, rgba(95,215,207,0.42) 0%, rgba(95,215,207,0.22) 34%, rgba(95,215,207,0.08) 58%, rgba(95,215,207,0) 78%)",
+      }}
+      aria-hidden="true"
+    />
+  )
+}
 
 export function IntroPage() {
   return (
@@ -81,71 +107,25 @@ export function IntroPage() {
               }}
               aria-hidden="true"
             >
-              <motion.div
-                className="pointer-events-none absolute top-[428px] left-[880px] size-[764px] rounded-full bg-[#5fd7cf]/30 blur-[150px]"
-                animate={{ x: [0, 18, 0], y: [0, -14, 0] }}
-                transition={{
-                  duration: 14,
-                  repeat: Infinity,
-                  ease: "easeInOut",
-                }}
-              />
-              <motion.div
-                className="pointer-events-none absolute top-[1117px] left-[720px] size-[764px] rounded-full bg-[#5fd7cf]/30 blur-[150px]"
-                animate={{ x: [0, -16, 0], y: [0, 18, 0] }}
-                transition={{
-                  duration: 16,
-                  repeat: Infinity,
-                  ease: "easeInOut",
-                }}
-              />
-              <motion.div
-                className="pointer-events-none absolute top-[2048px] left-[880px] size-[764px] rounded-full bg-[#5fd7cf]/30 blur-[150px]"
-                animate={{ x: [0, 14, 0], y: [0, 16, 0] }}
-                transition={{
-                  duration: 18,
-                  repeat: Infinity,
-                  ease: "easeInOut",
-                }}
-              />
-              <motion.div
+              <StaticGlow left={760} top={308} size={1004} opacity={0.34} />
+              <StaticGlow left={600} top={997} size={1004} opacity={0.32} />
+              <StaticGlow left={760} top={1928} size={1004} opacity={0.3} />
+              <div
                 className="pointer-events-none absolute top-[1322px] left-[-79px] size-[676px]"
-                animate={{ x: [0, 12, 0], y: [0, -10, 0] }}
-                transition={{
-                  duration: 15,
-                  repeat: Infinity,
-                  ease: "easeInOut",
-                }}
                 style={{
                   backgroundImage:
                     "radial-gradient(circle, rgba(255,255,255,0.52) 0%, rgba(255,255,255,0) 50%)",
                 }}
               />
-              <motion.div
-                className="pointer-events-none absolute top-0 right-0"
-                animate={{ x: [0, -10, 0], opacity: [0.85, 1, 0.85] }}
-                transition={{
-                  duration: 12,
-                  repeat: Infinity,
-                  ease: "easeInOut",
-                }}
-              >
+              <div className="pointer-events-none absolute top-0 right-0 opacity-90">
                 <LightStripTexture />
-              </motion.div>
-              <motion.div
-                className="pointer-events-none absolute top-0 left-[101px]"
-                animate={{ x: [0, 10, 0], opacity: [0.75, 1, 0.75] }}
-                transition={{
-                  duration: 13,
-                  repeat: Infinity,
-                  ease: "easeInOut",
-                }}
-              >
+              </div>
+              <div className="pointer-events-none absolute top-0 left-[101px] opacity-80">
                 <div className="flex">
                   <LightStripTexture />
                   <LightStripTexture className="ml-[736px]" />
                 </div>
-              </motion.div>
+              </div>
             </div>
             <ProductTeamIntroSection />
             <ProductTeamAboutSection />

--- a/src/features/intro/ui/components/FlowSteps.tsx
+++ b/src/features/intro/ui/components/FlowSteps.tsx
@@ -14,7 +14,7 @@ export function FlowSteps() {
       {PAINPOINT_STEPS.map((step, index) => (
         <Fragment key={step}>
           <motion.div
-            className="flex items-center justify-center gap-[7.5px] rounded-full bg-[rgba(251,252,252,0.05)] px-5.5 pt-2 pb-1.5 shadow-[inset_0_-1px_0_0_rgba(255,255,255,0.25)] backdrop-blur-[21px]"
+            className="flex items-center justify-center gap-[7.5px] rounded-full bg-[rgba(251,252,252,0.08)] px-5.5 pt-2 pb-1.5 shadow-[inset_0_-1px_0_0_rgba(255,255,255,0.25)]"
             variants={{
               hidden: { opacity: 0, y: 14, scale: 0.98 },
               visible: {

--- a/src/features/intro/ui/components/LandingHeader.tsx
+++ b/src/features/intro/ui/components/LandingHeader.tsx
@@ -16,6 +16,8 @@ export function LandingHeader() {
   const navigate = useNavigate()
   const [isVisible, setIsVisible] = useState(true)
   const lastScrollY = useRef(0)
+  const visibleRef = useRef(true)
+  const tickingRef = useRef(false)
   const addToast = useToastStore((s) => s.addToast)
 
   const handleDisabledClick = (item: HeaderNavItem) => {
@@ -30,21 +32,23 @@ export function LandingHeader() {
 
   useEffect(() => {
     const handleScroll = () => {
-      const currentScrollY = window.scrollY
-      const threshold = window.innerHeight
+      if (tickingRef.current) return
+      tickingRef.current = true
 
-      if (currentScrollY <= threshold) {
-        setIsVisible(true)
-      } else {
-        const isScrollingUp = currentScrollY < lastScrollY.current
-        if (isScrollingUp) {
-          setIsVisible(true)
-        } else {
-          setIsVisible(false)
+      requestAnimationFrame(() => {
+        const currentScrollY = window.scrollY
+        const threshold = window.innerHeight
+        const nextVisible =
+          currentScrollY <= threshold || currentScrollY < lastScrollY.current
+
+        if (visibleRef.current !== nextVisible) {
+          visibleRef.current = nextVisible
+          setIsVisible(nextVisible)
         }
-      }
 
-      lastScrollY.current = currentScrollY
+        lastScrollY.current = currentScrollY
+        tickingRef.current = false
+      })
     }
 
     window.addEventListener("scroll", handleScroll, { passive: true })
@@ -76,10 +80,8 @@ export function LandingHeader() {
         <nav
           className="relative flex items-center justify-center gap-1.5 rounded-[9999px] p-1.5"
           style={{
-            background: "rgba(251, 252, 252, 0.30)",
+            background: "rgba(33, 54, 51, 0.72)",
             boxShadow: "0 0 16px 0 rgba(10, 86, 80, 0.04)",
-            backdropFilter: "blur(21px)",
-            WebkitBackdropFilter: "blur(21px)",
           }}
           aria-label="랜딩 페이지 내비게이션"
         >

--- a/src/features/intro/ui/components/LandingHeader.tsx
+++ b/src/features/intro/ui/components/LandingHeader.tsx
@@ -31,11 +31,13 @@ export function LandingHeader() {
   }
 
   useEffect(() => {
+    let rafId: number | null = null
+
     const handleScroll = () => {
       if (tickingRef.current) return
       tickingRef.current = true
 
-      requestAnimationFrame(() => {
+      rafId = requestAnimationFrame(() => {
         const currentScrollY = window.scrollY
         const threshold = window.innerHeight
         const nextVisible =
@@ -52,7 +54,11 @@ export function LandingHeader() {
     }
 
     window.addEventListener("scroll", handleScroll, { passive: true })
-    return () => window.removeEventListener("scroll", handleScroll)
+    return () => {
+      window.removeEventListener("scroll", handleScroll)
+      if (rafId !== null) cancelAnimationFrame(rafId)
+      tickingRef.current = false
+    }
   }, [])
 
   return (

--- a/src/features/intro/ui/components/LightStripTexture.tsx
+++ b/src/features/intro/ui/components/LightStripTexture.tsx
@@ -16,7 +16,7 @@ export function LightStripTexture({ className = "" }: LightStripTextureProps) {
       {STRIP_OPACITIES.map((opacity, index) => (
         <span
           key={index}
-          className="h-full w-[69.14px] shrink-0 mix-blend-overlay backdrop-blur-[83px]"
+          className="h-full w-[69.14px] shrink-0"
           style={{ opacity, backgroundImage: STRIP_GRADIENT }}
         />
       ))}

--- a/src/features/intro/ui/components/SmoothGlow.tsx
+++ b/src/features/intro/ui/components/SmoothGlow.tsx
@@ -19,7 +19,7 @@ export function SmoothGlow({
 }: SmoothGlowProps) {
   return (
     <div
-      className="pointer-events-none absolute will-change-transform"
+      className="pointer-events-none absolute"
       style={{
         left,
         top,

--- a/src/features/intro/ui/sections/ManualGuide.tsx
+++ b/src/features/intro/ui/sections/ManualGuide.tsx
@@ -42,7 +42,7 @@ function PaginationBar({
   onDotClick,
 }: PaginationBarProps) {
   return (
-    <div className="absolute top-[852px] left-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center justify-center gap-[10px] rounded-[12px] border border-white/10 bg-[rgba(251,252,252,0.05)] px-[12px] py-[6px] backdrop-blur-[10px]">
+    <div className="absolute top-[852px] left-1/2 flex -translate-x-1/2 -translate-y-1/2 items-center justify-center gap-[10px] rounded-[12px] border border-white/10 bg-[rgba(21,36,34,0.72)] px-[12px] py-[6px]">
       <button
         onClick={onPrev}
         disabled={activeDot === 0}

--- a/src/features/intro/ui/sections/MatchingSection.tsx
+++ b/src/features/intro/ui/sections/MatchingSection.tsx
@@ -54,6 +54,7 @@ function smoothScrollTo(targetY: number, duration: number, onDone: () => void) {
 export function MatchingSection() {
   const ref = useRef<HTMLElement>(null)
   const directionRef = useRef(1)
+  const pageRef = useRef(0)
   const isProgrammaticRef = useRef(false)
   const cancelScrollRef = useRef<(() => void) | null>(null)
   const clearGuardTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -62,14 +63,20 @@ export function MatchingSection() {
     offset: ["start start", "end end"],
   })
   const [page, setPage] = useState(0)
+  const setCurrentPage = (nextPage: number) => {
+    pageRef.current = nextPage
+    setPage(nextPage)
+  }
+
   useMotionValueEvent(scrollYProgress, "change", (value) => {
     if (isProgrammaticRef.current) return
     const nextPage = Math.min(
       TOTAL_PAGE_COUNT - 1,
       Math.floor(value * TOTAL_PAGE_COUNT),
     )
-    directionRef.current = nextPage > page ? 1 : -1
-    setPage(nextPage)
+    if (nextPage === pageRef.current) return
+    directionRef.current = nextPage > pageRef.current ? 1 : -1
+    setCurrentPage(nextPage)
   })
 
   useEffect(() => {
@@ -81,16 +88,18 @@ export function MatchingSection() {
   function moveToPage(index: number) {
     const section = ref.current
     if (!section) {
-      setPage(index)
+      setCurrentPage(index)
       return
     }
+
+    if (index === pageRef.current) return
 
     const sectionTop = section.getBoundingClientRect().top + window.scrollY
     const scrollableHeight = section.offsetHeight - window.innerHeight
     const targetY =
       sectionTop + (scrollableHeight * index) / (TOTAL_PAGE_COUNT - 1)
 
-    setPage(index)
+    setCurrentPage(index)
     cancelScrollRef.current?.()
     if (clearGuardTimerRef.current) clearTimeout(clearGuardTimerRef.current)
     isProgrammaticRef.current = true

--- a/src/features/intro/ui/sections/MatchingSection.tsx
+++ b/src/features/intro/ui/sections/MatchingSection.tsx
@@ -70,9 +70,9 @@ export function MatchingSection() {
 
   useMotionValueEvent(scrollYProgress, "change", (value) => {
     if (isProgrammaticRef.current) return
-    const nextPage = Math.min(
-      TOTAL_PAGE_COUNT - 1,
-      Math.floor(value * TOTAL_PAGE_COUNT),
+    const nextPage = Math.max(
+      0,
+      Math.min(TOTAL_PAGE_COUNT - 1, Math.floor(value * TOTAL_PAGE_COUNT)),
     )
     if (nextPage === pageRef.current) return
     directionRef.current = nextPage > pageRef.current ? 1 : -1


### PR DESCRIPTION
## 📸 작업 내용

> 소개(랜딩) 페이지에서 GPU 합성 부하를 유발하던 요소들을 정리해 스크롤 렌더링 성능을 개선했습니다.

- 무한 반복 모션 글로우(`motion.div` × 5) 를 정적 radial-gradient 글로우 `StaticGlow` 로 대체해 상시 합성/리페인트 부하 제거
- 비용이 큰 `backdrop-filter: blur` 를 다수 제거하고 불투명 배경으로 대체 (랜딩 네비게이션, FlowSteps 칩, 라이트 스트립, 매뉴얼 가이드 페이지네이션 바)
- `will-change-transform` 제거로 불필요한 레이어 승격 방지 (`SmoothGlow`)
- 랜딩 헤더 스크롤 핸들러에 `requestAnimationFrame` throttle 적용 + 표시 상태 변화가 있을 때만 `setState` 호출
- 매칭 섹션에서 `pageRef` 로 현재 페이지를 추적해 동일 페이지로의 재설정 시 리렌더/스크롤 동작을 건너뛰도록 보정

## 🎞️ 주요 코드 설명

### 모션 글로우 → 정적 글로우 대체

```TypeScript
function StaticGlow({ left, top, size, opacity = 0.3 }: {
  left: number; top: number; size: number; opacity?: number
}) {
  return (
    <div
      className="pointer-events-none absolute rounded-full"
      style={{
        left, top, width: size, height: size, opacity,
        background:
          "radial-gradient(circle, rgba(95,215,207,0.42) 0%, rgba(95,215,207,0.22) 34%, rgba(95,215,207,0.08) 58%, rgba(95,215,207,0) 78%)",
      }}
      aria-hidden="true"
    />
  )
}
```

- 기존엔 `blur-[150px]` 글로우를 `motion.div` 로 무한 이동 애니메이션을 돌려 매 프레임 재합성이 발생했습니다. 큰 blur 합성 대신 radial-gradient 로 광량을 직접 그려 정적 렌더링으로 전환했습니다.

### 스크롤 핸들러 rAF throttle

```TypeScript
const handleScroll = () => {
  if (tickingRef.current) return
  tickingRef.current = true
  requestAnimationFrame(() => {
    const currentScrollY = window.scrollY
    const threshold = window.innerHeight
    const nextVisible =
      currentScrollY <= threshold || currentScrollY < lastScrollY.current
    if (visibleRef.current !== nextVisible) {
      visibleRef.current = nextVisible
      setIsVisible(nextVisible)
    }
    lastScrollY.current = currentScrollY
    tickingRef.current = false
  })
}
```

- 스크롤 이벤트마다 동기적으로 레이아웃 값을 읽고 `setState` 하던 로직을 프레임당 1회로 throttle 하고, 표시 상태가 실제로 바뀔 때만 리렌더가 일어나도록 했습니다.

## 🔗 연결된 이슈

- Connected: #532
- Closes #532