### PR TITLE
💄 style: 숫자 스텝퍼(Counter) 아이콘 Figma 정합 반영

### DIFF
--- a/src/routes/test/counter.tsx
+++ b/src/routes/test/counter.tsx
@@ -24,13 +24,35 @@ function Section({
   )
 }
 
-function ControlledCounter() {
-  const [value, setValue] = useState(0)
+function ControlledCounter({
+  label,
+  initialValue = 0,
+  min,
+  max,
+  step,
+  caption,
+}: {
+  label: string
+  initialValue?: number
+  min?: number
+  max?: number
+  step?: number
+  caption?: string
+}) {
+  const [value, setValue] = useState(initialValue)
   return (
     <div className="flex flex-col gap-2">
-      <Counter value={value} onChange={setValue} aria-label="수량" />
+      <Counter
+        value={value}
+        onChange={setValue}
+        min={min}
+        max={max}
+        step={step}
+        aria-label={label}
+      />
       <p className="text-caption-1-regular text-teal-gray-500">
         현재 값: <strong>{value}</strong>
+        {caption ? ` · ${caption}` : ""}
       </p>
     </div>
   )
@@ -45,49 +67,39 @@ function CounterTestPage() {
 
       <div className="flex flex-col gap-10">
         <Section title="기본 (min=0, 초기값=0)">
-          <ControlledCounter />
+          <ControlledCounter label="수량" />
         </Section>
 
         <Section title="min=1, max=5 (범위 제한)">
-          <div className="flex flex-col gap-2">
-            <Counter
-              value={3}
-              onChange={() => {}}
-              min={1}
-              max={5}
-              aria-label="제한된 수량"
-            />
-            <p className="text-caption-1-regular text-teal-gray-500">
-              value=3, min=1, max=5 (고정값 표시용)
-            </p>
-          </div>
+          <ControlledCounter
+            label="제한된 수량"
+            initialValue={3}
+            min={1}
+            max={5}
+            caption="min=1, max=5"
+          />
         </Section>
 
         <Section title="min=0, value=0 (감소 비활성)">
-          <Counter value={0} onChange={() => {}} aria-label="최솟값 상태" />
+          <ControlledCounter
+            label="최솟값 상태"
+            initialValue={0}
+            min={0}
+            caption="0에서 감소 비활성"
+          />
         </Section>
 
         <Section title="max=3, value=3 (증가 비활성)">
-          <Counter
-            value={3}
-            onChange={() => {}}
+          <ControlledCounter
+            label="최댓값 상태"
+            initialValue={3}
             max={3}
-            aria-label="최댓값 상태"
+            caption="3에서 증가 비활성"
           />
         </Section>
 
         <Section title="step=2">
-          <div className="flex flex-col gap-2">
-            <Counter
-              value={0}
-              onChange={() => {}}
-              step={2}
-              aria-label="2씩 증감"
-            />
-            <p className="text-caption-1-regular text-teal-gray-500">
-              2씩 증감 (고정값 표시용)
-            </p>
-          </div>
+          <ControlledCounter label="2씩 증감" initialValue={0} step={2} />
         </Section>
 
         <Section title="disabled">

--- a/src/shared/ui/Counter.tsx
+++ b/src/shared/ui/Counter.tsx
@@ -1,5 +1,3 @@
-import MinusIcon from "@/shared/assets/icon/minus/MinusIcon"
-import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import { cn } from "@/shared/lib/utils"
 
 import type { ComponentProps } from "react"
@@ -59,8 +57,19 @@ export function Counter({
         onClick={() => onChange(Math.max(min, value - step))}
         className={cn(btnClass, "rounded-l-[8px]")}
       >
-        {/* MinusIcon viewBox(36x38) 보정: size-7(28px)로 렌더해 선 길이를 PlusIcon과 맞춤 */}
-        <MinusIcon className="size-7" />
+        <svg
+          className="size-6"
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M6 12h12"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            strokeLinecap="round"
+          />
+        </svg>
       </button>
       <span
         aria-live="polite"
@@ -75,7 +84,19 @@ export function Counter({
         onClick={() => onChange(Math.min(max, value + step))}
         className={cn(btnClass, "rounded-r-[8px]")}
       >
-        <PlusIcon className="size-5" />
+        <svg
+          className="size-6"
+          viewBox="0 0 24 24"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M5.25 12h13.5M12 5.25v13.5"
+            stroke="currentColor"
+            strokeWidth={1.5}
+            strokeLinecap="round"
+          />
+        </svg>
       </button>
     </div>
   )


### PR DESCRIPTION
## 📸 작업 내용

- 숫자 스텝퍼 `Counter`(Figma "Stepper Button/Stepper", node 886-13987)의 `−`/`+` 아이콘을 Figma 스펙에 맞춰 정합했습니다.
  - 서로 다른 viewBox(`MinusIcon` 36×38, `PlusIcon` 16×16)로 강제 맞춤돼 있던 두 글리프를 24×24 인라인 SVG로 통일 (stroke 1.5px, `−` 12px / `+` 13.5px)
  - 공유 자산 `PlusIcon`은 다른 컴포넌트(`Button`/`FloatingActionButton`/`matching`)에서 사용 중이라 미변경 → 회귀 없음
  - 기존 viewBox 보정 해킹과 주석 제거
- 확인 페이지 `/test/counter`의 고정(no-op) 섹션들을 각자 상태를 갖는 인터랙티브 카운터로 전환했습니다 (disabled 섹션 제외).

> 레이아웃·색상·치수는 이미 Figma와 일치했고, 이번 변경은 아이콘 정합에 한정됩니다.

## 🎞️ 주요 코드 설명

### Counter ± 아이콘 인라인 SVG

24×24 viewBox를 24px(`size-6`)로 렌더해 path 단위 = 픽셀이 되도록 하여 Figma 기하를 정확히 재현합니다. 색상은 `currentColor`로 기존 활성/비활성 상속을 유지합니다.

```TypeScript
<svg className="size-6" viewBox="0 0 24 24" fill="none" aria-hidden="true">
  <path d="M6 12h12" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" />
</svg>
```

## 🖥️ 구현화면

로컬 `/test/counter`에서 렌더 기하를 측정해 Figma와 대조했습니다.

|        항목        |     Figma      |  렌더 측정   |
| :----------------: | :------------: | :----------: |
|    아이콘 박스     |      24px      |    24×24     |
|  `−` 선 / stroke   |  12px / 1.5px  |   12 / 1.5   |
|  `+` 팔 / stroke   | 13.5px / 1.5px |  13.5 / 1.5  |
|  `−` 색(비활성)    |  tealgray-400  |   #9ca3a3    |
|   `+` 색(활성)     |  tealgray-700  |   #404443    |

<img width="288" height="874" alt="image" src="https://github.com/user-attachments/assets/f185bc5f-4891-4b7b-99e4-05e737857c13" />



## 🔗 연결된 이슈

- Connected: #579
- Closes #579
