### PR TITLE
♻️ refactor: 사용성 조사 모달 렌더링 비활성화

### DIFF
--- a/scripts/check-boundaries.mjs
+++ b/scripts/check-boundaries.mjs
@@ -16,9 +16,9 @@
 
 import { execSync } from "node:child_process"
 
-// 2026-07-07 기준 lateral 위반 15건(features 슬라이스 간 수평 결합).
+// 2026-07-10 기준 lateral 위반 13건(features 슬라이스 간 수평 결합).
 // upward(역방향) 위반은 0이며 baseline 없이 무조건 차단한다.
-const LATERAL_BASELINE = 15
+const LATERAL_BASELINE = 13
 const RULE = "boundaries/dependencies"
 
 // 레이어 상하 순서(위->아래). 숫자가 클수록 하위 레이어다.

--- a/src/features/application/ui/MyApplicationView.tsx
+++ b/src/features/application/ui/MyApplicationView.tsx
@@ -8,7 +8,6 @@ import {
   type MyProjectApplicationResponse,
 } from "@/entities/project/api/matchingProject"
 import { ProjectDetailCard } from "@/features/project/list/ui/ProjectDetailCard"
-import { UsabilitySurvey } from "@/features/usability-survey"
 import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
 import { StatusChipTag } from "@/shared/ui/chip/StatusChipTag"
 import { EmptyState } from "@/shared/ui/EmptyState"
@@ -166,9 +165,6 @@ export function MyApplicationView() {
     enabled: gisuId != null,
   })
   const applications = raw.filter((a) => a.status !== "CANCELLED")
-  const hasMatchingResult = applications.some(
-    (a) => a.status === "APPROVED" || a.status === "REJECTED",
-  )
 
   if (!applications?.length) {
     return (
@@ -196,11 +192,6 @@ export function MyApplicationView() {
           }
         />
       ))}
-
-      <UsabilitySurvey
-        context="MATCHING_COMPLETED"
-        active={hasMatchingResult}
-      />
     </div>
   )
 }

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -24,7 +24,6 @@ import {
   mapApplicationFormToSections,
   projectKeys,
 } from "@/features/project/new/api"
-import { UsabilitySurvey } from "@/features/usability-survey"
 import { trackEvent } from "@/shared/analytics"
 import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
 import { ProjectLogo } from "@/shared/assets/icon/logo/ProjectLogo"
@@ -238,7 +237,6 @@ export function ProjectDetailCard({
     useState(false)
   const [isRecruitQuestionsModalOpen, setIsRecruitQuestionsModalOpen] =
     useState(false)
-  const [isSurveyActive, setIsSurveyActive] = useState(false)
   const {
     data: detail,
     dataUpdatedAt: detailDataUpdatedAt,
@@ -876,7 +874,6 @@ export function ProjectDetailCard({
                   void queryClient.invalidateQueries({
                     queryKey: ["myApplications", activeGisuId],
                   })
-                  setIsSurveyActive(true)
                 }}
               />
             )}
@@ -919,11 +916,6 @@ export function ProjectDetailCard({
           </Modal.Content>
         </Modal.Portal>
       </Modal.Root>
-
-      <UsabilitySurvey
-        context="APPLICATION_SUBMITTED"
-        active={isSurveyActive}
-      />
     </>
   )
 }

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -31,7 +31,6 @@ import { BranchSelector } from "@/features/matching/ui/BranchSelector"
 import { Calendar } from "@/features/matching/ui/Calendar"
 import { CalendarScheduleList } from "@/features/matching/ui/CalendarScheduleList"
 import { RoundForm } from "@/features/matching/ui/RoundForm"
-import { UsabilitySurvey } from "@/features/usability-survey"
 import InfoCircleIcon from "@/shared/assets/icon/infomation/InfoCircleIcon"
 import { Button } from "@/shared/ui/Button"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
@@ -92,7 +91,6 @@ function MatchingRoundsPage() {
     "idle",
   )
   const [showSaveModal, setShowSaveModal] = useState(false)
-  const [isSurveyActive, setIsSurveyActive] = useState(false)
   const [roundErrors, setRoundErrors] = useState(() =>
     PHASES.map(() => ({ startDate: false, endDate: false })),
   )
@@ -666,13 +664,7 @@ function MatchingRoundsPage() {
         confirmText="확인"
         onConfirm={() => {
           setShowSaveModal(false)
-          setIsSurveyActive(true)
         }}
-      />
-
-      <UsabilitySurvey
-        context="APPLICATION_MONITORING"
-        active={isSurveyActive}
       />
 
       {/* 페이지 이탈 모달 */}


### PR DESCRIPTION
## 📸 작업 내용

> 사용성 조사 모달이 더 이상 노출되지 않도록 프로덕션 마운트 지점을 제거했습니다.

- 렌더 도중 `localStorage`를 직접 조회(`hasSubmittedTemplate`)해 렌더 분기하던 사용성 조사 모달의 Hydration Mismatch 우려를 제거
- 마운트 3곳(`MyApplicationView`, `ProjectDetailCard`, `matching/rounds`)에서 `<UsabilitySurvey>` 및 관련 state/트리거/import 제거 (총 25줄 삭제)
- **완전 삭제가 아닌 "렌더링만 비활성화"**: `usability-survey` 피처 디렉토리와 테스트 라우트(`/test/usability-survey`)는 추후 복원을 위해 보존. 컴포넌트가 마운트되지 않아 문제의 localStorage 조회 경로 자체가 실행되지 않음

## 🎞️ 주요 코드 설명

### 마운트 지점 제거 (예: MyApplicationView)

```TypeScript
// Before
import { UsabilitySurvey } from "@/features/usability-survey"
// ...
const hasMatchingResult = applications.some(
  (a) => a.status === "APPROVED" || a.status === "REJECTED",
)
// ...
<UsabilitySurvey context="MATCHING_COMPLETED" active={hasMatchingResult} />

// After: import·파생 상태·JSX 모두 제거
```

- `ProjectDetailCard` / `rounds`는 `isSurveyActive` 상태와 `setIsSurveyActive(true)` 트리거도 함께 제거

## 🖥️ 구현화면

> UI 변경: 지원서 제출 완료 / 매칭 결과 확인 / 운영진 매칭 라운드 저장 완료 후 **사용성 조사 모달이 더 이상 노출되지 않음** (별도 캡쳐 없음)

## 🔗 연결된 이슈

- Connected: #561

## 💬 기타 더 이야기해볼 점

- 검증: `tsc -b`(미사용 import/변수 없음), `pnpm build` 통과 / 테스트 273건 통과 (실패 5건은 기존 `ProjectApplyModal.ui.test.tsx` 셋업 문제로 본 변경과 무관)
- 피처 코드가 데드코드로 남지만, 되돌리기 용이성(마운트 지점 재추가)을 우선한 결정
