### PR TITLE
✨ feat: Tooltip 라벨과 바깥 클릭 닫기 지원

### DIFF
--- a/src/features/application/ui/detail-modal/ModalApplicantPanel.tsx
+++ b/src/features/application/ui/detail-modal/ModalApplicantPanel.tsx
@@ -120,30 +120,23 @@ export function ModalApplicantPanel({
           {/* 액션 버튼 */}
           <div className="flex items-center gap-2.5">
             <Tooltip
+              label={
+                currentRound != null ? "지원자 배정 관리 Sheet" : "지원자 배정"
+              }
               content={
                 currentRound != null ? (
-                  <div className="text-left">
-                    <p className="text-caption-2-bold text-teal-500">
-                      지원자 배정 관리 Sheet
-                    </p>
-                    <p className="text-caption-2-regular text-teal-gray-600">
-                      합격/불합격 결과는 각 매칭 차수 종료 시 자동 확정됩니다.
-                      <br />각 차수 마감 전까지만 철회 가능하며, 이후에는 변경할
-                      수 없습니다.
-                    </p>
-                  </div>
+                  <>
+                    합격/불합격 결과는 각 매칭 차수 종료 시 자동 확정됩니다.
+                    <br />각 차수 마감 전까지만 철회 가능하며, 이후에는 변경할
+                    수 없습니다.
+                  </>
                 ) : (
-                  <div className="text-left">
-                    <p className="text-caption-2-bold text-teal-500">
-                      지원자 배정
-                    </p>
-                    <p className="text-caption-2-regular text-teal-gray-600">
-                      매칭 차수나 마감 기한과 관계없이 언제든 상태를 변경할 수
-                      있습니다.
-                      <br />
-                      변경 사항은 즉시 반영됩니다.
-                    </p>
-                  </div>
+                  <>
+                    매칭 차수나 마감 기한과 관계없이 언제든 상태를 변경할 수
+                    있습니다.
+                    <br />
+                    변경 사항은 즉시 반영됩니다.
+                  </>
                 )
               }
               size="big"

--- a/src/features/matching/ui/AssignmentModal.tsx
+++ b/src/features/matching/ui/AssignmentModal.tsx
@@ -147,18 +147,14 @@ export function AssignmentModal({
             </div>
             <div className="flex items-center gap-2.5">
               <Tooltip
+                label="팀원 수동 배정"
                 content={
-                  <div className="text-left">
-                    <p className="text-caption-2-bold text-teal-500">
-                      팀원 수동 배정
-                    </p>
-                    <p className="text-caption-2-regular text-teal-gray-600">
-                      매칭 차수나 마감 기한과 관계없이 팀원을 언제든 추가하거나
-                      해제할 수 있습니다.
-                      <br />
-                      변경 사항은 즉시 반영됩니다.
-                    </p>
-                  </div>
+                  <>
+                    매칭 차수나 마감 기한과 관계없이 팀원을 언제든 추가하거나
+                    해제할 수 있습니다.
+                    <br />
+                    변경 사항은 즉시 반영됩니다.
+                  </>
                 }
                 size="big"
                 dark={false}

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -600,21 +600,12 @@ function MatchingRoundsPage() {
 
                   {/* 툴팁: 매칭 차수 기간 설정 안내 */}
                   <Tooltip
-                    content={
-                      <div className="text-left">
-                        <p className="text-caption-2-medium font-bold text-teal-600">
-                          매칭 차수 기간 설정
-                        </p>
-                        <p className="text-caption-2-regular text-teal-gray-600">
-                          1차 매칭 시작 후에는 차수 기간을 변경할 수 없습니다.
-                        </p>
-                      </div>
-                    }
+                    label="매칭 차수 기간 설정"
+                    content="1차 매칭 시작 후에는 차수 기간을 변경할 수 없습니다."
                     size="big"
                     dark={false}
                     side="right"
                     sideOffset={8}
-                    className="h-13! w-69!"
                     triggerClassName="self-start -mt-6"
                   >
                     <button

--- a/src/routes/test/tooltip.tsx
+++ b/src/routes/test/tooltip.tsx
@@ -52,6 +52,31 @@ function TooltipTestPage() {
                 </div>
               )),
             )}
+            <div className="flex flex-col items-center gap-2">
+              <Tooltip
+                label="라벨"
+                content={
+                  <>
+                    사용자에게 정보를 안내 할 Tooltip Message
+                    <br />
+                    여러줄 가능
+                  </>
+                }
+                size="big"
+                dark={false}
+                side={side}
+              >
+                <button
+                  type="button"
+                  className="bg-teal-gray-100 text-teal-gray-700 text-label-2-medium cursor-pointer rounded-[6px] px-3 py-1.5"
+                >
+                  hover
+                </button>
+              </Tooltip>
+              <span className="text-caption-2-regular text-teal-gray-400">
+                big / light / label
+              </span>
+            </div>
           </div>
         </section>
       ))}

--- a/src/shared/ui/tooltip/Tooltip.test.tsx
+++ b/src/shared/ui/tooltip/Tooltip.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { Tooltip } from "./Tooltip"
+
+function Trigger() {
+  return <button type="button">도움말</button>
+}
+
+describe("Tooltip", () => {
+  it("밝은 큰 Tooltip에서 라벨과 본문을 피그마 토큰으로 표시한다", () => {
+    render(
+      <Tooltip
+        label="라벨"
+        content="사용자에게 정보를 안내합니다."
+        size="big"
+        dark={false}
+        defaultOpen
+      >
+        <Trigger />
+      </Tooltip>,
+    )
+
+    const tooltip = screen.getByRole("tooltip")
+
+    expect(screen.getByText("라벨")).toHaveClass(
+      "text-caption-3-bold",
+      "text-teal-600",
+    )
+    expect(screen.getByText("사용자에게 정보를 안내합니다.")).toHaveClass(
+      "text-caption-3-regular",
+      "text-left",
+    )
+    expect(tooltip).toHaveClass("shadow-drop-neutral-1")
+  })
+
+  it("라벨이 지원되지 않는 조합에서는 본문만 표시한다", () => {
+    render(
+      <Tooltip label="라벨" content="Tooltips" size="small" defaultOpen>
+        <Trigger />
+      </Tooltip>,
+    )
+
+    expect(screen.queryByText("라벨")).not.toBeInTheDocument()
+    expect(screen.getByText("Tooltips")).toHaveClass("text-center")
+  })
+
+  it("클릭하면 Tooltip을 열고 다시 클릭하면 닫는다", () => {
+    render(
+      <Tooltip content="Tooltips" delayDuration={0}>
+        <Trigger />
+      </Tooltip>,
+    )
+
+    const trigger = screen.getByRole("button", { name: "도움말" })
+
+    fireEvent.click(trigger)
+    expect(screen.getByRole("tooltip")).toBeInTheDocument()
+
+    fireEvent.click(trigger)
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument()
+  })
+
+  it("Tooltip 바깥을 누르면 열린 Tooltip을 닫는다", () => {
+    render(
+      <>
+        <Tooltip content="Tooltips" delayDuration={0}>
+          <Trigger />
+        </Tooltip>
+        <button type="button">바깥</button>
+      </>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "도움말" }))
+    expect(screen.getByRole("tooltip")).toBeInTheDocument()
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "바깥" }))
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument()
+  })
+})

--- a/src/shared/ui/tooltip/Tooltip.tsx
+++ b/src/shared/ui/tooltip/Tooltip.tsx
@@ -13,11 +13,11 @@ import { createPortal } from "react-dom"
 
 import { cn } from "@/shared/lib/utils"
 
-const tooltipContentVariants = cva("rounded-[6px] relative text-center", {
+const tooltipContentVariants = cva("relative rounded-[6px]", {
   variants: {
     size: {
-      big: "w-[221px] min-h-[52px] py-2 px-3 text-body-2-medium break-keep",
-      small: "py-1 px-2 text-caption-2-medium whitespace-nowrap",
+      big: "w-[221px] min-h-[52px] px-3 py-2",
+      small: "px-2 py-1",
     },
     dark: {
       true: "bg-teal-gray-500 text-white",
@@ -146,6 +146,7 @@ function TooltipArrow({
 
 interface TooltipProps {
   content: ReactNode
+  label?: ReactNode
   children: ReactNode
   size?: "big" | "small"
   dark?: boolean
@@ -163,6 +164,7 @@ interface TooltipProps {
 
 export function Tooltip({
   content,
+  label,
   children,
   size = "big",
   dark = true,
@@ -179,12 +181,14 @@ export function Tooltip({
 }: TooltipProps) {
   const tooltipId = useId()
   const isControlled = controlledOpen !== undefined
+  const isLabeled = label != null && size === "big" && !dark
 
   const [internalOpen, setInternalOpen] = useState(defaultOpen)
   const [position, setPosition] = useState<CSSProperties>({})
   const isOpen = isControlled ? controlledOpen : internalOpen
 
   const triggerRef = useRef<HTMLSpanElement>(null)
+  const tooltipRef = useRef<HTMLDivElement>(null)
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const autoHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -201,7 +205,7 @@ export function Tooltip({
         ),
       )
     }
-  }, [side, sideOffset])
+  }, [side, sideOffset, size])
 
   const handleOpen = useCallback(() => {
     if (pinned) return
@@ -220,18 +224,23 @@ export function Tooltip({
     onOpenChange?.(false)
   }, [pinned, isControlled, onOpenChange])
 
+  const closeTooltip = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    setPinned(false)
+    if (!isControlled) setInternalOpen(false)
+    onOpenChange?.(false)
+  }, [isControlled, onOpenChange])
+
   const handleClick = useCallback(() => {
     if (pinned) {
-      setPinned(false)
-      if (!isControlled) setInternalOpen(false)
-      onOpenChange?.(false)
+      closeTooltip()
     } else {
       updatePosition()
       setPinned(true)
       if (!isControlled) setInternalOpen(true)
       onOpenChange?.(true)
     }
-  }, [pinned, isControlled, onOpenChange, updatePosition])
+  }, [pinned, isControlled, onOpenChange, updatePosition, closeTooltip])
 
   useEffect(() => {
     return () => {
@@ -243,14 +252,29 @@ export function Tooltip({
   useEffect(() => {
     if (!isOpen || !autoHideDuration) return
     autoHideTimerRef.current = setTimeout(() => {
-      setPinned(false)
-      if (!isControlled) setInternalOpen(false)
-      onOpenChange?.(false)
+      closeTooltip()
     }, autoHideDuration)
     return () => {
       if (autoHideTimerRef.current) clearTimeout(autoHideTimerRef.current)
     }
-  }, [isOpen, autoHideDuration, isControlled, onOpenChange])
+  }, [isOpen, autoHideDuration, closeTooltip])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target
+      if (!(target instanceof Node)) return
+      if (
+        triggerRef.current?.contains(target) ||
+        tooltipRef.current?.contains(target)
+      )
+        return
+      closeTooltip()
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown)
+    return () => document.removeEventListener("pointerdown", handlePointerDown)
+  }, [isOpen, closeTooltip])
 
   useLayoutEffect(() => {
     if (!isOpen) return
@@ -280,15 +304,27 @@ export function Tooltip({
         createPortal(
           <div
             id={tooltipId}
+            ref={tooltipRef}
             role="tooltip"
             style={position}
             className={cn(
               tooltipContentVariants({ size, dark }),
-              !dark && "shadow-tooltip-light",
+              !dark && "shadow-drop-neutral-1",
               className,
             )}
           >
-            {content}
+            {isLabeled && (
+              <div className="text-caption-3-bold text-teal-600">{label}</div>
+            )}
+            <div
+              className={cn(
+                "text-caption-3-regular break-keep",
+                size === "small" && "whitespace-nowrap",
+                isLabeled ? "text-left" : "text-center",
+              )}
+            >
+              {content}
+            </div>
             <TooltipArrow size={size} dark={dark} side={side} />
           </div>,
           document.body,


### PR DESCRIPTION
## 📸 작업 내용

- 공용 Tooltip에 피그마 기준의 라벨 변형, Caption 3 텍스트 토큰, 밝은 배경 그림자를 적용했습니다.
- 제목과 본문을 직접 구성하던 Tooltip 사용처를 label API로 전환했습니다.
- Tooltip과 트리거 밖의 pointerdown에서 열린 Tooltip을 닫도록 개선했습니다.
- Tooltip 테스트 화면에 라벨 변형을 추가하고, 단위 테스트로 라벨·클릭·바깥 클릭 동작을 검증했습니다.

## 🎞️ 주요 코드 설명

- Tooltip은 triggerRef와 tooltipRef를 함께 확인해 내부 상호작용을 유지하면서 바깥 클릭만 닫기 처리합니다.
- label은 밝은 큰 Tooltip에서만 피그마의 제목·본문 계층으로 렌더링해 기존 크기·밝기 API와 호환됩니다.

## 🖥️ 구현화면

| Tooltip 변형 테스트 |
| :-----------------: |
| 로컬 `/test/tooltip`에서 확인 |

## 🔗 연결된 이슈

- Connected: #575
- Closes #575