### PR TITLE
♻️ refactor: _idCounter 제거하고 genId를 crypto.randomUUID로 교체

### DIFF
--- a/src/features/project/new/model/applicationQuestion.ts
+++ b/src/features/project/new/model/applicationQuestion.ts
@@ -25,10 +25,8 @@ export interface Section {
   questions: Question[]
 }
 
-let _idCounter = 0
-
 export function genId(): string {
-  return `q-${++_idCounter}`
+  return crypto.randomUUID()
 }
 
 export const PORTFOLIO_FIXED_TITLE =


### PR DESCRIPTION
## 📸 작업 내용

> 지원 문항 임시 id 생성 로직을 물리적으로 고유한 값으로 교체했습니다.

- 모듈 레벨 카운터 `let _idCounter = 0` 와 `q-${++_idCounter}` 방식을 제거하고 `genId()`가 `crypto.randomUUID()`를 반환하도록 변경
- 모듈 스코프 카운터가 SPA 수명 동안 누적되어 페이지 재진입 시 id가 이어지고 스토어 `reset()`에도 포함되지 않던 상태 누설을 해소
- `genId()` 시그니처(`() => string`)는 그대로라 사용처(`makeQuestion`, `applicationFormHydrator`)는 무변경

## 🎞️ 주요 코드 설명

### genId 교체

```TypeScript
// Before
let _idCounter = 0
export function genId(): string {
  return `q-${++_idCounter}`
}

// After
export function genId(): string {
  return crypto.randomUUID()
}
```

- 코드베이스 기존 관례(`useToastStore`, `kakaoSignIn`)와 동일하게 `crypto.randomUUID()` 사용
- `q-` prefix 형식에 의존하는 코드는 정의부 외 없음(grep 확인)

## 🖥️ 구현화면

> UI 변경 없음 (내부 id 생성 방식 변경으로 화면/동작 변화 없음)

## 🔗 연결된 이슈

- Connected: #560

## 💬 기타 더 이야기해볼 점

- 검증: `tsc -b`, `eslint`, `pnpm build` 통과 / 테스트 273건 통과 (실패 5건은 `ProjectApplyModal.ui.test.tsx`의 기존 QueryClientProvider 셋업 문제로 develop 기준 사전 존재, 본 변경과 무관)
