### PR TITLE
🐛 fix: 프로젝트 관리 경로 합/불 버튼 canDecide 미배선 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format:check": "prettier --check .",
     "test": "vitest",
     "test:run": "vitest run",
+    "test:tz": "TZ=Asia/Seoul vitest run && TZ=UTC vitest run && TZ=America/New_York vitest run",
     "prepare": "husky",
     "generate:api-types": "openapi-typescript ./openapi.yaml -o ./src/types/api.d.ts",
     "svgr": "npx @svgr/cli -d src/shared/assets --ignore-existing --typescript --no-dimensions --no-index public",

--- a/src/features/application/model/matchingDecision.test.ts
+++ b/src/features/application/model/matchingDecision.test.ts
@@ -76,4 +76,24 @@ describe("isRoundDecisionClosed", () => {
     expect(isRoundDecisionClosed(3, map, now)).toBe(false)
     expect(isRoundDecisionClosed(1, undefined, now)).toBe(false)
   })
+
+  // 인시던트(자정 직전 합불 불가) 회귀 방지: 마감 "정확한 순간" 경계 고정
+  describe("결정 마감 경계 (now vs deadline)", () => {
+    const deadline = new Date("2026-06-20T00:00:00Z").getTime()
+    const boundaryMap = buildDecisionDeadlineByRound([
+      makeRound("SECOND", "2026-06-20T00:00:00Z"),
+    ])
+
+    it("마감 1ms 전: 열림 (지원자 합불 가능)", () => {
+      expect(isRoundDecisionClosed(2, boundaryMap, deadline - 1)).toBe(false)
+    })
+
+    it("마감 정각(now === deadline): 열림 (> 비교라 잠그지 않음)", () => {
+      expect(isRoundDecisionClosed(2, boundaryMap, deadline)).toBe(false)
+    })
+
+    it("마감 1ms 후: 잠김 (자동 확정 영역)", () => {
+      expect(isRoundDecisionClosed(2, boundaryMap, deadline + 1)).toBe(true)
+    })
+  })
 })

--- a/src/features/matching/model/matchingRoundMock.test.ts
+++ b/src/features/matching/model/matchingRoundMock.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  computeDecisionDeadline,
+  parseServerDatetime,
+  toISODatetime,
+} from "./matchingRoundMock"
+
+// 차수 등록 환경(브라우저)이 KST(UTC+9)인지. 운영 기준 타임존.
+const AMBIENT_IS_KST =
+  new Date("2026-06-20T00:00:00").getTimezoneOffset() === -540
+
+// UTC instant -> KST(고정 +9h) 벽시계 문자열. ambient 타임존과 무관하게 동작.
+function kstWallClock(iso: string): string {
+  const kst = new Date(new Date(iso).getTime() + 9 * 60 * 60 * 1000)
+  const y = kst.getUTCFullYear()
+  const m = String(kst.getUTCMonth() + 1).padStart(2, "0")
+  const d = String(kst.getUTCDate()).padStart(2, "0")
+  const hh = String(kst.getUTCHours()).padStart(2, "0")
+  const mm = String(kst.getUTCMinutes()).padStart(2, "0")
+  return `${y}-${m}-${d} ${hh}:${mm}`
+}
+
+describe("computeDecisionDeadline (타임존 무관 — UTC instant 연산)", () => {
+  it("다음 차수 있음 -> 다음 차수 startsAt - 5분", () => {
+    expect(
+      computeDecisionDeadline(
+        "2026-06-19T03:00:00.000Z",
+        "2026-06-20T00:00:00.000Z",
+      ),
+    ).toBe("2026-06-19T23:55:00.000Z")
+  })
+
+  it("마지막 차수 -> endsAt + 12시간", () => {
+    expect(computeDecisionDeadline("2026-06-19T03:00:00.000Z", undefined)).toBe(
+      "2026-06-19T15:00:00.000Z",
+    )
+  })
+
+  // 인시던트 핵심: 운영자가 '자정 마감'으로 인지해도 다음 차수가 자정에 시작하면
+  // 2차 결정 마감은 자정 5분 전이다. (타임존과 무관한 규칙 자체를 고정)
+  it("다음 차수 자정(UTC) 시작 -> 결정 마감은 자정 5분 전(23:55Z), 자정이 아님", () => {
+    const deadline = computeDecisionDeadline(
+      "2026-06-19T03:00:00.000Z",
+      "2026-06-20T00:00:00.000Z",
+    )
+    expect(deadline).toBe("2026-06-19T23:55:00.000Z")
+    expect(deadline).not.toBe("2026-06-20T00:00:00.000Z")
+  })
+})
+
+describe("toISODatetime / parseServerDatetime (ambient 타임존 의존)", () => {
+  it("toISODatetime은 ambient 타임존 오프셋만큼 UTC instant가 이동한다", () => {
+    const offsetMs =
+      new Date("2026-06-20T00:00:00").getTimezoneOffset() * 60 * 1000
+    expect(toISODatetime("2026-06-20", "00:00", "start")).toBe(
+      new Date(Date.UTC(2026, 5, 20, 0, 0, 0) + offsetMs).toISOString(),
+    )
+  })
+
+  it("parse -> toISO 왕복은 같은 환경에서 벽시계를 보존한다", () => {
+    const utc = "2026-06-19T15:00:00.000Z"
+    const { date, time } = parseServerDatetime(utc)
+    expect(toISODatetime(date, time, "start")).toBe(utc)
+  })
+})
+
+// 차수를 KST 브라우저에서 등록했을 때만 의도대로 동작함을 고정.
+// 비-KST 환경(예: TZ=UTC)에서 돌리면 이 블록이 skip 되며, 그 자체로
+// "등록 환경 타임존에 동작이 좌우된다"는 사실을 드러낸다.
+describe.runIf(AMBIENT_IS_KST)("KST 환경 인시던트 재현", () => {
+  it("운영자가 '자정까지'로 인지한 2차 결정 마감은 실제 23:55 KST", () => {
+    const nextStart = toISODatetime("2026-06-20", "00:00", "start")
+    const deadline = computeDecisionDeadline("2026-06-19T03:00:00.000Z", nextStart)
+    expect(kstWallClock(deadline)).toBe("2026-06-19 23:55")
+  })
+
+  it("11:50~11:52(KST) 시도는 23:55 마감 이전이라 정상이면 열려 있어야 한다", () => {
+    const nextStart = toISODatetime("2026-06-20", "00:00", "start")
+    const deadlineMs = new Date(
+      computeDecisionDeadline("2026-06-19T03:00:00.000Z", nextStart),
+    ).getTime()
+    const tryAt = new Date("2026-06-19T14:51:00.000Z").getTime() // 23:51 KST
+    expect(tryAt < deadlineMs).toBe(true)
+  })
+})
+
+// 비-KST 환경에서 동일 입력이 어떻게 어긋나는지 명시적으로 고정 (CI TZ=UTC 가정).
+describe.runIf(!AMBIENT_IS_KST)("비-KST 환경에서의 마감 어긋남", () => {
+  it("같은 '자정' 입력이라도 ambient가 UTC면 결정 마감 KST 벽시계가 23:55가 아니다", () => {
+    const nextStart = toISODatetime("2026-06-20", "00:00", "start")
+    const deadline = computeDecisionDeadline("2026-06-19T03:00:00.000Z", nextStart)
+    expect(kstWallClock(deadline)).not.toBe("2026-06-19 23:55")
+  })
+})

--- a/src/features/matching/model/matchingRoundMock.ts
+++ b/src/features/matching/model/matchingRoundMock.ts
@@ -59,7 +59,7 @@ const PHASE_LABEL: Record<MatchingPhase, string> = {
 export const PHASES: MatchingPhase[] = ["FIRST", "SECOND", "THIRD"]
 
 // 서버 ISO datetime -> UI date + time 분리
-function parseServerDatetime(iso: string): { date: string; time: string } {
+export function parseServerDatetime(iso: string): { date: string; time: string } {
   const dt = new Date(iso)
   const y = dt.getFullYear()
   const m = String(dt.getMonth() + 1).padStart(2, "0")
@@ -78,6 +78,26 @@ export function toISODatetime(
   const suffix = seconds === "start" ? ":00.000" : ":59.999"
   const dt = new Date(`${date}T${time}${suffix}`)
   return dt.toISOString()
+}
+
+export const DECISION_DEADLINE_NEXT_GAP_MS = 5 * 60 * 1000
+export const DECISION_DEADLINE_LAST_GAP_MS = 12 * 60 * 60 * 1000
+
+// 결정 마감(decisionDeadline) 자동 계산
+// 다음 차수 있음 -> 다음 차수 startsAt - 5분 / 마지막 차수 -> endsAt + 12시간
+// 입력/출력 모두 UTC ISO 문자열 (epoch ms 연산이라 타임존 무관)
+export function computeDecisionDeadline(
+  endsAt: string,
+  nextStartsAt: string | undefined,
+): string {
+  if (nextStartsAt !== undefined) {
+    return new Date(
+      new Date(nextStartsAt).getTime() - DECISION_DEADLINE_NEXT_GAP_MS,
+    ).toISOString()
+  }
+  return new Date(
+    new Date(endsAt).getTime() + DECISION_DEADLINE_LAST_GAP_MS,
+  ).toISOString()
 }
 
 // 서버 응답 -> RoundSchedule 변환

--- a/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
+++ b/src/features/project/management/ui/ProjectManagementMoreMenu.tsx
@@ -7,6 +7,7 @@ import { useMemo, useRef, useState } from "react"
 import { useToastStore } from "@/components/toast/useToastStore"
 import { getProjectApplications } from "@/features/application/api/applicationApi"
 import { applicationKeys } from "@/features/application/api/applicationKeys"
+import { useProjectsPermissions } from "@/features/application/hooks/useProjectsPermissions"
 import {
   toApplicantDetail,
   toFrontRole,
@@ -76,6 +77,10 @@ export function ProjectManagementMoreMenu({
   const addToast = useToastStore((s) => s.addToast)
 
   const numericProjectId = Number(projectId)
+
+  const permissions = useProjectsPermissions([projectId], {
+    enabled: applicationOpen,
+  })
 
   const projectDetailQuery = useQuery({
     queryKey: ["projectDetail", numericProjectId],
@@ -449,6 +454,7 @@ export function ProjectManagementMoreMenu({
         <ApplicationDetailModal
           project={projectApplication}
           chapterName={chapterName}
+          canDecide={permissions.canDecide(projectId)}
           open={applicationOpen}
           onOpenChange={setApplicationOpen}
         />

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -21,6 +21,7 @@ import {
 import {
   type Branch,
   emptyRoundSchedules,
+  computeDecisionDeadline,
   MATCHING_TYPES,
   type MatchingType,
   PHASES,
@@ -295,17 +296,10 @@ function MatchingRoundsPage() {
         // decisionDeadline 자동 계산:
         // 다음 차수 있음 -> 다음 차수 startsAt - 5분
         // 마지막 차수 -> endsAt + 12시간
-        let decisionDeadline: string
-        const nextData = filledData[idx + 1]
-        if (nextData) {
-          decisionDeadline = new Date(
-            new Date(nextData.startsAt).getTime() - 5 * 60 * 1000,
-          ).toISOString()
-        } else {
-          decisionDeadline = new Date(
-            new Date(endsAt).getTime() + 12 * 60 * 60 * 1000,
-          ).toISOString()
-        }
+        const decisionDeadline = computeDecisionDeadline(
+          endsAt,
+          filledData[idx + 1]?.startsAt,
+        )
 
         if (round.id) {
           return updateMatchingRound(round.id, {


### PR DESCRIPTION
## 📸 작업 내용

> 프로젝트 관리 경로에서 지원자 합/불 버튼이 눌리지 않던 인시던트 핫픽스 + 회귀 방지 테스트

- **핫픽스**: 합/불 결정 모달은 두 경로(지원 현황 · 프로젝트 관리)에서 렌더되는데, 프로젝트 단위 권한(`canDecide`, 기본값 false)을 **지원 현황 경로만 배선하고 프로젝트 관리 경로는 누락**해 버튼이 조용히 비활성됨. 지원 현황 경로와 동일하게 `useProjectsPermissions`의 `canDecide`를 배선해 수정.
- **회귀 방지**: 결정 마감 계산을 `computeDecisionDeadline` 순수 함수로 추출하고, 마감 게이팅 경계(±1ms·정각)·타임존 매트릭스(KST/UTC/NY) 테스트 추가.

## 🎞️ 주요 코드 설명

### 프로젝트 관리 경로 canDecide 배선

```TypeScript
const permissions = useProjectsPermissions([projectId], { enabled: applicationOpen })

<ApplicationDetailModal
  project={projectApplication}
  chapterName={chapterName}
  canDecide={permissions.canDecide(projectId)}
  open={applicationOpen}
  onOpenChange={setApplicationOpen}
/>
```

- `ApplicationDetailModal`의 `canDecide` 기본값이 false(fail-closed)라, 권한을 안 넘기면 버튼이 비활성됨. 서버 `canDecide`는 소유권 기반이라 PO에겐 true → 순수 프론트 회귀였음.

### 타임존 검증

- `pnpm test:tz` (KST/UTC/NY) 로 마감 계산·표시의 타임존 의존성 검증.

## 🔗 연결된 이슈

- 인시던트 대응 핫픽스 (이슈 미연결)