### PR TITLE
🐛 fix: 토큰 갱신 실패 교착 상태 방지

### DIFF
--- a/src/shared/lib/axios.test.ts
+++ b/src/shared/lib/axios.test.ts
@@ -139,6 +139,21 @@ describe("토큰 갱신 실패", () => {
     expect(redirectToLogin).toHaveBeenCalledOnce()
   })
 
+  it("로그인 하위 경로의 401은 토큰 갱신 대상에서 제외한다", async () => {
+    const adapter = vi.fn<AxiosAdapter>(async (config) => {
+      return rejectUnauthorized(config)
+    })
+    const { api, clear, redirectToLogin } = await createSubject(adapter)
+
+    await expect(api.post("/v1/auth/login/email")).rejects.toBeInstanceOf(
+      AxiosError,
+    )
+
+    expect(adapter).toHaveBeenCalledOnce()
+    expect(clear).not.toHaveBeenCalled()
+    expect(redirectToLogin).not.toHaveBeenCalled()
+  })
+
   it("동시 요청 중 갱신이 실패하면 대기열의 요청도 모두 reject한다", async () => {
     let releaseRenew: () => void = () => undefined
     const renewGate = new Promise<void>((resolve) => {
@@ -344,4 +359,46 @@ describe("토큰 갱신 성공", () => {
 
     expect(renewAuthorizations).toEqual([undefined, undefined])
   })
+
+  it.each([
+    { authPath: TOKEN_RENEW_PATH, label: "토큰 갱신" },
+    { authPath: "/v1/auth/login/email", label: "로그인" },
+  ])(
+    "쿼리에 $label 경로가 포함된 일반 요청은 401 이후 토큰을 갱신한다",
+    async ({ authPath }) => {
+      const targetUrl = `/protected?next=${authPath}`
+      let protectedAttempt = 0
+      let renewCount = 0
+      let retryAuthorization: unknown
+      const adapter = vi.fn<AxiosAdapter>(async (config) => {
+        if (config.url === TOKEN_RENEW_PATH) {
+          renewCount += 1
+          return createResponse(config, 200, {
+            success: true,
+            result: {
+              accessToken: "new-access",
+              refreshToken: "new-refresh",
+            },
+          })
+        }
+
+        protectedAttempt += 1
+        if (protectedAttempt === 1) {
+          return rejectUnauthorized(config)
+        }
+
+        retryAuthorization = config.headers.Authorization
+        return createResponse(config, 200, {
+          success: true,
+          result: config.url,
+        })
+      })
+      const { api } = await createSubject(adapter)
+
+      await api.get(targetUrl)
+
+      expect(renewCount).toBe(1)
+      expect(retryAuthorization).toBe("Bearer new-access")
+    },
+  )
 })

--- a/src/shared/lib/axios.test.ts
+++ b/src/shared/lib/axios.test.ts
@@ -337,6 +337,7 @@ describe("토큰 갱신 성공", () => {
       })
     })
     const { api } = await createSubject(adapter)
+    api.defaults.headers.common.Authorization = "Bearer stale-access"
 
     await api.get("/protected/first")
     await api.get("/protected/second")

--- a/src/shared/lib/axios.test.ts
+++ b/src/shared/lib/axios.test.ts
@@ -1,0 +1,346 @@
+import { AxiosError } from "axios"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import type {
+  AxiosAdapter,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from "axios"
+
+vi.mock("@/shared/analytics", () => ({
+  getCurrentPagePath: () => "/",
+  trackApiRequest: vi.fn(),
+  trackEvent: vi.fn(),
+}))
+
+const TOKEN_RENEW_PATH = "/v1/auth/token/renew"
+
+function createResponse<T>(
+  config: InternalAxiosRequestConfig,
+  status: number,
+  data: T,
+): AxiosResponse<T> {
+  return {
+    config,
+    data,
+    headers: {},
+    status,
+    statusText: status === 200 ? "OK" : "Unauthorized",
+  }
+}
+
+function rejectUnauthorized(
+  config: InternalAxiosRequestConfig,
+): Promise<never> {
+  const response = createResponse(config, 401, {
+    success: false,
+    message: "Unauthorized",
+  })
+
+  return Promise.reject(
+    new AxiosError(
+      "Unauthorized",
+      AxiosError.ERR_BAD_REQUEST,
+      config,
+      undefined,
+      response,
+    ),
+  )
+}
+
+async function createSubject(
+  adapter: AxiosAdapter,
+  initialTokens: {
+    accessToken: string | null
+    refreshToken: string | null
+  } = {
+    accessToken: "expired-access",
+    refreshToken: "expired-refresh",
+  },
+) {
+  vi.resetModules()
+
+  const { setAuthBridge } = await import("./authBridge")
+  const { api } = await import("./axios")
+
+  let { accessToken, refreshToken } = initialTokens
+  const clear = vi.fn(() => {
+    accessToken = null
+    refreshToken = null
+  })
+  const redirectToLogin = vi.fn()
+  const setTokens = vi.fn(
+    (tokens: { accessToken: string; refreshToken: string }) => {
+      accessToken = tokens.accessToken
+      refreshToken = tokens.refreshToken
+    },
+  )
+
+  setAuthBridge({
+    clear,
+    getAccessToken: () => accessToken,
+    getRefreshToken: () => refreshToken,
+    redirectToLogin,
+    setTokens,
+  })
+  api.defaults.adapter = adapter
+
+  return { api, clear, redirectToLogin, setTokens }
+}
+
+async function observeSettlement(promise: Promise<unknown>) {
+  return Promise.race([
+    promise.then(
+      () => "resolved" as const,
+      () => "rejected" as const,
+    ),
+    new Promise<"pending">((resolve) => {
+      setTimeout(() => resolve("pending"), 100)
+    }),
+  ])
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("토큰 갱신 실패", () => {
+  it("갱신 요청이 401이면 대기하지 않고 인증 상태를 정리한다", async () => {
+    const adapter = vi.fn<AxiosAdapter>(async (config) => {
+      return rejectUnauthorized(config)
+    })
+    const { api, clear, redirectToLogin } = await createSubject(adapter)
+
+    const settlement = await observeSettlement(api.get("/v2/member/me"))
+
+    expect(settlement).toBe("rejected")
+    expect(
+      adapter.mock.calls.filter(([config]) =>
+        config.url?.includes(TOKEN_RENEW_PATH),
+      ),
+    ).toHaveLength(1)
+    expect(clear).toHaveBeenCalledOnce()
+    expect(redirectToLogin).toHaveBeenCalledOnce()
+  })
+
+  it("refresh token이 없으면 갱신 요청 없이 로그인으로 이동한다", async () => {
+    const adapter = vi.fn<AxiosAdapter>(async (config) => {
+      return rejectUnauthorized(config)
+    })
+    const { api, clear, redirectToLogin } = await createSubject(adapter, {
+      accessToken: "expired-access",
+      refreshToken: null,
+    })
+
+    await expect(api.get("/v2/member/me")).rejects.toBeInstanceOf(AxiosError)
+
+    expect(adapter).toHaveBeenCalledOnce()
+    expect(clear).toHaveBeenCalledOnce()
+    expect(redirectToLogin).toHaveBeenCalledOnce()
+  })
+
+  it("동시 요청 중 갱신이 실패하면 대기열의 요청도 모두 reject한다", async () => {
+    let releaseRenew: () => void = () => undefined
+    const renewGate = new Promise<void>((resolve) => {
+      releaseRenew = resolve
+    })
+    const adapter = vi.fn<AxiosAdapter>(async (config) => {
+      if (config.url?.includes(TOKEN_RENEW_PATH)) {
+        await renewGate
+      }
+      return rejectUnauthorized(config)
+    })
+    const { api, clear, redirectToLogin } = await createSubject(adapter)
+
+    const firstRequest = api.get("/protected/first")
+    const secondRequest = api.get("/protected/second")
+
+    await vi.waitFor(() => {
+      expect(adapter).toHaveBeenCalledTimes(3)
+    })
+    releaseRenew()
+
+    const settlements = await Promise.all([
+      observeSettlement(firstRequest),
+      observeSettlement(secondRequest),
+    ])
+
+    expect(settlements).toEqual(["rejected", "rejected"])
+    expect(
+      adapter.mock.calls.filter(([config]) =>
+        config.url?.includes(TOKEN_RENEW_PATH),
+      ),
+    ).toHaveLength(1)
+    expect(clear).toHaveBeenCalledOnce()
+    expect(redirectToLogin).toHaveBeenCalledOnce()
+  })
+})
+
+describe("토큰 갱신 성공", () => {
+  it("동시 요청 중 갱신이 성공하면 새 access token으로 원 요청을 재시도한다", async () => {
+    let releaseRenew: () => void = () => undefined
+    const renewGate = new Promise<void>((resolve) => {
+      releaseRenew = resolve
+    })
+    const protectedAttempts = new Map<string, number>()
+    const retryAuthorizations: unknown[] = []
+    const adapter = vi.fn<AxiosAdapter>(async (config) => {
+      if (config.url?.includes(TOKEN_RENEW_PATH)) {
+        await renewGate
+        return createResponse(config, 200, {
+          success: true,
+          result: {
+            accessToken: "new-access",
+            refreshToken: "new-refresh",
+          },
+        })
+      }
+
+      const url = config.url ?? ""
+      const attempt = (protectedAttempts.get(url) ?? 0) + 1
+      protectedAttempts.set(url, attempt)
+      if (attempt === 1) {
+        return rejectUnauthorized(config)
+      }
+
+      retryAuthorizations.push(config.headers.Authorization)
+      return createResponse(config, 200, {
+        success: true,
+        result: url,
+      })
+    })
+    const { api, clear, redirectToLogin, setTokens } =
+      await createSubject(adapter)
+
+    const firstRequest = api.get("/protected/first")
+    const secondRequest = api.get("/protected/second")
+
+    await vi.waitFor(() => {
+      expect(adapter).toHaveBeenCalledTimes(3)
+    })
+    releaseRenew()
+
+    await expect(
+      Promise.all([firstRequest, secondRequest]),
+    ).resolves.toHaveLength(2)
+    expect(setTokens).toHaveBeenCalledWith({
+      accessToken: "new-access",
+      refreshToken: "new-refresh",
+    })
+    expect(retryAuthorizations).toEqual([
+      "Bearer new-access",
+      "Bearer new-access",
+    ])
+    expect(clear).not.toHaveBeenCalled()
+    expect(redirectToLogin).not.toHaveBeenCalled()
+  })
+
+  it("새 토큰으로 재시도한 요청도 401이면 인증 상태를 정리한다", async () => {
+    const adapter = vi.fn<AxiosAdapter>(async (config) => {
+      if (config.url?.includes(TOKEN_RENEW_PATH)) {
+        return createResponse(config, 200, {
+          success: true,
+          result: {
+            accessToken: "new-access",
+            refreshToken: "new-refresh",
+          },
+        })
+      }
+
+      return rejectUnauthorized(config)
+    })
+    const { api, clear, redirectToLogin } = await createSubject(adapter)
+
+    await expect(api.get("/protected")).rejects.toBeInstanceOf(AxiosError)
+
+    expect(
+      adapter.mock.calls.filter(([config]) =>
+        config.url?.includes(TOKEN_RENEW_PATH),
+      ),
+    ).toHaveLength(1)
+    expect(clear).toHaveBeenCalledOnce()
+    expect(redirectToLogin).toHaveBeenCalledOnce()
+  })
+
+  it("동시 요청의 재시도가 401이어도 토큰 갱신은 한 번만 수행한다", async () => {
+    const requestCount = 20
+    let releaseRenew: () => void = () => undefined
+    const renewGate = new Promise<void>((resolve) => {
+      releaseRenew = resolve
+    })
+    const adapter = vi.fn<AxiosAdapter>(async (config) => {
+      if (config.url?.includes(TOKEN_RENEW_PATH)) {
+        await renewGate
+        return createResponse(config, 200, {
+          success: true,
+          result: {
+            accessToken: "new-access",
+            refreshToken: "new-refresh",
+          },
+        })
+      }
+
+      return rejectUnauthorized(config)
+    })
+    const { api, clear, redirectToLogin } = await createSubject(adapter)
+
+    const requests = Array.from({ length: requestCount }, (_, index) =>
+      api.get(`/protected/${index}`),
+    )
+
+    await vi.waitFor(() => {
+      expect(adapter).toHaveBeenCalledTimes(requestCount + 1)
+    })
+    releaseRenew()
+
+    const settlements = await Promise.all(requests.map(observeSettlement))
+
+    expect(settlements).toEqual(
+      Array.from({ length: requestCount }, () => "rejected"),
+    )
+    expect(
+      adapter.mock.calls.filter(([config]) =>
+        config.url?.includes(TOKEN_RENEW_PATH),
+      ),
+    ).toHaveLength(1)
+    expect(clear).toHaveBeenCalledOnce()
+    expect(redirectToLogin).toHaveBeenCalledOnce()
+  })
+
+  it("토큰 갱신 요청에는 이전 access token을 전송하지 않는다", async () => {
+    const protectedAttempts = new Map<string, number>()
+    const renewAuthorizations: unknown[] = []
+    let renewCount = 0
+    const adapter = vi.fn<AxiosAdapter>(async (config) => {
+      if (config.url?.includes(TOKEN_RENEW_PATH)) {
+        renewCount += 1
+        renewAuthorizations.push(config.headers.Authorization)
+        return createResponse(config, 200, {
+          success: true,
+          result: {
+            accessToken: `new-access-${renewCount}`,
+            refreshToken: `new-refresh-${renewCount}`,
+          },
+        })
+      }
+
+      const url = config.url ?? ""
+      const attempt = (protectedAttempts.get(url) ?? 0) + 1
+      protectedAttempts.set(url, attempt)
+      if (attempt === 1) {
+        return rejectUnauthorized(config)
+      }
+
+      return createResponse(config, 200, {
+        success: true,
+        result: url,
+      })
+    })
+    const { api } = await createSubject(adapter)
+
+    await api.get("/protected/first")
+    await api.get("/protected/second")
+
+    expect(renewAuthorizations).toEqual([undefined, undefined])
+  })
+})

--- a/src/shared/lib/axios.ts
+++ b/src/shared/lib/axios.ts
@@ -17,7 +17,24 @@ declare module "axios" {
   }
 }
 
+const AUTH_LOGIN_PATH = "/v1/auth/login"
 const TOKEN_RENEW_PATH = "/v1/auth/token/renew"
+
+function getRequestPathname(url: string | undefined) {
+  if (!url) return null
+  return new URL(url, "https://axios.local").pathname
+}
+
+function isLoginRequest(url: string | undefined) {
+  const pathname = getRequestPathname(url)
+  return (
+    pathname === AUTH_LOGIN_PATH || pathname?.startsWith(`${AUTH_LOGIN_PATH}/`)
+  )
+}
+
+function isTokenRenewRequest(url: string | undefined) {
+  return getRequestPathname(url) === TOKEN_RENEW_PATH
+}
 
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
@@ -29,7 +46,7 @@ export const api = axios.create({
 
 api.interceptors.request.use((config) => {
   config.analyticsStartTime = performance.now()
-  if (config.url?.includes(TOKEN_RENEW_PATH)) {
+  if (isTokenRenewRequest(config.url)) {
     config.headers.delete("Authorization")
     return config
   }
@@ -99,8 +116,8 @@ api.interceptors.response.use(
 
     if (
       error.response?.status !== 401 ||
-      originalRequest.url?.includes("/v1/auth/login") ||
-      originalRequest.url?.includes(TOKEN_RENEW_PATH)
+      isLoginRequest(originalRequest.url) ||
+      isTokenRenewRequest(originalRequest.url)
     ) {
       return Promise.reject(error)
     }

--- a/src/shared/lib/axios.ts
+++ b/src/shared/lib/axios.ts
@@ -17,6 +17,8 @@ declare module "axios" {
   }
 }
 
+const TOKEN_RENEW_PATH = "/v1/auth/token/renew"
+
 export const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL,
   timeout: 10000,
@@ -27,7 +29,10 @@ export const api = axios.create({
 
 api.interceptors.request.use((config) => {
   config.analyticsStartTime = performance.now()
-  if (config.url?.includes("/v1/auth/token/renew")) return config
+  if (config.url?.includes(TOKEN_RENEW_PATH)) {
+    config.headers.delete("Authorization")
+    return config
+  }
   const token = authBridge.getAccessToken()
   if (token) {
     config.headers.Authorization = `Bearer ${token}`
@@ -36,6 +41,7 @@ api.interceptors.request.use((config) => {
 })
 
 let isRefreshing = false
+let isRedirectingToLogin = false
 let pendingQueue: Array<{
   resolve: (token: string) => void
   reject: (err: unknown) => void
@@ -49,6 +55,19 @@ function drainQueue(token: string) {
 function rejectQueue(err: unknown) {
   pendingQueue.forEach(({ reject }) => reject(err))
   pendingQueue = []
+}
+
+function terminateAuthentication(
+  reason: "missing_refresh_token" | "renew_failed" | "retry_unauthorized",
+) {
+  if (isRedirectingToLogin) return
+  isRedirectingToLogin = true
+  trackEvent("auth_token_refresh_error", {
+    reason,
+    page_path: getCurrentPagePath(),
+  })
+  authBridge.clear()
+  authBridge.redirectToLogin()
 }
 
 api.interceptors.response.use(
@@ -80,20 +99,20 @@ api.interceptors.response.use(
 
     if (
       error.response?.status !== 401 ||
-      originalRequest._retry ||
-      originalRequest.url?.includes("/v1/auth/login")
+      originalRequest.url?.includes("/v1/auth/login") ||
+      originalRequest.url?.includes(TOKEN_RENEW_PATH)
     ) {
+      return Promise.reject(error)
+    }
+
+    if (originalRequest._retry) {
+      terminateAuthentication("retry_unauthorized")
       return Promise.reject(error)
     }
 
     const refreshToken = authBridge.getRefreshToken()
     if (!refreshToken) {
-      trackEvent("auth_token_refresh_error", {
-        reason: "missing_refresh_token",
-        page_path: getCurrentPagePath(),
-      })
-      authBridge.clear()
-      authBridge.redirectToLogin()
+      terminateAuthentication("missing_refresh_token")
       return Promise.reject(error)
     }
 
@@ -101,6 +120,7 @@ api.interceptors.response.use(
       return new Promise((resolve, reject) => {
         pendingQueue.push({
           resolve: (token) => {
+            originalRequest._retry = true
             originalRequest.headers = {
               ...originalRequest.headers,
               Authorization: `Bearer ${token}`,
@@ -121,10 +141,9 @@ api.interceptors.response.use(
           accessToken: string
           refreshToken: string
         }>
-      >("/v1/auth/token/renew", { refreshToken })
+      >(TOKEN_RENEW_PATH, { refreshToken })
       const { accessToken, refreshToken: newRefreshToken } = data.result
       authBridge.setTokens({ accessToken, refreshToken: newRefreshToken })
-      api.defaults.headers.common.Authorization = `Bearer ${accessToken}`
       drainQueue(accessToken)
       originalRequest.headers = {
         ...originalRequest.headers,
@@ -132,13 +151,8 @@ api.interceptors.response.use(
       }
       return api(originalRequest)
     } catch (refreshError) {
-      trackEvent("auth_token_refresh_error", {
-        reason: "renew_failed",
-        page_path: getCurrentPagePath(),
-      })
       rejectQueue(refreshError)
-      authBridge.clear()
-      authBridge.redirectToLogin()
+      terminateAuthentication("renew_failed")
       return Promise.reject(refreshError)
     } finally {
       isRefreshing = false


### PR DESCRIPTION
## 📸 작업 내용

- 만료된 access token과 refresh token으로 진입할 때 토큰 갱신 요청이 대기열에 다시 들어가 무한 대기하던 문제를 수정했습니다.
- 토큰 갱신 요청의 401 응답은 재갱신 대상에서 제외하고, Authorization 헤더를 전송하지 않도록 분리했습니다.
- 동시 요청은 한 번의 토큰 갱신 결과를 공유하며, 재시도 후에도 401이면 인증 상태 정리와 로그인 이동을 한 번만 실행합니다.
- 갱신 성공·실패, refresh token 누락, 동시 요청, 재시도 401, 헤더 제거를 포함한 회귀 테스트 7개를 추가했습니다.

## 🎞️ 주요 코드 설명

### 토큰 갱신 요청의 재진입 방지

- 갱신 경로를 공통 상수로 관리하고 요청·응답 인터셉터에서 동일하게 판별합니다.
- 갱신 요청이 실패하면 대기열에 등록하지 않고 바깥 갱신 흐름으로 오류를 전달합니다.

### 동시 요청의 단일 실패 처리

- 대기 중인 원 요청에도 재시도 상태를 기록해 추가 갱신을 차단합니다.
- 인증 종료 처리를 단일 함수로 통합하고 중복 로그인 이동과 분석 이벤트를 방지합니다.

## 🔗 연결된 이슈

- Connected: #606
- Closes #606


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 인증 토큰 갱신 요청에 기존 액세스 토큰이 전달되지 않도록 개선했습니다.
  - 토큰 갱신 성공 시 원래 요청이 새 토큰으로 자동 재시도됩니다.
  - 갱신 실패, 재시도 실패 또는 토큰 부재 시 인증 상태를 정리하고 로그인 화면으로 이동합니다.
  - 동시에 발생한 요청은 하나의 갱신 절차로 처리되며, 실패 시 대기 중인 요청도 안정적으로 종료됩니다.

- **테스트**
  - 토큰 갱신, 재시도, 동시 요청 및 실패 처리 시나리오를 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->