### PR TITLE
♻️ refactor: 옵션 버튼 컴포넌트 v2.0 디자인 개편

### DIFF
--- a/src/features/application/ui/detail-modal/ModalApplicantPanel.tsx
+++ b/src/features/application/ui/detail-modal/ModalApplicantPanel.tsx
@@ -198,16 +198,16 @@ export function ModalApplicantPanel({
                 }
               }}
             >
-              <OptionButton value="all" size="sm">
+              <OptionButton value="all" size="xs">
                 전체
               </OptionButton>
-              <OptionButton value="1" size="sm">
+              <OptionButton value="1" size="xs">
                 1차
               </OptionButton>
-              <OptionButton value="2" size="sm">
+              <OptionButton value="2" size="xs">
                 2차
               </OptionButton>
-              <OptionButton value="3" size="sm">
+              <OptionButton value="3" size="xs">
                 3차
               </OptionButton>
             </OptionButtonGroup>
@@ -224,16 +224,16 @@ export function ModalApplicantPanel({
                 }
               }}
             >
-              <OptionButton value="all" size="sm">
+              <OptionButton value="all" size="xs">
                 전체
               </OptionButton>
-              <OptionButton value="pass" size="sm">
+              <OptionButton value="pass" size="xs">
                 합격
               </OptionButton>
-              <OptionButton value="fail" size="sm">
+              <OptionButton value="fail" size="xs">
                 불합격
               </OptionButton>
-              <OptionButton value="pending" size="sm">
+              <OptionButton value="pending" size="xs">
                 대기
               </OptionButton>
             </OptionButtonGroup>

--- a/src/features/application/ui/detail-modal/ModalFormPanel.tsx
+++ b/src/features/application/ui/detail-modal/ModalFormPanel.tsx
@@ -189,6 +189,7 @@ export function ModalFormPanel({
                   <OptionButton
                     value="pass"
                     disabled={statusDisabled}
+                    size="xs"
                     className="h-7.5 w-20 gap-0.5 font-normal!"
                   >
                     합격
@@ -196,6 +197,7 @@ export function ModalFormPanel({
                   <OptionButton
                     value="fail"
                     disabled={statusDisabled}
+                    size="xs"
                     className="h-7.5 w-20 gap-0.5 font-normal!"
                   >
                     불합격

--- a/src/features/application/ui/detail-modal/ModalFormPanel.tsx
+++ b/src/features/application/ui/detail-modal/ModalFormPanel.tsx
@@ -206,6 +206,7 @@ export function ModalFormPanel({
                     <OptionButton
                       value="pending"
                       disabled={statusDisabled}
+                      size="xs"
                       className="h-7.5 w-20 gap-0.5 font-normal!"
                     >
                       대기

--- a/src/routes/test/option-button.tsx
+++ b/src/routes/test/option-button.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { type ReactNode } from "react"
 
 import { OptionButton } from "@/shared/ui/option-button/OptionButton"
 import { OptionButtonGroup } from "@/shared/ui/option-button/OptionButtonGroup"
@@ -7,13 +8,16 @@ export const Route = createFileRoute("/test/option-button")({
   component: OptionButtonTestPage,
 })
 
-function Section({
-  title,
-  children,
-}: {
-  title: string
-  children: React.ReactNode
-}) {
+type Size = "xl" | "sm" | "xs"
+
+const PARTS = [
+  { value: "design", label: "Design" },
+  { value: "frontend", label: "Frontend" },
+  { value: "backend", label: "Backend" },
+  { value: "pm", label: "PM" },
+]
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
   return (
     <section className="flex flex-col gap-4">
       <h2 className="border-teal-gray-100 text-label-1-semibold text-teal-gray-500 border-b pb-1">
@@ -24,53 +28,53 @@ function Section({
   )
 }
 
+function SelectRow({
+  size,
+  defaultValue,
+}: {
+  size?: Size
+  defaultValue?: string
+}) {
+  return (
+    <OptionButtonGroup variant="segmented" defaultValue={defaultValue}>
+      {PARTS.map((p) => (
+        <OptionButton key={p.value} size={size} value={p.value}>
+          {p.label}
+        </OptionButton>
+      ))}
+    </OptionButtonGroup>
+  )
+}
+
+function SizeBlock({ size, label }: { size?: Size; label: string }) {
+  return (
+    <Section title={label}>
+      <div className="flex flex-col items-start gap-3">
+        <SelectRow size={size} defaultValue="design" />
+        <SelectRow size={size} defaultValue="backend" />
+        <SelectRow size={size} />
+      </div>
+    </Section>
+  )
+}
+
 function OptionButtonTestPage() {
   return (
     <main className="bg-teal-gray-50 min-h-screen w-full p-10">
       <h1 className="text-heading-6-semibold text-teal-gray-900 mb-10">
-        OptionButton Test Page
+        OptionButton Test Page (V2.0)
       </h1>
 
       <div className="flex flex-col gap-10">
-        <Section title="Segmented — 선택 이동 (예시 1~4)">
-          <div className="flex flex-col gap-3">
-            <OptionButtonGroup variant="segmented" defaultValue="design">
-              <OptionButton value="design">Design</OptionButton>
-              <OptionButton value="frontend">Frontend</OptionButton>
-              <OptionButton value="backend">Backend</OptionButton>
-              <OptionButton value="pm">PM</OptionButton>
-            </OptionButtonGroup>
-            <OptionButtonGroup variant="segmented" defaultValue="frontend">
-              <OptionButton value="design">Design</OptionButton>
-              <OptionButton value="frontend">Frontend</OptionButton>
-              <OptionButton value="backend">Backend</OptionButton>
-              <OptionButton value="pm">PM</OptionButton>
-            </OptionButtonGroup>
-            <OptionButtonGroup variant="segmented" defaultValue="backend">
-              <OptionButton value="design">Design</OptionButton>
-              <OptionButton value="frontend">Frontend</OptionButton>
-              <OptionButton value="backend">Backend</OptionButton>
-              <OptionButton value="pm">PM</OptionButton>
-            </OptionButtonGroup>
-            <OptionButtonGroup variant="segmented" defaultValue="pm">
-              <OptionButton value="design">Design</OptionButton>
-              <OptionButton value="frontend">Frontend</OptionButton>
-              <OptionButton value="backend">Backend</OptionButton>
-              <OptionButton value="pm">PM</OptionButton>
-            </OptionButtonGroup>
-          </div>
-        </Section>
+        <SizeBlock
+          size="xl"
+          label="XL — 48px (선택 Left / 선택 Middle / 선택 없음)"
+        />
+        <SizeBlock size="sm" label="Sm (기본) — 38px" />
+        <SizeBlock size="xs" label="Xs — 28px" />
 
-        <Section title="Segmented — 선택 없음 (초기 상태)">
-          <OptionButtonGroup variant="segmented">
-            <OptionButton value="design">Design</OptionButton>
-            <OptionButton value="frontend">Frontend</OptionButton>
-            <OptionButton value="backend">Backend</OptionButton>
-          </OptionButtonGroup>
-        </Section>
-
-        <Section title="Segmented — Disabled">
-          <div className="flex flex-col gap-3">
+        <Section title="Disabled">
+          <div className="flex flex-col items-start gap-3">
             <OptionButtonGroup variant="segmented" defaultValue="frontend">
               <OptionButton value="design" disabled>
                 Design
@@ -81,115 +85,38 @@ function OptionButtonTestPage() {
               </OptionButton>
             </OptionButtonGroup>
             <OptionButtonGroup variant="segmented" defaultValue="frontend">
-              <OptionButton value="design">Design</OptionButton>
-              <OptionButton value="frontend" disabled>
-                Frontend
-              </OptionButton>
-              <OptionButton value="backend">Backend</OptionButton>
-            </OptionButtonGroup>
-          </div>
-        </Section>
-
-        <Section title="Segmented sm — 선택 이동 (Left/Mid/Right/Last)">
-          <div className="flex flex-col gap-3">
-            <OptionButtonGroup variant="segmented" defaultValue="design">
-              <OptionButton size="sm" value="design">
+              <OptionButton size="xs" value="design">
                 Design
               </OptionButton>
-              <OptionButton size="sm" value="frontend">
+              <OptionButton size="xs" value="frontend" disabled>
                 Frontend
               </OptionButton>
-              <OptionButton size="sm" value="backend">
+              <OptionButton size="xs" value="backend">
                 Backend
-              </OptionButton>
-              <OptionButton size="sm" value="pm">
-                PM
-              </OptionButton>
-            </OptionButtonGroup>
-            <OptionButtonGroup variant="segmented" defaultValue="frontend">
-              <OptionButton size="sm" value="design">
-                Design
-              </OptionButton>
-              <OptionButton size="sm" value="frontend">
-                Frontend
-              </OptionButton>
-              <OptionButton size="sm" value="backend">
-                Backend
-              </OptionButton>
-              <OptionButton size="sm" value="pm">
-                PM
-              </OptionButton>
-            </OptionButtonGroup>
-            <OptionButtonGroup variant="segmented" defaultValue="backend">
-              <OptionButton size="sm" value="design">
-                Design
-              </OptionButton>
-              <OptionButton size="sm" value="frontend">
-                Frontend
-              </OptionButton>
-              <OptionButton size="sm" value="backend">
-                Backend
-              </OptionButton>
-              <OptionButton size="sm" value="pm">
-                PM
-              </OptionButton>
-            </OptionButtonGroup>
-            <OptionButtonGroup variant="segmented" defaultValue="pm">
-              <OptionButton size="sm" value="design">
-                Design
-              </OptionButton>
-              <OptionButton size="sm" value="frontend">
-                Frontend
-              </OptionButton>
-              <OptionButton size="sm" value="backend">
-                Backend
-              </OptionButton>
-              <OptionButton size="sm" value="pm">
-                PM
               </OptionButton>
             </OptionButtonGroup>
           </div>
         </Section>
 
-        <Section title="Segmented sm — 선택 없음">
-          <OptionButtonGroup variant="segmented">
-            <OptionButton size="sm" value="design">
-              Design
+        <Section title="Multiple (다중 선택)">
+          <OptionButtonGroup
+            type="multiple"
+            variant="segmented"
+            defaultValue={["all"]}
+          >
+            <OptionButton size="xs" value="all">
+              전체
             </OptionButton>
-            <OptionButton size="sm" value="frontend">
-              Frontend
+            <OptionButton size="xs" value="1">
+              1차
             </OptionButton>
-            <OptionButton size="sm" value="backend">
-              Backend
+            <OptionButton size="xs" value="2">
+              2차
+            </OptionButton>
+            <OptionButton size="xs" value="3">
+              3차
             </OptionButton>
           </OptionButtonGroup>
-        </Section>
-
-        <Section title="Segmented sm — Disabled">
-          <div className="flex flex-col gap-3">
-            <OptionButtonGroup variant="segmented" defaultValue="frontend">
-              <OptionButton size="sm" value="design" disabled>
-                Design
-              </OptionButton>
-              <OptionButton size="sm" value="frontend">
-                Frontend
-              </OptionButton>
-              <OptionButton size="sm" value="backend" disabled>
-                Backend
-              </OptionButton>
-            </OptionButtonGroup>
-            <OptionButtonGroup variant="segmented" defaultValue="frontend">
-              <OptionButton size="sm" value="design">
-                Design
-              </OptionButton>
-              <OptionButton size="sm" value="frontend" disabled>
-                Frontend
-              </OptionButton>
-              <OptionButton size="sm" value="backend">
-                Backend
-              </OptionButton>
-            </OptionButtonGroup>
-          </div>
         </Section>
       </div>
     </main>

--- a/src/shared/ui/option-button/OptionButton.tsx
+++ b/src/shared/ui/option-button/OptionButton.tsx
@@ -11,14 +11,14 @@ const optionButtonVariants = cva(
   {
     variants: {
       selected: {
-        true: "border-teal-400 bg-teal-50 text-teal-600",
+        true: "border-teal-200 bg-teal-100 text-teal-500",
         false:
-          "border-teal-gray-300 bg-white text-teal-gray-900 hover:bg-teal-gray-50",
+          "border-teal-gray-200 bg-white text-teal-gray-700 hover:bg-teal-gray-50",
       },
       size: {
-        m: "h-10 gap-1 rounded-[8px] px-4 text-body-2-medium",
-        s: "h-9 gap-1 rounded-[8px] px-3 text-body-2-medium",
-        sm: "text-label-2-medium h-7 gap-2.5 rounded-[6px] py-1 pr-2.5 pl-1.5",
+        xl: "h-12 gap-1.5 rounded-[8px] px-7 text-subtitle-1-medium",
+        sm: "h-9.5 gap-1.5 rounded-[8px] px-5 text-label-1-medium",
+        xs: "h-7 gap-0.5 rounded-[6px] px-3 text-label-2-medium",
       },
     },
     compoundVariants: [
@@ -32,21 +32,15 @@ const optionButtonVariants = cva(
         class:
           "disabled:border-teal-gray-150 disabled:bg-white disabled:text-teal-gray-400",
       },
-      {
-        selected: true,
-        size: "sm",
-        class: "border-teal-200 bg-teal-100 text-teal-500",
-      },
     ],
-    defaultVariants: { size: "m", selected: false },
+    defaultVariants: { size: "sm", selected: false },
   },
 )
 
 export interface SegmentedPositionInfo {
   isFirst: boolean
   isLast: boolean
-  showLeft: boolean
-  showRight: boolean
+  gapLeft: boolean
 }
 
 interface OptionButtonProps extends Omit<
@@ -63,7 +57,7 @@ interface OptionButtonProps extends Omit<
 export function OptionButton({
   value,
   selected: selectedProp,
-  size = "m",
+  size = "sm",
   showCheck = true,
   _segmentedInfo,
   className,
@@ -81,6 +75,8 @@ export function OptionButton({
       : group.value === value
     : (selectedProp ?? false)
 
+  const checkSize = size === "xl" ? 24 : 16
+
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (isInGroup && value !== undefined) {
       group.onSelect(value)
@@ -89,33 +85,36 @@ export function OptionButton({
   }
 
   if (isSegmented && _segmentedInfo) {
-    const { isFirst, isLast, showLeft, showRight } = _segmentedInfo
-    const isSm = size === "sm"
+    const { isFirst, isLast, gapLeft } = _segmentedInfo
+    const sz = size ?? "sm"
 
+    const radiusFull = sz === "xs" ? "rounded-[6px]" : "rounded-[8px]"
+    const radiusLeft = sz === "xs" ? "rounded-l-[6px]" : "rounded-l-[8px]"
+    const radiusRight = sz === "xs" ? "rounded-r-[6px]" : "rounded-r-[8px]"
     const radiusClass =
       isFirst && isLast
-        ? isSelected
-          ? "rounded-[6px]"
-          : "rounded-[8px]"
+        ? radiusFull
         : isFirst
-          ? isSelected
-            ? "rounded-l-[6px] rounded-r-none"
-            : "rounded-l-[8px] rounded-r-none"
+          ? radiusLeft
           : isLast
-            ? isSelected
-              ? "rounded-r-[6px] rounded-l-none"
-              : "rounded-r-[8px] rounded-l-none"
+            ? radiusRight
             : "rounded-none"
 
-    const baseSize = isSm
-      ? "text-label-2-medium h-7 gap-2.5"
-      : "text-body-2-medium h-9.5 gap-2.5"
+    const heightClass = sz === "xl" ? "h-12" : sz === "xs" ? "h-7" : "h-9.5"
 
-    const selectedClass = isSm
-      ? "border border-teal-200 bg-teal-100 py-1 pr-2.5 pl-1.5 text-teal-500 disabled:border-teal-gray-150 disabled:bg-white disabled:text-teal-gray-400"
-      : "border border-teal-200 bg-teal-100 pr-5 pl-3 text-teal-600 disabled:border-teal-gray-150 disabled:bg-white disabled:text-teal-gray-400"
+    const selectedClass =
+      sz === "xl"
+        ? "text-subtitle-1-medium gap-1.5 py-1 pr-7 pl-4.5"
+        : sz === "xs"
+          ? "text-label-2-medium gap-0.5 py-1 pr-2.5 pl-1.5"
+          : "text-label-1-medium gap-1.5 py-1 pr-5 pl-3"
 
-    const unselectedPadding = isSm ? "px-2.5" : "px-5"
+    const unselectedClass =
+      sz === "xl"
+        ? "text-subtitle-1-medium py-1 px-7 font-normal!"
+        : sz === "xs"
+          ? "text-body-2-medium py-1 px-3"
+          : "text-body-1-regular py-1 px-5"
 
     return (
       <button
@@ -123,16 +122,20 @@ export function OptionButton({
         role="radio"
         aria-checked={isSelected}
         className={cn(
-          "inline-flex items-center justify-center font-medium transition-colors outline-none focus-visible:ring-2 focus-visible:ring-teal-400 disabled:cursor-not-allowed",
-          baseSize,
+          "inline-flex items-center justify-center transition-colors outline-none focus-visible:ring-2 focus-visible:ring-teal-400 disabled:cursor-not-allowed",
+          heightClass,
           radiusClass,
+          gapLeft && "ml-px",
           isSelected
-            ? selectedClass
+            ? cn(
+                "disabled:border-teal-gray-150 disabled:text-teal-gray-400 border border-teal-200 bg-teal-100 text-teal-500 disabled:bg-white",
+                selectedClass,
+              )
             : cn(
-                "border-teal-gray-200 text-teal-gray-900 hover:bg-teal-gray-50 disabled:border-teal-gray-150 disabled:text-teal-gray-400 border-t border-b bg-white disabled:bg-white disabled:hover:bg-white",
-                unselectedPadding,
-                showLeft && "border-l",
-                showRight && "border-r",
+                "border-teal-gray-200 text-teal-gray-700 hover:bg-teal-gray-50 disabled:border-teal-gray-150 disabled:text-teal-gray-400 border-t border-b bg-white disabled:bg-white disabled:hover:bg-white",
+                unselectedClass,
+                isFirst && "border-l",
+                isLast && "border-r",
               ),
           className,
         )}
@@ -140,7 +143,7 @@ export function OptionButton({
         {...props}
       >
         {showCheck && isSelected && (
-          <CheckIcon width={16} height={16} aria-hidden="true" />
+          <CheckIcon width={checkSize} height={checkSize} aria-hidden="true" />
         )}
         {children}
       </button>
@@ -163,7 +166,7 @@ export function OptionButton({
       {...props}
     >
       {showCheck && isSelected && (
-        <CheckIcon width={16} height={16} aria-hidden="true" />
+        <CheckIcon width={checkSize} height={checkSize} aria-hidden="true" />
       )}
       {children}
     </button>

--- a/src/shared/ui/option-button/OptionButton.tsx
+++ b/src/shared/ui/option-button/OptionButton.tsx
@@ -86,11 +86,13 @@ export function OptionButton({
 
   if (isSegmented && _segmentedInfo) {
     const { isFirst, isLast, gapLeft } = _segmentedInfo
-    const sz = size ?? "sm"
+    const resolvedSize = size ?? "sm"
 
-    const radiusFull = sz === "xs" ? "rounded-[6px]" : "rounded-[8px]"
-    const radiusLeft = sz === "xs" ? "rounded-l-[6px]" : "rounded-l-[8px]"
-    const radiusRight = sz === "xs" ? "rounded-r-[6px]" : "rounded-r-[8px]"
+    const radiusFull = resolvedSize === "xs" ? "rounded-[6px]" : "rounded-[8px]"
+    const radiusLeft =
+      resolvedSize === "xs" ? "rounded-l-[6px]" : "rounded-l-[8px]"
+    const radiusRight =
+      resolvedSize === "xs" ? "rounded-r-[6px]" : "rounded-r-[8px]"
     const radiusClass =
       isFirst && isLast
         ? radiusFull
@@ -100,19 +102,20 @@ export function OptionButton({
             ? radiusRight
             : "rounded-none"
 
-    const heightClass = sz === "xl" ? "h-12" : sz === "xs" ? "h-7" : "h-9.5"
+    const heightClass =
+      resolvedSize === "xl" ? "h-12" : resolvedSize === "xs" ? "h-7" : "h-9.5"
 
     const selectedClass =
-      sz === "xl"
+      resolvedSize === "xl"
         ? "text-subtitle-1-medium gap-1.5 py-1 pr-7 pl-4.5"
-        : sz === "xs"
+        : resolvedSize === "xs"
           ? "text-label-2-medium gap-0.5 py-1 pr-2.5 pl-1.5"
           : "text-label-1-medium gap-1.5 py-1 pr-5 pl-3"
 
     const unselectedClass =
-      sz === "xl"
+      resolvedSize === "xl"
         ? "text-subtitle-1-medium py-1 px-7 font-normal!"
-        : sz === "xs"
+        : resolvedSize === "xs"
           ? "text-body-2-medium py-1 px-3"
           : "text-body-1-regular py-1 px-5"
 

--- a/src/shared/ui/option-button/OptionButtonGroup.tsx
+++ b/src/shared/ui/option-button/OptionButtonGroup.tsx
@@ -78,6 +78,9 @@ export function OptionButtonGroup(props: OptionButtonGroupProps) {
       ? resolveSegmentedChildren(children, currentValue)
       : children
 
+  const segmentedRadius =
+    variant === "segmented" ? getSegmentedContainerRadius(children) : ""
+
   return (
     <OptionButtonGroupContext.Provider
       value={{
@@ -96,7 +99,7 @@ export function OptionButtonGroup(props: OptionButtonGroupProps) {
                 "flex flex-wrap gap-2",
                 orientation === "vertical" && "flex-col",
               )
-            : "bg-teal-gray-50 shadow-drop-neutral-2 flex rounded-lg",
+            : cn("bg-teal-gray-150 flex w-fit items-center", segmentedRadius),
           className,
         )}
       >
@@ -104,6 +107,14 @@ export function OptionButtonGroup(props: OptionButtonGroupProps) {
       </div>
     </OptionButtonGroupContext.Provider>
   )
+}
+
+function getSegmentedContainerRadius(children: ReactNode): string {
+  const first = React.Children.toArray(children).find(React.isValidElement) as
+    | React.ReactElement<React.ComponentProps<typeof OptionButton>>
+    | undefined
+  const size = first?.props.size ?? "sm"
+  return size === "xs" ? "rounded-[6px]" : "rounded-[8px]"
 }
 
 function resolveSegmentedChildren(
@@ -118,29 +129,24 @@ function resolveSegmentedChildren(
   const total = validChildren.length
   const values = validChildren.map((c) => c.props.value ?? "")
 
-  // For multiple selection, treat borders differently - show all borders
   const isMultiple = Array.isArray(currentValue)
+
+  const selectedAt = (i: number) => {
+    const v = values[i] ?? ""
+    return isMultiple
+      ? (currentValue as string[]).includes(v)
+      : v === currentValue
+  }
 
   return validChildren.map((child, i) => {
     const isFirst = i === 0
     const isLast = i === total - 1
-
-    let showLeft = true
-    let showRight = true
-
-    if (!isMultiple) {
-      const selectedIdx =
-        currentValue !== undefined ? values.indexOf(currentValue as string) : -1
-      const s = selectedIdx
-      showLeft = s === -1 ? true : isFirst || i < s
-      showRight = s === -1 ? true : isLast || i > s
-    }
+    const gapLeft = i > 0 && !selectedAt(i) && !selectedAt(i - 1)
 
     const segmentedInfo: SegmentedPositionInfo = {
       isFirst,
       isLast,
-      showLeft,
-      showRight,
+      gapLeft,
     }
 
     return React.cloneElement(child, { _segmentedInfo: segmentedInfo })


### PR DESCRIPTION
## 📸 작업 내용

> `OptionButton` / `OptionButtonGroup` 세그먼트 컴포넌트를 Figma v2.0 디자인으로 개편했습니다.

- **사이즈 체계 재편**: `m/s/sm` → `xl/sm/xs`로 정렬하고 **XL(48px) 신규 추가**, 사용처 없던 구 `s`(36px)는 폐기
- **divider 방식 전환**: 기존 border 기반 → v2.0의 **"컨테이너 배경 비침"** 방식 (비선택 버튼 좌우 세로 border 제거 + 비선택끼리 1px gap + 컨테이너 `bg-teal-gray-150`)
- **v2.0 스펙 정렬**: 사이즈별 타이포(20·16·14 / weight)·패딩·radius(8/8/6)·체크아이콘(24/16/16)을 디자인 토큰 기준으로 매핑
- **사용처 마이그레이션**: 지원자 필터(전체/차수·상태) `xs`, 합·불·대기 `xs`로 정렬, 컨테이너를 내용 폭(`w-fit`)으로 hug 처리
- 구버전의 Type 방향 변형(`_L`/`_R`/`Middle_L` 등)은 기존 코드가 그룹 내 위치를 자동 계산해 이미 처리 중이라 코드 변경 없이 수용됨

## 🎞️ 주요 코드 설명

### segmented divider — 배경 비침 방식으로 전환

기존에는 각 버튼의 좌우 border를 위치별로 켜고 끄며(`showLeft`/`showRight`) divider를 그렸으나, v2.0은 비선택 버튼의 좌우 세로 border를 없애고 **비선택끼리 인접한 경계에만 1px 간격**을 줘서 컨테이너 배경(`teal-gray-150`)이 비치도록 합니다. 선택 버튼은 사방 border로 스스로 경계를 만듭니다.

```TypeScript
// 비선택끼리 인접할 때만 1px gap → 컨테이너 배경이 divider로 비침
const gapLeft = i > 0 && !selectedAt(i) && !selectedAt(i - 1)

// 버튼 className
gapLeft && "ml-px",
!isSelected && "border-t border-b bg-white",   // 좌우 세로 border 없음
isFirst && "border-l",                          // 양 끝만 바깥 border + radius
isLast && "border-r",
```

## 🖥️ 구현화면

> 테스트 페이지 `/test/option-button` 에서 XL/Sm/Xs 3개 사이즈 · 선택 이동 · disabled · multiple 확인 가능합니다.
<img width="1600" height="1333" alt="option-button-v2-full" src="https://github.com/user-attachments/assets/bd41cea5-cf94-443d-9a38-0bedcba8e5d4" />


## 🔗 연결된 이슈

- Connected: #577
- Closes #577