### PR TITLE
💄 style: Text field(문항) 공용 컴포넌트 Figma 정합 반영

### DIFF
--- a/src/shared/ui/question-field/QuestionFieldBox.tsx
+++ b/src/shared/ui/question-field/QuestionFieldBox.tsx
@@ -19,7 +19,7 @@ export function QuestionFieldBox({
     <div
       data-state={state}
       className={cn(
-        "border-teal-gray-150 flex w-full flex-col justify-center gap-1.5 rounded-[12px] border bg-[color-mix(in_srgb,var(--color-teal-50)_40%,white)] px-5 py-4",
+        "border-teal-gray-100 flex w-full flex-col justify-center gap-1.5 rounded-[12px] border bg-white px-5 py-4",
         "data-[state=focus]:bg-[color-mix(in_srgb,var(--color-teal-50)_50%,white_50%)]",
         "data-[state=error]:border-error-500",
         className,

--- a/src/shared/ui/question-field/QuestionForm.tsx
+++ b/src/shared/ui/question-field/QuestionForm.tsx
@@ -97,13 +97,13 @@ export function QuestionForm({
         </button>
       )}
 
-      <div className="flex w-full flex-col items-end gap-4">
+      <div className="flex w-full flex-col items-end gap-2.5">
         {focused ? (
-          <div className="flex w-full items-start gap-2">
+          <div className="flex w-full items-start gap-1.5">
             <span className="text-heading-7-semibold bp1:w-7 w-6 shrink-0 text-teal-600">
               {index}
             </span>
-            <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
               <div className="relative">
                 <div
                   aria-hidden
@@ -141,7 +141,7 @@ export function QuestionForm({
                   autoResize(e.target)
                 }}
                 placeholder="설명 (선택 사항)"
-                className="text-body-2-regular text-teal-gray-400 placeholder:text-teal-gray-300 w-full resize-none overflow-hidden bg-transparent outline-none"
+                className="text-body-2-regular text-teal-gray-600 placeholder:text-teal-gray-300 w-full resize-none overflow-hidden bg-transparent outline-none"
               />
             </div>
           </div>

--- a/src/shared/ui/question-field/QuestionItemTitle.tsx
+++ b/src/shared/ui/question-field/QuestionItemTitle.tsx
@@ -16,11 +16,11 @@ export function QuestionItemTitle({
   className,
 }: QuestionItemTitleProps) {
   return (
-    <div className={cn("flex w-full items-start gap-2", className)}>
+    <div className={cn("flex w-full items-start gap-1.5", className)}>
       <span className="text-heading-7-semibold w-7 shrink-0 text-teal-600">
         {index}
       </span>
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
         <span className="text-heading-7-semibold break-keep whitespace-pre-wrap">
           {title ? (
             <span className="text-teal-gray-900">{title}</span>
@@ -30,7 +30,7 @@ export function QuestionItemTitle({
           {required && <span className="text-error-600 ml-1">*</span>}
         </span>
         {caption !== undefined && caption !== "" && (
-          <span className="text-body-2-regular text-teal-gray-400 break-keep whitespace-pre-wrap">
+          <span className="text-body-2-regular text-teal-gray-600 break-keep whitespace-pre-wrap">
             {caption}
           </span>
         )}


### PR DESCRIPTION
## 📸 작업 내용

- 텍스트 문항 필드(Figma "Text field", node 832-22055)를 최신 피그마 스펙에 정합했습니다.
  - `QuestionFieldBox`: 답변 박스 배경 `teal-50` 틴트 → `bg-white`, 보더 `teal-gray-150` → `teal-gray-100`
  - `QuestionItemTitle`: 번호↔제목 `gap-2→gap-1.5`(6px), 제목↔캡션 `gap-1→gap-1.5`(6px), 캡션 색 `teal-gray-400` → `teal-gray-600`
  - `QuestionForm`(편집 모드): 위 간격/캡션 색 미러링 + 제목↔박스 `gap-4→gap-2.5`(10px)
- 폰트·크기·radius·padding·번호 색 등 핵심 스펙은 이미 일치하여, 변경은 미세한 색/간격에 한정됩니다.

## 🎞️ 주요 코드 설명

### QuestionFieldBox 기본 상태

기본 상태를 피그마 스펙(흰 배경 + `tealgray-100` 보더)으로 맞췄습니다. `focus`/`error` 상태 처리는 기존 로직을 유지합니다.

```TypeScript
// before → after
"border-teal-gray-150 ... bg-[color-mix(in_srgb,var(--color-teal-50)_40%,white)] ..."
"border-teal-gray-100 ... bg-white ..."
```

## 🖥️ 구현화면

로컬 `/test/question-form`에서 렌더값을 측정해 피그마 Lg 스펙과 대조했습니다.

|        항목        |     Figma Lg      |  렌더 측정   |
| :----------------: | :---------------: | :----------: |
|    박스 배경       |       white       |  rgb(255,255,255) |
|    박스 보더       | `tealgray-100` #f6f7f7 | rgb(246,247,247) |
|    박스 radius     |        12         |     12px     |
|   박스 padding     |     px20 py16     |   20 / 16    |
|     캡션 색        | `#656b6b`(600)    |  rgb(101,107,107) |

## 🔗 연결된 이슈

- Connected: #590
- Closes #590

## 📚 참고자료

- 피그마: https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/%F0%9F%8D%92-UMC-Web?node-id=832-22055
- 확인 필요: 캡션 색이 피그마에서 Lg(`#656b6b`)와 Md(`#9ca3a3`)로 서로 어긋나 있습니다. 컴포넌트가 Lg 사이즈이므로 Lg 스펙(`teal-gray-600`)을 적용했으나, 디자이너 의도가 `teal-gray-400`이면 되돌려야 합니다.
