### PR TITLE
💄 style: 피그마 TextButton variant 적용

### DIFF
--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -28,6 +28,7 @@ import { Route as TestTooltipRouteImport } from './routes/test/tooltip'
 import { Route as TestToggleInputsRouteImport } from './routes/test/toggle-inputs'
 import { Route as TestToggleRouteImport } from './routes/test/toggle'
 import { Route as TestToastRouteImport } from './routes/test/toast'
+import { Route as TestTextButtonRouteImport } from './routes/test/text-button'
 import { Route as TestSocialButtonRouteImport } from './routes/test/social-button'
 import { Route as TestRatingFaceRouteImport } from './routes/test/rating-face'
 import { Route as TestQuestionFormRouteImport } from './routes/test/question-form'
@@ -161,6 +162,11 @@ const TestToggleRoute = TestToggleRouteImport.update({
 const TestToastRoute = TestToastRouteImport.update({
   id: '/test/toast',
   path: '/test/toast',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TestTextButtonRoute = TestTextButtonRouteImport.update({
+  id: '/test/text-button',
+  path: '/test/text-button',
   getParentRoute: () => rootRouteImport,
 } as any)
 const TestSocialButtonRoute = TestSocialButtonRouteImport.update({
@@ -403,6 +409,7 @@ export interface FileRoutesByFullPath {
   '/test/question-form': typeof TestQuestionFormRoute
   '/test/rating-face': typeof TestRatingFaceRoute
   '/test/social-button': typeof TestSocialButtonRoute
+  '/test/text-button': typeof TestTextButtonRoute
   '/test/toast': typeof TestToastRoute
   '/test/toggle': typeof TestToggleRoute
   '/test/toggle-inputs': typeof TestToggleInputsRoute
@@ -460,6 +467,7 @@ export interface FileRoutesByTo {
   '/test/question-form': typeof TestQuestionFormRoute
   '/test/rating-face': typeof TestRatingFaceRoute
   '/test/social-button': typeof TestSocialButtonRoute
+  '/test/text-button': typeof TestTextButtonRoute
   '/test/toast': typeof TestToastRoute
   '/test/toggle': typeof TestToggleRoute
   '/test/toggle-inputs': typeof TestToggleInputsRoute
@@ -520,6 +528,7 @@ export interface FileRoutesById {
   '/test/question-form': typeof TestQuestionFormRoute
   '/test/rating-face': typeof TestRatingFaceRoute
   '/test/social-button': typeof TestSocialButtonRoute
+  '/test/text-button': typeof TestTextButtonRoute
   '/test/toast': typeof TestToastRoute
   '/test/toggle': typeof TestToggleRoute
   '/test/toggle-inputs': typeof TestToggleInputsRoute
@@ -582,6 +591,7 @@ export interface FileRouteTypes {
     | '/test/question-form'
     | '/test/rating-face'
     | '/test/social-button'
+    | '/test/text-button'
     | '/test/toast'
     | '/test/toggle'
     | '/test/toggle-inputs'
@@ -639,6 +649,7 @@ export interface FileRouteTypes {
     | '/test/question-form'
     | '/test/rating-face'
     | '/test/social-button'
+    | '/test/text-button'
     | '/test/toast'
     | '/test/toggle'
     | '/test/toggle-inputs'
@@ -698,6 +709,7 @@ export interface FileRouteTypes {
     | '/test/question-form'
     | '/test/rating-face'
     | '/test/social-button'
+    | '/test/text-button'
     | '/test/toast'
     | '/test/toggle'
     | '/test/toggle-inputs'
@@ -755,6 +767,7 @@ export interface RootRouteChildren {
   TestQuestionFormRoute: typeof TestQuestionFormRoute
   TestRatingFaceRoute: typeof TestRatingFaceRoute
   TestSocialButtonRoute: typeof TestSocialButtonRoute
+  TestTextButtonRoute: typeof TestTextButtonRoute
   TestToastRoute: typeof TestToastRoute
   TestToggleRoute: typeof TestToggleRoute
   TestToggleInputsRoute: typeof TestToggleInputsRoute
@@ -900,6 +913,13 @@ declare module '@tanstack/react-router' {
       path: '/test/toast'
       fullPath: '/test/toast'
       preLoaderRoute: typeof TestToastRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/test/text-button': {
+      id: '/test/text-button'
+      path: '/test/text-button'
+      fullPath: '/test/text-button'
+      preLoaderRoute: typeof TestTextButtonRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/test/social-button': {
@@ -1313,6 +1333,7 @@ const rootRouteChildren: RootRouteChildren = {
   TestQuestionFormRoute: TestQuestionFormRoute,
   TestRatingFaceRoute: TestRatingFaceRoute,
   TestSocialButtonRoute: TestSocialButtonRoute,
+  TestTextButtonRoute: TestTextButtonRoute,
   TestToastRoute: TestToastRoute,
   TestToggleRoute: TestToggleRoute,
   TestToggleInputsRoute: TestToggleInputsRoute,

--- a/src/routes/login/default.tsx
+++ b/src/routes/login/default.tsx
@@ -243,7 +243,7 @@ function DefaultLoginPage() {
 
               <TextButton
                 onClick={() => navigate({ to: "/signup" })}
-                className="text-body-1-regular flex items-center justify-center px-1 py-0.5 text-teal-500"
+                color="primary"
               >
                 회원가입
               </TextButton>

--- a/src/routes/login/index.tsx
+++ b/src/routes/login/index.tsx
@@ -151,7 +151,7 @@ function SocialLoginPage() {
 
               <TextButton
                 onClick={() => navigate({ to: "/signup" })}
-                className="text-body-1-regular flex items-center justify-center px-1 py-0.5 text-teal-500"
+                color="primary"
               >
                 회원가입
               </TextButton>

--- a/src/routes/signup/index.tsx
+++ b/src/routes/signup/index.tsx
@@ -594,7 +594,7 @@ function SignUpPage() {
 
               <TextButton
                 onClick={() => navigate({ to: "/login" })}
-                className="text-body-1-regular text-teal-gray-500 hover:decoration-teal-gray-500 px-1 py-0.5 text-center"
+                color="neutral"
               >
                 {currentStep === "EMAIL" ? "이미 계정이 있어요" : "로그인으로"}
               </TextButton>

--- a/src/routes/signup/oauth.tsx
+++ b/src/routes/signup/oauth.tsx
@@ -582,7 +582,7 @@ function OAuthSignupPage() {
 
               <TextButton
                 onClick={() => navigate({ to: "/login" })}
-                className="text-body-1-regular text-teal-gray-500 hover:decoration-teal-gray-500 px-1 py-0.5 text-center"
+                color="neutral"
               >
                 {currentStep === "EMAIL" ? "이미 계정이 있어요" : "로그인으로"}
               </TextButton>

--- a/src/routes/test/text-button.tsx
+++ b/src/routes/test/text-button.tsx
@@ -47,7 +47,7 @@ function TextButtonTestPage() {
               </TextButton>
             </TextButtonSpecimen>
             <TextButtonSpecimen label="Neutral / Active">
-              <TextButton className="text-teal-gray-700 underline underline-offset-3">
+              <TextButton className="bg-teal-gray-200 text-teal-gray-700 rounded-sm underline underline-offset-3">
                 텍스트 버튼
               </TextButton>
             </TextButtonSpecimen>
@@ -65,7 +65,7 @@ function TextButtonTestPage() {
             <TextButtonSpecimen label="Primary / Active">
               <TextButton
                 color="primary"
-                className="text-teal-700 underline underline-offset-3"
+                className="rounded-sm bg-teal-100 text-teal-700 underline underline-offset-3"
               >
                 텍스트 버튼
               </TextButton>
@@ -87,7 +87,7 @@ function TextButtonTestPage() {
             <TextButtonSpecimen label="Neutral / Active">
               <TextButton
                 size="14"
-                className="text-teal-gray-900 underline underline-offset-3"
+                className="bg-teal-gray-200 text-teal-gray-900 rounded-sm underline underline-offset-3"
               >
                 텍스트 버튼
               </TextButton>

--- a/src/routes/test/text-button.tsx
+++ b/src/routes/test/text-button.tsx
@@ -41,13 +41,18 @@ function TextButtonTestPage() {
               <TextButton>텍스트 버튼</TextButton>
             </TextButtonSpecimen>
             <TextButtonSpecimen label="Neutral / Hover">
-              <TextButton className="underline">텍스트 버튼</TextButton>
+              <TextButton className="underline underline-offset-2">
+                텍스트 버튼
+              </TextButton>
             </TextButtonSpecimen>
             <TextButtonSpecimen label="Primary / Default">
               <TextButton color="primary">텍스트 버튼</TextButton>
             </TextButtonSpecimen>
             <TextButtonSpecimen label="Primary / Hover">
-              <TextButton color="primary" className="underline">
+              <TextButton
+                color="primary"
+                className="underline underline-offset-2"
+              >
                 텍스트 버튼
               </TextButton>
             </TextButtonSpecimen>
@@ -61,7 +66,7 @@ function TextButtonTestPage() {
               <TextButton size="14">텍스트 버튼</TextButton>
             </TextButtonSpecimen>
             <TextButtonSpecimen label="Neutral / Hover">
-              <TextButton size="14" className="underline">
+              <TextButton size="14" className="underline underline-offset-2">
                 텍스트 버튼
               </TextButton>
             </TextButtonSpecimen>

--- a/src/routes/test/text-button.tsx
+++ b/src/routes/test/text-button.tsx
@@ -41,7 +41,7 @@ function TextButtonTestPage() {
               <TextButton>텍스트 버튼</TextButton>
             </TextButtonSpecimen>
             <TextButtonSpecimen label="Neutral / Hover">
-              <TextButton className="underline underline-offset-4">
+              <TextButton className="underline underline-offset-3">
                 텍스트 버튼
               </TextButton>
             </TextButtonSpecimen>
@@ -51,7 +51,7 @@ function TextButtonTestPage() {
             <TextButtonSpecimen label="Primary / Hover">
               <TextButton
                 color="primary"
-                className="underline underline-offset-4"
+                className="underline underline-offset-3"
               >
                 텍스트 버튼
               </TextButton>
@@ -66,7 +66,7 @@ function TextButtonTestPage() {
               <TextButton size="14">텍스트 버튼</TextButton>
             </TextButtonSpecimen>
             <TextButtonSpecimen label="Neutral / Hover">
-              <TextButton size="14" className="underline underline-offset-4">
+              <TextButton size="14" className="underline underline-offset-3">
                 텍스트 버튼
               </TextButton>
             </TextButtonSpecimen>

--- a/src/routes/test/text-button.tsx
+++ b/src/routes/test/text-button.tsx
@@ -1,0 +1,73 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { TextButton } from "@/shared/ui/button/TextButton"
+
+export const Route = createFileRoute("/test/text-button")({
+  component: TextButtonTestPage,
+})
+
+function TextButtonSpecimen({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="border-teal-gray-150 flex min-h-24 min-w-40 flex-col items-center justify-center gap-3 rounded-xl border bg-white px-4 py-5">
+      {children}
+      <span className="text-caption-2-regular text-teal-gray-400">{label}</span>
+    </div>
+  )
+}
+
+function TextButtonTestPage() {
+  return (
+    <main className="bg-teal-gray-50 bp1:p-10 min-h-screen w-full p-6">
+      <div className="mx-auto flex w-full max-w-240 flex-col gap-10">
+        <header className="flex flex-col gap-2">
+          <h1 className="text-heading-6-semibold text-teal-gray-900">
+            TextButton
+          </h1>
+          <p className="text-body-2-regular text-teal-gray-500">
+            Figma 정의의 크기, 색상, hover 상태를 확인하는 페이지입니다.
+          </p>
+        </header>
+
+        <section className="flex flex-col gap-4">
+          <h2 className="text-label-1-semibold text-teal-gray-700">16px</h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <TextButtonSpecimen label="Neutral / Default">
+              <TextButton>텍스트 버튼</TextButton>
+            </TextButtonSpecimen>
+            <TextButtonSpecimen label="Neutral / Hover">
+              <TextButton className="underline">텍스트 버튼</TextButton>
+            </TextButtonSpecimen>
+            <TextButtonSpecimen label="Primary / Default">
+              <TextButton color="primary">텍스트 버튼</TextButton>
+            </TextButtonSpecimen>
+            <TextButtonSpecimen label="Primary / Hover">
+              <TextButton color="primary" className="underline">
+                텍스트 버튼
+              </TextButton>
+            </TextButtonSpecimen>
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-4">
+          <h2 className="text-label-1-semibold text-teal-gray-700">14px</h2>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <TextButtonSpecimen label="Neutral / Default">
+              <TextButton size="14">텍스트 버튼</TextButton>
+            </TextButtonSpecimen>
+            <TextButtonSpecimen label="Neutral / Hover">
+              <TextButton size="14" className="underline">
+                텍스트 버튼
+              </TextButton>
+            </TextButtonSpecimen>
+          </div>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/src/routes/test/text-button.tsx
+++ b/src/routes/test/text-button.tsx
@@ -30,18 +30,24 @@ function TextButtonTestPage() {
             TextButton
           </h1>
           <p className="text-body-2-regular text-teal-gray-500">
-            Figma 정의의 크기, 색상, hover 상태를 확인하는 페이지입니다.
+            Figma 정의의 크기, 색상과 확장한 hover·active 상태를 확인하는
+            페이지입니다.
           </p>
         </header>
 
         <section className="flex flex-col gap-4">
           <h2 className="text-label-1-semibold text-teal-gray-700">16px</h2>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             <TextButtonSpecimen label="Neutral / Default">
               <TextButton>텍스트 버튼</TextButton>
             </TextButtonSpecimen>
             <TextButtonSpecimen label="Neutral / Hover">
               <TextButton className="underline underline-offset-3">
+                텍스트 버튼
+              </TextButton>
+            </TextButtonSpecimen>
+            <TextButtonSpecimen label="Neutral / Active">
+              <TextButton className="text-teal-gray-700 underline underline-offset-3">
                 텍스트 버튼
               </TextButton>
             </TextButtonSpecimen>
@@ -56,17 +62,33 @@ function TextButtonTestPage() {
                 텍스트 버튼
               </TextButton>
             </TextButtonSpecimen>
+            <TextButtonSpecimen label="Primary / Active">
+              <TextButton
+                color="primary"
+                className="text-teal-700 underline underline-offset-3"
+              >
+                텍스트 버튼
+              </TextButton>
+            </TextButtonSpecimen>
           </div>
         </section>
 
         <section className="flex flex-col gap-4">
           <h2 className="text-label-1-semibold text-teal-gray-700">14px</h2>
-          <div className="grid gap-4 sm:grid-cols-2">
+          <div className="grid gap-4 sm:grid-cols-3">
             <TextButtonSpecimen label="Neutral / Default">
               <TextButton size="14">텍스트 버튼</TextButton>
             </TextButtonSpecimen>
             <TextButtonSpecimen label="Neutral / Hover">
               <TextButton size="14" className="underline underline-offset-3">
+                텍스트 버튼
+              </TextButton>
+            </TextButtonSpecimen>
+            <TextButtonSpecimen label="Neutral / Active">
+              <TextButton
+                size="14"
+                className="text-teal-gray-900 underline underline-offset-3"
+              >
                 텍스트 버튼
               </TextButton>
             </TextButtonSpecimen>

--- a/src/routes/test/text-button.tsx
+++ b/src/routes/test/text-button.tsx
@@ -41,7 +41,7 @@ function TextButtonTestPage() {
               <TextButton>텍스트 버튼</TextButton>
             </TextButtonSpecimen>
             <TextButtonSpecimen label="Neutral / Hover">
-              <TextButton className="underline underline-offset-2">
+              <TextButton className="underline underline-offset-4">
                 텍스트 버튼
               </TextButton>
             </TextButtonSpecimen>
@@ -51,7 +51,7 @@ function TextButtonTestPage() {
             <TextButtonSpecimen label="Primary / Hover">
               <TextButton
                 color="primary"
-                className="underline underline-offset-2"
+                className="underline underline-offset-4"
               >
                 텍스트 버튼
               </TextButton>
@@ -66,7 +66,7 @@ function TextButtonTestPage() {
               <TextButton size="14">텍스트 버튼</TextButton>
             </TextButtonSpecimen>
             <TextButtonSpecimen label="Neutral / Hover">
-              <TextButton size="14" className="underline underline-offset-2">
+              <TextButton size="14" className="underline underline-offset-4">
                 텍스트 버튼
               </TextButton>
             </TextButtonSpecimen>

--- a/src/shared/ui/button/TextButton.test.tsx
+++ b/src/shared/ui/button/TextButton.test.tsx
@@ -15,7 +15,7 @@ describe("TextButton", () => {
       "leading-6",
       "text-teal-gray-500",
       "hover:underline",
-      "hover:underline-offset-4",
+      "hover:underline-offset-3",
     )
   })
 

--- a/src/shared/ui/button/TextButton.test.tsx
+++ b/src/shared/ui/button/TextButton.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { TextButton } from "@/shared/ui/button/TextButton"
+
+describe("TextButton", () => {
+  it("renders the 16px neutral variant by default", () => {
+    render(<TextButton>텍스트 버튼</TextButton>)
+
+    const button = screen.getByRole("button", { name: "텍스트 버튼" })
+
+    expect(button).toHaveAttribute("type", "button")
+    expect(button).toHaveClass(
+      "text-[16px]",
+      "leading-6",
+      "text-teal-gray-500",
+      "hover:underline",
+    )
+  })
+
+  it("renders the primary variant with the Figma color", () => {
+    render(<TextButton color="primary">회원가입</TextButton>)
+
+    expect(screen.getByRole("button", { name: "회원가입" })).toHaveClass(
+      "text-teal-500",
+      "hover:decoration-teal-500",
+    )
+  })
+
+  it("renders the 14px neutral variant with its dedicated typography and color", () => {
+    render(
+      <TextButton size="14" color="neutral">
+        계정 설정
+      </TextButton>,
+    )
+
+    expect(screen.getByRole("button", { name: "계정 설정" })).toHaveClass(
+      "text-body-2-medium",
+      "text-teal-gray-700",
+      "hover:decoration-teal-gray-700",
+    )
+  })
+
+  it("prevents pointer interaction and removes underline when disabled", () => {
+    render(<TextButton disabled>비활성 버튼</TextButton>)
+
+    expect(screen.getByRole("button", { name: "비활성 버튼" })).toHaveClass(
+      "disabled:pointer-events-none",
+      "disabled:no-underline",
+      "disabled:opacity-50",
+    )
+  })
+})

--- a/src/shared/ui/button/TextButton.test.tsx
+++ b/src/shared/ui/button/TextButton.test.tsx
@@ -15,6 +15,7 @@ describe("TextButton", () => {
       "leading-6",
       "text-teal-gray-500",
       "hover:underline",
+      "hover:underline-offset-2",
     )
   })
 

--- a/src/shared/ui/button/TextButton.test.tsx
+++ b/src/shared/ui/button/TextButton.test.tsx
@@ -15,7 +15,7 @@ describe("TextButton", () => {
       "leading-6",
       "text-teal-gray-500",
       "hover:underline",
-      "hover:underline-offset-2",
+      "hover:underline-offset-4",
     )
   })
 

--- a/src/shared/ui/button/TextButton.test.tsx
+++ b/src/shared/ui/button/TextButton.test.tsx
@@ -16,8 +16,10 @@ describe("TextButton", () => {
       "text-teal-gray-500",
       "hover:underline",
       "hover:underline-offset-3",
+      "active:rounded-sm",
       "active:underline",
       "active:underline-offset-3",
+      "active:bg-teal-gray-200",
       "active:text-teal-gray-700",
     )
   })
@@ -28,6 +30,7 @@ describe("TextButton", () => {
     expect(screen.getByRole("button", { name: "회원가입" })).toHaveClass(
       "text-teal-500",
       "hover:decoration-teal-500",
+      "active:bg-teal-100",
       "active:text-teal-700",
     )
   })
@@ -43,6 +46,7 @@ describe("TextButton", () => {
       "text-body-2-medium",
       "text-teal-gray-700",
       "hover:decoration-teal-gray-700",
+      "active:bg-teal-gray-200",
       "active:text-teal-gray-900",
     )
   })

--- a/src/shared/ui/button/TextButton.test.tsx
+++ b/src/shared/ui/button/TextButton.test.tsx
@@ -16,6 +16,9 @@ describe("TextButton", () => {
       "text-teal-gray-500",
       "hover:underline",
       "hover:underline-offset-3",
+      "active:underline",
+      "active:underline-offset-3",
+      "active:text-teal-gray-700",
     )
   })
 
@@ -25,6 +28,7 @@ describe("TextButton", () => {
     expect(screen.getByRole("button", { name: "회원가입" })).toHaveClass(
       "text-teal-500",
       "hover:decoration-teal-500",
+      "active:text-teal-700",
     )
   })
 
@@ -39,6 +43,7 @@ describe("TextButton", () => {
       "text-body-2-medium",
       "text-teal-gray-700",
       "hover:decoration-teal-gray-700",
+      "active:text-teal-gray-900",
     )
   })
 

--- a/src/shared/ui/button/TextButton.tsx
+++ b/src/shared/ui/button/TextButton.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/shared/lib/utils"
 
 const textButtonVariants = cva(
-  "inline-flex items-center justify-center px-1 py-0.5 text-center transition-colors hover:underline disabled:pointer-events-none disabled:no-underline disabled:opacity-50",
+  "inline-flex items-center justify-center px-1 py-0.5 text-center transition-colors hover:underline hover:underline-offset-2 disabled:pointer-events-none disabled:no-underline disabled:opacity-50",
   {
     variants: {
       color: {

--- a/src/shared/ui/button/TextButton.tsx
+++ b/src/shared/ui/button/TextButton.tsx
@@ -3,13 +3,14 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/shared/lib/utils"
 
 const textButtonVariants = cva(
-  "inline-flex items-center justify-center px-1 py-0.5 text-center transition-colors hover:underline hover:underline-offset-3 active:underline active:underline-offset-3 disabled:pointer-events-none disabled:no-underline disabled:opacity-50",
+  "inline-flex items-center justify-center px-1 py-0.5 text-center transition-colors hover:underline hover:underline-offset-3 active:rounded-sm active:underline active:underline-offset-3 disabled:pointer-events-none disabled:no-underline disabled:opacity-50",
   {
     variants: {
       color: {
-        primary: "text-teal-500 hover:decoration-teal-500 active:text-teal-700",
+        primary:
+          "text-teal-500 hover:decoration-teal-500 active:bg-teal-100 active:text-teal-700",
         neutral:
-          "text-teal-gray-500 hover:decoration-teal-gray-500 active:text-teal-gray-700",
+          "text-teal-gray-500 hover:decoration-teal-gray-500 active:bg-teal-gray-200 active:text-teal-gray-700",
       },
       size: {
         "16": "text-[16px] leading-6 font-normal tracking-normal",

--- a/src/shared/ui/button/TextButton.tsx
+++ b/src/shared/ui/button/TextButton.tsx
@@ -1,24 +1,53 @@
+import { cva, type VariantProps } from "class-variance-authority"
+
 import { cn } from "@/shared/lib/utils"
 
-type TextButtonProps = React.ComponentPropsWithoutRef<"button">
+const textButtonVariants = cva(
+  "inline-flex items-center justify-center px-1 py-0.5 text-center transition-colors hover:underline disabled:pointer-events-none disabled:no-underline disabled:opacity-50",
+  {
+    variants: {
+      color: {
+        primary: "text-teal-500 hover:decoration-teal-500",
+        neutral: "text-teal-gray-500 hover:decoration-teal-gray-500",
+      },
+      size: {
+        "16": "text-[16px] leading-6 font-normal tracking-normal",
+        "14": "text-body-2-medium",
+      },
+    },
+    compoundVariants: [
+      {
+        color: "neutral",
+        size: "14",
+        className: "text-teal-gray-700 hover:decoration-teal-gray-700",
+      },
+    ],
+    defaultVariants: {
+      color: "neutral",
+      size: "16",
+    },
+  },
+)
+
+interface TextButtonProps
+  extends
+    Omit<React.ComponentPropsWithoutRef<"button">, "color">,
+    VariantProps<typeof textButtonVariants> {}
 
 export function TextButton({
   className,
   disabled,
   children,
   type = "button",
+  color,
+  size,
   ...props
 }: TextButtonProps) {
   return (
     <button
       type={type}
       disabled={disabled}
-      className={cn(
-        "text-left transition-colors",
-        !disabled && "hover:underline",
-        disabled && "opacity-50",
-        className,
-      )}
+      className={cn(textButtonVariants({ color, size }), className)}
       {...props}
     >
       {children}

--- a/src/shared/ui/button/TextButton.tsx
+++ b/src/shared/ui/button/TextButton.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/shared/lib/utils"
 
 const textButtonVariants = cva(
-  "inline-flex items-center justify-center px-1 py-0.5 text-center transition-colors hover:underline hover:underline-offset-2 disabled:pointer-events-none disabled:no-underline disabled:opacity-50",
+  "inline-flex items-center justify-center px-1 py-0.5 text-center transition-colors hover:underline hover:underline-offset-4 disabled:pointer-events-none disabled:no-underline disabled:opacity-50",
   {
     variants: {
       color: {

--- a/src/shared/ui/button/TextButton.tsx
+++ b/src/shared/ui/button/TextButton.tsx
@@ -3,12 +3,13 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/shared/lib/utils"
 
 const textButtonVariants = cva(
-  "inline-flex items-center justify-center px-1 py-0.5 text-center transition-colors hover:underline hover:underline-offset-3 disabled:pointer-events-none disabled:no-underline disabled:opacity-50",
+  "inline-flex items-center justify-center px-1 py-0.5 text-center transition-colors hover:underline hover:underline-offset-3 active:underline active:underline-offset-3 disabled:pointer-events-none disabled:no-underline disabled:opacity-50",
   {
     variants: {
       color: {
-        primary: "text-teal-500 hover:decoration-teal-500",
-        neutral: "text-teal-gray-500 hover:decoration-teal-gray-500",
+        primary: "text-teal-500 hover:decoration-teal-500 active:text-teal-700",
+        neutral:
+          "text-teal-gray-500 hover:decoration-teal-gray-500 active:text-teal-gray-700",
       },
       size: {
         "16": "text-[16px] leading-6 font-normal tracking-normal",
@@ -19,7 +20,8 @@ const textButtonVariants = cva(
       {
         color: "neutral",
         size: "14",
-        className: "text-teal-gray-700 hover:decoration-teal-gray-700",
+        className:
+          "text-teal-gray-700 hover:decoration-teal-gray-700 active:text-teal-gray-900",
       },
     ],
     defaultVariants: {

--- a/src/shared/ui/button/TextButton.tsx
+++ b/src/shared/ui/button/TextButton.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/shared/lib/utils"
 
 const textButtonVariants = cva(
-  "inline-flex items-center justify-center px-1 py-0.5 text-center transition-colors hover:underline hover:underline-offset-4 disabled:pointer-events-none disabled:no-underline disabled:opacity-50",
+  "inline-flex items-center justify-center px-1 py-0.5 text-center transition-colors hover:underline hover:underline-offset-3 disabled:pointer-events-none disabled:no-underline disabled:opacity-50",
   {
     variants: {
       color: {

--- a/src/widgets/navigation/header/ProfileDropdown.tsx
+++ b/src/widgets/navigation/header/ProfileDropdown.tsx
@@ -180,19 +180,21 @@ export function ProfileDropdown({
           {/* TODO: 기수 관리 페이지로 연결 */}
           <div className="flex flex-col gap-1 px-1.5">
             {canManageMembers && (
-              <TextButton className="text-body-2-medium text-teal-gray-700 hover:decoration-teal-gray-700 h-6 w-15">
+              <TextButton size="14" className="h-6 w-15">
                 기수 관리
               </TextButton>
             )}
             <TextButton
               onClick={() => navigate({ to: "/settings" })}
-              className="text-body-2-medium text-teal-gray-700 hover:decoration-teal-gray-700 h-6 w-15"
+              size="14"
+              className="h-6 w-15"
             >
               계정 설정
             </TextButton>
             <TextButton
               onClick={() => void handleLogout()}
-              className="text-body-2-medium text-error-500 hover:decoration-error-500 h-6 w-15"
+              size="14"
+              className="text-error-500 hover:decoration-error-500 h-6 w-15"
             >
               로그아웃
             </TextButton>


### PR DESCRIPTION
## 📸 작업 내용

- 피그마 TextButton 정의를 기존 공용 컴포넌트의 size·color variant API로 반영했습니다.
- 16px variant에는 피그마 기준 줄간격 1.5를 컴포넌트 범위로 적용했습니다.
- 로그인·회원가입·프로필 메뉴 사용처를 공용 variant API로 전환하고, 로그아웃의 error 색상 override는 유지했습니다.
- 기본·Primary·14px Neutral·disabled 동작을 단위 테스트로 검증했습니다.

## 🎞️ 주요 코드 설명

### TextButton variant API

- `size="16" | "14"`, `color="primary" | "neutral"` 조합으로 타이포그래피와 색상, hover 밑줄을 일관되게 제공합니다.
- 기존 native button props, `className`, disabled 동작을 보존했습니다.

## 구현 화면
<img width="1280" height="720" alt="text-button-active-surface-desktop" src="https://github.com/user-attachments/assets/4ed91c83-6acc-4faf-92f6-07abbc9a03f3" />


## 🔗 연결된 이슈

- Connected: #572
- Closes #572