### PR TITLE
💄 style: 공용 버튼 피그마 디자인 동기화

### DIFF
--- a/src/routes/test/button.tsx
+++ b/src/routes/test/button.tsx
@@ -1,6 +1,8 @@
 import { createFileRoute } from "@tanstack/react-router"
 
+import PersonButtonIcon from "@/shared/assets/icon/people/PersonButtonIcon"
 import { Button } from "@/shared/ui/Button"
+import { IconButton } from "@/shared/ui/button/IconButton"
 
 export const Route = createFileRoute("/test/button")({
   component: ButtonTestPage,
@@ -243,6 +245,25 @@ function ButtonTestPage() {
               })),
             )}
           />
+        </Section>
+
+        <Section title="Icon Only (IconButton)">
+          <div className="flex items-center gap-4">
+            <IconButton variant="fill" aria-label="예시 아이콘 버튼">
+              <PersonButtonIcon className="text-teal-gray-50 h-6 w-6" />
+            </IconButton>
+            <IconButton variant="weak" aria-label="예시 아이콘 버튼">
+              <PersonButtonIcon className="text-teal-gray-600 h-6 w-6" />
+            </IconButton>
+          </div>
+        </Section>
+
+        <Section title="Setting (= XL / Neutral / Weak)">
+          <div>
+            <Button size="xl" color="neutral" variant="weak">
+              버튼
+            </Button>
+          </div>
         </Section>
       </div>
     </main>

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -21,8 +21,8 @@ const buttonVariants = cva(
       size: {
         xl: "h-14 min-h-14 min-w-24 py-1 px-8 gap-2.5 text-heading-7-semibold",
         lg: "h-[50px] min-h-11 min-w-[84px] py-1 px-4 gap-2.5 rounded-[10px] text-heading-7-semibold",
-        m: "h-11 min-w-[90px] px-4",
-        s: "h-10 min-w-[74px] px-5",
+        m: "h-11 min-w-19 px-4",
+        s: "h-10 min-w-16 px-5 rounded-[10px]",
         xs: "h-[34px] pt-0.5",
       },
     },
@@ -56,14 +56,14 @@ const buttonVariants = cva(
         color: "white",
         size: "xs",
         className:
-          "shadow-inner-neutral-2 bg-teal-gray-50 text-teal-gray-600 hover:bg-teal-gray-100 disabled:bg-teal-gray-50 disabled:text-teal-gray-400",
+          "border border-teal-gray-400/25 bg-white text-teal-gray-700 hover:border-teal-gray-150 hover:bg-teal-gray-100 hover:shadow-inner-neutral-2 disabled:border-teal-gray-100 disabled:bg-teal-gray-50 disabled:text-teal-gray-300",
       },
       {
         variant: "weak",
         color: "white",
         size: "xs",
         className:
-          "shadow-inner-neutral-2 bg-transparent text-teal-gray-600 hover:bg-teal-gray-50 disabled:bg-transparent disabled:text-teal-gray-400",
+          "shadow-inner-neutral-2 bg-transparent text-teal-gray-700 hover:bg-teal-gray-50 disabled:bg-transparent disabled:text-teal-gray-300 disabled:shadow-none",
       },
     ],
     defaultVariants: {
@@ -127,8 +127,11 @@ export function Button({
         "group",
         buttonVariants({ variant, color, size }),
         size === "xs" &&
-          (icon ? "pr-3.5 pl-2" : "w-14.5 min-w-14.5 rounded-[8px]"),
+          (icon
+            ? "rounded-[10px] pr-3.5 pl-2"
+            : "w-14.5 min-w-14.5 rounded-[8px]"),
         size === "m" && "rounded-[10px]",
+        size === "xl" && color === "neutral" && "rounded-[10px]",
         icon && size === "s" && "min-h-10 rounded-[10px] py-1 pr-4 pl-2.5",
         icon && size === "m" && "min-h-11 min-w-19 py-1 pr-4 pl-3",
         isLoading && "pointer-events-none cursor-default select-none",
@@ -149,7 +152,10 @@ export function Button({
       {isLoading ? (
         <>
           <span className="sr-only">로딩 중</span>
-          <span className="flex items-center gap-1.25" aria-hidden="true">
+          <span
+            className="flex items-center gap-1.25 opacity-70"
+            aria-hidden="true"
+          >
             <span className="animation-duration-[1000ms] h-2 w-2 animate-pulse rounded-full bg-current opacity-100" />
             <span className="animation-duration-[1000ms] h-2 w-2 animate-pulse rounded-full bg-current opacity-60 [animation-delay:75ms]" />
             <span className="animation-duration-[1000ms] h-2 w-2 animate-pulse rounded-full bg-current opacity-20 [animation-delay:150ms]" />

--- a/src/shared/ui/button/IconButton.tsx
+++ b/src/shared/ui/button/IconButton.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/shared/lib/utils"
+import { Button } from "@/shared/ui/Button"
+
+import type { ButtonHTMLAttributes } from "react"
+
+interface IconButtonProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  "color"
+> {
+  variant?: "fill" | "weak"
+  "aria-label": string
+}
+
+export function IconButton({
+  variant = "fill",
+  className,
+  children,
+  ...props
+}: IconButtonProps) {
+  return (
+    <Button
+      variant={variant}
+      color="neutral"
+      size="m"
+      className={cn("min-w-13", className)}
+      {...props}
+    >
+      {children}
+    </Button>
+  )
+}

--- a/src/shared/ui/button/TeamMemberButton.tsx
+++ b/src/shared/ui/button/TeamMemberButton.tsx
@@ -1,7 +1,7 @@
 import { cva, type VariantProps } from "class-variance-authority"
 
 import PersonButtonIcon from "@/shared/assets/icon/people/PersonButtonIcon"
-import { Button } from "@/shared/ui/Button"
+import { IconButton } from "@/shared/ui/button/IconButton"
 
 import type { ButtonHTMLAttributes } from "react"
 
@@ -28,14 +28,13 @@ export function TeamMemberButton({
   ...props
 }: TeamMemberButtonProps) {
   return (
-    <Button
+    <IconButton
       variant={variant ?? "fill"}
-      color="neutral"
-      size="m"
-      className={`min-w-[3.25rem] rounded-xl ${className ?? ""}`}
+      aria-label="팀원 보기"
+      className={className}
       {...props}
     >
       <PersonButtonIcon className={iconVariants({ variant })} />
-    </Button>
+    </IconButton>
   )
 }

--- a/src/styles/color.css
+++ b/src/styles/color.css
@@ -7,7 +7,7 @@
   --color-white: #ffffff;
   --color-teal-gray-50: #fbfcfc;
   --color-teal-gray-100: #f6f7f7;
-  --color-teal-gray-150: #eceeee;
+  --color-teal-gray-150: #eff0f0;
   --color-teal-gray-200: #e9ecec;
   --color-teal-gray-300: #d3d8d8;
   --color-teal-gray-400: #9ca3a3;


### PR DESCRIPTION
## 📸 작업 내용

- 피그마 최신 Button 스펙에 맞춰 크기, 모서리, 색상 토큰, White XS 상태와 로딩 인디케이터를 동기화했습니다.
- 아이콘 전용 공용 `IconButton`을 추가하고 `TeamMemberButton`이 이를 재사용하도록 정리했습니다.
- `/test/button`에 Icon Only와 Setting 상태를 추가해 버튼 변형을 검증할 수 있게 했습니다.

## 🎞️ 주요 코드 설명

### 공용 아이콘 버튼 분리

- 아이콘 전용 버튼의 56×44px Neutral Fill/Weak 규격을 `IconButton`으로 분리해 팀원 버튼 등에서 같은 규격을 재사용합니다.

### 피그마 로딩 상태 정렬

- 로딩 인디케이터의 34px 중앙 배치와 전체 투명도를 피그마 규격에 맞춰 Sm 상태에서의 시각적 편차를 해소했습니다.

## 🔗 연결된 이슈

- Connected: #571
- Closes #571

## 구현 화면
<img width="1440" height="2807" alt="button-figma-desktop-5174-final" src="https://github.com/user-attachments/assets/8d819e2a-e13d-420e-960f-6b1a4aa5d5e6" />


## 📚 참고자료

- Figma: https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/%F0%9F%8D%92-UMC-Web?node-id=741-15571