### PR TITLE
✨ feat: 리크루팅 지원자 목록 그룹 뷰·역할별 케이스 확장

### DIFF
--- a/src/features/recruiting/index.ts
+++ b/src/features/recruiting/index.ts
@@ -3,4 +3,9 @@ export {
   EVALUATION_STAGES,
   type EvaluationStage,
 } from "./model/evaluationStage"
+export {
+  isRecruitingListRole,
+  RECRUITING_LIST_ROLES,
+  type RecruitingListRole,
+} from "./model/recruitingListRole"
 export { ApplicantListPage } from "./ui/ApplicantListPage"

--- a/src/features/recruiting/model/applicantList.mock.ts
+++ b/src/features/recruiting/model/applicantList.mock.ts
@@ -1,3 +1,5 @@
+import type { Chapter } from "@/entities/organization/model/chapters"
+
 import type {
   ApplicantRow,
   EvaluationProgress,
@@ -8,6 +10,10 @@ import type {
 export const APPLICANT_LIST_BASE_TIME_MOCK = "26-07-04 02:48"
 
 export const RECRUITING_TARGET_GISU_LABEL_MOCK = "UMC 11기"
+
+export const RECRUITING_MY_CHAPTER_MOCK: Chapter = "Ferrum"
+
+export const RECRUITING_MY_SCHOOL_MOCK = "이화여대"
 
 const evaluation = (
   progress: EvaluationProgress,
@@ -74,7 +80,10 @@ export const APPLICANT_LIST_MOCK: ApplicantRow[] = [
     recruitmentType: "regular",
     parts: ["web-pe"],
     evaluations: {
-      document: evaluation("done", 7, 7, "pass", "done"),
+      document: {
+        ...evaluation("done", 7, 7, "pass", "done"),
+        assignedToMe: true,
+      },
       interview: evaluation("done", 7, 7, "pass", "done"),
       final: evaluation("done", 5, 5, "pass", "done"),
     },
@@ -334,6 +343,40 @@ export const APPLICANT_LIST_MOCK: ApplicantRow[] = [
     parts: ["mobile-pe"],
     evaluations: {
       document: evaluation("inProgress", 3, 7, null, "inProgress"),
+      interview: null,
+      final: null,
+    },
+  },
+  {
+    applicationId: "122",
+    appliedAt: "2026-04-21T20:42:00",
+    interviewAt: null,
+    applicantName: "조은별",
+    chapter: "Ferrum",
+    school: "이화여대",
+    recruitmentType: "regular",
+    parts: ["design"],
+    evaluations: {
+      document: evaluation("inProgress", 4, 7, null, "before"),
+      interview: null,
+      final: null,
+    },
+  },
+  {
+    applicationId: "123",
+    appliedAt: "2026-04-21T20:15:00",
+    interviewAt: null,
+    applicantName: "남지호",
+    chapter: "Ferrum",
+    school: "이화여대",
+    recruitmentType: "additional",
+    additionalRound: 2,
+    parts: ["pm", "design"],
+    evaluations: {
+      document: {
+        ...evaluation("done", 7, 7, null, "done"),
+        assignedToMe: true,
+      },
       interview: null,
       final: null,
     },

--- a/src/features/recruiting/model/applicantListTypes.test.ts
+++ b/src/features/recruiting/model/applicantListTypes.test.ts
@@ -79,27 +79,39 @@ describe("applyCardFilters 정렬", () => {
 })
 
 describe("applyApplicantFilters 결과 필터", () => {
-  it("대기 결과는 평가 완료지만 결과가 미확정인 지원자만 포함한다", () => {
-    const pending = createApplicant("pending", "2026-04-22T09:00:00", "가천대")
-    pending.evaluations.document.progress = "done"
+  it("합격 결과 필터는 합격자만 포함한다", () => {
+    const passed = createApplicant("passed", "2026-04-22T09:00:00", "가천대")
+    passed.evaluations.document.progress = "done"
+    passed.evaluations.document.result = "pass"
 
-    const before = createApplicant("before", "2026-04-22T09:00:00", "한성대")
-    const inProgress = createApplicant(
-      "in-progress",
-      "2026-04-22T09:00:00",
-      "건국대",
-    )
-    inProgress.evaluations.document.progress = "inProgress"
+    const failed = createApplicant("failed", "2026-04-22T09:00:00", "건국대")
+    failed.evaluations.document.progress = "done"
+    failed.evaluations.document.result = "fail"
 
     const result = applyApplicantFilters(
-      [pending, before, inProgress],
-      { ...DEFAULT_APPLICANT_LIST_FILTERS, results: ["pending"] },
+      [passed, failed],
+      { ...DEFAULT_APPLICANT_LIST_FILTERS, results: ["pass"] },
       "document",
     )
 
-    expect(result.map(({ applicationId }) => applicationId)).toEqual([
-      "pending",
-    ])
+    expect(result.map(({ applicationId }) => applicationId)).toEqual(["passed"])
+  })
+
+  it("결과가 미확정인 지원자는 결과 필터에 포함되지 않는다", () => {
+    const doneNoResult = createApplicant(
+      "done-no-result",
+      "2026-04-22T09:00:00",
+      "가천대",
+    )
+    doneNoResult.evaluations.document.progress = "done"
+
+    const result = applyApplicantFilters(
+      [doneNoResult],
+      { ...DEFAULT_APPLICANT_LIST_FILTERS, results: ["pass", "fail"] },
+      "document",
+    )
+
+    expect(result).toHaveLength(0)
   })
 })
 

--- a/src/features/recruiting/model/applicantListTypes.test.ts
+++ b/src/features/recruiting/model/applicantListTypes.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest"
 
 import {
   type ApplicantRow,
+  applyApplicantFilters,
   applyCardFilters,
   DEFAULT_APPLICANT_CARD_FILTERS,
+  DEFAULT_APPLICANT_LIST_FILTERS,
   formatAppliedAtParts,
 } from "./applicantListTypes"
 
@@ -72,6 +74,31 @@ describe("applyCardFilters 정렬", () => {
     expect(result.map(({ applicationId }) => applicationId)).toEqual([
       "first",
       "second",
+    ])
+  })
+})
+
+describe("applyApplicantFilters 결과 필터", () => {
+  it("대기 결과는 평가 완료지만 결과가 미확정인 지원자만 포함한다", () => {
+    const pending = createApplicant("pending", "2026-04-22T09:00:00", "가천대")
+    pending.evaluations.document.progress = "done"
+
+    const before = createApplicant("before", "2026-04-22T09:00:00", "한성대")
+    const inProgress = createApplicant(
+      "in-progress",
+      "2026-04-22T09:00:00",
+      "건국대",
+    )
+    inProgress.evaluations.document.progress = "inProgress"
+
+    const result = applyApplicantFilters(
+      [pending, before, inProgress],
+      { ...DEFAULT_APPLICANT_LIST_FILTERS, results: ["pending"] },
+      "document",
+    )
+
+    expect(result.map(({ applicationId }) => applicationId)).toEqual([
+      "pending",
     ])
   })
 })

--- a/src/features/recruiting/model/applicantListTypes.test.ts
+++ b/src/features/recruiting/model/applicantListTypes.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest"
 
 import {
   type ApplicantRow,
-  applyApplicantFilters,
-  DEFAULT_APPLICANT_LIST_FILTERS,
+  applyCardFilters,
+  DEFAULT_APPLICANT_CARD_FILTERS,
   formatAppliedAtParts,
 } from "./applicantListTypes"
 
@@ -35,15 +35,15 @@ function createApplicant(
   }
 }
 
-describe("applyApplicantFilters 정렬", () => {
+describe("applyCardFilters 정렬", () => {
   it("등록 순을 학교순보다 우선 적용한다", () => {
     const older = createApplicant("older", "2026-04-21T09:00:00", "한성대")
     const newer = createApplicant("newer", "2026-04-22T09:00:00", "가천대")
 
-    const result = applyApplicantFilters(
+    const result = applyCardFilters(
       [newer, older],
       {
-        ...DEFAULT_APPLICANT_LIST_FILTERS,
+        ...DEFAULT_APPLICANT_CARD_FILTERS,
         sort: "registered",
         order: "school",
       },
@@ -60,10 +60,10 @@ describe("applyApplicantFilters 정렬", () => {
     const second = createApplicant("second", "2026-04-22T09:00:00", "한성대")
     const first = createApplicant("first", "2026-04-22T09:00:00", "가천대")
 
-    const result = applyApplicantFilters(
+    const result = applyCardFilters(
       [second, first],
       {
-        ...DEFAULT_APPLICANT_LIST_FILTERS,
+        ...DEFAULT_APPLICANT_CARD_FILTERS,
         order: "school",
       },
       "document",

--- a/src/features/recruiting/model/applicantListTypes.ts
+++ b/src/features/recruiting/model/applicantListTypes.ts
@@ -135,7 +135,7 @@ function matchesResultFilter(evaluation: StageEvaluation, results: string[]) {
   if (results.length === 0) return true
   return results.some((result) =>
     result === "pending"
-      ? evaluation.result === null
+      ? evaluation.progress === "done" && evaluation.result === null
       : evaluation.result === result,
   )
 }

--- a/src/features/recruiting/model/applicantListTypes.ts
+++ b/src/features/recruiting/model/applicantListTypes.ts
@@ -15,6 +15,7 @@ export interface StageEvaluation {
   totalCount: number
   result: EvaluationResult | null
   myProgress: EvaluationProgress
+  assignedToMe?: boolean
 }
 
 export interface ApplicantRow {
@@ -62,27 +63,37 @@ export type ApplicantOrder = (typeof APPLICANT_ORDER_OPTIONS)[number]["value"]
 export interface ApplicantListFilters {
   search: string
   bySchool: boolean
+  assignedOnly: boolean
   chapterTab: string
+  schoolTab: string
   chapters: string[]
   schools: string[]
   parts: string[]
   progresses: string[]
   results: string[]
+}
+
+export const DEFAULT_APPLICANT_LIST_FILTERS: ApplicantListFilters = {
+  search: "",
+  bySchool: false,
+  assignedOnly: false,
+  chapterTab: "all",
+  schoolTab: "all",
+  chapters: [],
+  schools: [],
+  parts: [],
+  progresses: [],
+  results: [],
+}
+
+export interface ApplicantCardFilters {
   includeRegular: boolean
   includeAdditional: boolean
   sort: ApplicantSort
   order: ApplicantOrder | ""
 }
 
-export const DEFAULT_APPLICANT_LIST_FILTERS: ApplicantListFilters = {
-  search: "",
-  bySchool: false,
-  chapterTab: "all",
-  chapters: [],
-  schools: [],
-  parts: [],
-  progresses: [],
-  results: [],
+export const DEFAULT_APPLICANT_CARD_FILTERS: ApplicantCardFilters = {
   includeRegular: true,
   includeAdditional: true,
   sort: "latest",
@@ -148,6 +159,13 @@ function compareByOrder(
   )
 }
 
+function scopeRowsToStage(rows: ApplicantRow[], stage: EvaluationStage) {
+  return rows.flatMap((row) => {
+    const evaluation = getStageEvaluation(row, stage)
+    return evaluation ? [{ row, evaluation }] : []
+  })
+}
+
 export function applyApplicantFilters(
   rows: ApplicantRow[],
   filters: ApplicantListFilters,
@@ -157,62 +175,77 @@ export function applyApplicantFilters(
   const chapters =
     filters.chapterTab === "all" ? filters.chapters : [filters.chapterTab]
 
-  const scoped = rows.flatMap((row) => {
-    const evaluation = getStageEvaluation(row, stage)
-    return evaluation ? [{ row, evaluation }] : []
-  })
+  const scoped = scopeRowsToStage(rows, stage)
 
   const normalizedSearch = search.toLowerCase()
 
-  const filtered = scoped.filter(({ row, evaluation }) => {
-    if (
-      normalizedSearch &&
-      !row.applicantName.toLowerCase().includes(normalizedSearch)
-    ) {
-      return false
-    }
-    if (chapters.length > 0 && !chapters.includes(row.chapter)) return false
-    if (filters.schools.length > 0 && !filters.schools.includes(row.school)) {
-      return false
-    }
-    if (
-      filters.parts.length > 0 &&
-      !row.parts.some((part) => filters.parts.includes(part))
-    ) {
-      return false
-    }
-    if (
-      filters.progresses.length > 0 &&
-      !filters.progresses.includes(evaluation.progress)
-    ) {
-      return false
-    }
-    if (!matchesResultFilter(evaluation, filters.results)) return false
-    if (!filters.includeRegular && row.recruitmentType === "regular") {
-      return false
-    }
-    if (!filters.includeAdditional && row.recruitmentType === "additional") {
-      return false
-    }
-    return true
-  })
+  return scoped
+    .filter(({ row, evaluation }) => {
+      if (
+        normalizedSearch &&
+        !row.applicantName.toLowerCase().includes(normalizedSearch)
+      ) {
+        return false
+      }
+      if (chapters.length > 0 && !chapters.includes(row.chapter)) return false
+      if (filters.schoolTab !== "all" && row.school !== filters.schoolTab) {
+        return false
+      }
+      if (filters.schools.length > 0 && !filters.schools.includes(row.school)) {
+        return false
+      }
+      if (
+        filters.parts.length > 0 &&
+        !row.parts.some((part) => filters.parts.includes(part))
+      ) {
+        return false
+      }
+      if (
+        filters.progresses.length > 0 &&
+        !filters.progresses.includes(evaluation.progress)
+      ) {
+        return false
+      }
+      if (!matchesResultFilter(evaluation, filters.results)) return false
+      if (filters.assignedOnly && !evaluation.assignedToMe) return false
+      return true
+    })
+    .map(({ row }) => row)
+}
 
-  return filtered
+export function applyCardFilters(
+  rows: ApplicantRow[],
+  cardFilters: ApplicantCardFilters,
+  stage: EvaluationStage,
+) {
+  return scopeRowsToStage(rows, stage)
+    .filter(({ row }) => {
+      if (!cardFilters.includeRegular && row.recruitmentType === "regular") {
+        return false
+      }
+      if (
+        !cardFilters.includeAdditional &&
+        row.recruitmentType === "additional"
+      ) {
+        return false
+      }
+      return true
+    })
     .sort((a, b) => {
       const byAppliedAt =
-        filters.sort === "latest"
+        cardFilters.sort === "latest"
           ? b.row.appliedAt.localeCompare(a.row.appliedAt)
           : a.row.appliedAt.localeCompare(b.row.appliedAt)
 
       if (byAppliedAt !== 0) return byAppliedAt
 
-      if (filters.order) {
+      if (cardFilters.order) {
         return compareByOrder(
           a.row,
           b.row,
           a.evaluation,
           b.evaluation,
-          filters.order,
+          cardFilters.order,
         )
       }
 

--- a/src/features/recruiting/model/applicantListTypes.ts
+++ b/src/features/recruiting/model/applicantListTypes.ts
@@ -133,11 +133,7 @@ function resultOrderRank(result: EvaluationResult | null) {
 
 function matchesResultFilter(evaluation: StageEvaluation, results: string[]) {
   if (results.length === 0) return true
-  return results.some((result) =>
-    result === "pending"
-      ? evaluation.progress === "done" && evaluation.result === null
-      : evaluation.result === result,
-  )
+  return evaluation.result !== null && results.includes(evaluation.result)
 }
 
 function compareByOrder(

--- a/src/features/recruiting/model/applicantListView.test.ts
+++ b/src/features/recruiting/model/applicantListView.test.ts
@@ -118,4 +118,17 @@ describe("그룹핑", () => {
       "이화여대",
     ])
   })
+
+  it("학교 목록에 없는 학교의 지원자도 그룹에 포함한다", () => {
+    const groups = groupRowsBySchool(
+      [...rows, createApplicant("d", "Ferrum", "신규대")],
+      ["Ferrum"],
+    )
+
+    expect(groups[0]?.schools.map(({ school }) => school)).toEqual([
+      "동국대",
+      "이화여대",
+      "신규대",
+    ])
+  })
 })

--- a/src/features/recruiting/model/applicantListView.test.ts
+++ b/src/features/recruiting/model/applicantListView.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  type ApplicantRow,
+  DEFAULT_APPLICANT_LIST_FILTERS,
+} from "./applicantListTypes"
+import {
+  groupRowsByChapter,
+  groupRowsBySchool,
+  resolveApplicantListViewKind,
+  resolveScopeChapters,
+} from "./applicantListView"
+
+import type { Chapter } from "@/entities/organization/model/chapters"
+
+function createApplicant(
+  applicationId: string,
+  chapter: Chapter,
+  school: string,
+): ApplicantRow {
+  return {
+    applicationId,
+    appliedAt: "2026-04-22T09:00:00",
+    interviewAt: null,
+    applicantName: applicationId,
+    chapter,
+    school,
+    recruitmentType: "regular",
+    parts: ["web-pe"],
+    evaluations: {
+      document: {
+        progress: "before",
+        doneCount: 0,
+        totalCount: 1,
+        result: null,
+        myProgress: "before",
+      },
+      interview: null,
+      final: null,
+    },
+  }
+}
+
+describe("resolveApplicantListViewKind", () => {
+  it("지부 탭을 선택하면 학교 그룹 뷰를 반환한다", () => {
+    expect(
+      resolveApplicantListViewKind({
+        ...DEFAULT_APPLICANT_LIST_FILTERS,
+        chapterTab: "Ferrum",
+      }),
+    ).toBe("schoolGroups")
+  })
+
+  it("학교별 보기를 켜면 학교 그룹 뷰를 반환한다", () => {
+    expect(
+      resolveApplicantListViewKind({
+        ...DEFAULT_APPLICANT_LIST_FILTERS,
+        bySchool: true,
+      }),
+    ).toBe("schoolGroups")
+  })
+
+  it("지부 드롭다운을 선택하면 지부 그룹 뷰를 반환한다", () => {
+    expect(
+      resolveApplicantListViewKind({
+        ...DEFAULT_APPLICANT_LIST_FILTERS,
+        chapters: ["Chromium", "Neon"],
+      }),
+    ).toBe("chapterGroups")
+  })
+
+  it("선택이 없으면 단일 카드 뷰를 반환한다", () => {
+    expect(resolveApplicantListViewKind(DEFAULT_APPLICANT_LIST_FILTERS)).toBe(
+      "single",
+    )
+  })
+})
+
+describe("resolveScopeChapters", () => {
+  it("지부 탭 선택 시 해당 지부만 반환한다", () => {
+    expect(
+      resolveScopeChapters({
+        ...DEFAULT_APPLICANT_LIST_FILTERS,
+        chapterTab: "Neon",
+      }),
+    ).toEqual(["Neon"])
+  })
+
+  it("지부 드롭다운 선택을 CHAPTERS 순서로 정규화한다", () => {
+    expect(
+      resolveScopeChapters({
+        ...DEFAULT_APPLICANT_LIST_FILTERS,
+        chapters: ["Neon", "Chromium"],
+      }),
+    ).toEqual(["Chromium", "Neon"])
+  })
+})
+
+describe("그룹핑", () => {
+  const rows = [
+    createApplicant("a", "Ferrum", "이화여대"),
+    createApplicant("b", "Chromium", "광운대"),
+    createApplicant("c", "Ferrum", "동국대"),
+  ]
+
+  it("지원자가 있는 지부만 지부 순서대로 그룹핑한다", () => {
+    const groups = groupRowsByChapter(rows, ["Chromium", "Ferrum", "Neon"])
+
+    expect(groups.map(({ chapter }) => chapter)).toEqual(["Chromium", "Ferrum"])
+  })
+
+  it("지부 내 학교를 학교 목록 순서로 그룹핑한다", () => {
+    const groups = groupRowsBySchool(rows, ["Ferrum"])
+
+    expect(groups).toHaveLength(1)
+    expect(groups[0]?.schools.map(({ school }) => school)).toEqual([
+      "동국대",
+      "이화여대",
+    ])
+  })
+})

--- a/src/features/recruiting/model/applicantListView.ts
+++ b/src/features/recruiting/model/applicantListView.ts
@@ -1,0 +1,73 @@
+import {
+  type Chapter,
+  CHAPTERS,
+  isChapter,
+} from "@/entities/organization/model/chapters"
+import { SCHOOLS_BY_BRANCH } from "@/shared/config/schools"
+
+import type { ApplicantListFilters, ApplicantRow } from "./applicantListTypes"
+
+export type ApplicantListViewKind = "single" | "chapterGroups" | "schoolGroups"
+
+export function resolveApplicantListViewKind(
+  filters: ApplicantListFilters,
+): ApplicantListViewKind {
+  if (filters.chapterTab !== "all") return "schoolGroups"
+  if (filters.bySchool) return "schoolGroups"
+  if (filters.chapters.length > 0) return "chapterGroups"
+  return "single"
+}
+
+export function resolveScopeChapters(filters: ApplicantListFilters): Chapter[] {
+  if (filters.chapterTab !== "all") {
+    return isChapter(filters.chapterTab) ? [filters.chapterTab] : []
+  }
+  const selected = filters.chapters.filter(isChapter)
+  return selected.length > 0
+    ? CHAPTERS.filter((chapter) => selected.includes(chapter))
+    : [...CHAPTERS]
+}
+
+export interface ChapterGroup {
+  chapter: Chapter
+  rows: ApplicantRow[]
+}
+
+export function groupRowsByChapter(
+  rows: ApplicantRow[],
+  chapters: Chapter[],
+): ChapterGroup[] {
+  return chapters
+    .map((chapter) => ({
+      chapter,
+      rows: rows.filter((row) => row.chapter === chapter),
+    }))
+    .filter((group) => group.rows.length > 0)
+}
+
+export interface SchoolGroup {
+  school: string
+  rows: ApplicantRow[]
+}
+
+export interface ChapterSchoolGroup {
+  chapter: Chapter
+  schools: SchoolGroup[]
+}
+
+export function groupRowsBySchool(
+  rows: ApplicantRow[],
+  chapters: Chapter[],
+): ChapterSchoolGroup[] {
+  return groupRowsByChapter(rows, chapters)
+    .map(({ chapter, rows: chapterRows }) => ({
+      chapter,
+      schools: SCHOOLS_BY_BRANCH[chapter]
+        .map((school) => ({
+          school,
+          rows: chapterRows.filter((row) => row.school === school),
+        }))
+        .filter((group) => group.rows.length > 0),
+    }))
+    .filter((group) => group.schools.length > 0)
+}

--- a/src/features/recruiting/model/applicantListView.ts
+++ b/src/features/recruiting/model/applicantListView.ts
@@ -62,7 +62,12 @@ export function groupRowsBySchool(
   return groupRowsByChapter(rows, chapters)
     .map(({ chapter, rows: chapterRows }) => ({
       chapter,
-      schools: SCHOOLS_BY_BRANCH[chapter]
+      schools: [
+        ...new Set([
+          ...SCHOOLS_BY_BRANCH[chapter],
+          ...chapterRows.map((row) => row.school),
+        ]),
+      ]
         .map((school) => ({
           school,
           rows: chapterRows.filter((row) => row.school === school),

--- a/src/features/recruiting/model/evaluationStage.ts
+++ b/src/features/recruiting/model/evaluationStage.ts
@@ -8,6 +8,12 @@ export const EVALUATION_STAGE_LABEL: Record<EvaluationStage, string> = {
   final: "최종 평가",
 }
 
+export const EVALUATION_STAGE_SHORT_LABEL: Record<EvaluationStage, string> = {
+  document: "서류",
+  interview: "면접",
+  final: "최종",
+}
+
 export const EVALUATION_STAGE_DESCRIPTION: Record<EvaluationStage, string> = {
   document: "전체 지원자의 서류 평가 현황과 결과를 확인합니다.",
   interview: "전체 지원자의 면접 평가 현황과 결과를 확인합니다.",

--- a/src/features/recruiting/model/recruitingListRole.ts
+++ b/src/features/recruiting/model/recruitingListRole.ts
@@ -1,0 +1,16 @@
+export const RECRUITING_LIST_ROLES = [
+  "central",
+  "chapterAdmin",
+  "schoolStaff",
+] as const
+
+export type RecruitingListRole = (typeof RECRUITING_LIST_ROLES)[number]
+
+export function isRecruitingListRole(
+  value: unknown,
+): value is RecruitingListRole {
+  return (
+    typeof value === "string" &&
+    (RECRUITING_LIST_ROLES as readonly string[]).includes(value)
+  )
+}

--- a/src/features/recruiting/ui/ApplicantFilterBar.test.tsx
+++ b/src/features/recruiting/ui/ApplicantFilterBar.test.tsx
@@ -40,4 +40,23 @@ describe("ApplicantFilterBar 지부 필터", () => {
     expect(screen.getByTestId("selected-schools")).toBeEmptyDOMElement()
     expect(screen.getByRole("button", { name: "학교" })).toBeInTheDocument()
   })
+
+  it("지부 스코프가 지정되면 학교별 체크와 지부 드롭다운을 숨긴다", () => {
+    render(
+      <ApplicantFilterBar
+        filters={DEFAULT_APPLICANT_LIST_FILTERS}
+        onFiltersChange={() => {}}
+        resultFilterLabel="서류 평가 결과"
+        chapterScope="Ferrum"
+      />,
+    )
+
+    expect(
+      screen.queryByRole("checkbox", { name: "학교별 보기" }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "지부" }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "학교" })).toBeInTheDocument()
+  })
 })

--- a/src/features/recruiting/ui/ApplicantFilterBar.tsx
+++ b/src/features/recruiting/ui/ApplicantFilterBar.tsx
@@ -1,6 +1,10 @@
 import { useState } from "react"
 
-import { CHAPTERS, isChapter } from "@/entities/organization/model/chapters"
+import {
+  type Chapter,
+  CHAPTERS,
+  isChapter,
+} from "@/entities/organization/model/chapters"
 import FilterIcon from "@/shared/assets/icon/filter/FilterIcon"
 import { SCHOOLS_BY_BRANCH } from "@/shared/config/schools"
 import { cn } from "@/shared/lib/utils"
@@ -11,6 +15,7 @@ import {
 } from "@/shared/ui/FilterDropDown"
 import { Checkbox } from "@/shared/ui/input/checkbox/Checkbox"
 import { SearchField } from "@/shared/ui/search-field/SearchField"
+import { Toggle } from "@/shared/ui/Toggle"
 
 import {
   type ApplicantListFilters,
@@ -43,7 +48,15 @@ const RESULT_OPTIONS = [
 
 function buildSchoolOptions(
   filters: ApplicantListFilters,
+  chapterScope?: Chapter,
 ): FilterDropdownOption[] {
+  if (chapterScope) {
+    return SCHOOLS_BY_BRANCH[chapterScope].map((school) => ({
+      value: school,
+      label: school,
+    }))
+  }
+
   const selectedChapters =
     filters.chapterTab === CHAPTER_ALL_VALUE
       ? filters.chapters.filter(isChapter)
@@ -62,6 +75,9 @@ interface ApplicantFilterBarProps {
   filters: ApplicantListFilters
   onFiltersChange: (partial: Partial<ApplicantListFilters>) => void
   resultFilterLabel: string
+  chapterScope?: Chapter
+  hideSchoolControls?: boolean
+  showAssignedToggle?: boolean
   className?: string
 }
 
@@ -69,10 +85,21 @@ export function ApplicantFilterBar({
   filters,
   onFiltersChange,
   resultFilterLabel,
+  chapterScope,
+  hideSchoolControls = false,
+  showAssignedToggle = false,
   className,
 }: ApplicantFilterBarProps) {
   const [openKey, setOpenKey] = useState<string | null>(null)
-  const schoolOptions = buildSchoolOptions(filters)
+  const schoolOptions = buildSchoolOptions(filters, chapterScope)
+  const showChapterFilter =
+    filters.chapterTab === CHAPTER_ALL_VALUE &&
+    !chapterScope &&
+    !hideSchoolControls
+  const showBySchool =
+    filters.chapterTab === CHAPTER_ALL_VALUE &&
+    !chapterScope &&
+    !hideSchoolControls
 
   const multiDropdownProps = (
     key: keyof Pick<
@@ -114,17 +141,34 @@ export function ApplicantFilterBar({
           <FilterIcon className="text-teal-gray-600 size-4" />
           필터
         </span>
-        <label className="flex cursor-pointer items-center gap-2">
-          <Checkbox
-            checked={filters.bySchool}
-            onChange={(checked) => onFiltersChange({ bySchool: checked })}
-            variant="primary"
-            aria-label="학교별 보기"
-          />
-          <span className="text-body-1-medium text-teal-gray-600">학교별</span>
-        </label>
+        {showAssignedToggle && (
+          <span className="flex items-center gap-2">
+            <span className="text-body-1-medium text-teal-gray-600">
+              내 담당 지원자
+            </span>
+            <Toggle
+              size="sm"
+              checked={filters.assignedOnly}
+              onChange={(checked) => onFiltersChange({ assignedOnly: checked })}
+              aria-label="내 담당 지원자만 보기"
+            />
+          </span>
+        )}
+        {showBySchool && (
+          <label className="flex cursor-pointer items-center gap-2">
+            <Checkbox
+              checked={filters.bySchool}
+              onChange={(checked) => onFiltersChange({ bySchool: checked })}
+              variant="primary"
+              aria-label="학교별 보기"
+            />
+            <span className="text-body-1-medium text-teal-gray-600">
+              학교별
+            </span>
+          </label>
+        )}
         <div className="flex items-center gap-2">
-          {filters.chapterTab === CHAPTER_ALL_VALUE && (
+          {showChapterFilter && (
             <FilterDropdown
               {...multiDropdownProps(
                 "chapters",
@@ -134,9 +178,11 @@ export function ApplicantFilterBar({
               )}
             />
           )}
-          <FilterDropdown
-            {...multiDropdownProps("schools", "학교", schoolOptions)}
-          />
+          {!hideSchoolControls && (
+            <FilterDropdown
+              {...multiDropdownProps("schools", "학교", schoolOptions)}
+            />
+          )}
           <FilterDropdown
             {...multiDropdownProps("parts", "지원 파트", PART_OPTIONS)}
           />

--- a/src/features/recruiting/ui/ApplicantFilterBar.tsx
+++ b/src/features/recruiting/ui/ApplicantFilterBar.tsx
@@ -43,7 +43,6 @@ const PROGRESS_OPTIONS = (["before", "inProgress", "done"] as const).map(
 const RESULT_OPTIONS = [
   { value: "pass", label: "합격" },
   { value: "fail", label: "불합격" },
-  { value: "pending", label: "대기" },
 ]
 
 function buildSchoolOptions(

--- a/src/features/recruiting/ui/ApplicantListPage.tsx
+++ b/src/features/recruiting/ui/ApplicantListPage.tsx
@@ -1,10 +1,13 @@
 import { useMemo, useState } from "react"
 
+import { SCHOOLS_BY_BRANCH } from "@/shared/config/schools"
 import { PageLabel } from "@/shared/ui/page-label/PageLabel"
 
 import {
   APPLICANT_LIST_BASE_TIME_MOCK,
   APPLICANT_LIST_MOCK,
+  RECRUITING_MY_CHAPTER_MOCK,
+  RECRUITING_MY_SCHOOL_MOCK,
   RECRUITING_TARGET_GISU_LABEL_MOCK,
 } from "../model/applicantList.mock"
 import {
@@ -15,13 +18,24 @@ import {
   getStageEvaluation,
 } from "../model/applicantListTypes"
 import {
+  groupRowsByChapter,
+  groupRowsBySchool,
+  resolveApplicantListViewKind,
+  resolveScopeChapters,
+} from "../model/applicantListView"
+import {
   EVALUATION_STAGE_DESCRIPTION,
   EVALUATION_STAGE_LABEL,
+  EVALUATION_STAGE_SHORT_LABEL,
   type EvaluationStage,
 } from "../model/evaluationStage"
 import { ApplicantFilterBar } from "./ApplicantFilterBar"
 import { ApplicantTableCard } from "./ApplicantTableCard"
 import { ChapterTabs } from "./ChapterTabs"
+import { SchoolTabs } from "./SchoolTabs"
+
+import type { RecruitingListRole } from "../model/recruitingListRole"
+import type { ApplicantColumnOptions } from "./applicantTableColumns"
 
 const RESULT_FILTER_LABEL: Record<EvaluationStage, string> = {
   document: "서류 평가 결과",
@@ -29,23 +43,47 @@ const RESULT_FILTER_LABEL: Record<EvaluationStage, string> = {
   final: "최종 평가 결과",
 }
 
+const CHAPTER_CARD_COLUMNS: ApplicantColumnOptions = { hideChapter: true }
+
+function pageDescription(stage: EvaluationStage, role: RecruitingListRole) {
+  const shortLabel = EVALUATION_STAGE_SHORT_LABEL[stage]
+  if (role === "chapterAdmin") {
+    return `지부 ${shortLabel} 평가 현황을 확인하고, 내 학교 지원자를 평가합니다.`
+  }
+  if (role === "schoolStaff") {
+    return `내 학교 지원자의 ${shortLabel} 평가 현황을 확인하고 평가합니다.`
+  }
+  return EVALUATION_STAGE_DESCRIPTION[stage]
+}
+
 interface ApplicantListPageProps {
   stage: EvaluationStage
+  role?: RecruitingListRole
   useMockData?: boolean
+  hasRecruitment?: boolean
 }
 
 export function ApplicantListPage({
   stage,
+  role = "central",
   useMockData = false,
+  hasRecruitment = true,
 }: ApplicantListPageProps) {
   const [filters, setFilters] = useState<ApplicantListFilters>(
     DEFAULT_APPLICANT_LIST_FILTERS,
   )
 
-  const rows = useMemo(
-    () => (useMockData ? APPLICANT_LIST_MOCK : []),
-    [useMockData],
-  )
+  const rows = useMemo(() => {
+    const base = useMockData ? APPLICANT_LIST_MOCK : []
+    if (role === "chapterAdmin") {
+      return base.filter((row) => row.chapter === RECRUITING_MY_CHAPTER_MOCK)
+    }
+    if (role === "schoolStaff") {
+      return base.filter((row) => row.school === RECRUITING_MY_SCHOOL_MOCK)
+    }
+    return base
+  }, [useMockData, role])
+
   const allStageRows = useMemo(
     () => rows.filter((row) => getStageEvaluation(row, stage)),
     [rows, stage],
@@ -55,6 +93,13 @@ export function ApplicantListPage({
     [rows, filters, stage],
   )
 
+  const viewKind =
+    role === "central" ? resolveApplicantListViewKind(filters) : "schoolGroups"
+  const scopeChapters =
+    role === "central"
+      ? resolveScopeChapters(filters)
+      : [RECRUITING_MY_CHAPTER_MOCK]
+
   const baseTime = useMockData
     ? APPLICANT_LIST_BASE_TIME_MOCK
     : formatBaseTime(new Date())
@@ -62,6 +107,30 @@ export function ApplicantListPage({
   const handleFiltersChange = (partial: Partial<ApplicantListFilters>) => {
     setFilters((prev) => ({ ...prev, ...partial }))
   }
+
+  const schoolCardColumns = useMemo<ApplicantColumnOptions>(
+    () => ({
+      hideChapter: true,
+      hideSchool: true,
+      showMyEvaluation: role === "schoolStaff" && filters.assignedOnly,
+    }),
+    [role, filters.assignedOnly],
+  )
+
+  const chapterGroups =
+    viewKind === "chapterGroups"
+      ? groupRowsByChapter(visibleRows, scopeChapters)
+      : []
+  const schoolGroups =
+    viewKind === "schoolGroups"
+      ? groupRowsBySchool(visibleRows, scopeChapters)
+      : []
+  const hasGroups =
+    viewKind === "chapterGroups"
+      ? chapterGroups.length > 0
+      : viewKind === "schoolGroups"
+        ? schoolGroups.length > 0
+        : false
 
   return (
     <div className="flex w-full max-w-286.5 flex-col">
@@ -72,35 +141,94 @@ export function ApplicantListPage({
           { id: stage, label: EVALUATION_STAGE_LABEL[stage] },
         ]}
         title={EVALUATION_STAGE_LABEL[stage]}
-        description={EVALUATION_STAGE_DESCRIPTION[stage]}
+        description={pageDescription(stage, role)}
         className="pl-3"
       />
-      <ChapterTabs
-        value={filters.chapterTab}
-        onValueChange={(chapterTab) =>
-          handleFiltersChange({ chapterTab, chapters: [], schools: [] })
-        }
-        className="mt-8"
-      />
+      {role === "central" && (
+        <ChapterTabs
+          value={filters.chapterTab}
+          onValueChange={(chapterTab) =>
+            handleFiltersChange({ chapterTab, chapters: [], schools: [] })
+          }
+          className="mt-8"
+        />
+      )}
+      {role === "chapterAdmin" && (
+        <SchoolTabs
+          schools={SCHOOLS_BY_BRANCH[RECRUITING_MY_CHAPTER_MOCK]}
+          value={filters.schoolTab}
+          onValueChange={(schoolTab) =>
+            handleFiltersChange({ schoolTab, schools: [] })
+          }
+          className="mt-8"
+        />
+      )}
       <ApplicantFilterBar
         filters={filters}
         onFiltersChange={handleFiltersChange}
         resultFilterLabel={RESULT_FILTER_LABEL[stage]}
+        chapterScope={
+          role === "chapterAdmin" ? RECRUITING_MY_CHAPTER_MOCK : undefined
+        }
+        hideSchoolControls={role === "schoolStaff"}
+        showAssignedToggle={role === "schoolStaff"}
         className="mt-6"
       />
-      <h2 className="text-heading-5-semibold mt-6 px-3 text-teal-700">
-        {RECRUITING_TARGET_GISU_LABEL_MOCK}
-      </h2>
-      <ApplicantTableCard
-        visibleRows={visibleRows}
-        allStageRows={allStageRows}
-        stage={stage}
-        totalCount={visibleRows.length}
-        baseTime={baseTime}
-        filters={filters}
-        onFiltersChange={handleFiltersChange}
-        className="mt-4"
-      />
+      {(viewKind === "single" || !hasGroups) && (
+        <>
+          <h2 className="text-heading-5-semibold mt-6 px-3 text-teal-700">
+            {RECRUITING_TARGET_GISU_LABEL_MOCK}
+          </h2>
+          <ApplicantTableCard
+            visibleRows={viewKind === "single" ? visibleRows : []}
+            allStageRows={allStageRows}
+            stage={stage}
+            baseTime={baseTime}
+            hasRecruitment={hasRecruitment}
+            className="mt-4"
+          />
+        </>
+      )}
+      {viewKind === "chapterGroups" &&
+        chapterGroups.map(({ chapter, rows: chapterRows }) => (
+          <section key={chapter} className="flex flex-col">
+            <h2 className="text-heading-5-semibold mt-6 px-3 text-teal-700">
+              {chapter}
+            </h2>
+            <ApplicantTableCard
+              visibleRows={chapterRows}
+              allStageRows={allStageRows.filter(
+                (row) => row.chapter === chapter,
+              )}
+              stage={stage}
+              baseTime={baseTime}
+              columns={CHAPTER_CARD_COLUMNS}
+              className="mt-4"
+            />
+          </section>
+        ))}
+      {viewKind === "schoolGroups" &&
+        schoolGroups.map(({ chapter, schools }) => (
+          <section key={chapter} className="flex flex-col">
+            <h2 className="text-heading-5-semibold mt-6 px-3 text-teal-700">
+              {chapter}
+            </h2>
+            {schools.map(({ school, rows: schoolRows }) => (
+              <ApplicantTableCard
+                key={school}
+                visibleRows={schoolRows}
+                allStageRows={allStageRows.filter(
+                  (row) => row.school === school,
+                )}
+                stage={stage}
+                baseTime={baseTime}
+                titleBase={school}
+                columns={schoolCardColumns}
+                className="mt-4"
+              />
+            ))}
+          </section>
+        ))}
     </div>
   )
 }

--- a/src/features/recruiting/ui/ApplicantListPage.tsx
+++ b/src/features/recruiting/ui/ApplicantListPage.tsx
@@ -132,6 +132,19 @@ export function ApplicantListPage({
         ? schoolGroups.length > 0
         : false
 
+  const emptyScopedSchool =
+    role !== "central" && !hasGroups
+      ? role === "schoolStaff"
+        ? RECRUITING_MY_SCHOOL_MOCK
+        : filters.schoolTab !== "all"
+          ? filters.schoolTab
+          : undefined
+      : undefined
+  const showScopedEmptyCard = role !== "central" && !hasGroups
+  const emptyScopedAllStageRows = emptyScopedSchool
+    ? allStageRows.filter((row) => row.school === emptyScopedSchool)
+    : allStageRows
+
   return (
     <div className="flex w-full max-w-286.5 flex-col">
       <PageLabel
@@ -174,7 +187,7 @@ export function ApplicantListPage({
         showAssignedToggle={role === "schoolStaff"}
         className="mt-6"
       />
-      {(viewKind === "single" || !hasGroups) && (
+      {(viewKind === "single" || !hasGroups) && !showScopedEmptyCard && (
         <>
           <h2 className="text-heading-5-semibold mt-6 px-3 text-teal-700">
             {RECRUITING_TARGET_GISU_LABEL_MOCK}
@@ -188,6 +201,23 @@ export function ApplicantListPage({
             className="mt-4"
           />
         </>
+      )}
+      {showScopedEmptyCard && (
+        <section className="flex flex-col">
+          <h2 className="text-heading-5-semibold mt-6 px-3 text-teal-700">
+            {RECRUITING_MY_CHAPTER_MOCK}
+          </h2>
+          <ApplicantTableCard
+            visibleRows={[]}
+            allStageRows={emptyScopedAllStageRows}
+            stage={stage}
+            baseTime={baseTime}
+            titleBase={emptyScopedSchool}
+            columns={schoolCardColumns}
+            hasRecruitment={hasRecruitment}
+            className="mt-4"
+          />
+        </section>
       )}
       {viewKind === "chapterGroups" &&
         chapterGroups.map(({ chapter, rows: chapterRows }) => (

--- a/src/features/recruiting/ui/ApplicantRow.test.tsx
+++ b/src/features/recruiting/ui/ApplicantRow.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
 
 import { ApplicantRow } from "./ApplicantRow"
 
@@ -37,14 +37,7 @@ function createApplicantRow(): ApplicantRowModel {
 
 describe("ApplicantRow", () => {
   it("지원 일시와 평가 수를 공용 라벨로 표시한다", () => {
-    render(
-      <ApplicantRow
-        row={createApplicantRow()}
-        stage="document"
-        expanded={false}
-        onToggle={() => {}}
-      />,
-    )
+    render(<ApplicantRow row={createApplicantRow()} stage="document" />)
 
     expect(screen.getByText("04/22")).toBeInTheDocument()
     expect(screen.getByText("03:33")).toBeInTheDocument()
@@ -54,24 +47,19 @@ describe("ApplicantRow", () => {
     expect(screen.getByText("7")).toHaveClass("text-teal-gray-600")
   })
 
-  it("일시가 없으면 대시를 표시하고 행 토글을 유지한다", () => {
-    const onToggle = vi.fn()
-
-    render(
-      <ApplicantRow
-        row={createApplicantRow()}
-        stage="interview"
-        expanded={false}
-        onToggle={onToggle}
-      />,
-    )
+  it("일시가 없으면 대시를 표시한다", () => {
+    render(<ApplicantRow row={createApplicantRow()} stage="interview" />)
 
     expect(screen.getByText("-")).toBeInTheDocument()
-    fireEvent.click(screen.getByRole("button", { name: "지원자 상세 펼치기" }))
-    expect(onToggle).toHaveBeenCalledOnce()
   })
 
-  it("평가가 완료됐지만 결과가 없으면 대기 태그를 표시한다", () => {
+  it("행 확장 토글 버튼을 렌더하지 않는다", () => {
+    render(<ApplicantRow row={createApplicantRow()} stage="document" />)
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+  })
+
+  it("평가가 완료됐어도 결과가 없으면 결과 태그를 표시하지 않는다", () => {
     const row = createApplicantRow()
     row.evaluations.document = {
       progress: "done",
@@ -81,29 +69,11 @@ describe("ApplicantRow", () => {
       myProgress: "done",
     }
 
-    render(
-      <ApplicantRow
-        row={row}
-        stage="document"
-        expanded={false}
-        onToggle={() => {}}
-      />,
-    )
-
-    expect(screen.getByText("대기")).toBeInTheDocument()
-  })
-
-  it("평가가 진행 중이면 대기 태그를 표시하지 않는다", () => {
-    render(
-      <ApplicantRow
-        row={createApplicantRow()}
-        stage="document"
-        expanded={false}
-        onToggle={() => {}}
-      />,
-    )
+    render(<ApplicantRow row={row} stage="document" />)
 
     expect(screen.queryByText("대기")).not.toBeInTheDocument()
+    expect(screen.queryByText("합격")).not.toBeInTheDocument()
+    expect(screen.queryByText("불합격")).not.toBeInTheDocument()
   })
 
   it("최종 평가에서는 일시 컬럼과 평가 수를 렌더하지 않는다", () => {
@@ -116,14 +86,7 @@ describe("ApplicantRow", () => {
       myProgress: "done",
     }
 
-    render(
-      <ApplicantRow
-        row={row}
-        stage="final"
-        expanded={false}
-        onToggle={() => {}}
-      />,
-    )
+    render(<ApplicantRow row={row} stage="final" />)
 
     expect(screen.queryByText("04/22")).not.toBeInTheDocument()
     expect(screen.queryByText("-")).not.toBeInTheDocument()

--- a/src/features/recruiting/ui/ApplicantRow.test.tsx
+++ b/src/features/recruiting/ui/ApplicantRow.test.tsx
@@ -71,6 +71,41 @@ describe("ApplicantRow", () => {
     expect(onToggle).toHaveBeenCalledOnce()
   })
 
+  it("평가가 완료됐지만 결과가 없으면 대기 태그를 표시한다", () => {
+    const row = createApplicantRow()
+    row.evaluations.document = {
+      progress: "done",
+      doneCount: 7,
+      totalCount: 7,
+      result: null,
+      myProgress: "done",
+    }
+
+    render(
+      <ApplicantRow
+        row={row}
+        stage="document"
+        expanded={false}
+        onToggle={() => {}}
+      />,
+    )
+
+    expect(screen.getByText("대기")).toBeInTheDocument()
+  })
+
+  it("평가가 진행 중이면 대기 태그를 표시하지 않는다", () => {
+    render(
+      <ApplicantRow
+        row={createApplicantRow()}
+        stage="document"
+        expanded={false}
+        onToggle={() => {}}
+      />,
+    )
+
+    expect(screen.queryByText("대기")).not.toBeInTheDocument()
+  })
+
   it("최종 평가에서는 일시 컬럼과 평가 수를 렌더하지 않는다", () => {
     const row = createApplicantRow()
     row.evaluations.final = {

--- a/src/features/recruiting/ui/ApplicantRow.tsx
+++ b/src/features/recruiting/ui/ApplicantRow.tsx
@@ -1,4 +1,3 @@
-import FilterDropDownIcon from "@/shared/assets/icon/chevron/FilterDropDownIcon"
 import { cn } from "@/shared/lib/utils"
 import { PartTagChip } from "@/shared/ui/chip/PartTagChip"
 import { StatusChipTag } from "@/shared/ui/chip/StatusChipTag"
@@ -29,30 +28,21 @@ const STAGE_TIME_LABEL: Record<EvaluationStage, string> = {
 interface ApplicantRowProps {
   row: ApplicantRowModel
   stage: EvaluationStage
-  expanded: boolean
-  onToggle: () => void
   columns?: ApplicantColumnOptions
 }
 
-export function ApplicantRow({
-  row,
-  stage,
-  expanded,
-  onToggle,
-  columns,
-}: ApplicantRowProps) {
+export function ApplicantRow({ row, stage, columns }: ApplicantRowProps) {
   const evaluation = getStageEvaluation(row, stage)
   if (!evaluation) return null
 
   const visibleColumns = new Set(getVisibleApplicantColumns(stage, columns))
   const timeAt = stage === "interview" ? row.interviewAt : row.appliedAt
   const timestamp = timeAt ? formatAppliedAtParts(timeAt) : null
-  const showPending = evaluation.progress === "done" && !evaluation.result
 
   return (
     <div
       role="row"
-      className="border-teal-gray-150/60 hover:bg-teal-gray-50 flex h-17 items-center gap-2.5 border-b bg-white pr-5.5 pl-2.5 transition-colors"
+      className="border-teal-gray-150/60 hover:bg-teal-gray-50 flex h-17 items-center border-b bg-white pr-5.5 pl-2.5 transition-colors"
     >
       <div className="flex min-w-0 flex-1 items-center">
         {visibleColumns.has("appliedAt") &&
@@ -121,27 +111,11 @@ export function ApplicantRow({
           )}
         </span>
         <span className={APPLICANT_COLUMNS.result}>
-          {evaluation.result ? (
+          {evaluation.result && (
             <StatusChipTag type="tag" value={evaluation.result} />
-          ) : (
-            showPending && <StatusChipTag type="tag" value="pending" />
           )}
         </span>
       </div>
-      <button
-        type="button"
-        aria-label={expanded ? "지원자 상세 접기" : "지원자 상세 펼치기"}
-        aria-expanded={expanded}
-        onClick={onToggle}
-        className="shadow-inner-neutral-1 flex size-7.5 shrink-0 items-center justify-center rounded-[10px] bg-white"
-      >
-        <FilterDropDownIcon
-          className={cn(
-            "text-teal-gray-700 transition-transform",
-            expanded && "rotate-180",
-          )}
-        />
-      </button>
     </div>
   )
 }

--- a/src/features/recruiting/ui/ApplicantRow.tsx
+++ b/src/features/recruiting/ui/ApplicantRow.tsx
@@ -11,7 +11,11 @@ import {
   formatRecruitmentType,
   getStageEvaluation,
 } from "../model/applicantListTypes"
-import { APPLICANT_COLUMNS } from "./applicantTableColumns"
+import {
+  APPLICANT_COLUMNS,
+  type ApplicantColumnOptions,
+  getVisibleApplicantColumns,
+} from "./applicantTableColumns"
 import { EvaluationStatusChip } from "./EvaluationStatusChip"
 
 import type { EvaluationStage } from "../model/evaluationStage"
@@ -27,6 +31,7 @@ interface ApplicantRowProps {
   stage: EvaluationStage
   expanded: boolean
   onToggle: () => void
+  columns?: ApplicantColumnOptions
 }
 
 export function ApplicantRow({
@@ -34,12 +39,15 @@ export function ApplicantRow({
   stage,
   expanded,
   onToggle,
+  columns,
 }: ApplicantRowProps) {
   const evaluation = getStageEvaluation(row, stage)
   if (!evaluation) return null
 
+  const visibleColumns = new Set(getVisibleApplicantColumns(stage, columns))
   const timeAt = stage === "interview" ? row.interviewAt : row.appliedAt
   const timestamp = timeAt ? formatAppliedAtParts(timeAt) : null
+  const showPending = evaluation.progress === "done" && !evaluation.result
 
   return (
     <div
@@ -47,7 +55,7 @@ export function ApplicantRow({
       className="border-teal-gray-150/60 hover:bg-teal-gray-50 flex h-17 items-center gap-2.5 border-b bg-white pr-5.5 pl-2.5 transition-colors"
     >
       <div className="flex min-w-0 flex-1 items-center">
-        {stage !== "final" &&
+        {visibleColumns.has("appliedAt") &&
           (timestamp ? (
             <TimestampLabel
               date={timestamp.date}
@@ -70,16 +78,20 @@ export function ApplicantRow({
             {row.applicantName}
           </span>
         </span>
-        <span className={APPLICANT_COLUMNS.chapter}>
-          <span className="text-body-2-medium text-teal-gray-900 truncate">
-            {row.chapter}
+        {visibleColumns.has("chapter") && (
+          <span className={APPLICANT_COLUMNS.chapter}>
+            <span className="text-body-2-medium text-teal-gray-900 truncate">
+              {row.chapter}
+            </span>
           </span>
-        </span>
-        <span className={APPLICANT_COLUMNS.school}>
-          <span className="text-body-2-medium text-teal-gray-900 truncate">
-            {row.school}
+        )}
+        {visibleColumns.has("school") && (
+          <span className={APPLICANT_COLUMNS.school}>
+            <span className="text-body-2-medium text-teal-gray-900 truncate">
+              {row.school}
+            </span>
           </span>
-        </span>
+        )}
         <span
           className={cn(
             "text-body-2-medium text-teal-gray-900 whitespace-nowrap",
@@ -93,6 +105,11 @@ export function ApplicantRow({
             <PartTagChip key={part} role={part} type="light" />
           ))}
         </span>
+        {visibleColumns.has("myEvaluation") && (
+          <span className={APPLICANT_COLUMNS.myEvaluation}>
+            <EvaluationStatusChip progress={evaluation.myProgress} />
+          </span>
+        )}
         <span className={APPLICANT_COLUMNS.progress}>
           <EvaluationStatusChip progress={evaluation.progress} />
           {stage !== "final" && (
@@ -104,8 +121,10 @@ export function ApplicantRow({
           )}
         </span>
         <span className={APPLICANT_COLUMNS.result}>
-          {evaluation.result && (
+          {evaluation.result ? (
             <StatusChipTag type="tag" value={evaluation.result} />
+          ) : (
+            showPending && <StatusChipTag type="tag" value="pending" />
           )}
         </span>
       </div>

--- a/src/features/recruiting/ui/ApplicantTableCard.test.tsx
+++ b/src/features/recruiting/ui/ApplicantTableCard.test.tsx
@@ -1,7 +1,6 @@
-import { render, screen } from "@testing-library/react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
 
-import { DEFAULT_APPLICANT_LIST_FILTERS } from "../model/applicantListTypes"
 import { ApplicantTableCard } from "./ApplicantTableCard"
 
 import type {
@@ -41,10 +40,7 @@ function renderCard(visibleRows: ApplicantRow[], allStageRows: ApplicantRow[]) {
       visibleRows={visibleRows}
       allStageRows={allStageRows}
       stage="document"
-      totalCount={visibleRows.length}
       baseTime="26-07-04 02:48"
-      filters={DEFAULT_APPLICANT_LIST_FILTERS}
-      onFiltersChange={() => {}}
     />,
   )
 }
@@ -75,5 +71,56 @@ describe("ApplicantTableCard", () => {
     renderCard([], [])
 
     expect(screen.getByText("지원 전")).toBeInTheDocument()
+  })
+
+  it("모집 공고가 없으면 모집 전 상태와 안내 문구를 표시한다", () => {
+    render(
+      <ApplicantTableCard
+        visibleRows={[]}
+        allStageRows={[]}
+        stage="document"
+        baseTime="26-07-04 02:48"
+        hasRecruitment={false}
+      />,
+    )
+
+    expect(screen.getByText("모집 전")).toBeInTheDocument()
+    expect(
+      screen.getByText("현재 등록된 모집 공고가 없습니다."),
+    ).toBeInTheDocument()
+  })
+
+  it("추가 모집만 선택하고 비어 있으면 추가 모집 문구를 표시한다", () => {
+    render(
+      <ApplicantTableCard
+        visibleRows={[]}
+        allStageRows={[]}
+        stage="document"
+        baseTime="26-07-04 02:48"
+        initialCardFilters={{ includeRegular: false }}
+      />,
+    )
+
+    expect(
+      screen.getByText("현재 추가 모집 지원자가 없습니다."),
+    ).toBeInTheDocument()
+  })
+
+  it("마지막 남은 모집 체크는 해제할 수 없다", () => {
+    render(
+      <ApplicantTableCard
+        visibleRows={[]}
+        allStageRows={[]}
+        stage="document"
+        baseTime="26-07-04 02:48"
+        initialCardFilters={{ includeRegular: false }}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "추가 모집 포함" }))
+
+    expect(
+      screen.getByRole("checkbox", { name: "추가 모집 포함" }),
+    ).toBeChecked()
   })
 })

--- a/src/features/recruiting/ui/ApplicantTableCard.tsx
+++ b/src/features/recruiting/ui/ApplicantTableCard.tsx
@@ -127,7 +127,6 @@ export function ApplicantTableCard({
   const [openDropdown, setOpenDropdown] = useState<"sort" | "order" | null>(
     null,
   )
-  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
 
   const rows = useMemo(
     () => applyCardFilters(visibleRows, cardFilters, stage),
@@ -139,27 +138,9 @@ export function ApplicantTableCard({
     CARD_STATUS_TAG[
       deriveCardStatus(allStageRows, cardFilters, stage, hasRecruitment)
     ]
-  const hasExpanded = rows.some((row) => expandedIds.has(row.applicationId))
 
   const handleCardFiltersChange = (partial: Partial<ApplicantCardFilters>) => {
     setCardFilters((prev) => ({ ...prev, ...partial }))
-  }
-
-  const toggleRow = (applicationId: string) => {
-    setExpandedIds((prev) => {
-      const next = new Set(prev)
-      if (next.has(applicationId)) next.delete(applicationId)
-      else next.add(applicationId)
-      return next
-    })
-  }
-
-  const toggleAll = () => {
-    setExpandedIds((prev) =>
-      rows.some((row) => prev.has(row.applicationId))
-        ? new Set<string>()
-        : new Set(rows.map((row) => row.applicationId)),
-    )
   }
 
   return (
@@ -276,20 +257,13 @@ export function ApplicantTableCard({
           </div>
         ) : (
           <>
-            <ApplicantTableHead
-              stage={stage}
-              columns={columns}
-              hasExpanded={hasExpanded}
-              onToggleAll={toggleAll}
-            />
+            <ApplicantTableHead stage={stage} columns={columns} />
             {rows.map((row) => (
               <ApplicantRow
                 key={row.applicationId}
                 row={row}
                 stage={stage}
                 columns={columns}
-                expanded={expandedIds.has(row.applicationId)}
-                onToggle={() => toggleRow(row.applicationId)}
               />
             ))}
           </>

--- a/src/features/recruiting/ui/ApplicantTableCard.tsx
+++ b/src/features/recruiting/ui/ApplicantTableCard.tsx
@@ -53,12 +53,22 @@ function deriveCardTitle(
 
 function deriveCardStatus(
   allStageRows: ApplicantRowModel[],
+  cardFilters: ApplicantCardFilters,
   stage: EvaluationStage,
   hasRecruitment: boolean,
 ): CardStatus {
   if (!hasRecruitment) return "beforeRecruit"
 
   const evaluations = allStageRows.flatMap((row) => {
+    if (!cardFilters.includeRegular && row.recruitmentType === "regular") {
+      return []
+    }
+    if (
+      !cardFilters.includeAdditional &&
+      row.recruitmentType === "additional"
+    ) {
+      return []
+    }
     const evaluation = getStageEvaluation(row, stage)
     return evaluation ? [evaluation] : []
   })
@@ -126,7 +136,9 @@ export function ApplicantTableCard({
 
   const isEmpty = rows.length === 0
   const statusTag =
-    CARD_STATUS_TAG[deriveCardStatus(allStageRows, stage, hasRecruitment)]
+    CARD_STATUS_TAG[
+      deriveCardStatus(allStageRows, cardFilters, stage, hasRecruitment)
+    ]
   const hasExpanded = rows.some((row) => expandedIds.has(row.applicationId))
 
   const handleCardFiltersChange = (partial: Partial<ApplicantCardFilters>) => {

--- a/src/features/recruiting/ui/ApplicantTableCard.tsx
+++ b/src/features/recruiting/ui/ApplicantTableCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 
 import { cn } from "@/shared/lib/utils"
 import { FilterDropdown } from "@/shared/ui/FilterDropDown"
@@ -8,14 +8,17 @@ import { Tag, type TagTone } from "@/shared/ui/tag/Tag"
 import {
   APPLICANT_ORDER_OPTIONS,
   APPLICANT_SORT_OPTIONS,
-  type ApplicantListFilters,
+  type ApplicantCardFilters,
   type ApplicantRow as ApplicantRowModel,
+  applyCardFilters,
+  DEFAULT_APPLICANT_CARD_FILTERS,
   getStageEvaluation,
 } from "../model/applicantListTypes"
 import { ApplicantRow } from "./ApplicantRow"
 import { ApplicantTableHead } from "./ApplicantTableHead"
 
 import type { EvaluationStage } from "../model/evaluationStage"
+import type { ApplicantColumnOptions } from "./applicantTableColumns"
 
 type CardStatus =
   | "beforeRecruit"
@@ -34,10 +37,27 @@ const CARD_STATUS_TAG: Record<CardStatus, { tone: TagTone; label: string }> = {
   beforeEval: { tone: "gray", label: "평가 전" },
 }
 
+function deriveCardTitle(
+  titleBase: string | undefined,
+  cardFilters: ApplicantCardFilters,
+) {
+  if (!titleBase) return "전체 지원자"
+  if (cardFilters.includeRegular && !cardFilters.includeAdditional) {
+    return `${titleBase} 정규 지원자`
+  }
+  if (!cardFilters.includeRegular && cardFilters.includeAdditional) {
+    return `${titleBase} 추가 지원자`
+  }
+  return `${titleBase} 전체 지원자`
+}
+
 function deriveCardStatus(
   allStageRows: ApplicantRowModel[],
   stage: EvaluationStage,
+  hasRecruitment: boolean,
 ): CardStatus {
+  if (!hasRecruitment) return "beforeRecruit"
+
   const evaluations = allStageRows.flatMap((row) => {
     const evaluation = getStageEvaluation(row, stage)
     return evaluation ? [evaluation] : []
@@ -51,14 +71,31 @@ function deriveCardStatus(
   return allDone ? "evaluated" : "evaluating"
 }
 
+function deriveEmptyMessage(
+  cardFilters: ApplicantCardFilters,
+  hasRecruitment: boolean,
+) {
+  const additionalOnly =
+    cardFilters.includeAdditional && !cardFilters.includeRegular
+  if (!hasRecruitment) {
+    return additionalOnly
+      ? "현재 추가 모집 중인 공고가 없습니다."
+      : "현재 등록된 모집 공고가 없습니다."
+  }
+  return additionalOnly
+    ? "현재 추가 모집 지원자가 없습니다."
+    : "현재 지원자가 없습니다."
+}
+
 interface ApplicantTableCardProps {
   visibleRows: ApplicantRowModel[]
   allStageRows: ApplicantRowModel[]
   stage: EvaluationStage
-  totalCount: number
   baseTime: string
-  filters: ApplicantListFilters
-  onFiltersChange: (partial: Partial<ApplicantListFilters>) => void
+  titleBase?: string
+  columns?: ApplicantColumnOptions
+  initialCardFilters?: Partial<ApplicantCardFilters>
+  hasRecruitment?: boolean
   className?: string
 }
 
@@ -66,22 +103,35 @@ export function ApplicantTableCard({
   visibleRows,
   allStageRows,
   stage,
-  totalCount,
   baseTime,
-  filters,
-  onFiltersChange,
+  titleBase,
+  columns,
+  initialCardFilters,
+  hasRecruitment = true,
   className,
 }: ApplicantTableCardProps) {
+  const [cardFilters, setCardFilters] = useState<ApplicantCardFilters>({
+    ...DEFAULT_APPLICANT_CARD_FILTERS,
+    ...initialCardFilters,
+  })
   const [openDropdown, setOpenDropdown] = useState<"sort" | "order" | null>(
     null,
   )
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
 
-  const isEmpty = visibleRows.length === 0
-  const statusTag = CARD_STATUS_TAG[deriveCardStatus(allStageRows, stage)]
-  const hasExpanded = visibleRows.some((row) =>
-    expandedIds.has(row.applicationId),
+  const rows = useMemo(
+    () => applyCardFilters(visibleRows, cardFilters, stage),
+    [visibleRows, cardFilters, stage],
   )
+
+  const isEmpty = rows.length === 0
+  const statusTag =
+    CARD_STATUS_TAG[deriveCardStatus(allStageRows, stage, hasRecruitment)]
+  const hasExpanded = rows.some((row) => expandedIds.has(row.applicationId))
+
+  const handleCardFiltersChange = (partial: Partial<ApplicantCardFilters>) => {
+    setCardFilters((prev) => ({ ...prev, ...partial }))
+  }
 
   const toggleRow = (applicationId: string) => {
     setExpandedIds((prev) => {
@@ -94,9 +144,9 @@ export function ApplicantTableCard({
 
   const toggleAll = () => {
     setExpandedIds((prev) =>
-      visibleRows.some((row) => prev.has(row.applicationId))
+      rows.some((row) => prev.has(row.applicationId))
         ? new Set<string>()
-        : new Set(visibleRows.map((row) => row.applicationId)),
+        : new Set(rows.map((row) => row.applicationId)),
     )
   }
 
@@ -109,15 +159,16 @@ export function ApplicantTableCard({
     >
       <div className="flex h-10 items-center justify-between">
         <h3 className="text-heading-6-semibold text-teal-gray-700">
-          전체 지원자
+          {deriveCardTitle(titleBase, cardFilters)}
         </h3>
         <div className="flex items-center gap-4">
           <label className="flex cursor-pointer items-center gap-2">
             <Checkbox
-              checked={filters.includeRegular}
-              onChange={(checked) =>
-                onFiltersChange({ includeRegular: checked })
-              }
+              checked={cardFilters.includeRegular}
+              onChange={(checked) => {
+                if (!checked && !cardFilters.includeAdditional) return
+                handleCardFiltersChange({ includeRegular: checked })
+              }}
               variant="primary"
               aria-label="정규 모집 포함"
             />
@@ -127,10 +178,11 @@ export function ApplicantTableCard({
           </label>
           <label className="flex cursor-pointer items-center gap-2">
             <Checkbox
-              checked={filters.includeAdditional}
-              onChange={(checked) =>
-                onFiltersChange({ includeAdditional: checked })
-              }
+              checked={cardFilters.includeAdditional}
+              onChange={(checked) => {
+                if (!checked && !cardFilters.includeRegular) return
+                handleCardFiltersChange({ includeAdditional: checked })
+              }}
               variant="primary"
               aria-label="추가 모집 포함"
             />
@@ -148,14 +200,14 @@ export function ApplicantTableCard({
             }
             onRequestClose={() => setOpenDropdown(null)}
             options={APPLICANT_SORT_OPTIONS}
-            selectedValue={filters.sort}
+            selectedValue={cardFilters.sort}
             selectedLabel={
               APPLICANT_SORT_OPTIONS.find(
-                (option) => option.value === filters.sort,
+                (option) => option.value === cardFilters.sort,
               )?.label
             }
             onSelect={(value) =>
-              onFiltersChange({
+              handleCardFiltersChange({
                 sort: value === "registered" ? "registered" : "latest",
               })
             }
@@ -170,16 +222,18 @@ export function ApplicantTableCard({
             }
             onRequestClose={() => setOpenDropdown(null)}
             options={APPLICANT_ORDER_OPTIONS}
-            selectedValue={filters.order === "" ? undefined : filters.order}
+            selectedValue={
+              cardFilters.order === "" ? undefined : cardFilters.order
+            }
             selectedLabel={
               APPLICANT_ORDER_OPTIONS.find(
-                (option) => option.value === filters.order,
+                (option) => option.value === cardFilters.order,
               )?.label
             }
             onSelect={(value) =>
-              onFiltersChange({
+              handleCardFiltersChange({
                 order:
-                  filters.order === value
+                  cardFilters.order === value
                     ? ""
                     : (APPLICANT_ORDER_OPTIONS.find(
                         (option) => option.value === value,
@@ -195,7 +249,7 @@ export function ApplicantTableCard({
         </span>
         <span className="bg-teal-gray-200 h-3 w-px" aria-hidden="true" />
         <span className="text-body-1-regular text-teal-gray-400">
-          총 {totalCount.toLocaleString()} 명
+          총 {visibleRows.length.toLocaleString()} 명
         </span>
         <Tag tone={statusTag.tone} className="ml-1">
           {statusTag.label}
@@ -205,21 +259,23 @@ export function ApplicantTableCard({
         {isEmpty ? (
           <div className="flex min-h-75 items-center justify-center">
             <p className="text-body-2-regular text-teal-gray-400">
-              현재 지원자가 없습니다.
+              {deriveEmptyMessage(cardFilters, hasRecruitment)}
             </p>
           </div>
         ) : (
           <>
             <ApplicantTableHead
               stage={stage}
+              columns={columns}
               hasExpanded={hasExpanded}
               onToggleAll={toggleAll}
             />
-            {visibleRows.map((row) => (
+            {rows.map((row) => (
               <ApplicantRow
                 key={row.applicationId}
                 row={row}
                 stage={stage}
+                columns={columns}
                 expanded={expandedIds.has(row.applicationId)}
                 onToggle={() => toggleRow(row.applicationId)}
               />

--- a/src/features/recruiting/ui/ApplicantTableCard.tsx
+++ b/src/features/recruiting/ui/ApplicantTableCard.tsx
@@ -249,7 +249,7 @@ export function ApplicantTableCard({
         </span>
         <span className="bg-teal-gray-200 h-3 w-px" aria-hidden="true" />
         <span className="text-body-1-regular text-teal-gray-400">
-          총 {visibleRows.length.toLocaleString()} 명
+          총 {rows.length.toLocaleString()} 명
         </span>
         <Tag tone={statusTag.tone} className="ml-1">
           {statusTag.label}

--- a/src/features/recruiting/ui/ApplicantTableHead.tsx
+++ b/src/features/recruiting/ui/ApplicantTableHead.tsx
@@ -4,34 +4,37 @@ import { ExpandableTableHead } from "@/shared/ui/table/ExpandableTableHead"
 import {
   APPLICANT_COLUMNS,
   type ApplicantColumnKey,
+  type ApplicantColumnOptions,
+  getVisibleApplicantColumns,
 } from "./applicantTableColumns"
 
 import type { EvaluationStage } from "../model/evaluationStage"
 
-function buildHeadLabels(
-  stage: EvaluationStage,
-): { key: ApplicantColumnKey; label: string }[] {
-  const labels: { key: ApplicantColumnKey; label: string }[] = []
-  if (stage !== "final") {
-    labels.push({
-      key: "appliedAt",
-      label: stage === "interview" ? "면접 일시" : "지원 일시",
-    })
+function columnLabel(key: ApplicantColumnKey, stage: EvaluationStage) {
+  if (key === "appliedAt") {
+    return stage === "interview" ? "면접 일시" : "지원 일시"
   }
-  labels.push(
-    { key: "applicant", label: "지원자" },
-    { key: "chapter", label: "지부" },
-    { key: "school", label: "학교" },
-    { key: "type", label: "유형" },
-    { key: "parts", label: "지원 파트" },
-    { key: "progress", label: "평가 상태" },
-    { key: "result", label: stage === "final" ? "최종 결과" : "평가 결과" },
-  )
-  return labels
+  if (key === "result") {
+    return stage === "final" ? "최종 결과" : "평가 결과"
+  }
+  const labels: Record<
+    Exclude<ApplicantColumnKey, "appliedAt" | "result">,
+    string
+  > = {
+    applicant: "지원자",
+    chapter: "지부",
+    school: "학교",
+    type: "유형",
+    parts: "지원 파트",
+    myEvaluation: "내 담당 평가",
+    progress: "평가 상태",
+  }
+  return labels[key]
 }
 
 interface ApplicantTableHeadProps {
   stage: EvaluationStage
+  columns?: ApplicantColumnOptions
   hasExpanded?: boolean
   onToggleAll?: () => void
   className?: string
@@ -39,11 +42,12 @@ interface ApplicantTableHeadProps {
 
 export function ApplicantTableHead({
   stage,
+  columns,
   hasExpanded = false,
   onToggleAll,
   className,
 }: ApplicantTableHeadProps) {
-  const headLabels = buildHeadLabels(stage)
+  const visibleColumns = getVisibleApplicantColumns(stage, columns)
 
   return (
     <ExpandableTableHead
@@ -52,7 +56,7 @@ export function ApplicantTableHead({
       className={cn("gap-2.5", className)}
     >
       <div className="flex min-w-0 flex-1 items-center">
-        {headLabels.map(({ key, label }) => (
+        {visibleColumns.map((key) => (
           <span
             key={key}
             role="columnheader"
@@ -62,7 +66,7 @@ export function ApplicantTableHead({
               key === "parts" && "justify-center",
             )}
           >
-            {label}
+            {columnLabel(key, stage)}
           </span>
         ))}
       </div>

--- a/src/features/recruiting/ui/ApplicantTableHead.tsx
+++ b/src/features/recruiting/ui/ApplicantTableHead.tsx
@@ -35,26 +35,18 @@ function columnLabel(key: ApplicantColumnKey, stage: EvaluationStage) {
 interface ApplicantTableHeadProps {
   stage: EvaluationStage
   columns?: ApplicantColumnOptions
-  hasExpanded?: boolean
-  onToggleAll?: () => void
   className?: string
 }
 
 export function ApplicantTableHead({
   stage,
   columns,
-  hasExpanded = false,
-  onToggleAll,
   className,
 }: ApplicantTableHeadProps) {
   const visibleColumns = getVisibleApplicantColumns(stage, columns)
 
   return (
-    <ExpandableTableHead
-      expanded={hasExpanded}
-      onToggle={onToggleAll}
-      className={cn("gap-2.5", className)}
-    >
+    <ExpandableTableHead className={cn("gap-2.5", className)}>
       <div className="flex min-w-0 flex-1 items-center">
         {visibleColumns.map((key) => (
           <span

--- a/src/features/recruiting/ui/SchoolTabs.tsx
+++ b/src/features/recruiting/ui/SchoolTabs.tsx
@@ -1,0 +1,33 @@
+import { cn } from "@/shared/lib/utils"
+import { SegmentButton } from "@/shared/ui/segment-button/SegmentButton"
+
+interface SchoolTabsProps {
+  schools: readonly string[]
+  value: string
+  onValueChange: (value: string) => void
+  className?: string
+}
+
+export function SchoolTabs({
+  schools,
+  value,
+  onValueChange,
+  className,
+}: SchoolTabsProps) {
+  const items = [
+    { value: "all", label: "전체" },
+    ...schools.map((school) => ({ value: school, label: school })),
+  ]
+
+  return (
+    <SegmentButton
+      items={items}
+      value={value}
+      onValueChange={(next) =>
+        onValueChange(schools.includes(next) ? next : "all")
+      }
+      className={cn("flex w-full", className)}
+      itemClassName="flex-1"
+    />
+  )
+}

--- a/src/features/recruiting/ui/applicantTableColumns.ts
+++ b/src/features/recruiting/ui/applicantTableColumns.ts
@@ -1,3 +1,5 @@
+import type { EvaluationStage } from "../model/evaluationStage"
+
 export const APPLICANT_COLUMNS = {
   appliedAt: "flex min-w-36 flex-1 items-center justify-center px-4",
   applicant: "flex min-w-27.5 flex-1 items-center px-5",
@@ -5,8 +7,30 @@ export const APPLICANT_COLUMNS = {
   school: "flex min-w-30 flex-1 items-center px-4",
   type: "flex min-w-21.5 shrink-0 items-center justify-center px-2.5",
   parts: "flex min-w-50 flex-1 items-center gap-2 px-4",
+  myEvaluation: "flex min-w-27.5 flex-1 items-center justify-center px-4",
   progress: "flex min-w-35 flex-1 items-center gap-2.5 px-4",
   result: "flex min-w-22.5 flex-1 items-center px-4",
 } as const
 
 export type ApplicantColumnKey = keyof typeof APPLICANT_COLUMNS
+
+export interface ApplicantColumnOptions {
+  hideChapter?: boolean
+  hideSchool?: boolean
+  showMyEvaluation?: boolean
+}
+
+export function getVisibleApplicantColumns(
+  stage: EvaluationStage,
+  options: ApplicantColumnOptions = {},
+): ApplicantColumnKey[] {
+  const columns: ApplicantColumnKey[] = []
+  if (stage !== "final") columns.push("appliedAt")
+  columns.push("applicant")
+  if (!options.hideChapter) columns.push("chapter")
+  if (!options.hideSchool) columns.push("school")
+  columns.push("type", "parts")
+  if (options.showMyEvaluation) columns.push("myEvaluation")
+  columns.push("progress", "result")
+  return columns
+}

--- a/src/features/recruiting/ui/applicantTableColumns.ts
+++ b/src/features/recruiting/ui/applicantTableColumns.ts
@@ -1,15 +1,15 @@
 import type { EvaluationStage } from "../model/evaluationStage"
 
 export const APPLICANT_COLUMNS = {
-  appliedAt: "flex min-w-36 flex-1 items-center justify-center px-4",
-  applicant: "flex min-w-27.5 flex-1 items-center px-5",
+  appliedAt: "flex min-w-36 flex-1 items-center justify-center px-6",
+  applicant: "flex min-w-27.5 flex-1 items-center px-6",
   chapter: "flex min-w-30 flex-1 items-center px-4",
   school: "flex min-w-30 flex-1 items-center px-4",
-  type: "flex min-w-21.5 shrink-0 items-center justify-center px-2.5",
+  type: "flex min-w-23.5 shrink-0 items-center justify-center px-4",
   parts: "flex min-w-50 flex-1 items-center gap-2 px-4",
   myEvaluation: "flex min-w-27.5 flex-1 items-center justify-center px-4",
-  progress: "flex min-w-35 flex-1 items-center gap-2.5 px-4",
-  result: "flex min-w-22.5 flex-1 items-center px-4",
+  progress: "flex min-w-31 flex-1 items-center gap-2.5 px-4",
+  result: "flex min-w-22.5 flex-1 items-center px-6",
 } as const
 
 export type ApplicantColumnKey = keyof typeof APPLICANT_COLUMNS

--- a/src/routes/test/recruiting-applicants.tsx
+++ b/src/routes/test/recruiting-applicants.tsx
@@ -4,6 +4,8 @@ import {
   ApplicantListPage,
   EVALUATION_STAGES,
   type EvaluationStage,
+  isRecruitingListRole,
+  type RecruitingListRole,
 } from "@/features/recruiting"
 import Footer from "@/widgets/footer/Footer"
 import Header from "@/widgets/navigation/header/Header"
@@ -13,16 +15,23 @@ function parseStage(value: unknown): EvaluationStage {
   return EVALUATION_STAGES.find((stage) => stage === value) ?? "document"
 }
 
+function parseRole(value: unknown): RecruitingListRole {
+  return isRecruitingListRole(value) ? value : "central"
+}
+
 export const Route = createFileRoute("/test/recruiting-applicants")({
   validateSearch: (search: Record<string, unknown>) => ({
     empty: search.empty === true || search.empty === "true",
+    noRecruitment:
+      search.noRecruitment === true || search.noRecruitment === "true",
     stage: parseStage(search.stage),
+    role: parseRole(search.role),
   }),
   component: RecruitingApplicantsTestPage,
 })
 
 function RecruitingApplicantsTestPage() {
-  const { empty, stage } = Route.useSearch()
+  const { empty, noRecruitment, stage, role } = Route.useSearch()
   const activePathname = `/recruiting/evaluations/${stage}`
 
   return (
@@ -32,7 +41,12 @@ function RecruitingApplicantsTestPage() {
         <RecruitingSideBar activePathname={activePathname} />
         <div className="flex min-w-0 flex-1 flex-col">
           <div className="min-h-200 px-8 pt-10 pb-20">
-            <ApplicantListPage stage={stage} useMockData={!empty} />
+            <ApplicantListPage
+              stage={stage}
+              role={role}
+              useMockData={!empty && !noRecruitment}
+              hasRecruitment={!noRecruitment}
+            />
           </div>
         </div>
       </div>

--- a/src/shared/lib/utils.ts
+++ b/src/shared/lib/utils.ts
@@ -27,6 +27,7 @@ const twMerge = extendTailwindMerge({
         "text-body-2-regular",
         "text-body-3-medium",
         "text-body-3-regular",
+        "text-body-4-regular",
         "text-label-1-semibold",
         "text-label-1-medium",
         "text-label-2-medium",

--- a/src/shared/ui/Message.test.tsx
+++ b/src/shared/ui/Message.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { Message } from "./Message"
+
+describe("Message", () => {
+  it.each([
+    ["error", "text-error-500"],
+    ["success", "text-success-600"],
+    ["default", "text-teal-gray-500"],
+    ["warning", "text-warning-500"],
+  ] as const)("%s 상태에 맞는 색상을 적용한다", (tone, colorClass) => {
+    render(<Message tone={tone}>안내 메시지</Message>)
+
+    const message = screen.getByText("안내 메시지").parentElement
+
+    expect(message).toHaveClass("text-body-2-medium", colorClass)
+    expect(message?.querySelector("svg")).toHaveAttribute("aria-hidden", "true")
+  })
+
+  it("기본 상태는 오류 스타일을 적용한다", () => {
+    render(<Message>오류 메시지</Message>)
+
+    expect(screen.getByText("오류 메시지").parentElement).toHaveClass(
+      "text-error-500",
+    )
+  })
+
+  it("전달한 className을 기본 스타일에 병합한다", () => {
+    render(<Message className="mt-2">안내 메시지</Message>)
+
+    expect(screen.getByText("안내 메시지").parentElement).toHaveClass("mt-2")
+  })
+})

--- a/src/shared/ui/Message.tsx
+++ b/src/shared/ui/Message.tsx
@@ -1,0 +1,51 @@
+import CircleBang from "@/shared/assets/icon/bang/CircleBang"
+import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
+import InfoCircleIcon from "@/shared/assets/icon/infomation/InfoCircleIcon"
+import WarningTriangleIcon from "@/shared/assets/icon/infomation/WarningTriangleIcon"
+import { cn } from "@/shared/lib/utils"
+
+import type { HTMLAttributes, ReactNode } from "react"
+
+const messageToneClasses = {
+  error: "text-error-500",
+  success: "text-success-600",
+  default: "text-teal-gray-500",
+  warning: "text-warning-500",
+} as const
+
+const messageIcons = {
+  error: CircleBang,
+  success: CheckIcon,
+  default: InfoCircleIcon,
+  warning: WarningTriangleIcon,
+} as const
+
+export type MessageTone = keyof typeof messageToneClasses
+
+interface MessageProps extends HTMLAttributes<HTMLSpanElement> {
+  children: ReactNode
+  tone?: MessageTone
+}
+
+export function Message({
+  children,
+  tone = "error",
+  className,
+  ...props
+}: MessageProps) {
+  const Icon = messageIcons[tone]
+
+  return (
+    <span
+      className={cn(
+        "text-body-2-medium inline-flex items-center gap-1",
+        messageToneClasses[tone],
+        className,
+      )}
+      {...props}
+    >
+      <Icon aria-hidden="true" className="size-4 shrink-0" />
+      <span>{children}</span>
+    </span>
+  )
+}

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -131,6 +131,11 @@
   --text-body-3-regular-leading: 1.5;
   --text-body-3-regular-tracking: 0em;
 
+  --text-body-4-regular-size: 1rem;
+  --text-body-4-regular-weight: 400;
+  --text-body-4-regular-leading: 1.6;
+  --text-body-4-regular-tracking: -0.01em;
+
   /* -------------------------
    * Label
    * ------------------------- */
@@ -372,6 +377,13 @@
   font-weight: var(--text-body-3-regular-weight);
   line-height: var(--text-body-3-regular-leading);
   letter-spacing: var(--text-body-3-regular-tracking);
+}
+
+@utility text-body-4-regular {
+  font-size: var(--text-body-4-regular-size);
+  font-weight: var(--text-body-4-regular-weight);
+  line-height: var(--text-body-4-regular-leading);
+  letter-spacing: var(--text-body-4-regular-tracking);
 }
 
 @utility text-label-1-semibold {


### PR DESCRIPTION
## 작업 내용

리크루팅 지원자 목록을 역할과 필터 범위에 따라 단일·지부별·학교별 카드로 제공하도록 확장하고, 최신 시안과 리뷰 피드백을 반영했습니다. 공용 상태 메시지 컴포넌트와 Body 4 타이포그래피 토큰도 추가했습니다.

### 지원자 목록 그룹 뷰 및 역할별 케이스

- 카드 내부에서 정규·추가 모집 선택과 정렬을 독립적으로 관리하도록 페이지 필터와 카드 필터를 분리했습니다.
- 중앙 운영진은 지부 탭, 지부장은 자기 지부와 학교 탭, 교내 운영진은 자기 학교 범위를 사용하도록 역할별 UI·설명·필터를 분기했습니다.
- 지부 선택 시 지부별 카드, 학교별 보기와 지부 탭 선택 시 학교별 카드를 렌더링하며, 각 보기에서 불필요한 지부·학교 컬럼을 숨깁니다.
- 교내 운영진의 내 담당 지원자 토글과 내 담당 평가 컬럼을 추가했습니다.
- 모집 전·지원 전 등 빈 상태에서도 역할별 지부·학교 구조와 상태 범위를 유지합니다.
- 테스트 라우트에서 `role`과 `noRecruitment` 파라미터로 역할별·모집 전 상태를 확인할 수 있습니다.

### 최신 시안 및 리뷰 반영

- 카드 총원과 상태 태그를 카드의 정규·추가 모집 필터 결과에 맞춰 표시합니다.
- 설정에 없는 학교도 실제 지원자 데이터에서 추출해 학교 그룹에 포함합니다.
- 대기 상태를 최신 시안에 맞춰 결과 배지·필터·필터 로직에서 제거했습니다.
- 확장 콘텐츠가 없는 행의 세브론과 헤더 전체 확장 토글을 제거하고, 테이블 셀 너비를 최신 헤더 시안에 맞췄습니다.

### 공용 컴포넌트 및 디자인 토큰

- 오류·성공·기본·경고 상태를 지원하는 `Message` 공용 컴포넌트를 추가했습니다.
- 16px, Regular 400, line-height 160%, letter-spacing -1% 사양의 `text-body-4-regular` 타이포그래피 유틸리티를 추가했습니다.

## 검증

- `pnpm build`
- `pnpm exec vitest run src/features/recruiting/model/applicantListTypes.test.ts`
- `pnpm exec vitest run src/shared/ui/Message.test.tsx`
- ESLint 및 Prettier 훅 통과

## 연결된 이슈

- Closes #601

## 참고 디자인

- [지부별 그룹](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/UMC-Web?node-id=10132-215262)
- [학교별 그룹](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/UMC-Web?node-id=10161-241762)
- [지부 선택](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/UMC-Web?node-id=10132-218420)
- [지부장 뷰](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/UMC-Web?node-id=10170-251852)
- [내 담당 평가](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/UMC-Web?node-id=10202-154798)
- [상태 메시지](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/%F0%9F%8D%92-UMC-Web?node-id=3427-119235)
- [Body 4 타이포그래피](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/%F0%9F%8D%92-UMC-Web?node-id=10541-228844)
