### PR TITLE
✨ feat: 토스트바 Text Button 추가 및 v2.0 디자인 정렬

### DIFF
--- a/src/routes/test/toast.tsx
+++ b/src/routes/test/toast.tsx
@@ -73,6 +73,58 @@ function ToastTestPage() {
         >
           notice (서비스 공지)
         </button>
+        <button
+          type="button"
+          onClick={() =>
+            addToast({
+              message: "지원이 취소되었습니다.",
+              color: "primary",
+              variant: "deep",
+              type: "default",
+              duration: 6000,
+              action: {
+                label: "실행 취소",
+                onClick: () =>
+                  addToast({
+                    message: "실행을 취소했습니다.",
+                    color: "primary",
+                    variant: "weak",
+                    type: "default",
+                    duration: 2000,
+                  }),
+              },
+            })
+          }
+          className="text-label-1-medium w-fit rounded-[8px] bg-teal-200 px-4 py-2 text-teal-700"
+        >
+          Text Button (primary/deep, 6s)
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            addToast({
+              message: "업로드에 실패했습니다.",
+              color: "red",
+              variant: "deep",
+              type: "default",
+              duration: 6000,
+              action: {
+                label: "다시 시도",
+                onClick: () =>
+                  addToast({
+                    message: "다시 시도합니다.",
+                    color: "red",
+                    variant: "weak",
+                    type: "default",
+                    duration: 2000,
+                  }),
+              },
+            })
+          }
+          className="text-label-1-medium bg-error-200 text-error-700 w-fit rounded-[8px] px-4 py-2"
+        >
+          Text Button (red/deep, 6s)
+        </button>
       </div>
     </main>
   )

--- a/src/shared/ui/toast/Toast.tsx
+++ b/src/shared/ui/toast/Toast.tsx
@@ -20,8 +20,8 @@ const toastVariants = cva(
         red: "",
       },
       type: {
-        default: "justify-between shadow-drop-neutral-2",
-        time: "justify-between shadow-drop-neutral-2",
+        default: "justify-between shadow-drop-neutral-1",
+        time: "justify-between shadow-drop-neutral-1",
         notice: "justify-center shadow-drop-neutral-1",
       },
     },
@@ -45,13 +45,18 @@ const iconColorMap = {
 } as const
 
 const textColorMap = {
-  primary: "text-teal-700",
-  red: "text-error-700",
+  primary: { deep: "text-teal-700", weak: "text-teal-600" },
+  red: { deep: "text-error-700", weak: "text-error-600" },
 } as const
 
 const countdownColorMap = {
-  primary: "text-teal-600",
+  primary: "text-teal-500",
   red: "text-teal-gray-400",
+} as const
+
+const actionColorMap = {
+  primary: "text-teal-500",
+  red: "text-error-500",
 } as const
 
 interface ToastProps extends VariantProps<typeof toastVariants> {
@@ -59,6 +64,7 @@ interface ToastProps extends VariantProps<typeof toastVariants> {
   remaining: number
   isDismissing: boolean
   onDismiss: () => void
+  action?: { label: string; onClick: () => void }
 }
 
 export function Toast({
@@ -69,8 +75,15 @@ export function Toast({
   remaining,
   isDismissing,
   onDismiss,
+  action,
 }: ToastProps) {
   const resolvedColor = color ?? "primary"
+  const resolvedVariant = variant ?? "deep"
+
+  const handleAction = () => {
+    action?.onClick()
+    onDismiss()
+  }
 
   return (
     <div
@@ -93,7 +106,7 @@ export function Toast({
           <span
             className={cn(
               "text-center wrap-break-word whitespace-pre-line",
-              textColorMap[resolvedColor],
+              textColorMap[resolvedColor][resolvedVariant],
             )}
           >
             {message}
@@ -117,13 +130,24 @@ export function Toast({
             <span
               className={cn(
                 "wrap-break-word whitespace-pre-line",
-                textColorMap[resolvedColor],
+                textColorMap[resolvedColor][resolvedVariant],
               )}
             >
               {message}
             </span>
           </div>
-          {type === "time" ? (
+          {action ? (
+            <button
+              type="button"
+              onClick={handleAction}
+              className={cn(
+                "shrink-0 underline",
+                actionColorMap[resolvedColor],
+              )}
+            >
+              {action.label}
+            </button>
+          ) : type === "time" ? (
             <span
               className={cn(
                 "text-label-1-medium",
@@ -139,7 +163,7 @@ export function Toast({
               className="text-teal-gray-400 flex items-center justify-center"
               aria-label="토스트 닫기"
             >
-              <SvgCloseIcon width={20} height={20} />
+              <SvgCloseIcon width={24} height={24} />
             </button>
           )}
         </>

--- a/src/shared/ui/toast/Toast.tsx
+++ b/src/shared/ui/toast/Toast.tsx
@@ -5,6 +5,8 @@ import SvgCloseIcon from "@/shared/assets/icon/close/CloseIcon"
 import RubberConeIcon from "@/shared/assets/icon/error/RubberConeIcon"
 import { cn } from "@/shared/lib/utils"
 
+import { type ToastAction } from "./useToastStore"
+
 export const FADE_OUT_DURATION = 300
 
 const toastVariants = cva(
@@ -64,7 +66,7 @@ interface ToastProps extends VariantProps<typeof toastVariants> {
   remaining: number
   isDismissing: boolean
   onDismiss: () => void
-  action?: { label: string; onClick: () => void }
+  action?: ToastAction
 }
 
 export function Toast({

--- a/src/shared/ui/toast/Toast.tsx
+++ b/src/shared/ui/toast/Toast.tsx
@@ -81,8 +81,11 @@ export function Toast({
   const resolvedVariant = variant ?? "deep"
 
   const handleAction = () => {
-    action?.onClick()
-    onDismiss()
+    try {
+      action?.onClick()
+    } finally {
+      onDismiss()
+    }
   }
 
   return (

--- a/src/shared/ui/toast/ToastProvider.tsx
+++ b/src/shared/ui/toast/ToastProvider.tsx
@@ -113,7 +113,7 @@ export function ToastProvider() {
 
   return (
     <div
-      className="pointer-events-none fixed inset-x-0 bottom-20 z-9999 flex flex-col items-center"
+      className="pointer-events-none fixed inset-x-0 bottom-24 z-9999 flex flex-col items-center"
       aria-live="polite"
       aria-label="알림 목록"
     >
@@ -147,6 +147,7 @@ export function ToastProvider() {
                 remaining={remainingMap.get(toast.id) ?? toast.duration}
                 isDismissing={dismissingIds.has(toast.id)}
                 onDismiss={() => dismiss(toast.id)}
+                action={toast.action}
               />
             </div>
           </div>

--- a/src/shared/ui/toast/useToastStore.ts
+++ b/src/shared/ui/toast/useToastStore.ts
@@ -7,6 +7,7 @@ export interface ToastItem {
   variant: "deep" | "weak"
   type: "default" | "time" | "notice"
   duration: number
+  action?: { label: string; onClick: () => void }
 }
 
 type AddToastOptions = Omit<ToastItem, "id">

--- a/src/shared/ui/toast/useToastStore.ts
+++ b/src/shared/ui/toast/useToastStore.ts
@@ -1,5 +1,10 @@
 import { create } from "zustand"
 
+export interface ToastAction {
+  label: string
+  onClick: () => void
+}
+
 export interface ToastItem {
   id: string
   message: string
@@ -7,7 +12,7 @@ export interface ToastItem {
   variant: "deep" | "weak"
   type: "default" | "time" | "notice"
   duration: number
-  action?: { label: string; onClick: () => void }
+  action?: ToastAction
 }
 
 type AddToastOptions = Omit<ToastItem, "id">


### PR DESCRIPTION
## 📸 작업 내용

> 토스트바에 클릭 가능한 액션 버튼(Text Button)을 추가하고, Figma v2.0 세부 스펙에 맞춰 정렬했습니다.

- **Text Button 신규**: `addToast`에 옵셔널 `action?: { label; onClick }` 추가 → 우측을 X 대신 **밑줄 텍스트 버튼**으로 렌더(primary teal-500 / red error-500), 클릭 시 `onClick` 실행 후 토스트 자동 닫힘
- **하위호환**: `action`은 옵셔널이라 기존 호출 30여 곳은 영향 없음
- **세부 정렬**: 표시 위치 하단 **80→96px**, X 버튼 **20→24px**, 그림자 **Neutral_1**(#40444329) 통일, weak 메시지(teal-600)·카운트다운(teal-500) 색 정렬
- color(primary/red)·variant(deep/weak)·type(default/time/notice) 3축은 기존 구현이 이미 v2.0과 일치해 값 조정만 반영

## 🎞️ 주요 코드 설명

### action 유무로 우측 요소 분기

`type`은 그대로 두고, `action` 필드 유무로 우측(닫기 영역)을 분기합니다. action 버튼 클릭 시 콜백 실행 후 토스트를 닫습니다.

```TypeScript
const handleAction = () => {
  action?.onClick()
  onDismiss()
}

// 우측: action > 카운트다운(time) > X 순으로 분기
{action ? (
  <button type="button" onClick={handleAction}
    className={cn("shrink-0 underline", actionColorMap[resolvedColor])}>
    {action.label}
  </button>
) : type === "time" ? (
  <span>{Math.ceil(remaining / 1000)}s</span>
) : (
  <button type="button" onClick={onDismiss} aria-label="토스트 닫기">
    <SvgCloseIcon width={24} height={24} />
  </button>
)}
```

## 🖥️ 구현화면

> 테스트 페이지 `/test/toast` 에서 Text Button(primary/red) 데모 확인 가능합니다.

computed style 실측으로 다음을 검증했습니다:
- 위치 `bottom: 96px`, 그림자 `rgba(64,68,67,0.16) 0 4 16`(Neutral_1), radius 12px
- Text Button: primary `teal-500`(#0e8179) / red `error-500`(#db3939), underline, 16px
- X 버튼 24px, deep primary 배경 teal-200 / deep red 배경 error-200

## 🔗 연결된 이슈

- Connected: #582
- Closes #582