### PR TITLE
♻️ refactor: 사이드바 아코디언 인터랙션·애니메이션 제거

### DIFF
--- a/src/widgets/navigation/sidebar/SideBar.tsx
+++ b/src/widgets/navigation/sidebar/SideBar.tsx
@@ -53,7 +53,6 @@ export default function SideBar({ className, activePathname }: SideBarProps) {
           {visibleSections.map(({ id, title, icon, menus }) => (
             <SideBarMenu
               key={id}
-              id={id}
               title={title}
               icon={icon}
               isActive={activeSectionId === id}

--- a/src/widgets/navigation/sidebar/SideBar.tsx
+++ b/src/widgets/navigation/sidebar/SideBar.tsx
@@ -1,8 +1,7 @@
 import { useNavigate, useRouterState } from "@tanstack/react-router"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef } from "react"
 
 import { useViewModeStore } from "@/entities/member/view-mode"
-import { SIDEBAR_ITEMS } from "@/shared/config/navigation"
 import { resolveNavigationFromPathname } from "@/shared/config/navigationResolve"
 import { cn } from "@/shared/lib/utils"
 
@@ -24,23 +23,8 @@ export default function SideBar({ className, activePathname }: SideBarProps) {
   const mode = useViewModeStore((s) => s.mode)
   const prevModeRef = useRef(mode)
 
-  const [manualOpenSectionId, setManualOpenSectionId] = useState<string>(() => {
-    const active = resolveNavigationFromPathname(pathname, visibleSections)
-    const initialSectionId =
-      active?.section.id ?? visibleSections[0]?.id ?? SIDEBAR_ITEMS[0]?.id
-
-    return initialSectionId ?? ""
-  })
   const active = resolveNavigationFromPathname(pathname, visibleSections)
   const activeSectionId = active?.section.id
-
-  useEffect(() => {
-    const ids = new Set(visibleSections.map((section) => section.id))
-    setManualOpenSectionId((prev) => {
-      if (ids.has(prev)) return prev
-      return activeSectionId ?? visibleSections[0]?.id ?? ""
-    })
-  }, [visibleSections, activeSectionId])
 
   useEffect(() => {
     if (prevModeRef.current === mode) return
@@ -73,11 +57,6 @@ export default function SideBar({ className, activePathname }: SideBarProps) {
               title={title}
               icon={icon}
               isActive={activeSectionId === id}
-              isOpen={activeSectionId === id || manualOpenSectionId === id}
-              onToggle={() => {
-                if (activeSectionId === id) return
-                setManualOpenSectionId((prev) => (prev === id ? "" : id))
-              }}
             >
               {menus.map((menu) => (
                 <SideBarMenuItem

--- a/src/widgets/navigation/sidebar/menu/SideBarMenu.tsx
+++ b/src/widgets/navigation/sidebar/menu/SideBarMenu.tsx
@@ -3,7 +3,6 @@ import { SideBarMenuTitle } from "./SideBarMenuTitle"
 import type { ComponentType, SVGProps } from "react"
 
 interface SideBarMenuProps {
-  id: string
   title: string
   icon: ComponentType<SVGProps<SVGSVGElement>>
   isActive: boolean
@@ -11,7 +10,6 @@ interface SideBarMenuProps {
 }
 
 export function SideBarMenu({
-  id,
   title,
   icon,
   isActive,
@@ -20,13 +18,7 @@ export function SideBarMenu({
   return (
     <div className="flex w-42 flex-col">
       <SideBarMenuTitle title={title} icon={icon} isActive={isActive} />
-      <div
-        id={`sidebar-menu-${id}`}
-        role="region"
-        className="flex flex-col gap-1 py-0.5"
-      >
-        {children}
-      </div>
+      <div className="flex flex-col gap-1 py-0.5">{children}</div>
     </div>
   )
 }

--- a/src/widgets/navigation/sidebar/menu/SideBarMenu.tsx
+++ b/src/widgets/navigation/sidebar/menu/SideBarMenu.tsx
@@ -1,5 +1,3 @@
-import { AnimatePresence, motion } from "motion/react"
-
 import { SideBarMenuTitle } from "./SideBarMenuTitle"
 
 import type { ComponentType, SVGProps } from "react"
@@ -9,14 +7,7 @@ interface SideBarMenuProps {
   title: string
   icon: ComponentType<SVGProps<SVGSVGElement>>
   isActive: boolean
-  isOpen: boolean
-  onToggle: () => void
   children: React.ReactNode
-}
-
-const menuVariants = {
-  open: { transition: { staggerChildren: 0.03 } },
-  closed: {},
 }
 
 export function SideBarMenu({
@@ -24,43 +15,18 @@ export function SideBarMenu({
   title,
   icon,
   isActive,
-  isOpen,
-  onToggle,
   children,
 }: SideBarMenuProps) {
   return (
     <div className="flex w-42 flex-col">
-      <SideBarMenuTitle
-        id={id}
-        title={title}
-        icon={icon}
-        isActive={isActive}
-        isOpen={isOpen}
-        onToggle={onToggle}
-      />
-      <AnimatePresence>
-        {isOpen && (
-          <motion.div
-            id={`sidebar-menu-${id}`}
-            role="region"
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: "auto", opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.35, ease: "easeInOut" }}
-            className="overflow-hidden"
-          >
-            <motion.div
-              initial="closed"
-              animate="open"
-              exit="closed"
-              variants={menuVariants}
-              className="flex flex-col gap-1 py-0.5"
-            >
-              {children}
-            </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+      <SideBarMenuTitle title={title} icon={icon} isActive={isActive} />
+      <div
+        id={`sidebar-menu-${id}`}
+        role="region"
+        className="flex flex-col gap-1 py-0.5"
+      >
+        {children}
+      </div>
     </div>
   )
 }

--- a/src/widgets/navigation/sidebar/menu/SideBarMenuItem.tsx
+++ b/src/widgets/navigation/sidebar/menu/SideBarMenuItem.tsx
@@ -1,5 +1,4 @@
 import { Link, useMatchRoute } from "@tanstack/react-router"
-import { motion } from "motion/react"
 
 import { cn } from "@/shared/lib/utils"
 
@@ -8,11 +7,6 @@ interface SideBarMenuItemProps {
   to: string
   indicator?: React.ReactNode
   activePathname?: string
-}
-
-const itemVariants = {
-  open: { opacity: 1, y: 0 },
-  closed: { opacity: 0, y: -4 },
 }
 
 export function SideBarMenuItem({
@@ -27,19 +21,17 @@ export function SideBarMenuItem({
     : !!matchRoute({ to })
 
   return (
-    <motion.div variants={itemVariants} transition={{ duration: 0.15 }}>
-      <Link
-        to={to}
-        className={cn(
-          "flex h-9 w-full items-center gap-2.75 rounded-[12px] px-5",
-          isActive
-            ? "text-subtitle-4-semibold text-teal-700"
-            : "text-body-2-medium text-teal-gray-600 hover:bg-teal-gray-50",
-        )}
-      >
-        {indicator ?? <span aria-hidden="true">-</span>}
-        <span>{title}</span>
-      </Link>
-    </motion.div>
+    <Link
+      to={to}
+      className={cn(
+        "flex h-9 w-full items-center gap-2.75 rounded-[12px] px-5",
+        isActive
+          ? "text-subtitle-4-semibold text-teal-700"
+          : "text-body-2-medium text-teal-gray-600 hover:bg-teal-gray-50",
+      )}
+    >
+      {indicator ?? <span aria-hidden="true">-</span>}
+      <span>{title}</span>
+    </Link>
   )
 }

--- a/src/widgets/navigation/sidebar/menu/SideBarMenuTitle.tsx
+++ b/src/widgets/navigation/sidebar/menu/SideBarMenuTitle.tsx
@@ -3,55 +3,40 @@ import { cn } from "@/shared/lib/utils"
 import type { ComponentType, SVGProps } from "react"
 
 interface SideBarMenuTitleProps {
-  id: string
   title: string
   icon: ComponentType<SVGProps<SVGSVGElement>>
   isActive: boolean
-  isOpen: boolean
-  onToggle: () => void
 }
 
 export function SideBarMenuTitle({
-  id,
   title,
   icon: Icon,
   isActive,
-  isOpen,
-  onToggle,
 }: SideBarMenuTitleProps) {
-  const isHighlighted = isActive || isOpen
-
   return (
-    <button
-      className="flex h-12 w-full items-center"
-      onClick={onToggle}
-      aria-expanded={isOpen}
-      aria-controls={`sidebar-menu-${id}`}
-    >
+    <div className="flex h-12 w-full items-center">
       <div
         className={cn(
-          "hover:bg-teal-gray-100 flex h-12 w-39 items-center gap-2 rounded-[12px] pl-3 transition-all duration-200 ease-in-out",
-          isHighlighted
-            ? "shadow-inner-primary-1 bg-teal-100 hover:bg-teal-100"
-            : "",
+          "flex h-12 w-39 items-center gap-2 rounded-[12px] pl-3",
+          isActive ? "shadow-inner-primary-1 bg-teal-100" : "",
         )}
       >
         <Icon
           aria-hidden="true"
           className={cn(
             "h-5 w-5",
-            isHighlighted ? "text-teal-600" : "text-teal-gray-400",
+            isActive ? "text-teal-600" : "text-teal-gray-400",
           )}
         />
         <div
           className={cn(
             "text-subtitle-3-semibold",
-            isHighlighted ? "text-teal-600" : "text-teal-gray-600",
+            isActive ? "text-teal-600" : "text-teal-gray-600",
           )}
         >
           {title}
         </div>
       </div>
-    </button>
+    </div>
   )
 }


### PR DESCRIPTION
## 📸 작업 내용

> 사이드바 아코디언(접힘/펼침)이 불편하다는 의견에 따라, 인터랙션과 애니메이션을 제거하고 모든 섹션을 항상 펼친 상태로 변경했습니다.

- **애니메이션 제거**: `SideBarMenu`/`SideBarMenuItem`의 framer-motion(`AnimatePresence`, `motion`, `height 0→auto`, `staggerChildren`) 전부 제거
- **토글/상태 제거**: `SideBar`의 `manualOpenSectionId` 상태 + 정리 useEffect, `SideBarMenuTitle`의 토글 `button` → `div`(`onClick`/`aria-expanded`/`aria-controls`/hover 제거)
- **결과**: 모든 섹션이 항상 펼쳐진 상태, 접기 불가
- **유지**: 활성 섹션 하이라이트(`activeSectionId` 기반), 뷰 모드 드롭다운(별개 기능)

## 🎞️ 주요 코드 설명

### 아코디언 → 항상 펼침

`SideBarMenu`에서 `isOpen` 조건부 렌더와 framer-motion 래퍼를 걷어내고 children을 항상 렌더합니다.

```TypeScript
// Before: AnimatePresence + motion.div (height 0→auto, opacity, stagger)
// After:
<div className="flex w-42 flex-col">
  <SideBarMenuTitle title={title} icon={icon} isActive={isActive} />
  <div id={`sidebar-menu-${id}`} role="region" className="flex flex-col gap-1 py-0.5">
    {children}
  </div>
</div>
```

## 🖥️ 구현화면

> 사이드바는 로그인 후 화면이라, 로컬에서 하위 컴포넌트를 실제 메뉴 데이터로 렌더해 computed 실측으로 검증했습니다.

- 애니메이션 흔적 없음: inline `height` 스타일 **0개**
- 토글 제거: `button` **0개**, `aria-expanded`/`aria-controls` **0개**
- 항상 펼침: 2개 섹션 · 메뉴 8개 전부 렌더

| 사이드바 (항상 펼침) |
| :-------------------------: |
| <img src = "" width ="240"> |

## 🔗 연결된 이슈

- Connected: #592
- Closes #592