### PR TITLE
✨ feat: 리크루팅 지원자 목록 면접 전형/최종 평가 확장

### DIFF
--- a/src/features/recruiting/model/applicantList.mock.ts
+++ b/src/features/recruiting/model/applicantList.mock.ts
@@ -29,8 +29,8 @@ export const APPLICANT_LIST_MOCK: ApplicantRow[] = [
     parts: ["design"],
     evaluations: {
       document: evaluation("done", 7, 7, "pass", "done"),
-      interview: evaluation("inProgress", 3, 7, null, "inProgress"),
-      final: null,
+      interview: evaluation("done", 7, 7, "pass", "done"),
+      final: evaluation("inProgress", 2, 5, null, "inProgress"),
     },
   },
   {
@@ -45,7 +45,7 @@ export const APPLICANT_LIST_MOCK: ApplicantRow[] = [
     evaluations: {
       document: evaluation("done", 7, 7, "pass", "done"),
       interview: evaluation("done", 7, 7, "pass", "done"),
-      final: evaluation("inProgress", 2, 5, null, "before"),
+      final: evaluation("done", 5, 5, "pass", "done"),
     },
   },
   {
@@ -105,8 +105,8 @@ export const APPLICANT_LIST_MOCK: ApplicantRow[] = [
     parts: ["web-pe", "mobile-pe"],
     evaluations: {
       document: evaluation("done", 7, 7, "pass", "done"),
-      interview: evaluation("inProgress", 5, 7, null, "done"),
-      final: null,
+      interview: evaluation("done", 7, 7, "pass", "done"),
+      final: evaluation("done", 5, 5, "fail", "done"),
     },
   },
   {
@@ -289,7 +289,7 @@ export const APPLICANT_LIST_MOCK: ApplicantRow[] = [
     evaluations: {
       document: evaluation("done", 7, 7, "pass", "done"),
       interview: evaluation("done", 7, 7, "pass", "done"),
-      final: evaluation("done", 5, 5, "fail", "done"),
+      final: evaluation("before", 0, 5, null, "before"),
     },
   },
   {

--- a/src/features/recruiting/ui/ApplicantListPage.tsx
+++ b/src/features/recruiting/ui/ApplicantListPage.tsx
@@ -12,6 +12,7 @@ import {
   applyApplicantFilters,
   DEFAULT_APPLICANT_LIST_FILTERS,
   formatBaseTime,
+  getStageEvaluation,
 } from "../model/applicantListTypes"
 import {
   EVALUATION_STAGE_DESCRIPTION,
@@ -45,7 +46,11 @@ export function ApplicantListPage({
     () => (useMockData ? APPLICANT_LIST_MOCK : []),
     [useMockData],
   )
-  const filteredRows = useMemo(
+  const allStageRows = useMemo(
+    () => rows.filter((row) => getStageEvaluation(row, stage)),
+    [rows, stage],
+  )
+  const visibleRows = useMemo(
     () => applyApplicantFilters(rows, filters, stage),
     [rows, filters, stage],
   )
@@ -87,9 +92,10 @@ export function ApplicantListPage({
         {RECRUITING_TARGET_GISU_LABEL_MOCK}
       </h2>
       <ApplicantTableCard
-        rows={filteredRows}
+        visibleRows={visibleRows}
+        allStageRows={allStageRows}
         stage={stage}
-        totalCount={filteredRows.length}
+        totalCount={visibleRows.length}
         baseTime={baseTime}
         filters={filters}
         onFiltersChange={handleFiltersChange}

--- a/src/features/recruiting/ui/ApplicantRow.test.tsx
+++ b/src/features/recruiting/ui/ApplicantRow.test.tsx
@@ -70,4 +70,29 @@ describe("ApplicantRow", () => {
     fireEvent.click(screen.getByRole("button", { name: "지원자 상세 펼치기" }))
     expect(onToggle).toHaveBeenCalledOnce()
   })
+
+  it("최종 평가에서는 일시 컬럼과 평가 수를 렌더하지 않는다", () => {
+    const row = createApplicantRow()
+    row.evaluations.final = {
+      progress: "done",
+      doneCount: 5,
+      totalCount: 5,
+      result: "pass",
+      myProgress: "done",
+    }
+
+    render(
+      <ApplicantRow
+        row={row}
+        stage="final"
+        expanded={false}
+        onToggle={() => {}}
+      />,
+    )
+
+    expect(screen.queryByText("04/22")).not.toBeInTheDocument()
+    expect(screen.queryByText("-")).not.toBeInTheDocument()
+    expect(screen.queryByText("/")).not.toBeInTheDocument()
+    expect(screen.getByText("완료")).toBeInTheDocument()
+  })
 })

--- a/src/features/recruiting/ui/ApplicantRow.tsx
+++ b/src/features/recruiting/ui/ApplicantRow.tsx
@@ -11,7 +11,7 @@ import {
   formatRecruitmentType,
   getStageEvaluation,
 } from "../model/applicantListTypes"
-import { APPLICANT_COLUMNS } from "./ApplicantTableHead"
+import { APPLICANT_COLUMNS } from "./applicantTableColumns"
 import { EvaluationStatusChip } from "./EvaluationStatusChip"
 
 import type { EvaluationStage } from "../model/evaluationStage"
@@ -47,23 +47,24 @@ export function ApplicantRow({
       className="border-teal-gray-150/60 hover:bg-teal-gray-50 flex h-17 items-center gap-2.5 border-b bg-white pr-5.5 pl-2.5 transition-colors"
     >
       <div className="flex min-w-0 flex-1 items-center">
-        {timestamp ? (
-          <TimestampLabel
-            date={timestamp.date}
-            time={timestamp.time}
-            action={STAGE_TIME_LABEL[stage]}
-            className={APPLICANT_COLUMNS.appliedAt}
-          />
-        ) : (
-          <span
-            className={cn(
-              "text-body-2-regular text-teal-gray-900",
-              APPLICANT_COLUMNS.appliedAt,
-            )}
-          >
-            -
-          </span>
-        )}
+        {stage !== "final" &&
+          (timestamp ? (
+            <TimestampLabel
+              date={timestamp.date}
+              time={timestamp.time}
+              action={STAGE_TIME_LABEL[stage]}
+              className={APPLICANT_COLUMNS.appliedAt}
+            />
+          ) : (
+            <span
+              className={cn(
+                "text-body-2-regular text-teal-gray-900",
+                APPLICANT_COLUMNS.appliedAt,
+              )}
+            >
+              -
+            </span>
+          ))}
         <span className={APPLICANT_COLUMNS.applicant}>
           <span className="text-body-2-medium text-teal-gray-900 truncate">
             {row.applicantName}

--- a/src/features/recruiting/ui/ApplicantTableCard.test.tsx
+++ b/src/features/recruiting/ui/ApplicantTableCard.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { DEFAULT_APPLICANT_LIST_FILTERS } from "../model/applicantListTypes"
+import { ApplicantTableCard } from "./ApplicantTableCard"
+
+import type {
+  ApplicantRow,
+  EvaluationProgress,
+} from "../model/applicantListTypes"
+
+function createApplicant(
+  progress: EvaluationProgress = "inProgress",
+): ApplicantRow {
+  return {
+    applicationId: "101",
+    appliedAt: "2026-04-22T03:33:00",
+    interviewAt: null,
+    applicantName: "테스터",
+    chapter: "Chromium",
+    school: "테스트대",
+    recruitmentType: "regular",
+    parts: ["web-pe"],
+    evaluations: {
+      document: {
+        progress,
+        doneCount: progress === "done" ? 7 : progress === "before" ? 0 : 3,
+        totalCount: 7,
+        result: progress === "done" ? "pass" : null,
+        myProgress: progress,
+      },
+      interview: null,
+      final: null,
+    },
+  }
+}
+
+function renderCard(visibleRows: ApplicantRow[], allStageRows: ApplicantRow[]) {
+  return render(
+    <ApplicantTableCard
+      visibleRows={visibleRows}
+      allStageRows={allStageRows}
+      stage="document"
+      totalCount={visibleRows.length}
+      baseTime="26-07-04 02:48"
+      filters={DEFAULT_APPLICANT_LIST_FILTERS}
+      onFiltersChange={() => {}}
+    />,
+  )
+}
+
+describe("ApplicantTableCard", () => {
+  it("필터 결과가 비어도 원본 전형 데이터로 카드 상태를 계산한다", () => {
+    renderCard([], [createApplicant()])
+
+    expect(screen.getByText("평가 진행중")).toBeInTheDocument()
+    expect(screen.queryByText("지원 전")).not.toBeInTheDocument()
+    expect(screen.getByText("현재 지원자가 없습니다.")).toBeInTheDocument()
+  })
+
+  it("전형 평가가 모두 완료되면 평가 완료 상태를 표시한다", () => {
+    renderCard([], [createApplicant("done")])
+
+    expect(screen.getByText("평가 완료")).toBeInTheDocument()
+  })
+
+  it("전형 평가가 모두 시작 전이면 평가 전 상태를 표시한다", () => {
+    renderCard([], [createApplicant("before")])
+
+    expect(screen.getByText("평가 전")).toBeInTheDocument()
+    expect(screen.queryByText("평가 진행중")).not.toBeInTheDocument()
+  })
+
+  it("원본 전형 데이터가 없으면 지원 전 상태를 표시한다", () => {
+    renderCard([], [])
+
+    expect(screen.getByText("지원 전")).toBeInTheDocument()
+  })
+})

--- a/src/features/recruiting/ui/ApplicantTableCard.tsx
+++ b/src/features/recruiting/ui/ApplicantTableCard.tsx
@@ -3,38 +3,57 @@ import { useState } from "react"
 import { cn } from "@/shared/lib/utils"
 import { FilterDropdown } from "@/shared/ui/FilterDropDown"
 import { Checkbox } from "@/shared/ui/input/checkbox/Checkbox"
+import { Tag, type TagTone } from "@/shared/ui/tag/Tag"
 
 import {
   APPLICANT_ORDER_OPTIONS,
   APPLICANT_SORT_OPTIONS,
   type ApplicantListFilters,
   type ApplicantRow as ApplicantRowModel,
+  getStageEvaluation,
 } from "../model/applicantListTypes"
 import { ApplicantRow } from "./ApplicantRow"
 import { ApplicantTableHead } from "./ApplicantTableHead"
 
 import type { EvaluationStage } from "../model/evaluationStage"
 
-type CardStatus = "beforeApply" | "evaluating"
+type CardStatus =
+  | "beforeRecruit"
+  | "beforeApply"
+  | "evaluating"
+  | "evaluated"
+  | "delayed"
+  | "beforeEval"
 
-const CARD_STATUS_STYLE: Record<
-  CardStatus,
-  { dot: string; text: string; label: string }
-> = {
-  beforeApply: {
-    dot: "bg-teal-gray-400",
-    text: "text-teal-gray-500",
-    label: "지원 전",
-  },
-  evaluating: {
-    dot: "bg-warning-500",
-    text: "text-warning-500",
-    label: "평가 진행 중",
-  },
+const CARD_STATUS_TAG: Record<CardStatus, { tone: TagTone; label: string }> = {
+  beforeRecruit: { tone: "gray", label: "모집 전" },
+  beforeApply: { tone: "gray", label: "지원 전" },
+  evaluating: { tone: "orange", label: "평가 진행중" },
+  evaluated: { tone: "teal", label: "평가 완료" },
+  delayed: { tone: "red", label: "평가 지연" },
+  beforeEval: { tone: "gray", label: "평가 전" },
+}
+
+function deriveCardStatus(
+  allStageRows: ApplicantRowModel[],
+  stage: EvaluationStage,
+): CardStatus {
+  const evaluations = allStageRows.flatMap((row) => {
+    const evaluation = getStageEvaluation(row, stage)
+    return evaluation ? [evaluation] : []
+  })
+
+  if (evaluations.length === 0) return "beforeApply"
+  if (evaluations.every(({ progress }) => progress === "before")) {
+    return "beforeEval"
+  }
+  const allDone = evaluations.every(({ progress }) => progress === "done")
+  return allDone ? "evaluated" : "evaluating"
 }
 
 interface ApplicantTableCardProps {
-  rows: ApplicantRowModel[]
+  visibleRows: ApplicantRowModel[]
+  allStageRows: ApplicantRowModel[]
   stage: EvaluationStage
   totalCount: number
   baseTime: string
@@ -44,7 +63,8 @@ interface ApplicantTableCardProps {
 }
 
 export function ApplicantTableCard({
-  rows,
+  visibleRows,
+  allStageRows,
   stage,
   totalCount,
   baseTime,
@@ -57,10 +77,11 @@ export function ApplicantTableCard({
   )
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
 
-  const isEmpty = rows.length === 0
-  const status: CardStatus = isEmpty ? "beforeApply" : "evaluating"
-  const statusStyle = CARD_STATUS_STYLE[status]
-  const hasExpanded = expandedIds.size > 0
+  const isEmpty = visibleRows.length === 0
+  const statusTag = CARD_STATUS_TAG[deriveCardStatus(allStageRows, stage)]
+  const hasExpanded = visibleRows.some((row) =>
+    expandedIds.has(row.applicationId),
+  )
 
   const toggleRow = (applicationId: string) => {
     setExpandedIds((prev) => {
@@ -73,9 +94,9 @@ export function ApplicantTableCard({
 
   const toggleAll = () => {
     setExpandedIds((prev) =>
-      prev.size > 0
+      visibleRows.some((row) => prev.has(row.applicationId))
         ? new Set<string>()
-        : new Set(rows.map((row) => row.applicationId)),
+        : new Set(visibleRows.map((row) => row.applicationId)),
     )
   }
 
@@ -176,20 +197,9 @@ export function ApplicantTableCard({
         <span className="text-body-1-regular text-teal-gray-400">
           총 {totalCount.toLocaleString()} 명
         </span>
-        <span className="ml-1 inline-flex h-6 items-center gap-1.5">
-          <span
-            className={cn("size-3 rounded-full", statusStyle.dot)}
-            aria-hidden="true"
-          />
-          <span
-            className={cn(
-              "text-label-2-medium whitespace-nowrap",
-              statusStyle.text,
-            )}
-          >
-            {statusStyle.label}
-          </span>
-        </span>
+        <Tag tone={statusTag.tone} className="ml-1">
+          {statusTag.label}
+        </Tag>
       </div>
       <div role="table" className="mt-8 flex flex-col">
         {isEmpty ? (
@@ -201,10 +211,11 @@ export function ApplicantTableCard({
         ) : (
           <>
             <ApplicantTableHead
+              stage={stage}
               hasExpanded={hasExpanded}
               onToggleAll={toggleAll}
             />
-            {rows.map((row) => (
+            {visibleRows.map((row) => (
               <ApplicantRow
                 key={row.applicationId}
                 row={row}

--- a/src/features/recruiting/ui/ApplicantTableHead.test.tsx
+++ b/src/features/recruiting/ui/ApplicantTableHead.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { ApplicantTableHead } from "./ApplicantTableHead"
+
+describe("ApplicantTableHead", () => {
+  it("서류 전형은 지원 일시와 평가 결과 헤더를 표시한다", () => {
+    render(<ApplicantTableHead stage="document" />)
+
+    expect(screen.getByText("지원 일시")).toBeInTheDocument()
+    expect(screen.getByText("평가 결과")).toBeInTheDocument()
+  })
+
+  it("면접 전형은 첫 헤더를 면접 일시로 표시한다", () => {
+    render(<ApplicantTableHead stage="interview" />)
+
+    expect(screen.getByText("면접 일시")).toBeInTheDocument()
+    expect(screen.queryByText("지원 일시")).not.toBeInTheDocument()
+  })
+
+  it("최종 평가는 일시 헤더 없이 최종 결과를 표시한다", () => {
+    render(<ApplicantTableHead stage="final" />)
+
+    expect(screen.queryByText("지원 일시")).not.toBeInTheDocument()
+    expect(screen.queryByText("면접 일시")).not.toBeInTheDocument()
+    expect(screen.getByText("최종 결과")).toBeInTheDocument()
+    expect(screen.queryByText("평가 결과")).not.toBeInTheDocument()
+  })
+})

--- a/src/features/recruiting/ui/ApplicantTableHead.tsx
+++ b/src/features/recruiting/ui/ApplicantTableHead.tsx
@@ -1,39 +1,50 @@
 import { cn } from "@/shared/lib/utils"
 import { ExpandableTableHead } from "@/shared/ui/table/ExpandableTableHead"
 
-export const APPLICANT_COLUMNS = {
-  appliedAt: "flex min-w-36 flex-1 items-center justify-center px-4",
-  applicant: "flex min-w-27.5 flex-1 items-center px-5",
-  chapter: "flex min-w-30 flex-1 items-center px-4",
-  school: "flex min-w-30 flex-1 items-center px-4",
-  type: "flex min-w-21.5 shrink-0 items-center justify-center px-2.5",
-  parts: "flex min-w-50 flex-1 items-center gap-2 px-4",
-  progress: "flex min-w-35 flex-1 items-center gap-2.5 px-4",
-  result: "flex min-w-22.5 flex-1 items-center px-4",
-} as const
+import {
+  APPLICANT_COLUMNS,
+  type ApplicantColumnKey,
+} from "./applicantTableColumns"
 
-const HEAD_LABELS: { key: keyof typeof APPLICANT_COLUMNS; label: string }[] = [
-  { key: "appliedAt", label: "지원 일시" },
-  { key: "applicant", label: "지원자" },
-  { key: "chapter", label: "지부" },
-  { key: "school", label: "학교" },
-  { key: "type", label: "유형" },
-  { key: "parts", label: "지원 파트" },
-  { key: "progress", label: "평가 상태" },
-  { key: "result", label: "평가 결과" },
-]
+import type { EvaluationStage } from "../model/evaluationStage"
+
+function buildHeadLabels(
+  stage: EvaluationStage,
+): { key: ApplicantColumnKey; label: string }[] {
+  const labels: { key: ApplicantColumnKey; label: string }[] = []
+  if (stage !== "final") {
+    labels.push({
+      key: "appliedAt",
+      label: stage === "interview" ? "면접 일시" : "지원 일시",
+    })
+  }
+  labels.push(
+    { key: "applicant", label: "지원자" },
+    { key: "chapter", label: "지부" },
+    { key: "school", label: "학교" },
+    { key: "type", label: "유형" },
+    { key: "parts", label: "지원 파트" },
+    { key: "progress", label: "평가 상태" },
+    { key: "result", label: stage === "final" ? "최종 결과" : "평가 결과" },
+  )
+  return labels
+}
 
 interface ApplicantTableHeadProps {
+  stage: EvaluationStage
   hasExpanded?: boolean
   onToggleAll?: () => void
   className?: string
 }
 
 export function ApplicantTableHead({
+  stage,
   hasExpanded = false,
   onToggleAll,
   className,
 }: ApplicantTableHeadProps) {
+  const headLabels = buildHeadLabels(stage)
+
   return (
     <ExpandableTableHead
       expanded={hasExpanded}
@@ -41,7 +52,7 @@ export function ApplicantTableHead({
       className={cn("gap-2.5", className)}
     >
       <div className="flex min-w-0 flex-1 items-center">
-        {HEAD_LABELS.map(({ key, label }) => (
+        {headLabels.map(({ key, label }) => (
           <span
             key={key}
             role="columnheader"

--- a/src/features/recruiting/ui/applicantTableColumns.ts
+++ b/src/features/recruiting/ui/applicantTableColumns.ts
@@ -1,0 +1,12 @@
+export const APPLICANT_COLUMNS = {
+  appliedAt: "flex min-w-36 flex-1 items-center justify-center px-4",
+  applicant: "flex min-w-27.5 flex-1 items-center px-5",
+  chapter: "flex min-w-30 flex-1 items-center px-4",
+  school: "flex min-w-30 flex-1 items-center px-4",
+  type: "flex min-w-21.5 shrink-0 items-center justify-center px-2.5",
+  parts: "flex min-w-50 flex-1 items-center gap-2 px-4",
+  progress: "flex min-w-35 flex-1 items-center gap-2.5 px-4",
+  result: "flex min-w-22.5 flex-1 items-center px-4",
+} as const
+
+export type ApplicantColumnKey = keyof typeof APPLICANT_COLUMNS

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -60,6 +60,8 @@ import { Route as MatchingNoticePublishRouteImport } from './routes/matching/not
 import { Route as MatchingApplicationsRouteImport } from './routes/matching/applications'
 import { Route as LoginDefaultRouteImport } from './routes/login/default'
 import { Route as MatchingProjectsIndexRouteImport } from './routes/matching/projects/index'
+import { Route as RecruitingEvaluationsInterviewRouteImport } from './routes/recruiting/evaluations/interview'
+import { Route as RecruitingEvaluationsFinalRouteImport } from './routes/recruiting/evaluations/final'
 import { Route as RecruitingEvaluationsDocumentRouteImport } from './routes/recruiting/evaluations/document'
 import { Route as OauthKakaoCallbackRouteImport } from './routes/oauth/kakao/callback'
 import { Route as MatchingProjectsNewRouteImport } from './routes/matching/projects/new'
@@ -331,6 +333,18 @@ const MatchingProjectsIndexRoute = MatchingProjectsIndexRouteImport.update({
   path: '/projects/',
   getParentRoute: () => MatchingRouteRoute,
 } as any)
+const RecruitingEvaluationsInterviewRoute =
+  RecruitingEvaluationsInterviewRouteImport.update({
+    id: '/evaluations/interview',
+    path: '/evaluations/interview',
+    getParentRoute: () => RecruitingRouteRoute,
+  } as any)
+const RecruitingEvaluationsFinalRoute =
+  RecruitingEvaluationsFinalRouteImport.update({
+    id: '/evaluations/final',
+    path: '/evaluations/final',
+    getParentRoute: () => RecruitingRouteRoute,
+  } as any)
 const RecruitingEvaluationsDocumentRoute =
   RecruitingEvaluationsDocumentRouteImport.update({
     id: '/evaluations/document',
@@ -459,6 +473,8 @@ export interface FileRoutesByFullPath {
   '/matching/projects/new': typeof MatchingProjectsNewRoute
   '/oauth/kakao/callback': typeof OauthKakaoCallbackRoute
   '/recruiting/evaluations/document': typeof RecruitingEvaluationsDocumentRoute
+  '/recruiting/evaluations/final': typeof RecruitingEvaluationsFinalRoute
+  '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRoute
   '/matching/projects/': typeof MatchingProjectsIndexRoute
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/edit/$projectId': typeof MatchingProjectsEditProjectIdRoute
@@ -520,6 +536,8 @@ export interface FileRoutesByTo {
   '/matching/projects/new': typeof MatchingProjectsNewRoute
   '/oauth/kakao/callback': typeof OauthKakaoCallbackRoute
   '/recruiting/evaluations/document': typeof RecruitingEvaluationsDocumentRoute
+  '/recruiting/evaluations/final': typeof RecruitingEvaluationsFinalRoute
+  '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRoute
   '/matching/projects': typeof MatchingProjectsIndexRoute
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/edit/$projectId': typeof MatchingProjectsEditProjectIdRoute
@@ -586,6 +604,8 @@ export interface FileRoutesById {
   '/matching/projects/new': typeof MatchingProjectsNewRoute
   '/oauth/kakao/callback': typeof OauthKakaoCallbackRoute
   '/recruiting/evaluations/document': typeof RecruitingEvaluationsDocumentRoute
+  '/recruiting/evaluations/final': typeof RecruitingEvaluationsFinalRoute
+  '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRoute
   '/matching/projects/': typeof MatchingProjectsIndexRoute
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/edit/$projectId': typeof MatchingProjectsEditProjectIdRoute
@@ -653,6 +673,8 @@ export interface FileRouteTypes {
     | '/matching/projects/new'
     | '/oauth/kakao/callback'
     | '/recruiting/evaluations/document'
+    | '/recruiting/evaluations/final'
+    | '/recruiting/evaluations/interview'
     | '/matching/projects/'
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/edit/$projectId'
@@ -714,6 +736,8 @@ export interface FileRouteTypes {
     | '/matching/projects/new'
     | '/oauth/kakao/callback'
     | '/recruiting/evaluations/document'
+    | '/recruiting/evaluations/final'
+    | '/recruiting/evaluations/interview'
     | '/matching/projects'
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/edit/$projectId'
@@ -779,6 +803,8 @@ export interface FileRouteTypes {
     | '/matching/projects/new'
     | '/oauth/kakao/callback'
     | '/recruiting/evaluations/document'
+    | '/recruiting/evaluations/final'
+    | '/recruiting/evaluations/interview'
     | '/matching/projects/'
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/edit/$projectId'
@@ -1192,6 +1218,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MatchingProjectsIndexRouteImport
       parentRoute: typeof MatchingRouteRoute
     }
+    '/recruiting/evaluations/interview': {
+      id: '/recruiting/evaluations/interview'
+      path: '/evaluations/interview'
+      fullPath: '/recruiting/evaluations/interview'
+      preLoaderRoute: typeof RecruitingEvaluationsInterviewRouteImport
+      parentRoute: typeof RecruitingRouteRoute
+    }
+    '/recruiting/evaluations/final': {
+      id: '/recruiting/evaluations/final'
+      path: '/evaluations/final'
+      fullPath: '/recruiting/evaluations/final'
+      preLoaderRoute: typeof RecruitingEvaluationsFinalRouteImport
+      parentRoute: typeof RecruitingRouteRoute
+    }
     '/recruiting/evaluations/document': {
       id: '/recruiting/evaluations/document'
       path: '/evaluations/document'
@@ -1373,10 +1413,14 @@ const MatchingRouteRouteWithChildren = MatchingRouteRoute._addFileChildren(
 
 interface RecruitingRouteRouteChildren {
   RecruitingEvaluationsDocumentRoute: typeof RecruitingEvaluationsDocumentRoute
+  RecruitingEvaluationsFinalRoute: typeof RecruitingEvaluationsFinalRoute
+  RecruitingEvaluationsInterviewRoute: typeof RecruitingEvaluationsInterviewRoute
 }
 
 const RecruitingRouteRouteChildren: RecruitingRouteRouteChildren = {
   RecruitingEvaluationsDocumentRoute: RecruitingEvaluationsDocumentRoute,
+  RecruitingEvaluationsFinalRoute: RecruitingEvaluationsFinalRoute,
+  RecruitingEvaluationsInterviewRoute: RecruitingEvaluationsInterviewRoute,
 }
 
 const RecruitingRouteRouteWithChildren = RecruitingRouteRoute._addFileChildren(

--- a/src/routes/recruiting/evaluations/final.tsx
+++ b/src/routes/recruiting/evaluations/final.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { ApplicantListPage } from "@/features/recruiting"
+
+export const Route = createFileRoute("/recruiting/evaluations/final")({
+  component: FinalEvaluationListPage,
+})
+
+function FinalEvaluationListPage() {
+  return <ApplicantListPage stage="final" />
+}

--- a/src/routes/recruiting/evaluations/interview.tsx
+++ b/src/routes/recruiting/evaluations/interview.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { ApplicantListPage } from "@/features/recruiting"
+
+export const Route = createFileRoute("/recruiting/evaluations/interview")({
+  component: InterviewEvaluationListPage,
+})
+
+function InterviewEvaluationListPage() {
+  return <ApplicantListPage stage="interview" />
+}

--- a/src/routes/test/recruiting-applicants.tsx
+++ b/src/routes/test/recruiting-applicants.tsx
@@ -1,20 +1,29 @@
 import { createFileRoute } from "@tanstack/react-router"
 
-import { ApplicantListPage } from "@/features/recruiting"
+import {
+  ApplicantListPage,
+  EVALUATION_STAGES,
+  type EvaluationStage,
+} from "@/features/recruiting"
 import Footer from "@/widgets/footer/Footer"
 import Header from "@/widgets/navigation/header/Header"
 import RecruitingSideBar from "@/widgets/navigation/sidebar/RecruitingSideBar"
 
+function parseStage(value: unknown): EvaluationStage {
+  return EVALUATION_STAGES.find((stage) => stage === value) ?? "document"
+}
+
 export const Route = createFileRoute("/test/recruiting-applicants")({
   validateSearch: (search: Record<string, unknown>) => ({
     empty: search.empty === true || search.empty === "true",
+    stage: parseStage(search.stage),
   }),
   component: RecruitingApplicantsTestPage,
 })
 
 function RecruitingApplicantsTestPage() {
-  const { empty } = Route.useSearch()
-  const activePathname = "/recruiting/evaluations/document"
+  const { empty, stage } = Route.useSearch()
+  const activePathname = `/recruiting/evaluations/${stage}`
 
   return (
     <main className="flex h-full min-h-screen w-full flex-col">
@@ -23,7 +32,7 @@ function RecruitingApplicantsTestPage() {
         <RecruitingSideBar activePathname={activePathname} />
         <div className="flex min-w-0 flex-1 flex-col">
           <div className="min-h-200 px-8 pt-10 pb-20">
-            <ApplicantListPage stage="document" useMockData={!empty} />
+            <ApplicantListPage stage={stage} useMockData={!empty} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 📸 작업 내용

> 작업한 내용을 두괄식으로 작성해주세요

서류 전형 지원자 목록 구조를 재사용해 **면접 전형 / 최종 평가 목록**을 추가했습니다. `ApplicantListPage`에 `stage`를 주입하는 단일 페이지 위에 전형별 컬럼·헤더·상태 태그 변형을 얹었습니다.

- 전형별 컬럼 분기: 면접은 "면접 일시"(interviewAt 기반), 최종은 일시 컬럼·평가 수 카운터 제거 + "최종 결과" 라벨
- 컬럼 상수(`APPLICANT_COLUMNS`)를 `applicantTableColumns`로 분리해 Head/Row가 공유
- 카드 상태 태그를 공용 `Tag` 6상태(모집 전/지원 전/평가 진행중/평가 완료/평가 지연/평가 전)로 교체, 필터와 무관한 전체 전형(`allStageRows`) 기준으로 파생
- `/recruiting/evaluations/interview`, `/recruiting/evaluations/final` 라우트 추가 + 테스트 라우트 `?stage=` 파라미터
- mock 퍼널을 "면접 합격자만 최종 진출"로 논리 일관되게 확장 (최종 5명: 평가 중/합격/합격/불합격/평가 전)
- 다각도 적대적 검증 반영: 전원 미시작 코호트를 "평가 전"으로 정정, 확장 토글을 표시 행 기준으로 정합화

## 🎞️ 주요 코드 설명

### 전형(stage)별 헤더/행 분기

```TypeScript
function buildHeadLabels(stage: EvaluationStage) {
  const labels: { key: ApplicantColumnKey; label: string }[] = []
  if (stage !== "final") {
    labels.push({
      key: "appliedAt",
      label: stage === "interview" ? "면접 일시" : "지원 일시",
    })
  }
  labels.push(
    /* 공통 컬럼 */
    { key: "result", label: stage === "final" ? "최종 결과" : "평가 결과" },
  )
  return labels
}
```

- 최종은 일시 컬럼을 헤더/행 양쪽에서 동일 가드로 제거해 컬럼 대칭 유지. 행 카운터도 `stage !== "final"`에서만 렌더.

### 카드 상태 태그 — 필터 무관 전체 전형 기준 파생

```TypeScript
function deriveCardStatus(
  allStageRows: ApplicantRowModel[],
  stage: EvaluationStage,
): CardStatus {
  const evaluations = allStageRows.flatMap((row) => {
    const evaluation = getStageEvaluation(row, stage)
    return evaluation ? [evaluation] : []
  })
  if (evaluations.length === 0) return "beforeApply"
  if (evaluations.every(({ progress }) => progress === "before")) return "beforeEval"
  const allDone = evaluations.every(({ progress }) => progress === "done")
  return allDone ? "evaluated" : "evaluating"
}
```

- 표시용 `visibleRows`(필터 적용)와 상태 산출용 `allStageRows`(필터 무관 전체)를 분리해, 필터로 목록이 비어도 카드 뱃지는 전체 전형 진행 상황을 반영.
- `모집 전`·`평가 지연`은 서버 API(모집 마감·지연 판정) 연동 시 도달하는 상태로 맵에 존치.

## 🖥️ 구현화면

> localhost 캡처(1440px)입니다. 로컬 저장본을 첨부합니다.
<img width="1440" height="1415" alt="recruiting-final-list-full" src="https://github.com/user-attachments/assets/8c6f327a-6e6d-4234-9644-ab1fc34b741f" />
<img width="1440" height="1619" alt="recruiting-interview-list-full" src="https://github.com/user-attachments/assets/8b832684-2450-4a23-8247-840e37112a8f" />


## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #600

## 📚 참고자료

- 면접 지원자 목록 시안: https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/UMC-Web?node-id=10170-276954
- 최종 목록 시안: https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/UMC-Web?node-id=10204-60974

## 💬 기타 더 이야기해볼 점

- 면접 목록 "최신 순" 정렬 기준: 현재 appliedAt 기준. interviewAt 기준으로 바꿀지 디자이너 확인 필요.
- 행 chevron 인터랙션: 시안상 인라인 확장 상태가 없고 "이동" 패턴(상세 페이지)으로 보임 — 상세는 Phase 4, 서버·디자인 확정 대기라 현재는 토글 골격만 유지.
