### PR TITLE
🚀 release: v1.1.10 develop → main 배포

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 형식은 [Keep a Changelog](https://keepachangelog.com/ko/1.1.0/)를 따르며, 버전 관리는 [Semantic Versioning](https://semver.org/lang/ko/)을 따릅니다.
 
+## [1.1.10] - 2026-07-03
+
+지원 현황 Top4 라벨이 활성 차수를 반영하도록 정정한 hotfix 배포입니다.
+
+### Fixed (수정)
+
+- **지원 현황 Top4 차수 정정** — 3차 지원 기간 중 Top4가 1차 기준으로 표시되던 문제를 활성 차수(activeRound) 기준으로 수정 (#546)
+
 ## [1.1.9] - 2026-06-20
 
 지원 현황·매칭의 권한 분기를 프로젝트 권한 capability 기반으로 정비하고, 소개 페이지 성능을 개선한 배포입니다.
@@ -219,6 +227,7 @@ v1.0.0 이후 develop에 누적된 변경을 배포합니다. 데모데이 소�
 
 UMC 데모데이 매칭 시스템 첫 공식 릴리스.
 
+[1.1.10]: https://github.com/UMC-PRODUCT/umc-product-web-v2/compare/v1.1.9...v1.1.10
 [1.1.9]: https://github.com/UMC-PRODUCT/umc-product-web-v2/compare/v1.1.8...v1.1.9
 [1.1.8]: https://github.com/UMC-PRODUCT/umc-product-web-v2/compare/v1.1.7...v1.1.8
 [1.1.7]: https://github.com/UMC-PRODUCT/umc-product-web-v2/compare/v1.1.6...v1.1.7

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "umc-product-web-v2",
   "private": true,
-  "version": "1.1.9",
+  "version": "1.1.10",
   "type": "module",
   "engines": {
     "node": ">=22.12.0"


### PR DESCRIPTION
## 📸 작업 내용

# v1.1.10 (2026-07-03)

main에 선반영된 지원 현황 Top4 차수 hotfix를 develop로 역머지하고 v1.1.10으로 정식화한 배포다.

### 새로 추가된 것들

없음.

### 개선된 것들

없음.

### 변경된 동작

없음 — 신규 스펙 변경 없음.

### 수정된 문제

**지원 현황**

- 3차 지원 기간 중 Top4가 1차 기준으로 표시되던 문제를 활성 차수(activeRound) 기준으로 표시하도록 수정한다. hotfix는 #547·#548로 main에 선반영됐고, 본 배포에서 develop로 역머지(#552)·v1.1.10으로 정식 기록한다. (#546)

### Deprecated

없음.

### 문서 업데이트

- CHANGELOG에 v1.1.10 항목을 추가한다.

## 🔗 연결된 이슈

- Closes #551
