### PR TITLE
✨ feat: 지원자 목록 클릭 동작 및 역할별 지원서 권한 게이팅

### DIFF
--- a/src/features/application/ui/ApplicationDetailModal.tsx
+++ b/src/features/application/ui/ApplicationDetailModal.tsx
@@ -8,8 +8,15 @@ import { CtaModal } from "@/shared/ui/modal/CtaModal"
 
 import { updateApplicationDecision } from "../api/applicationApi"
 import { applicationKeys } from "../api/applicationKeys"
-import { useApplicationDetail } from "../hooks/useApplications"
-import { toApplicantFormData, toServerStatus } from "../model/mappers"
+import {
+  useApplicationDetail,
+  useProjectApplications,
+} from "../hooks/useApplications"
+import {
+  toApplicantDetail,
+  toApplicantFormData,
+  toServerStatus,
+} from "../model/mappers"
 import { isRoundDecisionClosed } from "../model/matchingDecision"
 import { ModalApplicantPanel } from "./detail-modal/ModalApplicantPanel"
 import { ModalFormPanel } from "./detail-modal/ModalFormPanel"
@@ -31,6 +38,8 @@ interface ApplicationDetailModalProps {
   hidePendingStatus?: boolean
   /** 프로젝트 단위 합/불 결정 권한 (projects/permissions의 application.canDecide) */
   canDecide?: boolean
+  /** 모달 오픈 시 미리 선택할 지원서 ID (챌린저 이름 클릭으로 지원서 상세 바로 열기) */
+  initialApplicantId?: string
 }
 
 // 합/불 상태 변경 확인 모달 문구 (대기는 PM 뷰에서 노출되지 않으나 타입 완전성 위해 포함)
@@ -75,6 +84,7 @@ export function ApplicationDetailModal({
   disableFormPanel = false,
   hidePendingStatus = false,
   canDecide = false,
+  initialApplicantId,
 }: ApplicationDetailModalProps) {
   const addToast = useToastStore((s) => s.addToast)
 
@@ -95,13 +105,30 @@ export function ApplicationDetailModal({
   // 이중 실행 방지용 ref (Strict Mode 대응)
   const emptyToastShownRef = useRef(false)
 
-  // 지원자 없는 프로젝트 모달 오픈 시 토스트 노출
+  // admin 등 project.applicants가 비어 있으면 지원자 목록을 직접 조회(펼침 목록 캐시 재사용)
+  const lazyApplicantsQuery = useProjectApplications(
+    project.applicants.length === 0 ? Number(project.id) : 0,
+  )
+  const baseApplicants = useMemo(
+    () =>
+      project.applicants.length > 0
+        ? project.applicants
+        : (lazyApplicantsQuery.data ?? []).map(toApplicantDetail),
+    [project.applicants, lazyApplicantsQuery.data],
+  )
+
+  // 지원자 없는 프로젝트 모달 오픈 시 토스트 노출 (lazy 로드 완료 후 실제 지원자 0명일 때만)
   useEffect(() => {
     if (!open) {
       emptyToastShownRef.current = false
       return
     }
-    if (project.applicants.length === 0 && !emptyToastShownRef.current) {
+    if (
+      !initialApplicantId &&
+      !lazyApplicantsQuery.isLoading &&
+      baseApplicants.length === 0 &&
+      !emptyToastShownRef.current
+    ) {
       emptyToastShownRef.current = true
       addToast({
         message: "아직 지원한 챌린저가 없습니다.",
@@ -111,21 +138,35 @@ export function ApplicationDetailModal({
         duration: 3000,
       })
     }
-  }, [open, addToast])
+  }, [
+    open,
+    addToast,
+    initialApplicantId,
+    baseApplicants.length,
+    lazyApplicantsQuery.isLoading,
+  ])
 
   // 합/불 결정 권한은 프로젝트 단위(application.canDecide)로 상위에서 전달받는다
   const canApproveApplicant = (_applicantId: string): boolean => canDecide
 
-  const projectWithOverrides = useMemo(() => {
-    if (Object.keys(statusOverrides).length === 0) return project
-    return {
-      ...project,
-      applicants: project.applicants.map((a) => {
-        const override = statusOverrides[a.id]
-        return override ? { ...a, status: override } : a
-      }),
+  // 챌린저 이름 클릭으로 지정된 지원자를 모달 오픈 시 선택 → 지원서 상세(폼) 바로 표시
+  // 단, 폼 조회 권한이 없는 역할(disableFormPanel)은 목록만 보고 폼은 열지 않는다
+  useEffect(() => {
+    if (open && initialApplicantId && !disableFormPanel) {
+      setSelectedApplicantId(initialApplicantId)
     }
-  }, [project, statusOverrides])
+  }, [open, initialApplicantId, disableFormPanel])
+
+  const projectWithOverrides = useMemo(() => {
+    const applicants =
+      Object.keys(statusOverrides).length === 0
+        ? baseApplicants
+        : baseApplicants.map((a) => {
+            const override = statusOverrides[a.id]
+            return override ? { ...a, status: override } : a
+          })
+    return { ...project, applicants }
+  }, [project, baseApplicants, statusOverrides])
 
   const selectedApplicant = selectedApplicantId
     ? (projectWithOverrides.applicants.find(
@@ -295,6 +336,7 @@ export function ApplicationDetailModal({
                 decisionDeadlineByRound={decisionDeadlineByRound}
                 canApproveApplicant={canApproveApplicant}
                 approvePermissionLoading={false}
+                disableFormPanel={disableFormPanel}
                 statusOptions={hidePendingStatus ? ["pass", "fail"] : undefined}
                 className="w-full"
               />

--- a/src/features/application/ui/ApplicationTableSection.tsx
+++ b/src/features/application/ui/ApplicationTableSection.tsx
@@ -109,6 +109,19 @@ export function ApplicationTableSection({
   const [detailModalOpen, setDetailModalOpen] = useState(false)
   const [selectedProject, setSelectedProject] =
     useState<ProjectApplication | null>(null)
+  // 챌린저 이름 클릭 시 미리 선택할 지원서 ID (지원서 상세 바로 열기)
+  const [initialApplicantId, setInitialApplicantId] = useState<
+    string | undefined
+  >(undefined)
+
+  const openApplicantDetail = (
+    targetProject: ProjectApplication,
+    applicationId: string,
+  ) => {
+    setSelectedProject(targetProject)
+    setInitialApplicantId(applicationId)
+    setDetailModalOpen(true)
+  }
 
   // 필터 상태
   const [openFilter, setOpenFilter] = useState<string | null>(null)
@@ -331,6 +344,7 @@ export function ApplicationTableSection({
                     ? undefined
                     : () => {
                         setSelectedProject(project)
+                        setInitialApplicantId(undefined)
                         setDetailModalOpen(true)
                       }
                 }
@@ -339,7 +353,12 @@ export function ApplicationTableSection({
 
               {isExpanded &&
                 (lazyLoadApplicants ? (
-                  <LazyApplicantRows projectId={project.id} />
+                  <LazyApplicantRows
+                    projectId={project.id}
+                    onApplicantClick={(applicationId) =>
+                      openApplicantDetail(project, applicationId)
+                    }
+                  />
                 ) : project.applicants.length > 0 ? (
                   <div className="border-teal-gray-150 py-1">
                     {project.applicants.map((applicant) => (
@@ -352,6 +371,9 @@ export function ApplicationTableSection({
                         status={applicant.status}
                         processedAt={applicant.processedAt}
                         appliedAt={applicant.appliedAt}
+                        onChallengerClick={() =>
+                          openApplicantDetail(project, applicant.id)
+                        }
                       />
                     ))}
                   </div>
@@ -382,12 +404,16 @@ export function ApplicationTableSection({
           project={selectedProject}
           chapterName={chapterName ?? ""}
           open={detailModalOpen}
-          onOpenChange={setDetailModalOpen}
+          onOpenChange={(next) => {
+            setDetailModalOpen(next)
+            if (!next) setInitialApplicantId(undefined)
+          }}
           currentRound={currentRound}
           decisionDeadlineByRound={decisionDeadlineByRound}
           disableFormPanel={disableFormPanel}
           hidePendingStatus={hidePendingStatus}
           canDecide={canDecide}
+          initialApplicantId={initialApplicantId}
         />
       )}
     </div>

--- a/src/features/application/ui/LazyApplicantRows.tsx
+++ b/src/features/application/ui/LazyApplicantRows.tsx
@@ -4,9 +4,13 @@ import { ApplicantDetailRow } from "./ApplicantDetailRow"
 
 interface LazyApplicantRowsProps {
   projectId: string
+  onApplicantClick?: (applicationId: string) => void
 }
 
-export function LazyApplicantRows({ projectId }: LazyApplicantRowsProps) {
+export function LazyApplicantRows({
+  projectId,
+  onApplicantClick,
+}: LazyApplicantRowsProps) {
   const query = useProjectApplications(Number(projectId))
 
   if (query.isLoading) {
@@ -43,6 +47,9 @@ export function LazyApplicantRows({ projectId }: LazyApplicantRowsProps) {
           status={applicant.status}
           processedAt={applicant.processedAt}
           appliedAt={applicant.appliedAt}
+          onChallengerClick={
+            onApplicantClick ? () => onApplicantClick(applicant.id) : undefined
+          }
         />
       ))}
     </div>

--- a/src/features/application/ui/detail-modal/ApplicantRoleSection.tsx
+++ b/src/features/application/ui/detail-modal/ApplicantRoleSection.tsx
@@ -17,6 +17,8 @@ interface ApplicantRoleSectionProps {
   canApproveApplicant: (applicantId: string) => boolean
   approvePermissionLoading: boolean
   statusOptions?: StatusValue[]
+  /** 지원서 상세 조회 권한 없음 - 지원자 이름 버튼 비활성 */
+  nameDisabled?: boolean
   className?: string
 }
 
@@ -31,6 +33,7 @@ export function ApplicantRoleSection({
   canApproveApplicant,
   approvePermissionLoading,
   statusOptions,
+  nameDisabled = false,
   className,
 }: ApplicantRoleSectionProps) {
   const roundCounts = applicants.reduce<Record<number, number>>((acc, a) => {
@@ -97,6 +100,7 @@ export function ApplicantRoleSection({
               onStatusChange={(s) => onStatusChange?.(applicant.id, s)}
               statusDisabled={statusDisabled}
               statusOptions={statusOptions}
+              nameDisabled={nameDisabled}
             />
           )
         })}

--- a/src/features/application/ui/detail-modal/ApplicantRow.tsx
+++ b/src/features/application/ui/detail-modal/ApplicantRow.tsx
@@ -16,6 +16,8 @@ interface ApplicantRowProps {
   onStatusChange?: (status: StatusValue) => void
   statusDisabled?: boolean
   statusOptions?: StatusValue[]
+  /** 지원서 상세 조회 권한 없음 - 이름 버튼 비활성(폼 열기 차단) */
+  nameDisabled?: boolean
 }
 
 export function ApplicantRow({
@@ -30,6 +32,7 @@ export function ApplicantRow({
   onStatusChange,
   statusDisabled = false,
   statusOptions,
+  nameDisabled = false,
 }: ApplicantRowProps) {
   return (
     <div
@@ -41,9 +44,11 @@ export function ApplicantRow({
         <button
           type="button"
           onClick={onClick}
+          disabled={nameDisabled}
           className={cn(
             "flex h-12.5 w-37.5 flex-col justify-center rounded-lg px-3.5 text-left",
             isSelected && "bg-teal-50",
+            nameDisabled && "cursor-not-allowed",
           )}
         >
           <span className="text-body-2-medium text-teal-gray-900">{name}</span>

--- a/src/features/application/ui/detail-modal/ModalApplicantPanel.tsx
+++ b/src/features/application/ui/detail-modal/ModalApplicantPanel.tsx
@@ -41,6 +41,8 @@ interface ModalApplicantPanelProps {
   canApproveApplicant: (applicantId: string) => boolean
   approvePermissionLoading: boolean
   statusOptions?: StatusValue[]
+  /** 지원서 상세 조회 권한 없음(학교 회장단/운영국원 등) - 지원자 이름 버튼 비활성 */
+  disableFormPanel?: boolean
   className?: string
 }
 
@@ -60,6 +62,7 @@ export function ModalApplicantPanel({
   canApproveApplicant,
   approvePermissionLoading,
   statusOptions,
+  disableFormPanel = false,
   className,
 }: ModalApplicantPanelProps) {
   const filteredApplicants = useMemo(() => {
@@ -272,6 +275,7 @@ export function ModalApplicantPanel({
                 canApproveApplicant={canApproveApplicant}
                 approvePermissionLoading={approvePermissionLoading}
                 statusOptions={statusOptions}
+                nameDisabled={disableFormPanel}
               />
             ))}
 

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -143,10 +143,7 @@ function MatchingApplicationsPage() {
   const availablePerRound = challenger.availablePerRound
 
   // PM 뷰 프로젝트별 capability (목록/통계/승인 노출 게이팅)
-  const pmProjectIds = useMemo(
-    () => pmProjects.map((p) => p.id),
-    [pmProjects],
-  )
+  const pmProjectIds = useMemo(() => pmProjects.map((p) => p.id), [pmProjects])
   const pmPermissions = useProjectsPermissions(pmProjectIds, {
     enabled: showPmSection && pmProjectIds.length > 0,
   })
@@ -218,8 +215,13 @@ function MatchingApplicationsPage() {
                       projects={adminProjects}
                       currentRound={admin.currentRound}
                       chapterName={selectedChapter}
-                      disableProjectModal
                       lazyLoadApplicants
+                      disableFormPanel={
+                        !(
+                          isCentralCore(identity) ||
+                          isChapterPresident(identity)
+                        )
+                      }
                     />
                   )}
                 </div>


### PR DESCRIPTION
## 📸 작업 내용

- **프로젝트 제목 클릭 → 지원자 목록 모달**: 운영진 뷰에서 동작하지 않던 제목 버튼을 매칭 결과 시트처럼 해당 프로젝트의 지원자 목록 모달이 열리도록 연결.
- **지원자 이름 클릭 → 지원서 상세(폼)**: 핸들러가 비어 있던 이름 버튼을 해당 지원서 상세로 연결(목록이 비어 있으면 지연 조회).
- **역할별 권한 게이팅**: `GET /api/v1/projects/permissions` capability(`application.canReadList`/`canDecide`)와 지원서 상세 조회 권한에 맞춰 노출 정비.
  - 지원서 상세 조회 권한이 없는 역할은 모달은 열되 **개별 지원서 폼 진입 비활성**(이름 버튼 disabled).
  - 합/불·대기 결정 버튼은 결정 권한(PO·진행 중 차수)에서만 활성, 그 외 읽기 전용.
- 운영진 뷰 모달의 **빈-지원자 토스트 오표시** 수정(지연 조회 완료 후 실제 0명일 때만 노출).

## 🎞️ 주요 코드 설명

> 프로젝트 단위 capability를 prop으로 흘려 모달 내부 폼/결정 노출을 게이팅

```TypeScript
// 지원서 상세 조회 권한 없는 역할: 모달은 열되 폼은 비활성
<ApplicationTableSection
  disableFormPanel={!(isCentralCore(identity) || isChapterPresident(identity))}
/>

// 이름 클릭으로 지정한 지원자는 권한 있을 때만 폼 자동 선택
useEffect(() => {
  if (open && initialApplicantId && !disableFormPanel) {
    setSelectedApplicantId(initialApplicantId)
  }
}, [open, initialApplicantId, disableFormPanel])
```

## 🔗 연결된 이슈

- Connected: #536
- Closes #536