### PR TITLE
🎨 디자인시스템 타이포그래피·컬러 토큰 재편

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -135,12 +135,18 @@
   --color-chip-springboot-300: var(--color-chip-springboot-300);
   --color-chip-springboot-500: var(--color-chip-springboot-500);
 
-  --color-role-central-200: var(--color-role-central-200);
-  --color-role-central-600: var(--color-role-central-600);
-  --color-role-campus-200: var(--color-role-campus-200);
-  --color-role-campus-600: var(--color-role-campus-600);
+  --color-role-hq-200: var(--color-role-hq-200);
+  --color-role-hq-600: var(--color-role-hq-600);
+  --color-role-chapter-200: var(--color-role-chapter-200);
+  --color-role-chapter-600: var(--color-role-chapter-600);
+  --color-role-school-200: var(--color-role-school-200);
+  --color-role-school-600: var(--color-role-school-600);
   --color-role-challenger-200: var(--color-role-challenger-200);
   --color-role-challenger-600: var(--color-role-challenger-600);
+  --color-role-superadmin-200: var(--color-role-superadmin-200);
+  --color-role-superadmin-600: var(--color-role-superadmin-600);
+  --color-role-product-200: var(--color-role-product-200);
+  --color-role-product-600: var(--color-role-product-600);
 
   --color-accent-teal-normal: var(--color-accent-teal-normal);
   --color-accent-teal-bright: var(--color-accent-teal-bright);

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -135,6 +135,16 @@
   --color-chip-springboot-300: var(--color-chip-springboot-300);
   --color-chip-springboot-500: var(--color-chip-springboot-500);
 
+  --color-chip-pm-100: var(--color-chip-pm-100);
+  --color-chip-pm-300: var(--color-chip-pm-300);
+  --color-chip-pm-500: var(--color-chip-pm-500);
+  --color-chip-mobile-pe-100: var(--color-chip-mobile-pe-100);
+  --color-chip-mobile-pe-300: var(--color-chip-mobile-pe-300);
+  --color-chip-mobile-pe-500: var(--color-chip-mobile-pe-500);
+  --color-chip-web-pe-100: var(--color-chip-web-pe-100);
+  --color-chip-web-pe-300: var(--color-chip-web-pe-300);
+  --color-chip-web-pe-500: var(--color-chip-web-pe-500);
+
   --color-role-hq-200: var(--color-role-hq-200);
   --color-role-hq-600: var(--color-role-hq-600);
   --color-role-chapter-200: var(--color-role-chapter-200);

--- a/src/features/project/list/ui/team-member-modal/TeamMemberRow.tsx
+++ b/src/features/project/list/ui/team-member-modal/TeamMemberRow.tsx
@@ -17,7 +17,7 @@ export function TeamMemberRow({
     <div className="border-teal-gray-100 flex items-center gap-2 rounded-lg border bg-white px-2 py-1">
       <NumberTag value={index} />
       <div className="flex items-center gap-1.5">
-        <span className="text-body-2-medium text-teal-gray-900 font-medium whitespace-nowrap">
+        <span className="text-body-2-medium text-teal-gray-900 whitespace-nowrap">
           {nickname}/{name}
         </span>
         <div className="bg-teal-gray-300 h-3 w-px rounded-full" />

--- a/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
+++ b/src/features/project/new/ui/basic-info/BasicInfoForm.tsx
@@ -607,7 +607,7 @@ export const BasicInfoForm = forwardRef<
                 }
                 setIsMultiPm((prev) => !prev)
               }}
-              className="text-body-2-medium text-teal-gray-400 flex items-center gap-1 self-start pl-0.5 font-medium underline decoration-solid underline-offset-auto"
+              className="text-body-2-medium text-teal-gray-400 flex items-center gap-1 self-start pl-0.5 underline decoration-solid underline-offset-auto"
             >
               <InfoCircleIcon width={14} height={14} aria-hidden="true" />
               <span>

--- a/src/features/usability-survey/ui/QuestionHeader.tsx
+++ b/src/features/usability-survey/ui/QuestionHeader.tsx
@@ -6,7 +6,7 @@ interface QuestionHeaderProps {
 export const QuestionHeader = ({ number, question }: QuestionHeaderProps) => {
   return (
     <div className="flex w-full items-start gap-2.5">
-      <span className="text-caption-1-medium mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-teal-100 pt-0.5 font-semibold text-teal-600 shadow-[-1px_2.5px_4px_0_rgba(228,228,228,0.2)_inset]">
+      <span className="text-caption-1-semibold mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-teal-100 pt-0.5 text-teal-600 shadow-[-1px_2.5px_4px_0_rgba(228,228,228,0.2)_inset]">
         {number}
       </span>
       <p className="text-heading-7-semibold flex-1 text-teal-700">{question}</p>

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as MatchingIndexRouteImport } from './routes/matching/index'
 import { Route as LoginIndexRouteImport } from './routes/login/index'
 import { Route as AdminIndexRouteImport } from './routes/admin/index'
 import { Route as TestUsabilitySurveyRouteImport } from './routes/test/usability-survey'
+import { Route as TestTypographyRouteImport } from './routes/test/typography'
 import { Route as TestTooltipRouteImport } from './routes/test/tooltip'
 import { Route as TestToggleInputsRouteImport } from './routes/test/toggle-inputs'
 import { Route as TestToggleRouteImport } from './routes/test/toggle'
@@ -135,6 +136,11 @@ const AdminIndexRoute = AdminIndexRouteImport.update({
 const TestUsabilitySurveyRoute = TestUsabilitySurveyRouteImport.update({
   id: '/test/usability-survey',
   path: '/test/usability-survey',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TestTypographyRoute = TestTypographyRouteImport.update({
+  id: '/test/typography',
+  path: '/test/typography',
   getParentRoute: () => rootRouteImport,
 } as any)
 const TestTooltipRoute = TestTooltipRouteImport.update({
@@ -401,6 +407,7 @@ export interface FileRoutesByFullPath {
   '/test/toggle': typeof TestToggleRoute
   '/test/toggle-inputs': typeof TestToggleInputsRoute
   '/test/tooltip': typeof TestTooltipRoute
+  '/test/typography': typeof TestTypographyRoute
   '/test/usability-survey': typeof TestUsabilitySurveyRoute
   '/admin/': typeof AdminIndexRoute
   '/login/': typeof LoginIndexRoute
@@ -457,6 +464,7 @@ export interface FileRoutesByTo {
   '/test/toggle': typeof TestToggleRoute
   '/test/toggle-inputs': typeof TestToggleInputsRoute
   '/test/tooltip': typeof TestTooltipRoute
+  '/test/typography': typeof TestTypographyRoute
   '/test/usability-survey': typeof TestUsabilitySurveyRoute
   '/admin': typeof AdminIndexRoute
   '/login': typeof LoginIndexRoute
@@ -516,6 +524,7 @@ export interface FileRoutesById {
   '/test/toggle': typeof TestToggleRoute
   '/test/toggle-inputs': typeof TestToggleInputsRoute
   '/test/tooltip': typeof TestTooltipRoute
+  '/test/typography': typeof TestTypographyRoute
   '/test/usability-survey': typeof TestUsabilitySurveyRoute
   '/admin/': typeof AdminIndexRoute
   '/login/': typeof LoginIndexRoute
@@ -577,6 +586,7 @@ export interface FileRouteTypes {
     | '/test/toggle'
     | '/test/toggle-inputs'
     | '/test/tooltip'
+    | '/test/typography'
     | '/test/usability-survey'
     | '/admin/'
     | '/login/'
@@ -633,6 +643,7 @@ export interface FileRouteTypes {
     | '/test/toggle'
     | '/test/toggle-inputs'
     | '/test/tooltip'
+    | '/test/typography'
     | '/test/usability-survey'
     | '/admin'
     | '/login'
@@ -691,6 +702,7 @@ export interface FileRouteTypes {
     | '/test/toggle'
     | '/test/toggle-inputs'
     | '/test/tooltip'
+    | '/test/typography'
     | '/test/usability-survey'
     | '/admin/'
     | '/login/'
@@ -747,6 +759,7 @@ export interface RootRouteChildren {
   TestToggleRoute: typeof TestToggleRoute
   TestToggleInputsRoute: typeof TestToggleInputsRoute
   TestTooltipRoute: typeof TestTooltipRoute
+  TestTypographyRoute: typeof TestTypographyRoute
   TestUsabilitySurveyRoute: typeof TestUsabilitySurveyRoute
   LoginIndexRoute: typeof LoginIndexRoute
   SignupIndexRoute: typeof SignupIndexRoute
@@ -852,6 +865,13 @@ declare module '@tanstack/react-router' {
       path: '/test/usability-survey'
       fullPath: '/test/usability-survey'
       preLoaderRoute: typeof TestUsabilitySurveyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/test/typography': {
+      id: '/test/typography'
+      path: '/test/typography'
+      fullPath: '/test/typography'
+      preLoaderRoute: typeof TestTypographyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/test/tooltip': {
@@ -1297,6 +1317,7 @@ const rootRouteChildren: RootRouteChildren = {
   TestToggleRoute: TestToggleRoute,
   TestToggleInputsRoute: TestToggleInputsRoute,
   TestTooltipRoute: TestTooltipRoute,
+  TestTypographyRoute: TestTypographyRoute,
   TestUsabilitySurveyRoute: TestUsabilitySurveyRoute,
   LoginIndexRoute: LoginIndexRoute,
   SignupIndexRoute: SignupIndexRoute,

--- a/src/routes/test/chip.tsx
+++ b/src/routes/test/chip.tsx
@@ -18,6 +18,8 @@ const PARTS = [
   "nodejs",
 ] as const
 
+const NEW_PARTS = ["pm", "design", "mobile-pe", "web-pe"] as const
+
 const PART_TYPES = ["default", "light"] as const
 
 const ROLES = [
@@ -55,6 +57,44 @@ function ChipTestPage() {
           </thead>
           <tbody>
             {PARTS.map((part) => (
+              <tr key={part}>
+                <td className="text-caption-2-regular text-teal-gray-400 py-2 pr-8 align-middle">
+                  {part}
+                </td>
+                {PART_TYPES.map((type) => (
+                  <td key={type} className="px-6 py-2 text-center align-middle">
+                    <PartTagChip role={part} type={type} />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <h1 className="text-heading-6-semibold text-teal-gray-900">
+          Part Tag Chip (통합 체계)
+        </h1>
+
+        <table className="border-collapse">
+          <thead>
+            <tr>
+              <th className="text-caption-2-regular text-teal-gray-400 w-36 pr-8 pb-3 text-left font-normal">
+                role
+              </th>
+              {PART_TYPES.map((type) => (
+                <th
+                  key={type}
+                  className="text-caption-2-regular text-teal-gray-400 px-6 pb-3 text-center font-normal"
+                >
+                  {type}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {NEW_PARTS.map((part) => (
               <tr key={part}>
                 <td className="text-caption-2-regular text-teal-gray-400 py-2 pr-8 align-middle">
                   {part}

--- a/src/routes/test/chip.tsx
+++ b/src/routes/test/chip.tsx
@@ -20,7 +20,14 @@ const PARTS = [
 
 const PART_TYPES = ["default", "light"] as const
 
-const ROLES = ["central", "campus", "challenger"] as const
+const ROLES = [
+  "hq",
+  "chapter",
+  "school",
+  "challenger",
+  "superadmin",
+  "product",
+] as const
 
 function ChipTestPage() {
   return (

--- a/src/routes/test/typography.tsx
+++ b/src/routes/test/typography.tsx
@@ -1,0 +1,387 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/test/typography")({
+  component: TypographyTestPage,
+})
+
+interface TypeToken {
+  className: string
+  name: string
+  weight: string
+  metric: string
+  tracking: string
+  isNew?: boolean
+}
+
+interface TypeGroup {
+  title: string
+  items: TypeToken[]
+}
+
+const SAMPLE = "세상의 틀을 깰 챌린저들이 하나로 모이는 곳"
+
+const GROUPS: TypeGroup[] = [
+  {
+    title: "Display",
+    items: [
+      {
+        className: "text-display-1-bold",
+        name: "Display 1",
+        weight: "Bold (700)",
+        metric: "48px / 120%",
+        tracking: "-3%",
+      },
+      {
+        className: "text-display-2-medium",
+        name: "Display 2",
+        weight: "Medium (500)",
+        metric: "40px / 120%",
+        tracking: "-2%",
+      },
+    ],
+  },
+  {
+    title: "Heading",
+    items: [
+      {
+        className: "text-heading-1-bold",
+        name: "Heading 1",
+        weight: "Bold (700)",
+        metric: "36px / 125%",
+        tracking: "-2%",
+      },
+      {
+        className: "text-heading-2-bold",
+        name: "Heading 2",
+        weight: "Bold (700)",
+        metric: "32px / 125%",
+        tracking: "-2%",
+      },
+      {
+        className: "text-heading-3-semibold",
+        name: "Heading 3",
+        weight: "SemiBold (600)",
+        metric: "28px / 130%",
+        tracking: "-2%",
+      },
+      {
+        className: "text-heading-4-semibold",
+        name: "Heading 4",
+        weight: "SemiBold (600)",
+        metric: "26px / 135%",
+        tracking: "-2%",
+      },
+      {
+        className: "text-heading-5-bold",
+        name: "Heading 5",
+        weight: "Bold (700)",
+        metric: "24px / 135%",
+        tracking: "-2%",
+      },
+      {
+        className: "text-heading-5-semibold",
+        name: "Heading 5",
+        weight: "SemiBold (600)",
+        metric: "24px / 135%",
+        tracking: "-2%",
+      },
+      {
+        className: "text-heading-6-semibold",
+        name: "Heading 6",
+        weight: "SemiBold (600)",
+        metric: "20px / 140%",
+        tracking: "-1%",
+      },
+      {
+        className: "text-heading-7-semibold",
+        name: "Heading 7",
+        weight: "SemiBold (600)",
+        metric: "18px / 140%",
+        tracking: "-1%",
+      },
+      {
+        className: "text-heading-7-medium",
+        name: "Heading 7",
+        weight: "Medium (500)",
+        metric: "18px / 140%",
+        tracking: "-1%",
+        isNew: true,
+      },
+    ],
+  },
+  {
+    title: "Subtitle",
+    items: [
+      {
+        className: "text-subtitle-1-semibold",
+        name: "Subtitle 1",
+        weight: "SemiBold (600)",
+        metric: "20px / 150%",
+        tracking: "-1%",
+      },
+      {
+        className: "text-subtitle-1-medium",
+        name: "Subtitle 1",
+        weight: "Medium (500)",
+        metric: "20px / 150%",
+        tracking: "-1%",
+      },
+      {
+        className: "text-subtitle-2-medium",
+        name: "Subtitle 2",
+        weight: "Medium (500)",
+        metric: "18px / 150%",
+        tracking: "-1%",
+      },
+      {
+        className: "text-subtitle-3-semibold",
+        name: "Subtitle 3",
+        weight: "SemiBold (600)",
+        metric: "16px / 150%",
+        tracking: "-1%",
+      },
+      {
+        className: "text-subtitle-4-semibold",
+        name: "Subtitle 4",
+        weight: "SemiBold (600)",
+        metric: "14px / 150%",
+        tracking: "-1%",
+      },
+    ],
+  },
+  {
+    title: "Body",
+    items: [
+      {
+        className: "text-body-1-semibold",
+        name: "Body 1",
+        weight: "SemiBold (600)",
+        metric: "16px / 145%",
+        tracking: "-1%",
+        isNew: true,
+      },
+      {
+        className: "text-body-1-medium",
+        name: "Body 1",
+        weight: "Medium (500)",
+        metric: "16px / 145%",
+        tracking: "-1%",
+      },
+      {
+        className: "text-body-1-regular",
+        name: "Body 1",
+        weight: "Regular (400)",
+        metric: "16px / 145%",
+        tracking: "-1%",
+      },
+      {
+        className: "text-body-2-medium",
+        name: "Body 2",
+        weight: "Medium (500)",
+        metric: "14px / 150%",
+        tracking: "-1%",
+      },
+      {
+        className: "text-body-2-regular",
+        name: "Body 2",
+        weight: "Regular (400)",
+        metric: "14px / 160%",
+        tracking: "-1%",
+      },
+      {
+        className: "text-body-3-medium",
+        name: "Body 3",
+        weight: "Medium (500)",
+        metric: "12px / 150%",
+        tracking: "0%",
+      },
+      {
+        className: "text-body-3-regular",
+        name: "Body 3",
+        weight: "Regular (400)",
+        metric: "12px / 150%",
+        tracking: "0%",
+      },
+    ],
+  },
+  {
+    title: "Label",
+    items: [
+      {
+        className: "text-label-1-semibold",
+        name: "Label 1",
+        weight: "SemiBold (600)",
+        metric: "16px / 140%",
+        tracking: "-2%",
+      },
+      {
+        className: "text-label-1-medium",
+        name: "Label 1",
+        weight: "Medium (500)",
+        metric: "16px / 140%",
+        tracking: "-2%",
+      },
+      {
+        className: "text-label-2-medium",
+        name: "Label 2",
+        weight: "Medium (500)",
+        metric: "14px / 145%",
+        tracking: "0%",
+      },
+      {
+        className: "text-label-3-bold",
+        name: "Label 3",
+        weight: "Bold (700)",
+        metric: "12px / 140%",
+        tracking: "0%",
+        isNew: true,
+      },
+      {
+        className: "text-label-3-semibold",
+        name: "Label 3",
+        weight: "SemiBold (600)",
+        metric: "12px / 140%",
+        tracking: "0%",
+      },
+      {
+        className: "text-label-3-medium",
+        name: "Label 3",
+        weight: "Medium (500)",
+        metric: "12px / 140%",
+        tracking: "0%",
+        isNew: true,
+      },
+      {
+        className: "text-label-4-medium",
+        name: "Label 4",
+        weight: "Medium (500)",
+        metric: "10px / 150%",
+        tracking: "0%",
+      },
+      {
+        className: "text-label-4-regular",
+        name: "Label 4",
+        weight: "Regular (400)",
+        metric: "10px / 150%",
+        tracking: "0%",
+        isNew: true,
+      },
+    ],
+  },
+  {
+    title: "Caption",
+    items: [
+      {
+        className: "text-caption-1-semibold",
+        name: "Caption 1",
+        weight: "SemiBold (600)",
+        metric: "13px / 145%",
+        tracking: "0%",
+        isNew: true,
+      },
+      {
+        className: "text-caption-1-medium",
+        name: "Caption 1",
+        weight: "Medium (500)",
+        metric: "13px / 145%",
+        tracking: "0%",
+      },
+      {
+        className: "text-caption-2-medium",
+        name: "Caption 2",
+        weight: "Medium (500)",
+        metric: "12px / 150%",
+        tracking: "0%",
+      },
+      {
+        className: "text-caption-2-regular",
+        name: "Caption 2",
+        weight: "Regular (400)",
+        metric: "12px / 150%",
+        tracking: "0%",
+      },
+      {
+        className: "text-caption-3-bold",
+        name: "Caption 3",
+        weight: "Bold (700)",
+        metric: "11px / 160%",
+        tracking: "0%",
+        isNew: true,
+      },
+      {
+        className: "text-caption-3-medium",
+        name: "Caption 3",
+        weight: "Medium (500)",
+        metric: "11px / 160%",
+        tracking: "-2%",
+      },
+      {
+        className: "text-caption-3-regular",
+        name: "Caption 3",
+        weight: "Regular (400)",
+        metric: "11px / 160%",
+        tracking: "-2%",
+      },
+    ],
+  },
+]
+
+const TOTAL = GROUPS.reduce((sum, group) => sum + group.items.length, 0)
+const NEW_COUNT = GROUPS.reduce(
+  (sum, group) => sum + group.items.filter((item) => item.isNew).length,
+  0,
+)
+
+function TypographyTestPage() {
+  return (
+    <main className="bg-teal-gray-50 min-h-screen w-full p-10">
+      <h1 className="text-heading-4-semibold text-teal-gray-900 mb-2">
+        Typography Test Page
+      </h1>
+      <p className="text-body-2-medium text-teal-gray-500 mb-10">
+        총 {TOTAL}개 토큰 (신규 {NEW_COUNT}개)
+      </p>
+
+      <div className="flex flex-col gap-12">
+        {GROUPS.map((group) => (
+          <section key={group.title}>
+            <h2 className="text-heading-6-semibold border-teal-gray-200 mb-4 border-b pb-2 text-teal-600">
+              {group.title}
+            </h2>
+            <div className="flex flex-col divide-y divide-gray-100">
+              {group.items.map((item) => (
+                <div
+                  key={item.className}
+                  className="grid grid-cols-[220px_140px_120px_60px_1fr] items-center gap-4 py-4"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="text-label-2-medium text-teal-gray-900">
+                      {item.name}
+                    </span>
+                    {item.isNew && (
+                      <span className="text-caption-3-bold rounded bg-teal-500 px-1.5 py-0.5 text-white">
+                        NEW
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-caption-2-regular text-teal-gray-500">
+                    {item.weight}
+                  </span>
+                  <span className="text-caption-2-regular text-teal-gray-500">
+                    {item.metric}
+                  </span>
+                  <span className="text-caption-2-regular text-teal-gray-500">
+                    {item.tracking}
+                  </span>
+                  <span className={`${item.className} text-teal-gray-900`}>
+                    {SAMPLE}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/src/shared/lib/roleTagMapper.ts
+++ b/src/shared/lib/roleTagMapper.ts
@@ -3,16 +3,16 @@ import type { Role } from "@/shared/ui/chip/RoleTagChip"
 
 const ROLE_MAP: Record<RoleType, Role> = {
   CHALLENGER: "challenger",
-  SUPER_ADMIN: "central",
-  CENTRAL_PRESIDENT: "central",
-  CENTRAL_VICE_PRESIDENT: "central",
-  CENTRAL_OPERATING_TEAM_MEMBER: "central",
-  CENTRAL_EDUCATION_TEAM_MEMBER: "central",
-  CHAPTER_PRESIDENT: "central",
-  SCHOOL_PRESIDENT: "campus",
-  SCHOOL_VICE_PRESIDENT: "campus",
-  SCHOOL_PART_LEADER: "campus",
-  SCHOOL_ETC_ADMIN: "challenger",
+  SUPER_ADMIN: "superadmin",
+  CENTRAL_PRESIDENT: "hq",
+  CENTRAL_VICE_PRESIDENT: "hq",
+  CENTRAL_OPERATING_TEAM_MEMBER: "hq",
+  CENTRAL_EDUCATION_TEAM_MEMBER: "hq",
+  CHAPTER_PRESIDENT: "chapter",
+  SCHOOL_PRESIDENT: "school",
+  SCHOOL_VICE_PRESIDENT: "school",
+  SCHOOL_PART_LEADER: "school",
+  SCHOOL_ETC_ADMIN: "school",
 }
 
 export function toRoleTag(roleType: RoleType): Role {

--- a/src/shared/ui/chip/PartTagChip.tsx
+++ b/src/shared/ui/chip/PartTagChip.tsx
@@ -14,6 +14,9 @@ const partTagChipVariants = cva(
         android: "w-16.5",
         springboot: "w-22",
         nodejs: "w-16.5",
+        pm: "w-9",
+        "mobile-pe": "w-22",
+        "web-pe": "w-20",
       },
       type: {
         default: "",
@@ -43,6 +46,16 @@ const partTagChipVariants = cva(
         className: "bg-chip-springboot-100",
       },
       { role: "nodejs", type: "light", className: "bg-chip-nodejs-100" },
+      { role: "pm", type: "default", className: "bg-chip-pm-300" },
+      {
+        role: "mobile-pe",
+        type: "default",
+        className: "bg-chip-mobile-pe-300",
+      },
+      { role: "web-pe", type: "default", className: "bg-chip-web-pe-300" },
+      { role: "pm", type: "light", className: "bg-chip-pm-100" },
+      { role: "mobile-pe", type: "light", className: "bg-chip-mobile-pe-100" },
+      { role: "web-pe", type: "light", className: "bg-chip-web-pe-100" },
     ],
     defaultVariants: {
       type: "default",
@@ -58,6 +71,9 @@ const ROLE_LABEL = {
   android: "Android",
   springboot: "SpringBoot",
   nodejs: "Node.js",
+  pm: "PM",
+  "mobile-pe": "Mobile PE",
+  "web-pe": "Web PE",
 } as const
 
 type Role = keyof typeof ROLE_LABEL

--- a/src/shared/ui/chip/RoleTagChip.tsx
+++ b/src/shared/ui/chip/RoleTagChip.tsx
@@ -7,9 +7,12 @@ const roleTagChipVariants = cva(
   {
     variants: {
       role: {
-        central: "bg-role-central-200 text-role-central-600",
-        campus: "bg-role-campus-200 text-role-campus-600",
+        hq: "bg-role-hq-200 text-role-hq-600",
+        chapter: "bg-role-chapter-200 text-role-chapter-600",
+        school: "bg-role-school-200 text-role-school-600",
         challenger: "bg-role-challenger-200 text-role-challenger-600",
+        superadmin: "bg-role-superadmin-200 text-role-superadmin-600",
+        product: "bg-role-product-200 text-role-product-600",
       },
       size: {
         default: "rounded-[6px] px-2 py-[3px] text-label-2-medium",
@@ -23,9 +26,12 @@ const roleTagChipVariants = cva(
 )
 
 const ROLE_LABEL = {
-  central: "중앙 운영진",
-  campus: "교내 운영진",
+  hq: "중앙 운영진",
+  chapter: "지부장",
+  school: "교내 운영진",
   challenger: "챌린저",
+  superadmin: "슈퍼 어드민",
+  product: "프로덕트",
 } as const
 
 export type Role = keyof typeof ROLE_LABEL

--- a/src/styles/color.css
+++ b/src/styles/color.css
@@ -106,6 +106,21 @@
   --color-chip-springboot-500: #b79778;
 
   /* -------------------------
+   * Color / Semantic / Chip / Part (통합 체계)
+   * ------------------------- */
+  --color-chip-pm-100: #f3ebff;
+  --color-chip-pm-300: #e8d8fc;
+  --color-chip-pm-500: #b887ea;
+
+  --color-chip-mobile-pe-100: #f0f4ff;
+  --color-chip-mobile-pe-300: #e5ebff;
+  --color-chip-mobile-pe-500: #8ea5f6;
+
+  --color-chip-web-pe-100: #fff6e0;
+  --color-chip-web-pe-300: #fff4db;
+  --color-chip-web-pe-500: #e3c36a;
+
+  /* -------------------------
    * Color / Semantic / Chip / Role
    * ------------------------- */
   --color-role-hq-200: #eae4ff;

--- a/src/styles/color.css
+++ b/src/styles/color.css
@@ -108,14 +108,23 @@
   /* -------------------------
    * Color / Semantic / Chip / Role
    * ------------------------- */
-  --color-role-central-200: #eae4ff;
-  --color-role-central-600: #5a43b8;
+  --color-role-hq-200: #eae4ff;
+  --color-role-hq-600: #5a43b8;
 
-  --color-role-campus-200: #e4edff;
-  --color-role-campus-600: #3b63c7;
+  --color-role-chapter-200: #ede3d9;
+  --color-role-chapter-600: #b79778;
 
-  --color-role-challenger-200: #e1f4f1;
+  --color-role-school-200: #ebf0ff;
+  --color-role-school-600: #3b63c7;
+
+  --color-role-challenger-200: #caece8;
   --color-role-challenger-600: #0b6b64;
+
+  --color-role-superadmin-200: #caece8;
+  --color-role-superadmin-600: #0b6b64;
+
+  --color-role-product-200: #ededed;
+  --color-role-product-600: #333333;
 
   /* -------------------------
    * Color / Accent Teal

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -1,19 +1,19 @@
 @import "pretendard/dist/web/variable/pretendardvariable-dynamic-subset.css";
 
-/* 최종 편집 : 2026.04.12 */
-/* 가장 하단의 정의된 유틸리티 클래스(29개)로 사용하시면 됩니다! */
+/* 최종 편집 : 2026.07.12 */
+/* 가장 하단의 정의된 유틸리티 클래스(38개)로 사용하시면 됩니다! */
 
 :root {
   /* -------------------------
    * Display
    * ------------------------- */
   --text-display-1-bold-size: 3rem;
-  --text-display-1-bold-weight: 600;
+  --text-display-1-bold-weight: 700;
   --text-display-1-bold-leading: 1.2;
   --text-display-1-bold-tracking: -0.03em;
 
   --text-display-medium-2-size: 2.5rem;
-  --text-display-medium-2-weight: 400;
+  --text-display-medium-2-weight: 500;
   --text-display-medium-2-leading: 1.2;
   --text-display-medium-2-tracking: -0.02em;
 
@@ -21,103 +21,113 @@
    * Heading
    * ------------------------- */
   --text-heading-1-bold-size: 2.25rem;
-  --text-heading-1-bold-weight: 600;
+  --text-heading-1-bold-weight: 700;
   --text-heading-1-bold-leading: 1.25;
   --text-heading-1-bold-tracking: -0.02em;
 
   --text-heading-2-bold-size: 2rem;
-  --text-heading-2-bold-weight: 600;
+  --text-heading-2-bold-weight: 700;
   --text-heading-2-bold-leading: 1.25;
   --text-heading-2-bold-tracking: -0.02em;
 
   --text-heading-3-semibold-size: 1.75rem;
-  --text-heading-3-semibold-weight: 500;
+  --text-heading-3-semibold-weight: 600;
   --text-heading-3-semibold-leading: 1.3;
   --text-heading-3-semibold-tracking: -0.02em;
 
   --text-heading-4-semibold-size: 1.625rem;
-  --text-heading-4-semibold-weight: 500;
+  --text-heading-4-semibold-weight: 600;
   --text-heading-4-semibold-leading: 1.35;
   --text-heading-4-semibold-tracking: -0.02em;
 
   --text-heading-5-semibold-size: 1.5rem;
-  --text-heading-5-semibold-weight: 500;
+  --text-heading-5-semibold-weight: 600;
   --text-heading-5-semibold-leading: 1.35;
   --text-heading-5-semibold-tracking: -0.02em;
 
   --text-heading-5-bold-size: 1.5rem;
-  --text-heading-5-bold-weight: 600;
+  --text-heading-5-bold-weight: 700;
   --text-heading-5-bold-leading: 1.35;
   --text-heading-5-bold-tracking: -0.02em;
 
   --text-heading-6-semibold-size: 1.25rem;
-  --text-heading-6-semibold-weight: 500;
+  --text-heading-6-semibold-weight: 600;
   --text-heading-6-semibold-leading: 1.4;
   --text-heading-6-semibold-tracking: -0.01em;
 
   --text-heading-7-semibold-size: 1.125rem;
-  --text-heading-7-semibold-weight: 500;
+  --text-heading-7-semibold-weight: 600;
   --text-heading-7-semibold-leading: 1.4;
   --text-heading-7-semibold-tracking: -0.01em;
+
+  --text-heading-7-medium-size: 1.125rem;
+  --text-heading-7-medium-weight: 500;
+  --text-heading-7-medium-leading: 1.4;
+  --text-heading-7-medium-tracking: -0.01em;
 
   /* -------------------------
    * Subtitle
    * ------------------------- */
   --text-subtitle-1-semibold-size: 1.25rem;
-  --text-subtitle-1-semibold-weight: 500;
+  --text-subtitle-1-semibold-weight: 600;
   --text-subtitle-1-semibold-leading: 1.5;
   --text-subtitle-1-semibold-tracking: -0.01em;
 
   --text-subtitle-1-medium-size: 1.25rem;
-  --text-subtitle-1-medium-weight: 400;
+  --text-subtitle-1-medium-weight: 500;
   --text-subtitle-1-medium-leading: 1.5;
   --text-subtitle-1-medium-tracking: -0.01em;
 
   --text-subtitle-2-medium-size: 1.125rem;
-  --text-subtitle-2-medium-weight: 400;
+  --text-subtitle-2-medium-weight: 500;
   --text-subtitle-2-medium-leading: 1.5;
   --text-subtitle-2-medium-tracking: -0.01em;
 
   --text-subtitle-3-semibold-size: 1rem;
-  --text-subtitle-3-semibold-weight: 500;
+  --text-subtitle-3-semibold-weight: 600;
   --text-subtitle-3-semibold-leading: 1.5;
   --text-subtitle-3-semibold-tracking: -0.01em;
 
   --text-subtitle-4-semibold-size: 0.875rem;
-  --text-subtitle-4-semibold-weight: 500;
+  --text-subtitle-4-semibold-weight: 600;
   --text-subtitle-4-semibold-leading: 1.5;
   --text-subtitle-4-semibold-tracking: -0.01em;
 
   /* -------------------------
    * Body
    * ------------------------- */
+  --text-body-1-semibold-size: 1rem;
+  --text-body-1-semibold-weight: 600;
+  --text-body-1-semibold-leading: 1.45;
+  --text-body-1-semibold-tracking: -0.01em;
+
   --text-body-1-medium-size: 1rem;
-  --text-body-1-medium-weight: 400;
+  --text-body-1-medium-weight: 500;
   --text-body-1-medium-leading: 1.45;
   --text-body-1-medium-tracking: -0.01em;
 
   --text-body-1-regular-size: 1rem;
-  --text-body-1-regular-weight: 300;
+  --text-body-1-regular-weight: 400;
   --text-body-1-regular-leading: 1.45;
   --text-body-1-regular-tracking: -0.01em;
 
   --text-body-2-medium-size: 0.875rem;
-  --text-body-2-medium-weight: 400;
+  --text-body-2-medium-weight: 500;
   --text-body-2-medium-leading: 1.5;
   --text-body-2-medium-tracking: -0.01em;
 
   --text-body-2-regular-size: 0.875rem;
-  --text-body-2-regular-weight: 300;
+  --text-body-2-regular-weight: 400;
   --text-body-2-regular-leading: 1.6;
   --text-body-2-regular-tracking: -0.01em;
 
   --text-body-3-medium-size: 0.75rem;
-  --text-body-3-medium-weight: 400;
+  --text-body-3-medium-weight: 500;
   --text-body-3-medium-leading: 1.5;
   --text-body-3-medium-tracking: 0em;
 
   --text-body-3-regular-size: 0.75rem;
-  --text-body-3-regular-weight: 300;
+  --text-body-3-regular-weight: 400;
   --text-body-3-regular-leading: 1.5;
   --text-body-3-regular-tracking: 0em;
 
@@ -125,57 +135,82 @@
    * Label
    * ------------------------- */
   --text-label-1-semibold-size: 1rem;
-  --text-label-1-semibold-weight: 500;
+  --text-label-1-semibold-weight: 600;
   --text-label-1-semibold-leading: 1.4;
   --text-label-1-semibold-tracking: -0.02em;
 
   --text-label-1-medium-size: 1rem;
-  --text-label-1-medium-weight: 400;
+  --text-label-1-medium-weight: 500;
   --text-label-1-medium-leading: 1.4;
   --text-label-1-medium-tracking: -0.02em;
 
   --text-label-2-medium-size: 0.875rem;
-  --text-label-2-medium-weight: 400;
+  --text-label-2-medium-weight: 500;
   --text-label-2-medium-leading: 1.45;
   --text-label-2-medium-tracking: 0em;
 
+  --text-label-3-bold-size: 0.75rem;
+  --text-label-3-bold-weight: 700;
+  --text-label-3-bold-leading: 1.4;
+  --text-label-3-bold-tracking: 0em;
+
   --text-label-3-semibold-size: 0.75rem;
-  --text-label-3-semibold-weight: 500;
+  --text-label-3-semibold-weight: 600;
   --text-label-3-semibold-leading: 1.4;
   --text-label-3-semibold-tracking: 0em;
 
-  --text-label-4-medium-size: 0.75rem;
-  --text-label-4-medium-weight: 400;
-  --text-label-4-medium-leading: 1.4;
+  --text-label-3-medium-size: 0.75rem;
+  --text-label-3-medium-weight: 500;
+  --text-label-3-medium-leading: 1.4;
+  --text-label-3-medium-tracking: 0em;
+
+  --text-label-4-medium-size: 0.625rem;
+  --text-label-4-medium-weight: 500;
+  --text-label-4-medium-leading: 1.5;
   --text-label-4-medium-tracking: 0em;
+
+  --text-label-4-regular-size: 0.625rem;
+  --text-label-4-regular-weight: 400;
+  --text-label-4-regular-leading: 1.5;
+  --text-label-4-regular-tracking: 0em;
 
   /* -------------------------
    * Caption
    * ------------------------- */
+  --text-caption-1-semibold-size: 0.8125rem;
+  --text-caption-1-semibold-weight: 600;
+  --text-caption-1-semibold-leading: 1.45;
+  --text-caption-1-semibold-tracking: 0em;
+
   --text-caption-1-medium-size: 0.8125rem;
-  --text-caption-1-medium-weight: 400;
+  --text-caption-1-medium-weight: 500;
   --text-caption-1-medium-leading: 1.45;
   --text-caption-1-medium-tracking: 0em;
 
   --text-caption-2-medium-size: 0.75rem;
-  --text-caption-2-medium-weight: 400;
+  --text-caption-2-medium-weight: 500;
   --text-caption-2-medium-leading: 1.5;
   --text-caption-2-medium-tracking: 0em;
 
   --text-caption-2-regular-size: 0.75rem;
-  --text-caption-2-regular-weight: 300;
+  --text-caption-2-regular-weight: 400;
   --text-caption-2-regular-leading: 1.5;
   --text-caption-2-regular-tracking: 0em;
 
-  --text-caption-3-regular-size: 0.6875rem;
-  --text-caption-3-regular-weight: 300;
-  --text-caption-3-regular-leading: 1.6;
-  --text-caption-3-regular-tracking: -0.02em;
+  --text-caption-3-bold-size: 0.6875rem;
+  --text-caption-3-bold-weight: 700;
+  --text-caption-3-bold-leading: 1.6;
+  --text-caption-3-bold-tracking: 0em;
 
   --text-caption-3-medium-size: 0.6875rem;
   --text-caption-3-medium-weight: 500;
   --text-caption-3-medium-leading: 1.6;
   --text-caption-3-medium-tracking: -0.02em;
+
+  --text-caption-3-regular-size: 0.6875rem;
+  --text-caption-3-regular-weight: 400;
+  --text-caption-3-regular-leading: 1.6;
+  --text-caption-3-regular-tracking: -0.02em;
 }
 
 @utility text-display-1-bold {
@@ -248,6 +283,13 @@
   letter-spacing: var(--text-heading-7-semibold-tracking);
 }
 
+@utility text-heading-7-medium {
+  font-size: var(--text-heading-7-medium-size);
+  font-weight: var(--text-heading-7-medium-weight);
+  line-height: var(--text-heading-7-medium-leading);
+  letter-spacing: var(--text-heading-7-medium-tracking);
+}
+
 @utility text-subtitle-1-semibold {
   font-size: var(--text-subtitle-1-semibold-size);
   font-weight: var(--text-subtitle-1-semibold-weight);
@@ -281,6 +323,13 @@
   font-weight: var(--text-subtitle-4-semibold-weight);
   line-height: var(--text-subtitle-4-semibold-leading);
   letter-spacing: var(--text-subtitle-4-semibold-tracking);
+}
+
+@utility text-body-1-semibold {
+  font-size: var(--text-body-1-semibold-size);
+  font-weight: var(--text-body-1-semibold-weight);
+  line-height: var(--text-body-1-semibold-leading);
+  letter-spacing: var(--text-body-1-semibold-tracking);
 }
 
 @utility text-body-1-medium {
@@ -346,6 +395,13 @@
   letter-spacing: var(--text-label-2-medium-tracking);
 }
 
+@utility text-label-3-bold {
+  font-size: var(--text-label-3-bold-size);
+  font-weight: var(--text-label-3-bold-weight);
+  line-height: var(--text-label-3-bold-leading);
+  letter-spacing: var(--text-label-3-bold-tracking);
+}
+
 @utility text-label-3-semibold {
   font-size: var(--text-label-3-semibold-size);
   font-weight: var(--text-label-3-semibold-weight);
@@ -353,11 +409,32 @@
   letter-spacing: var(--text-label-3-semibold-tracking);
 }
 
+@utility text-label-3-medium {
+  font-size: var(--text-label-3-medium-size);
+  font-weight: var(--text-label-3-medium-weight);
+  line-height: var(--text-label-3-medium-leading);
+  letter-spacing: var(--text-label-3-medium-tracking);
+}
+
 @utility text-label-4-medium {
   font-size: var(--text-label-4-medium-size);
   font-weight: var(--text-label-4-medium-weight);
   line-height: var(--text-label-4-medium-leading);
   letter-spacing: var(--text-label-4-medium-tracking);
+}
+
+@utility text-label-4-regular {
+  font-size: var(--text-label-4-regular-size);
+  font-weight: var(--text-label-4-regular-weight);
+  line-height: var(--text-label-4-regular-leading);
+  letter-spacing: var(--text-label-4-regular-tracking);
+}
+
+@utility text-caption-1-semibold {
+  font-size: var(--text-caption-1-semibold-size);
+  font-weight: var(--text-caption-1-semibold-weight);
+  line-height: var(--text-caption-1-semibold-leading);
+  letter-spacing: var(--text-caption-1-semibold-tracking);
 }
 
 @utility text-caption-1-medium {
@@ -381,11 +458,11 @@
   letter-spacing: var(--text-caption-2-regular-tracking);
 }
 
-@utility text-caption-3-regular {
-  font-size: var(--text-caption-3-regular-size);
-  font-weight: var(--text-caption-3-regular-weight);
-  line-height: var(--text-caption-3-regular-leading);
-  letter-spacing: var(--text-caption-3-regular-tracking);
+@utility text-caption-3-bold {
+  font-size: var(--text-caption-3-bold-size);
+  font-weight: var(--text-caption-3-bold-weight);
+  line-height: var(--text-caption-3-bold-leading);
+  letter-spacing: var(--text-caption-3-bold-tracking);
 }
 
 @utility text-caption-3-medium {
@@ -393,4 +470,11 @@
   font-weight: var(--text-caption-3-medium-weight);
   line-height: var(--text-caption-3-medium-leading);
   letter-spacing: var(--text-caption-3-medium-tracking);
+}
+
+@utility text-caption-3-regular {
+  font-size: var(--text-caption-3-regular-size);
+  font-weight: var(--text-caption-3-regular-weight);
+  line-height: var(--text-caption-3-regular-leading);
+  letter-spacing: var(--text-caption-3-regular-tracking);
 }


### PR DESCRIPTION
## 📸 작업 내용

> 디자인시스템 토큰(타이포그래피·컬러)을 피그마 스펙에 맞춰 재편했습니다.

- **타이포그래피**: 전체 토큰 weight 정정(Bold 700 / SemiBold 600 / Medium 500 / Regular 400), `label-4-medium` 크기 10px·행간 150% 정정, 신규 7개 토큰 추가(총 38개), 유틸 weight override 정리 3곳
- **컬러 — 역할(Role)**: 역할 태그 색 토큰 3개 → 6개 재편(hq / chapter / school / challenger / superadmin / product) 및 `RoleTagChip`·`roleTagMapper` 매핑 배선
- **컬러 — 파트(Part)**: 기존 7개 파트 칩(구버전 페이지 호환)은 유지하고, 통합 체계 칩(PM / Design / Mobile PE / Web PE)을 `PartTagChip`에 병행 추가

> ⚠️ 파트 도메인 전면 재편(Mobile/Server PE 통합)과 Server PE 색은 백엔드 `ChallengerPart` 미개편(여전히 8개 파트 반환)·피그마 Server PE 색 부재로 이번 범위에서 제외했습니다. 후속 이슈로 진행 예정입니다.

## 🎞️ 주요 코드 설명

### 역할 태그 매핑 재배선

`roleTagMapper.ts`에서 백엔드 `RoleType`을 6개 역할 태그로 재배선했습니다. 아래 두 역할은 표시가 변경됩니다.

- `SUPER_ADMIN` → "슈퍼 어드민"(기존 "중앙 운영진")
- `SCHOOL_ETC_ADMIN` → "교내 운영진"(기존 "챌린저", "기타 교내 운영진"이라 교내 그룹으로 이동)

`product`는 대응 백엔드 역할이 없어 색 토큰·variant만 정의하고 매핑은 후속 배선합니다.

### 통합 파트 칩

`PartTagChip`에 `pm` / `mobile-pe` / `web-pe` variant를 추가했습니다(기존 7개 유지, `design` 재사용). 색은 기존 토큰 값을 재사용합니다.

## 🖥️ 구현화면

> 로컬 검증 페이지에서 확인 가능합니다.

- 타이포그래피 토큰(38개, 신규 7개): `/test/typography`
- 파트·역할 칩: `/test/chip`
<img width="2880" height="6106" alt="typography-tokens-final" src="https://github.com/user-attachments/assets/84c1e361-7024-4b89-b30b-3a385a53afc1" />
<img width="2880" height="2672" alt="part-chip-dual-system-fixed" src="https://github.com/user-attachments/assets/29e01169-bc11-41fd-a709-33c744649ac9" />


## 🔗 연결된 이슈

- Connected: #568
