### PR TITLE
✨ feat: 리크루팅 서류 평가 상세 페이지 구현

### DIFF
--- a/src/features/recruiting/index.ts
+++ b/src/features/recruiting/index.ts
@@ -9,3 +9,4 @@ export {
   type RecruitingListRole,
 } from "./model/recruitingListRole"
 export { ApplicantListPage } from "./ui/ApplicantListPage"
+export { ApplicationEvaluationDetailPage } from "./ui/detail/ApplicationEvaluationDetailPage"

--- a/src/features/recruiting/model/applicationDetail.mock.ts
+++ b/src/features/recruiting/model/applicationDetail.mock.ts
@@ -1,254 +1,265 @@
+import {
+  APPLICANT_LIST_MOCK,
+  RECRUITING_TARGET_GISU_LABEL_MOCK,
+} from "./applicantList.mock"
+import {
+  type ApplicantRow,
+  formatRecruitmentType,
+  getStageEvaluation,
+} from "./applicantListTypes"
+
+import type { PartTag } from "@/shared/model/domain"
+
 import type {
   ApplicationDetail,
   ApplicationSection,
   OperatorEvaluation,
+  StageEvaluationDetail,
 } from "./applicationDetail"
+import type { EvaluationStage } from "./evaluationStage"
 
-const BASIC_SECTION: ApplicationSection = {
-  sectionId: "sec-basic",
-  type: "common",
-  title: "기본 문항",
-  questions: [
-    {
-      questionId: "q-basic-1",
-      type: "radio",
-      title: "신규 지원자이신가요?",
-      required: true,
-      options: [
-        { optionId: "opt-basic-1-1", content: "네, 신규 지원입니다" },
-        { optionId: "opt-basic-1-2", content: "아니요, 기존 챌린저입니다" },
-      ],
-      textValue: null,
-      selectedOptionIds: ["opt-basic-1-2"],
-      files: [],
-    },
-    {
-      questionId: "q-basic-2",
-      type: "shortText",
-      title: "지원자님의 성함을 알려주세요.",
-      required: true,
-      options: [],
-      textValue: "이예원",
-      selectedOptionIds: [],
-      files: [],
-    },
-    {
-      questionId: "q-basic-3",
-      type: "radio",
-      title: "1지망 지원 파트를 알려주세요.",
-      required: true,
-      options: [
-        { optionId: "opt-basic-3-1", content: "PM" },
-        { optionId: "opt-basic-3-2", content: "Design" },
-        { optionId: "opt-basic-3-3", content: "Web Product Engineering" },
-        { optionId: "opt-basic-3-4", content: "Mobile Product Engineering" },
-      ],
-      textValue: null,
-      selectedOptionIds: ["opt-basic-3-2"],
-      files: [],
-    },
-    {
-      questionId: "q-basic-4",
-      type: "radio",
-      title: "2지망 지원 파트를 알려주세요.",
-      required: true,
-      options: [
-        { optionId: "opt-basic-4-1", content: "PM" },
-        { optionId: "opt-basic-4-2", content: "Design" },
-        { optionId: "opt-basic-4-3", content: "Web Product Engineering" },
-        { optionId: "opt-basic-4-4", content: "Mobile Product Engineering" },
-      ],
-      textValue: null,
-      selectedOptionIds: ["opt-basic-4-3"],
-      files: [],
-    },
-    {
-      questionId: "q-basic-5",
-      type: "shortText",
-      title: "이메일 주소를 입력해 주세요.",
-      description:
-        "모든 전형 안내는 입력하신 메일 주소로 발송되오니, 정확한 주소를 기재해 주시기 바랍니다.",
-      required: true,
-      options: [],
-      textValue: "2eeyone@hanyang.ac.kr",
-      selectedOptionIds: [],
-      files: [],
-    },
-  ],
+const RECRUITING_PARTS: PartTag[] = ["pm", "design", "web-pe", "mobile-pe"]
+
+const PART_LABEL: Partial<Record<PartTag, string>> = {
+  pm: "PM",
+  design: "Design",
+  "web-pe": "Web Product Engineering",
+  "mobile-pe": "Mobile Product Engineering",
 }
 
-const DESIGN_SECTION: ApplicationSection = {
-  sectionId: "sec-design",
-  type: "part",
-  title: "Design",
-  questions: [
-    {
-      questionId: "q-design-1",
-      type: "checkbox",
-      title: "사용 가능한 기술 스택을 선택하세요.",
-      required: true,
-      options: [
-        { optionId: "opt-design-1-1", content: "Figma" },
-        { optionId: "opt-design-1-2", content: "Illustration" },
-      ],
-      textValue: null,
-      selectedOptionIds: ["opt-design-1-1"],
-      files: [],
-    },
-    {
-      questionId: "q-design-2",
-      type: "portfolio",
-      title: "포트폴리오를 링크 혹은 PDF 파일의 형태로 제출하세요.",
-      required: true,
-      options: [],
-      textValue: null,
-      selectedOptionIds: [],
-      files: [
-        {
-          fileId: "file-design-1",
-          name: "2026_UXUI 포트폴리오_이방토",
-          url: "https://example.com/portfolio-uxui.pdf",
-        },
-      ],
-    },
-    {
-      questionId: "q-design-3",
-      type: "shortText",
-      title: "지원자님의 성함을 알려주세요.",
-      required: true,
-      options: [],
-      textValue: "이예원",
-      selectedOptionIds: [],
-      files: [],
-    },
-  ],
+const PART_STACK: Partial<Record<PartTag, string[]>> = {
+  pm: ["Notion", "Slack"],
+  design: ["Figma", "Illustration"],
+  "web-pe": ["Figma", "Github"],
+  "mobile-pe": ["Swift", "Kotlin"],
 }
 
-const WEB_SECTION: ApplicationSection = {
-  sectionId: "sec-web",
-  type: "part",
-  title: "Web Product Engineering",
-  questions: [
-    {
-      questionId: "q-web-1",
-      type: "checkbox",
-      title: "사용 가능한 기술 스택을 선택하세요.",
-      required: true,
-      options: [
-        { optionId: "opt-web-1-1", content: "Figma" },
-        { optionId: "opt-web-1-2", content: "Github" },
-      ],
-      textValue: null,
-      selectedOptionIds: ["opt-web-1-2"],
-      files: [],
-    },
-    {
-      questionId: "q-web-2",
-      type: "portfolio",
-      title: "포트폴리오를 링크 혹은 PDF 파일의 형태로 제출하세요.",
-      required: true,
-      options: [],
-      textValue: null,
-      selectedOptionIds: [],
-      files: [
-        {
-          fileId: "file-web-1",
-          name: "2026_Web 포트폴리오_이방토",
-          url: "https://example.com/portfolio-web.pdf",
-        },
-      ],
-    },
-    {
-      questionId: "q-web-3",
-      type: "shortText",
-      title: "지원자님의 성함을 알려주세요.",
-      required: true,
-      options: [],
-      textValue: "이예원",
-      selectedOptionIds: [],
-      files: [],
-    },
-    {
-      questionId: "q-web-4",
-      type: "shortText",
-      title: "지원자님의 성함을 알려주세요.",
-      required: true,
-      options: [],
-      textValue: "이예원",
-      selectedOptionIds: [],
-      files: [],
-    },
-  ],
+function partLabel(part: PartTag) {
+  return PART_LABEL[part] ?? part
 }
 
-const DOCUMENT_OPERATORS: OperatorEvaluation[] = [
-  {
-    evaluatorId: "op-bella",
-    evaluatorName: "벨라/황지원",
-    stage: "document",
-    progress: "done",
-    result: "pass",
-    comment:
-      "포트폴리오의 내용이 탄탄하고 좋다. 특히 UX적으로 역량있는 디자이너인듯하다. 걸리는 것은 4학년 이라는 점이다.",
-  },
-  {
-    evaluatorId: "op-park",
-    evaluatorName: "박방토/박예원",
-    stage: "document",
-    progress: "done",
-    result: "fail",
-    comment: null,
-  },
-  {
-    evaluatorId: "op-me",
-    evaluatorName: "이방토/이예원",
-    stage: "document",
-    progress: "before",
-    result: null,
-    comment: null,
-  },
-  {
-    evaluatorId: "op-4",
-    evaluatorName: "제옹/정의찬",
-    stage: "document",
-    progress: "before",
-    result: null,
-    comment: null,
-  },
-  {
-    evaluatorId: "op-5",
-    evaluatorName: "삼이/이희원",
-    stage: "document",
-    progress: "before",
-    result: null,
-    comment: null,
-  },
+function partOptionId(part: PartTag) {
+  return `opt-part-${part}`
+}
+
+function partStack(part: PartTag) {
+  return PART_STACK[part] ?? []
+}
+
+const PART_OPTIONS = RECRUITING_PARTS.map((part) => ({
+  optionId: partOptionId(part),
+  content: partLabel(part),
+}))
+
+function buildBasicSection(row: ApplicantRow): ApplicationSection {
+  const firstPart = row.parts[0]
+  const secondPart = row.parts[1]
+  return {
+    sectionId: "sec-basic",
+    type: "common",
+    title: "기본 문항",
+    questions: [
+      {
+        questionId: "q-basic-1",
+        type: "radio",
+        title: "신규 지원자이신가요?",
+        required: true,
+        options: [
+          { optionId: "opt-basic-1-1", content: "네, 신규 지원입니다" },
+          { optionId: "opt-basic-1-2", content: "아니요, 기존 챌린저입니다" },
+        ],
+        textValue: null,
+        selectedOptionIds: ["opt-basic-1-2"],
+        files: [],
+      },
+      {
+        questionId: "q-basic-2",
+        type: "shortText",
+        title: "지원자님의 성함을 알려주세요.",
+        required: true,
+        options: [],
+        textValue: row.applicantName,
+        selectedOptionIds: [],
+        files: [],
+      },
+      {
+        questionId: "q-basic-3",
+        type: "radio",
+        title: "1지망 지원 파트를 알려주세요.",
+        required: true,
+        options: PART_OPTIONS,
+        textValue: null,
+        selectedOptionIds: firstPart ? [partOptionId(firstPart)] : [],
+        files: [],
+      },
+      {
+        questionId: "q-basic-4",
+        type: "radio",
+        title: "2지망 지원 파트를 알려주세요.",
+        required: true,
+        options: PART_OPTIONS,
+        textValue: null,
+        selectedOptionIds: secondPart ? [partOptionId(secondPart)] : [],
+        files: [],
+      },
+      {
+        questionId: "q-basic-5",
+        type: "shortText",
+        title: "이메일 주소를 입력해 주세요.",
+        description:
+          "모든 전형 안내는 입력하신 메일 주소로 발송되오니, 정확한 주소를 기재해 주시기 바랍니다.",
+        required: true,
+        options: [],
+        textValue: `umc.${row.applicationId}@example.com`,
+        selectedOptionIds: [],
+        files: [],
+      },
+    ],
+  }
+}
+
+function buildPartSection(
+  row: ApplicantRow,
+  part: PartTag,
+): ApplicationSection {
+  return {
+    sectionId: `sec-part-${part}`,
+    type: "part",
+    title: partLabel(part),
+    questions: [
+      {
+        questionId: `q-${part}-1`,
+        type: "checkbox",
+        title: "사용 가능한 기술 스택을 선택하세요.",
+        required: true,
+        options: partStack(part).map((content, index) => ({
+          optionId: `opt-${part}-${index}`,
+          content,
+        })),
+        textValue: null,
+        selectedOptionIds: [`opt-${part}-0`],
+        files: [],
+      },
+      {
+        questionId: `q-${part}-2`,
+        type: "portfolio",
+        title: "포트폴리오를 링크 혹은 PDF 파일의 형태로 제출하세요.",
+        required: true,
+        options: [],
+        textValue: null,
+        selectedOptionIds: [],
+        files: [
+          {
+            fileId: `file-${part}`,
+            name: `2026_${partLabel(part)} 포트폴리오_${row.applicantName}`,
+            url: "https://example.com/portfolio.pdf",
+          },
+        ],
+      },
+      {
+        questionId: `q-${part}-3`,
+        type: "shortText",
+        title: "지원 동기를 알려주세요.",
+        required: true,
+        options: [],
+        textValue: `${partLabel(part)} 파트로 성장하고 싶어 지원했습니다.`,
+        selectedOptionIds: [],
+        files: [],
+      },
+    ],
+  }
+}
+
+const OPERATOR_NAME_POOL = [
+  "벨라/황지원",
+  "박방토/박예원",
+  "제옹/정의찬",
+  "삼이/이희원",
+  "시안/우자영",
+  "원/김동민",
 ]
 
-export const RECRUITING_APPLICATION_DETAIL_MOCK: ApplicationDetail = {
-  applicationId: "app-101",
-  applicantName: "이예원",
-  chapter: "Chromium",
-  school: "한양대 ERICA",
-  recruitmentLabel: "한양대 ERICA UMC 11기 2차 정규 모집",
-  parts: ["design", "web-pe"],
-  reachedStages: ["document", "interview"],
-  finalResult: null,
-  sections: [BASIC_SECTION, DESIGN_SECTION, WEB_SECTION],
-  evaluations: {
-    document: {
-      stage: "document",
-      myEvaluatorId: "op-me",
-      locked: false,
-      operators: DOCUMENT_OPERATORS,
+const OPERATOR_COMMENT =
+  "포트폴리오의 방향성과 경험이 인상적입니다. 다음 전형에서 더 확인하면 좋겠습니다."
+
+function buildStageDetail(
+  row: ApplicantRow,
+  stage: EvaluationStage,
+): StageEvaluationDetail | null {
+  const stageEvaluation = getStageEvaluation(row, stage)
+  if (!stageEvaluation) return null
+
+  const myDone = stageEvaluation.myProgress === "done"
+  const othersDone = Math.max(
+    0,
+    myDone ? stageEvaluation.doneCount - 1 : stageEvaluation.doneCount,
+  )
+
+  const me: OperatorEvaluation = {
+    evaluatorId: "op-me",
+    evaluatorName: "이방토/이예원",
+    stage,
+    progress: stageEvaluation.myProgress,
+    result: myDone ? stageEvaluation.result : null,
+    comment: myDone ? "" : null,
+  }
+
+  const others: OperatorEvaluation[] = Array.from(
+    { length: Math.max(0, stageEvaluation.totalCount - 1) },
+    (_, index): OperatorEvaluation => {
+      const done = index < othersDone
+      return {
+        evaluatorId: `op-${stage}-${index + 1}`,
+        evaluatorName:
+          OPERATOR_NAME_POOL[index % OPERATOR_NAME_POOL.length] ?? "운영진",
+        stage,
+        progress: done ? "done" : "before",
+        result: done ? (stageEvaluation.result ?? "pass") : null,
+        comment: done && index === 0 ? OPERATOR_COMMENT : null,
+      }
     },
-    interview: null,
-    final: null,
-  },
+  )
+
+  return {
+    stage,
+    myEvaluatorId: "op-me",
+    locked: false,
+    operators: [me, ...others],
+  }
+}
+
+const STAGES: EvaluationStage[] = ["document", "interview", "final"]
+
+function buildDetailFromRow(row: ApplicantRow): ApplicationDetail {
+  return {
+    applicationId: row.applicationId,
+    applicantName: row.applicantName,
+    chapter: row.chapter,
+    school: row.school,
+    recruitmentLabel: `${row.school} ${RECRUITING_TARGET_GISU_LABEL_MOCK} ${formatRecruitmentType(row)} 모집`,
+    parts: row.parts,
+    reachedStages: STAGES.filter((stage) => getStageEvaluation(row, stage)),
+    finalResult: getStageEvaluation(row, "final")?.result ?? null,
+    sections: [
+      buildBasicSection(row),
+      ...row.parts.map((part) => buildPartSection(row, part)),
+    ],
+    evaluations: {
+      document: buildStageDetail(row, "document"),
+      interview: buildStageDetail(row, "interview"),
+      final: buildStageDetail(row, "final"),
+    },
+  }
 }
 
 export function getApplicationDetailMock(
   applicationId: string,
 ): ApplicationDetail {
-  return { ...RECRUITING_APPLICATION_DETAIL_MOCK, applicationId }
+  const row =
+    APPLICANT_LIST_MOCK.find((item) => item.applicationId === applicationId) ??
+    APPLICANT_LIST_MOCK[0]
+  if (!row) {
+    throw new Error("APPLICANT_LIST_MOCK must not be empty")
+  }
+  return buildDetailFromRow({ ...row, applicationId })
 }

--- a/src/features/recruiting/model/applicationDetail.mock.ts
+++ b/src/features/recruiting/model/applicationDetail.mock.ts
@@ -1,0 +1,254 @@
+import type {
+  ApplicationDetail,
+  ApplicationSection,
+  OperatorEvaluation,
+} from "./applicationDetail"
+
+const BASIC_SECTION: ApplicationSection = {
+  sectionId: "sec-basic",
+  type: "common",
+  title: "기본 문항",
+  questions: [
+    {
+      questionId: "q-basic-1",
+      type: "radio",
+      title: "신규 지원자이신가요?",
+      required: true,
+      options: [
+        { optionId: "opt-basic-1-1", content: "네, 신규 지원입니다" },
+        { optionId: "opt-basic-1-2", content: "아니요, 기존 챌린저입니다" },
+      ],
+      textValue: null,
+      selectedOptionIds: ["opt-basic-1-2"],
+      files: [],
+    },
+    {
+      questionId: "q-basic-2",
+      type: "shortText",
+      title: "지원자님의 성함을 알려주세요.",
+      required: true,
+      options: [],
+      textValue: "이예원",
+      selectedOptionIds: [],
+      files: [],
+    },
+    {
+      questionId: "q-basic-3",
+      type: "radio",
+      title: "1지망 지원 파트를 알려주세요.",
+      required: true,
+      options: [
+        { optionId: "opt-basic-3-1", content: "PM" },
+        { optionId: "opt-basic-3-2", content: "Design" },
+        { optionId: "opt-basic-3-3", content: "Web Product Engineering" },
+        { optionId: "opt-basic-3-4", content: "Mobile Product Engineering" },
+      ],
+      textValue: null,
+      selectedOptionIds: ["opt-basic-3-2"],
+      files: [],
+    },
+    {
+      questionId: "q-basic-4",
+      type: "radio",
+      title: "2지망 지원 파트를 알려주세요.",
+      required: true,
+      options: [
+        { optionId: "opt-basic-4-1", content: "PM" },
+        { optionId: "opt-basic-4-2", content: "Design" },
+        { optionId: "opt-basic-4-3", content: "Web Product Engineering" },
+        { optionId: "opt-basic-4-4", content: "Mobile Product Engineering" },
+      ],
+      textValue: null,
+      selectedOptionIds: ["opt-basic-4-3"],
+      files: [],
+    },
+    {
+      questionId: "q-basic-5",
+      type: "shortText",
+      title: "이메일 주소를 입력해 주세요.",
+      description:
+        "모든 전형 안내는 입력하신 메일 주소로 발송되오니, 정확한 주소를 기재해 주시기 바랍니다.",
+      required: true,
+      options: [],
+      textValue: "2eeyone@hanyang.ac.kr",
+      selectedOptionIds: [],
+      files: [],
+    },
+  ],
+}
+
+const DESIGN_SECTION: ApplicationSection = {
+  sectionId: "sec-design",
+  type: "part",
+  title: "Design",
+  questions: [
+    {
+      questionId: "q-design-1",
+      type: "checkbox",
+      title: "사용 가능한 기술 스택을 선택하세요.",
+      required: true,
+      options: [
+        { optionId: "opt-design-1-1", content: "Figma" },
+        { optionId: "opt-design-1-2", content: "Illustration" },
+      ],
+      textValue: null,
+      selectedOptionIds: ["opt-design-1-1"],
+      files: [],
+    },
+    {
+      questionId: "q-design-2",
+      type: "portfolio",
+      title: "포트폴리오를 링크 혹은 PDF 파일의 형태로 제출하세요.",
+      required: true,
+      options: [],
+      textValue: null,
+      selectedOptionIds: [],
+      files: [
+        {
+          fileId: "file-design-1",
+          name: "2026_UXUI 포트폴리오_이방토",
+          url: "https://example.com/portfolio-uxui.pdf",
+        },
+      ],
+    },
+    {
+      questionId: "q-design-3",
+      type: "shortText",
+      title: "지원자님의 성함을 알려주세요.",
+      required: true,
+      options: [],
+      textValue: "이예원",
+      selectedOptionIds: [],
+      files: [],
+    },
+  ],
+}
+
+const WEB_SECTION: ApplicationSection = {
+  sectionId: "sec-web",
+  type: "part",
+  title: "Web Product Engineering",
+  questions: [
+    {
+      questionId: "q-web-1",
+      type: "checkbox",
+      title: "사용 가능한 기술 스택을 선택하세요.",
+      required: true,
+      options: [
+        { optionId: "opt-web-1-1", content: "Figma" },
+        { optionId: "opt-web-1-2", content: "Github" },
+      ],
+      textValue: null,
+      selectedOptionIds: ["opt-web-1-2"],
+      files: [],
+    },
+    {
+      questionId: "q-web-2",
+      type: "portfolio",
+      title: "포트폴리오를 링크 혹은 PDF 파일의 형태로 제출하세요.",
+      required: true,
+      options: [],
+      textValue: null,
+      selectedOptionIds: [],
+      files: [
+        {
+          fileId: "file-web-1",
+          name: "2026_Web 포트폴리오_이방토",
+          url: "https://example.com/portfolio-web.pdf",
+        },
+      ],
+    },
+    {
+      questionId: "q-web-3",
+      type: "shortText",
+      title: "지원자님의 성함을 알려주세요.",
+      required: true,
+      options: [],
+      textValue: "이예원",
+      selectedOptionIds: [],
+      files: [],
+    },
+    {
+      questionId: "q-web-4",
+      type: "shortText",
+      title: "지원자님의 성함을 알려주세요.",
+      required: true,
+      options: [],
+      textValue: "이예원",
+      selectedOptionIds: [],
+      files: [],
+    },
+  ],
+}
+
+const DOCUMENT_OPERATORS: OperatorEvaluation[] = [
+  {
+    evaluatorId: "op-bella",
+    evaluatorName: "벨라/황지원",
+    stage: "document",
+    progress: "done",
+    result: "pass",
+    comment:
+      "포트폴리오의 내용이 탄탄하고 좋다. 특히 UX적으로 역량있는 디자이너인듯하다. 걸리는 것은 4학년 이라는 점이다.",
+  },
+  {
+    evaluatorId: "op-park",
+    evaluatorName: "박방토/박예원",
+    stage: "document",
+    progress: "done",
+    result: "fail",
+    comment: null,
+  },
+  {
+    evaluatorId: "op-me",
+    evaluatorName: "이방토/이예원",
+    stage: "document",
+    progress: "before",
+    result: null,
+    comment: null,
+  },
+  {
+    evaluatorId: "op-4",
+    evaluatorName: "제옹/정의찬",
+    stage: "document",
+    progress: "before",
+    result: null,
+    comment: null,
+  },
+  {
+    evaluatorId: "op-5",
+    evaluatorName: "삼이/이희원",
+    stage: "document",
+    progress: "before",
+    result: null,
+    comment: null,
+  },
+]
+
+export const RECRUITING_APPLICATION_DETAIL_MOCK: ApplicationDetail = {
+  applicationId: "app-101",
+  applicantName: "이예원",
+  chapter: "Chromium",
+  school: "한양대 ERICA",
+  recruitmentLabel: "한양대 ERICA UMC 11기 2차 정규 모집",
+  parts: ["design", "web-pe"],
+  reachedStages: ["document", "interview"],
+  finalResult: null,
+  sections: [BASIC_SECTION, DESIGN_SECTION, WEB_SECTION],
+  evaluations: {
+    document: {
+      stage: "document",
+      myEvaluatorId: "op-me",
+      locked: false,
+      operators: DOCUMENT_OPERATORS,
+    },
+    interview: null,
+    final: null,
+  },
+}
+
+export function getApplicationDetailMock(
+  applicationId: string,
+): ApplicationDetail {
+  return { ...RECRUITING_APPLICATION_DETAIL_MOCK, applicationId }
+}

--- a/src/features/recruiting/model/applicationDetail.ts
+++ b/src/features/recruiting/model/applicationDetail.ts
@@ -1,0 +1,95 @@
+import type { Chapter } from "@/entities/organization/model/chapters"
+import type { PartTag } from "@/shared/model/domain"
+
+import type { EvaluationProgress, EvaluationResult } from "./applicantListTypes"
+import type { EvaluationStage } from "./evaluationStage"
+
+export type ApplicationQuestionType =
+  | "shortText"
+  | "longText"
+  | "radio"
+  | "checkbox"
+  | "dropdown"
+  | "file"
+  | "portfolio"
+
+export interface ApplicationQuestionOption {
+  optionId: string
+  content: string
+}
+
+export interface ApplicationQuestionFile {
+  fileId: string
+  name: string
+  url: string
+}
+
+export interface ApplicationQuestion {
+  questionId: string
+  type: ApplicationQuestionType
+  title: string
+  description?: string
+  required: boolean
+  options: ApplicationQuestionOption[]
+  textValue: string | null
+  selectedOptionIds: string[]
+  files: ApplicationQuestionFile[]
+}
+
+export interface ApplicationSection {
+  sectionId: string
+  type: "common" | "part"
+  title: string
+  questions: ApplicationQuestion[]
+}
+
+export interface OperatorEvaluation {
+  evaluatorId: string
+  evaluatorName: string
+  stage: EvaluationStage
+  progress: EvaluationProgress
+  result: EvaluationResult | null
+  comment: string | null
+}
+
+export interface StageEvaluationDetail {
+  stage: EvaluationStage
+  myEvaluatorId: string
+  locked: boolean
+  lockReason?: string
+  operators: OperatorEvaluation[]
+}
+
+export interface ApplicationDetail {
+  applicationId: string
+  applicantName: string
+  chapter: Chapter
+  school: string
+  recruitmentLabel: string
+  parts: PartTag[]
+  reachedStages: EvaluationStage[]
+  finalResult: EvaluationResult | null
+  sections: ApplicationSection[]
+  evaluations: Record<EvaluationStage, StageEvaluationDetail | null>
+}
+
+export function getStageEvaluationDetail(
+  detail: ApplicationDetail,
+  stage: EvaluationStage,
+) {
+  return detail.evaluations[stage]
+}
+
+export function getMyEvaluation(evaluation: StageEvaluationDetail) {
+  return evaluation.operators.find(
+    (operator) => operator.evaluatorId === evaluation.myEvaluatorId,
+  )
+}
+
+export function countOperatorProgress(operators: OperatorEvaluation[]) {
+  const total = operators.length
+  const done = operators.filter(
+    (operator) => operator.progress === "done",
+  ).length
+  return { done, total }
+}

--- a/src/features/recruiting/ui/ApplicantRow.test.tsx
+++ b/src/features/recruiting/ui/ApplicantRow.test.tsx
@@ -1,9 +1,13 @@
 import { render, screen } from "@testing-library/react"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { ApplicantRow } from "./ApplicantRow"
 
 import type { ApplicantRow as ApplicantRowModel } from "../model/applicantListTypes"
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => vi.fn(),
+}))
 
 function createApplicantRow(): ApplicantRowModel {
   return {

--- a/src/features/recruiting/ui/ApplicantRow.tsx
+++ b/src/features/recruiting/ui/ApplicantRow.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from "@tanstack/react-router"
+
 import { cn } from "@/shared/lib/utils"
 import { PartTagChip } from "@/shared/ui/chip/PartTagChip"
 import { StatusChipTag } from "@/shared/ui/chip/StatusChipTag"
@@ -32,17 +34,43 @@ interface ApplicantRowProps {
 }
 
 export function ApplicantRow({ row, stage, columns }: ApplicantRowProps) {
+  const navigate = useNavigate()
   const evaluation = getStageEvaluation(row, stage)
   if (!evaluation) return null
 
   const visibleColumns = new Set(getVisibleApplicantColumns(stage, columns))
   const timeAt = stage === "interview" ? row.interviewAt : row.appliedAt
   const timestamp = timeAt ? formatAppliedAtParts(timeAt) : null
+  const navigable = stage === "document"
+
+  const openDetail = () => {
+    if (!navigable) return
+    navigate({
+      to: "/recruiting/evaluations/document/$applicationId",
+      params: { applicationId: row.applicationId },
+    })
+  }
 
   return (
     <div
       role="row"
-      className="border-teal-gray-150/60 hover:bg-teal-gray-50 flex h-17 items-center border-b bg-white pr-5.5 pl-2.5 transition-colors"
+      tabIndex={navigable ? 0 : undefined}
+      onClick={navigable ? openDetail : undefined}
+      onKeyDown={
+        navigable
+          ? (event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault()
+                openDetail()
+              }
+            }
+          : undefined
+      }
+      className={cn(
+        "border-teal-gray-150/60 hover:bg-teal-gray-50 flex h-17 items-center border-b bg-white pr-5.5 pl-2.5 transition-colors",
+        navigable &&
+          "focus-visible:bg-teal-gray-50 cursor-pointer outline-none",
+      )}
     >
       <div className="flex min-w-0 flex-1 items-center">
         {visibleColumns.has("appliedAt") &&

--- a/src/features/recruiting/ui/detail/ApplicationEvaluationDetailPage.tsx
+++ b/src/features/recruiting/ui/detail/ApplicationEvaluationDetailPage.tsx
@@ -1,0 +1,120 @@
+import { Link } from "@tanstack/react-router"
+import { useState } from "react"
+
+import LeftChevronIcon from "@/shared/assets/icon/chevron/LeftChevronIcon"
+import { Breadcrumb } from "@/shared/ui/breadcrumb/Breadcrumb"
+
+import { getApplicationDetailMock } from "../../model/applicationDetail.mock"
+import {
+  EVALUATION_STAGE_LABEL,
+  EVALUATION_STAGE_SHORT_LABEL,
+  type EvaluationStage,
+} from "../../model/evaluationStage"
+import { ApplicationFormReadonly } from "./ApplicationFormReadonly"
+import { EvaluationStepper } from "./EvaluationStepper"
+import { MyStageEvaluationPanel } from "./MyStageEvaluationPanel"
+import { OperatorEvaluationList } from "./OperatorEvaluationList"
+
+import type { EvaluationResult } from "../../model/applicantListTypes"
+
+const STAGE_LIST_PATH: Record<EvaluationStage, string> = {
+  document: "/recruiting/evaluations/document",
+  interview: "/recruiting/evaluations/interview",
+  final: "/recruiting/evaluations/final",
+}
+
+interface ApplicationEvaluationDetailPageProps {
+  stage: EvaluationStage
+  applicationId: string
+}
+
+export function ApplicationEvaluationDetailPage({
+  stage,
+  applicationId,
+}: ApplicationEvaluationDetailPageProps) {
+  const [detail, setDetail] = useState(() =>
+    getApplicationDetailMock(applicationId),
+  )
+  const evaluation = detail.evaluations[stage]
+  const listPath = STAGE_LIST_PATH[stage]
+
+  const handleComplete = (result: EvaluationResult, comment: string) => {
+    setDetail((prev) => {
+      const current = prev.evaluations[stage]
+      if (!current) return prev
+      return {
+        ...prev,
+        evaluations: {
+          ...prev.evaluations,
+          [stage]: {
+            ...current,
+            operators: current.operators.map((operator) =>
+              operator.evaluatorId === current.myEvaluatorId
+                ? { ...operator, progress: "done", result, comment }
+                : operator,
+            ),
+          },
+        },
+      }
+    })
+  }
+
+  return (
+    <div className="flex w-full max-w-286.5 flex-col gap-8">
+      <div className="flex flex-col gap-5 pl-3">
+        <Breadcrumb
+          items={[
+            { id: "recruiting", label: "리크루팅" },
+            { id: "evaluation-management", label: "평가 관리" },
+            { id: stage, label: EVALUATION_STAGE_LABEL[stage], to: listPath },
+            {
+              id: "detail",
+              label: `지원서 ${EVALUATION_STAGE_SHORT_LABEL[stage]} 평가`,
+            },
+          ]}
+        />
+        <Link
+          to={listPath}
+          className="text-body-2-medium text-teal-gray-500 hover:text-teal-gray-700 flex w-fit items-center gap-1"
+        >
+          <LeftChevronIcon width={16} height={16} />
+          지원자 목록으로
+        </Link>
+        <div className="flex flex-col gap-1">
+          <span className="text-body-2-semibold text-teal-600">
+            {detail.chapter}
+          </span>
+          <h1 className="text-heading-4-semibold text-teal-gray-900">
+            {detail.applicantName} 지원서
+          </h1>
+          <span className="text-body-2-regular text-teal-gray-500">
+            {detail.recruitmentLabel}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex gap-6">
+        <div className="min-w-0 flex-1">
+          <ApplicationFormReadonly sections={detail.sections} />
+        </div>
+        <div className="flex w-115 shrink-0 flex-col gap-5">
+          <EvaluationStepper
+            applicationId={applicationId}
+            stage={stage}
+            reachedStages={detail.reachedStages}
+          />
+          {evaluation && (
+            <>
+              <MyStageEvaluationPanel
+                evaluation={evaluation}
+                stage={stage}
+                onComplete={handleComplete}
+              />
+              <OperatorEvaluationList evaluation={evaluation} />
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/recruiting/ui/detail/ApplicationFormReadonly.tsx
+++ b/src/features/recruiting/ui/detail/ApplicationFormReadonly.tsx
@@ -1,0 +1,47 @@
+import { cn } from "@/shared/lib/utils"
+
+import { ReadonlyAnswerField } from "./ReadonlyAnswerField"
+
+import type { ApplicationSection } from "../../model/applicationDetail"
+
+interface ApplicationFormReadonlyProps {
+  sections: ApplicationSection[]
+  className?: string
+}
+
+function padIndex(index: number) {
+  return String(index + 1).padStart(2, "0")
+}
+
+export function ApplicationFormReadonly({
+  sections,
+  className,
+}: ApplicationFormReadonlyProps) {
+  return (
+    <div className={cn("flex flex-col gap-8", className)}>
+      {sections.map((section) => (
+        <section key={section.sectionId} className="flex flex-col gap-6">
+          <h3
+            className={cn(
+              "text-heading-6-semibold rounded-[10px] px-5 py-3",
+              section.type === "common"
+                ? "bg-teal-100 text-teal-700"
+                : "bg-teal-50 text-teal-600",
+            )}
+          >
+            {section.title}
+          </h3>
+          <div className="flex flex-col gap-6 px-1">
+            {section.questions.map((question, index) => (
+              <ReadonlyAnswerField
+                key={question.questionId}
+                question={question}
+                index={padIndex(index)}
+              />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/src/features/recruiting/ui/detail/EvaluationResultToggle.tsx
+++ b/src/features/recruiting/ui/detail/EvaluationResultToggle.tsx
@@ -1,0 +1,68 @@
+import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
+import { cn } from "@/shared/lib/utils"
+
+import type { EvaluationResult } from "../../model/applicantListTypes"
+
+interface EvaluationResultToggleProps {
+  value: EvaluationResult | null
+  onChange: (value: EvaluationResult) => void
+  failLabel?: string
+  passLabel?: string
+  disabled?: boolean
+  className?: string
+}
+
+const OPTIONS: {
+  value: EvaluationResult
+  side: "left" | "right"
+}[] = [
+  { value: "fail", side: "left" },
+  { value: "pass", side: "right" },
+]
+
+export function EvaluationResultToggle({
+  value,
+  onChange,
+  failLabel = "불합격",
+  passLabel = "합격",
+  disabled = false,
+  className,
+}: EvaluationResultToggleProps) {
+  return (
+    <div
+      role="radiogroup"
+      className={cn(
+        "bg-teal-gray-150 inline-flex w-fit gap-px overflow-hidden rounded-[8px]",
+        disabled && "opacity-40",
+        className,
+      )}
+    >
+      {OPTIONS.map(({ value: optionValue, side }) => {
+        const selected = value === optionValue
+        const label = optionValue === "fail" ? failLabel : passLabel
+        return (
+          <button
+            key={optionValue}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            disabled={disabled}
+            onClick={() => onChange(optionValue)}
+            className={cn(
+              "text-subtitle-3-semibold flex h-11 min-w-22 items-center justify-center gap-1.5 px-7 py-1 transition-colors",
+              side === "left" ? "rounded-l-[8px]" : "rounded-r-[8px]",
+              selected
+                ? "border border-teal-200 bg-teal-100 text-teal-500"
+                : "text-teal-gray-700 bg-white",
+              !disabled && !selected && "hover:bg-teal-gray-50",
+              disabled && "cursor-not-allowed",
+            )}
+          >
+            {selected && <CheckIcon className="size-5 shrink-0" />}
+            <span className="whitespace-nowrap">{label}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/features/recruiting/ui/detail/EvaluationStepper.tsx
+++ b/src/features/recruiting/ui/detail/EvaluationStepper.tsx
@@ -1,0 +1,51 @@
+import { useNavigate } from "@tanstack/react-router"
+
+import { cn } from "@/shared/lib/utils"
+import { SegmentButton } from "@/shared/ui/segment-button/SegmentButton"
+
+import {
+  EVALUATION_STAGE_LABEL,
+  type EvaluationStage,
+} from "../../model/evaluationStage"
+
+interface EvaluationStepperProps {
+  applicationId: string
+  stage: EvaluationStage
+  reachedStages: EvaluationStage[]
+  className?: string
+}
+
+const NAVIGABLE_STAGES: EvaluationStage[] = ["document"]
+
+export function EvaluationStepper({
+  applicationId,
+  stage,
+  reachedStages,
+  className,
+}: EvaluationStepperProps) {
+  const navigate = useNavigate()
+
+  const items = reachedStages.map((reached) => ({
+    value: reached,
+    label: EVALUATION_STAGE_LABEL[reached],
+    disabled: !NAVIGABLE_STAGES.includes(reached),
+  }))
+
+  return (
+    <SegmentButton
+      type="number"
+      items={items}
+      value={stage}
+      onValueChange={(next) => {
+        if (next === "document") {
+          navigate({
+            to: "/recruiting/evaluations/document/$applicationId",
+            params: { applicationId },
+          })
+        }
+      }}
+      itemClassName="flex-1"
+      className={cn("w-full", className)}
+    />
+  )
+}

--- a/src/features/recruiting/ui/detail/MyStageEvaluationPanel.tsx
+++ b/src/features/recruiting/ui/detail/MyStageEvaluationPanel.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react"
+
+import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
+import { cn } from "@/shared/lib/utils"
+import { Button } from "@/shared/ui/Button"
+import { CounterLabel } from "@/shared/ui/CounterLabel"
+
+import {
+  getMyEvaluation,
+  type StageEvaluationDetail,
+} from "../../model/applicationDetail"
+import {
+  EVALUATION_STAGE_SHORT_LABEL,
+  type EvaluationStage,
+} from "../../model/evaluationStage"
+import { EvaluationResultToggle } from "./EvaluationResultToggle"
+
+import type { EvaluationResult } from "../../model/applicantListTypes"
+
+const COMMENT_MAX_LENGTH = 500
+
+interface MyStageEvaluationPanelProps {
+  evaluation: StageEvaluationDetail
+  stage: EvaluationStage
+  onComplete: (result: EvaluationResult, comment: string) => void
+}
+
+export function MyStageEvaluationPanel({
+  evaluation,
+  stage,
+  onComplete,
+}: MyStageEvaluationPanelProps) {
+  const myEvaluation = getMyEvaluation(evaluation)
+  const [result, setResult] = useState<EvaluationResult | null>(
+    myEvaluation?.result ?? null,
+  )
+  const [comment, setComment] = useState(myEvaluation?.comment ?? "")
+
+  const shortLabel = EVALUATION_STAGE_SHORT_LABEL[stage]
+  const locked = evaluation.locked
+
+  return (
+    <section className="border-teal-gray-100 flex flex-col gap-5 rounded-[16px] border bg-white p-6">
+      <h3 className="text-heading-6-semibold text-teal-gray-800">
+        내 {shortLabel} 평가
+      </h3>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-body-2-medium text-teal-gray-700">
+          평가 결과 <span className="text-error-600">*</span>
+        </span>
+        <EvaluationResultToggle
+          value={result}
+          onChange={setResult}
+          disabled={locked}
+        />
+        {locked && evaluation.lockReason && (
+          <p className="text-body-2-regular text-teal-gray-500 mt-1 flex items-center gap-1.5">
+            <CheckIcon className="text-teal-gray-400 size-4 shrink-0" />
+            {evaluation.lockReason}
+          </p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <span className="text-body-2-medium text-teal-gray-700">코멘트</span>
+        <div className="border-teal-gray-100 flex min-h-30 w-full flex-col gap-1.5 rounded-[12px] border bg-white px-5 py-4">
+          <textarea
+            value={comment}
+            onChange={(event) => setComment(event.target.value)}
+            maxLength={COMMENT_MAX_LENGTH}
+            disabled={locked}
+            placeholder="코멘트를 작성해주세요."
+            className={cn(
+              "text-body-1-regular text-teal-gray-900 placeholder:text-teal-gray-400",
+              "w-full flex-1 resize-none border-none bg-transparent outline-none",
+              "disabled:cursor-not-allowed",
+            )}
+          />
+          <CounterLabel
+            current={comment.length}
+            total={COMMENT_MAX_LENGTH}
+            size="sm"
+            className="self-end"
+          />
+        </div>
+      </div>
+
+      {!locked && (
+        <div className="flex justify-end">
+          <Button
+            size="m"
+            disabled={result === null}
+            onClick={() => {
+              if (result !== null) onComplete(result, comment)
+            }}
+          >
+            평가 완료
+          </Button>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/features/recruiting/ui/detail/MyStageEvaluationPanel.tsx
+++ b/src/features/recruiting/ui/detail/MyStageEvaluationPanel.tsx
@@ -70,6 +70,7 @@ export function MyStageEvaluationPanel({
             onChange={(event) => setComment(event.target.value)}
             maxLength={COMMENT_MAX_LENGTH}
             disabled={locked}
+            aria-label="코멘트"
             placeholder="코멘트를 작성해주세요."
             className={cn(
               "text-body-1-regular text-teal-gray-900 placeholder:text-teal-gray-400",

--- a/src/features/recruiting/ui/detail/OperatorEvaluationList.tsx
+++ b/src/features/recruiting/ui/detail/OperatorEvaluationList.tsx
@@ -1,0 +1,108 @@
+import { cn } from "@/shared/lib/utils"
+import { StatusChipTag } from "@/shared/ui/chip/StatusChipTag"
+
+import {
+  countOperatorProgress,
+  getMyEvaluation,
+  type StageEvaluationDetail,
+} from "../../model/applicationDetail"
+import { EVALUATION_STAGE_LABEL } from "../../model/evaluationStage"
+
+interface OperatorEvaluationListProps {
+  evaluation: StageEvaluationDetail
+}
+
+function OperatorStatusChip({ done }: { done: boolean }) {
+  return (
+    <span
+      className={cn(
+        "text-label-2-medium inline-flex h-6 items-center justify-center rounded-[6px] px-2 py-0.5 whitespace-nowrap",
+        done
+          ? "bg-teal-100 text-teal-600"
+          : "bg-teal-gray-150 text-teal-gray-600",
+      )}
+    >
+      {done ? "평가 완료" : "평가 전"}
+    </span>
+  )
+}
+
+function SortIcon() {
+  return (
+    <svg
+      width={18}
+      height={18}
+      viewBox="0 0 18 18"
+      fill="none"
+      aria-hidden="true"
+      className="text-teal-gray-400"
+    >
+      <path
+        d="M6 3.5v11M6 14.5 3.5 12M12 14.5v-11M12 3.5 14.5 6"
+        stroke="currentColor"
+        strokeWidth={1.4}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+export function OperatorEvaluationList({
+  evaluation,
+}: OperatorEvaluationListProps) {
+  const { done, total } = countOperatorProgress(evaluation.operators)
+  const myEvaluation = getMyEvaluation(evaluation)
+  const revealed = myEvaluation?.progress === "done"
+
+  return (
+    <section className="border-teal-gray-100 flex flex-col gap-4 rounded-[16px] border bg-white p-6">
+      <div className="flex items-center justify-between">
+        <h3 className="text-heading-6-semibold text-teal-gray-800">
+          운영진 평가 <span className="text-teal-500">{done}</span>
+          <span className="text-teal-gray-400">/{total}</span>
+        </h3>
+        {revealed && <SortIcon />}
+      </div>
+
+      {revealed ? (
+        <ul className="flex flex-col">
+          {evaluation.operators.map((operator) => {
+            const operatorDone = operator.progress === "done"
+            return (
+              <li
+                key={operator.evaluatorId}
+                className="border-teal-gray-100/60 flex flex-col gap-2 border-b py-4 first:pt-0 last:border-b-0 last:pb-0"
+              >
+                <div className="flex items-center gap-3">
+                  <span className="text-body-2-medium text-teal-gray-900 w-28 shrink-0 truncate">
+                    {operator.evaluatorName}
+                  </span>
+                  <span className="text-body-2-regular text-teal-gray-500 w-20 shrink-0">
+                    {EVALUATION_STAGE_LABEL[operator.stage]}
+                  </span>
+                  <OperatorStatusChip done={operatorDone} />
+                  <span className="flex-1" />
+                  {operator.result && (
+                    <StatusChipTag type="tag" value={operator.result} />
+                  )}
+                </div>
+                {operatorDone && (
+                  <p className="text-body-2-regular text-teal-gray-600 pl-28 whitespace-pre-wrap">
+                    {operator.comment || "작성된 코멘트가 없습니다"}
+                  </p>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      ) : (
+        <div className="flex min-h-24 items-center justify-center">
+          <p className="text-body-2-regular text-teal-gray-400">
+            나의 평가를 등록 후에 확인할 수 있습니다.
+          </p>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/features/recruiting/ui/detail/ReadonlyAnswerField.tsx
+++ b/src/features/recruiting/ui/detail/ReadonlyAnswerField.tsx
@@ -22,7 +22,11 @@ function OptionRow({
   content: string
 }) {
   return (
-    <div className="flex items-center gap-2">
+    <div
+      role={kind}
+      aria-checked={selected}
+      className="flex items-center gap-2"
+    >
       {kind === "radio" ? (
         <RadioIndicator checked={selected} variant="primary" />
       ) : (

--- a/src/features/recruiting/ui/detail/ReadonlyAnswerField.tsx
+++ b/src/features/recruiting/ui/detail/ReadonlyAnswerField.tsx
@@ -115,7 +115,7 @@ function AnswerBody({ question }: { question: ApplicationQuestion }) {
     <QuestionFieldBox>
       <span
         className={cn(
-          "text-body-1-regular",
+          "text-body-1-regular wrap-break-word whitespace-pre-wrap",
           question.textValue ? "text-teal-gray-900" : "text-teal-gray-400",
         )}
       >

--- a/src/features/recruiting/ui/detail/ReadonlyAnswerField.tsx
+++ b/src/features/recruiting/ui/detail/ReadonlyAnswerField.tsx
@@ -58,24 +58,36 @@ function AnswerBody({ question }: { question: ApplicationQuestion }) {
   }
 
   if (question.type === "file" || question.type === "portfolio") {
+    const link = question.textValue
+    const isEmpty = !link && question.files.length === 0
     return (
       <QuestionFieldBox className="gap-2">
-        {question.files.length === 0 ? (
+        {isEmpty && (
           <span className="text-body-1-regular text-teal-gray-400">-</span>
-        ) : (
-          question.files.map((file) => (
-            <a
-              key={file.fileId}
-              href={file.url}
-              target="_blank"
-              rel="noreferrer"
-              className="text-body-1-regular text-teal-gray-700 flex items-center gap-1.5 underline-offset-2 hover:underline"
-            >
-              <FileClip className="text-teal-gray-500 size-5 shrink-0" />
-              <span className="truncate">{file.name}</span>
-            </a>
-          ))
         )}
+        {link && (
+          <a
+            href={link}
+            target="_blank"
+            rel="noreferrer"
+            className="text-body-1-regular text-teal-gray-700 flex items-center gap-1.5 underline-offset-2 hover:underline"
+          >
+            <FileClip className="text-teal-gray-500 size-5 shrink-0" />
+            <span className="truncate">{link}</span>
+          </a>
+        )}
+        {question.files.map((file) => (
+          <a
+            key={file.fileId}
+            href={file.url}
+            target="_blank"
+            rel="noreferrer"
+            className="text-body-1-regular text-teal-gray-700 flex items-center gap-1.5 underline-offset-2 hover:underline"
+          >
+            <FileClip className="text-teal-gray-500 size-5 shrink-0" />
+            <span className="truncate">{file.name}</span>
+          </a>
+        ))}
       </QuestionFieldBox>
     )
   }

--- a/src/features/recruiting/ui/detail/ReadonlyAnswerField.tsx
+++ b/src/features/recruiting/ui/detail/ReadonlyAnswerField.tsx
@@ -1,0 +1,133 @@
+import FileClip from "@/shared/assets/icon/upload/FileClip"
+import { cn } from "@/shared/lib/utils"
+import { CheckboxIndicator } from "@/shared/ui/input/checkbox/CheckboxIndicator"
+import { RadioIndicator } from "@/shared/ui/input/radio/RadioIndicator"
+import { QuestionFieldBox } from "@/shared/ui/question-field/QuestionFieldBox"
+import { QuestionItemTitle } from "@/shared/ui/question-field/QuestionItemTitle"
+
+import type { ApplicationQuestion } from "../../model/applicationDetail"
+
+interface ReadonlyAnswerFieldProps {
+  question: ApplicationQuestion
+  index: string
+}
+
+function OptionRow({
+  kind,
+  selected,
+  content,
+}: {
+  kind: "radio" | "checkbox"
+  selected: boolean
+  content: string
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      {kind === "radio" ? (
+        <RadioIndicator checked={selected} variant="primary" />
+      ) : (
+        <CheckboxIndicator checked={selected} variant="primary" />
+      )}
+      <span
+        className={cn(
+          "text-body-1-regular",
+          selected ? "text-teal-gray-900" : "text-teal-gray-600",
+        )}
+      >
+        {content}
+      </span>
+    </div>
+  )
+}
+
+function AnswerBody({ question }: { question: ApplicationQuestion }) {
+  if (question.type === "radio" || question.type === "checkbox") {
+    const kind = question.type === "radio" ? "radio" : "checkbox"
+    return (
+      <QuestionFieldBox className="gap-3">
+        {question.options.map((option) => (
+          <OptionRow
+            key={option.optionId}
+            kind={kind}
+            selected={question.selectedOptionIds.includes(option.optionId)}
+            content={option.content}
+          />
+        ))}
+      </QuestionFieldBox>
+    )
+  }
+
+  if (question.type === "file" || question.type === "portfolio") {
+    return (
+      <QuestionFieldBox className="gap-2">
+        {question.files.length === 0 ? (
+          <span className="text-body-1-regular text-teal-gray-400">-</span>
+        ) : (
+          question.files.map((file) => (
+            <a
+              key={file.fileId}
+              href={file.url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-body-1-regular text-teal-gray-700 flex items-center gap-1.5 underline-offset-2 hover:underline"
+            >
+              <FileClip className="text-teal-gray-500 size-5 shrink-0" />
+              <span className="truncate">{file.name}</span>
+            </a>
+          ))
+        )}
+      </QuestionFieldBox>
+    )
+  }
+
+  if (question.type === "dropdown") {
+    const selectedContent = question.options
+      .filter((option) => question.selectedOptionIds.includes(option.optionId))
+      .map((option) => option.content)
+      .join(", ")
+    return (
+      <QuestionFieldBox>
+        <span
+          className={cn(
+            "text-body-1-regular",
+            selectedContent ? "text-teal-gray-900" : "text-teal-gray-400",
+          )}
+        >
+          {selectedContent || "-"}
+        </span>
+      </QuestionFieldBox>
+    )
+  }
+
+  return (
+    <QuestionFieldBox>
+      <span
+        className={cn(
+          "text-body-1-regular",
+          question.textValue ? "text-teal-gray-900" : "text-teal-gray-400",
+        )}
+      >
+        {question.textValue || "-"}
+      </span>
+    </QuestionFieldBox>
+  )
+}
+
+export function ReadonlyAnswerField({
+  question,
+  index,
+}: ReadonlyAnswerFieldProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <QuestionItemTitle
+        index={index}
+        title={question.title}
+        caption={question.description}
+        required={question.required}
+      />
+      <div className="pl-8.5">
+        <AnswerBody question={question} />
+      </div>
+    </div>
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -32,6 +32,7 @@ import { Route as TestToastRouteImport } from './routes/test/toast'
 import { Route as TestTextFieldRouteImport } from './routes/test/text-field'
 import { Route as TestTextButtonRouteImport } from './routes/test/text-button'
 import { Route as TestSocialButtonRouteImport } from './routes/test/social-button'
+import { Route as TestRecruitingApplicationDetailRouteImport } from './routes/test/recruiting-application-detail'
 import { Route as TestRecruitingApplicantsRouteImport } from './routes/test/recruiting-applicants'
 import { Route as TestRatingFaceRouteImport } from './routes/test/rating-face'
 import { Route as TestQuestionFormRouteImport } from './routes/test/question-form'
@@ -71,6 +72,7 @@ import { Route as AdminChallengerRecordsRouteImport } from './routes/admin/chall
 import { Route as AdminChallengerPointsRouteImport } from './routes/admin/challenger/points'
 import { Route as MatchingProjectsAnnounceRouteRouteImport } from './routes/matching/projects/announce/route'
 import { Route as MatchingProjectsAnnounceIndexRouteImport } from './routes/matching/projects/announce/index'
+import { Route as RecruitingEvaluationsDocumentApplicationIdRouteImport } from './routes/recruiting/evaluations/document.$applicationId'
 import { Route as MatchingProjectsEditProjectIdRouteImport } from './routes/matching/projects/edit.$projectId'
 import { Route as MatchingProjectsAnnounceNoticePublishRouteImport } from './routes/matching/projects/announce/notice-publish'
 import { Route as MatchingProjectsAnnounceNoticePublishNoticeIdRouteImport } from './routes/matching/projects/announce/notice-publish.$noticeId'
@@ -190,6 +192,12 @@ const TestSocialButtonRoute = TestSocialButtonRouteImport.update({
   path: '/test/social-button',
   getParentRoute: () => rootRouteImport,
 } as any)
+const TestRecruitingApplicationDetailRoute =
+  TestRecruitingApplicationDetailRouteImport.update({
+    id: '/test/recruiting-application-detail',
+    path: '/test/recruiting-application-detail',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const TestRecruitingApplicantsRoute =
   TestRecruitingApplicantsRouteImport.update({
     id: '/test/recruiting-applicants',
@@ -395,6 +403,12 @@ const MatchingProjectsAnnounceIndexRoute =
     path: '/',
     getParentRoute: () => MatchingProjectsAnnounceRouteRoute,
   } as any)
+const RecruitingEvaluationsDocumentApplicationIdRoute =
+  RecruitingEvaluationsDocumentApplicationIdRouteImport.update({
+    id: '/$applicationId',
+    path: '/$applicationId',
+    getParentRoute: () => RecruitingEvaluationsDocumentRoute,
+  } as any)
 const MatchingProjectsEditProjectIdRoute =
   MatchingProjectsEditProjectIdRouteImport.update({
     id: '/projects/edit/$projectId',
@@ -450,6 +464,7 @@ export interface FileRoutesByFullPath {
   '/test/question-form': typeof TestQuestionFormRoute
   '/test/rating-face': typeof TestRatingFaceRoute
   '/test/recruiting-applicants': typeof TestRecruitingApplicantsRoute
+  '/test/recruiting-application-detail': typeof TestRecruitingApplicationDetailRoute
   '/test/social-button': typeof TestSocialButtonRoute
   '/test/text-button': typeof TestTextButtonRoute
   '/test/text-field': typeof TestTextFieldRoute
@@ -472,12 +487,13 @@ export interface FileRoutesByFullPath {
   '/matching/projects/management': typeof MatchingProjectsManagementRoute
   '/matching/projects/new': typeof MatchingProjectsNewRoute
   '/oauth/kakao/callback': typeof OauthKakaoCallbackRoute
-  '/recruiting/evaluations/document': typeof RecruitingEvaluationsDocumentRoute
+  '/recruiting/evaluations/document': typeof RecruitingEvaluationsDocumentRouteWithChildren
   '/recruiting/evaluations/final': typeof RecruitingEvaluationsFinalRoute
   '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRoute
   '/matching/projects/': typeof MatchingProjectsIndexRoute
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/edit/$projectId': typeof MatchingProjectsEditProjectIdRoute
+  '/recruiting/evaluations/document/$applicationId': typeof RecruitingEvaluationsDocumentApplicationIdRoute
   '/matching/projects/announce/': typeof MatchingProjectsAnnounceIndexRoute
   '/matching/projects/announce/notice-publish/$noticeId': typeof MatchingProjectsAnnounceNoticePublishNoticeIdRoute
 }
@@ -514,6 +530,7 @@ export interface FileRoutesByTo {
   '/test/question-form': typeof TestQuestionFormRoute
   '/test/rating-face': typeof TestRatingFaceRoute
   '/test/recruiting-applicants': typeof TestRecruitingApplicantsRoute
+  '/test/recruiting-application-detail': typeof TestRecruitingApplicationDetailRoute
   '/test/social-button': typeof TestSocialButtonRoute
   '/test/text-button': typeof TestTextButtonRoute
   '/test/text-field': typeof TestTextFieldRoute
@@ -535,12 +552,13 @@ export interface FileRoutesByTo {
   '/matching/projects/management': typeof MatchingProjectsManagementRoute
   '/matching/projects/new': typeof MatchingProjectsNewRoute
   '/oauth/kakao/callback': typeof OauthKakaoCallbackRoute
-  '/recruiting/evaluations/document': typeof RecruitingEvaluationsDocumentRoute
+  '/recruiting/evaluations/document': typeof RecruitingEvaluationsDocumentRouteWithChildren
   '/recruiting/evaluations/final': typeof RecruitingEvaluationsFinalRoute
   '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRoute
   '/matching/projects': typeof MatchingProjectsIndexRoute
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/edit/$projectId': typeof MatchingProjectsEditProjectIdRoute
+  '/recruiting/evaluations/document/$applicationId': typeof RecruitingEvaluationsDocumentApplicationIdRoute
   '/matching/projects/announce': typeof MatchingProjectsAnnounceIndexRoute
   '/matching/projects/announce/notice-publish/$noticeId': typeof MatchingProjectsAnnounceNoticePublishNoticeIdRoute
 }
@@ -581,6 +599,7 @@ export interface FileRoutesById {
   '/test/question-form': typeof TestQuestionFormRoute
   '/test/rating-face': typeof TestRatingFaceRoute
   '/test/recruiting-applicants': typeof TestRecruitingApplicantsRoute
+  '/test/recruiting-application-detail': typeof TestRecruitingApplicationDetailRoute
   '/test/social-button': typeof TestSocialButtonRoute
   '/test/text-button': typeof TestTextButtonRoute
   '/test/text-field': typeof TestTextFieldRoute
@@ -603,12 +622,13 @@ export interface FileRoutesById {
   '/matching/projects/management': typeof MatchingProjectsManagementRoute
   '/matching/projects/new': typeof MatchingProjectsNewRoute
   '/oauth/kakao/callback': typeof OauthKakaoCallbackRoute
-  '/recruiting/evaluations/document': typeof RecruitingEvaluationsDocumentRoute
+  '/recruiting/evaluations/document': typeof RecruitingEvaluationsDocumentRouteWithChildren
   '/recruiting/evaluations/final': typeof RecruitingEvaluationsFinalRoute
   '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRoute
   '/matching/projects/': typeof MatchingProjectsIndexRoute
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/edit/$projectId': typeof MatchingProjectsEditProjectIdRoute
+  '/recruiting/evaluations/document/$applicationId': typeof RecruitingEvaluationsDocumentApplicationIdRoute
   '/matching/projects/announce/': typeof MatchingProjectsAnnounceIndexRoute
   '/matching/projects/announce/notice-publish/$noticeId': typeof MatchingProjectsAnnounceNoticePublishNoticeIdRoute
 }
@@ -650,6 +670,7 @@ export interface FileRouteTypes {
     | '/test/question-form'
     | '/test/rating-face'
     | '/test/recruiting-applicants'
+    | '/test/recruiting-application-detail'
     | '/test/social-button'
     | '/test/text-button'
     | '/test/text-field'
@@ -678,6 +699,7 @@ export interface FileRouteTypes {
     | '/matching/projects/'
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/edit/$projectId'
+    | '/recruiting/evaluations/document/$applicationId'
     | '/matching/projects/announce/'
     | '/matching/projects/announce/notice-publish/$noticeId'
   fileRoutesByTo: FileRoutesByTo
@@ -714,6 +736,7 @@ export interface FileRouteTypes {
     | '/test/question-form'
     | '/test/rating-face'
     | '/test/recruiting-applicants'
+    | '/test/recruiting-application-detail'
     | '/test/social-button'
     | '/test/text-button'
     | '/test/text-field'
@@ -741,6 +764,7 @@ export interface FileRouteTypes {
     | '/matching/projects'
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/edit/$projectId'
+    | '/recruiting/evaluations/document/$applicationId'
     | '/matching/projects/announce'
     | '/matching/projects/announce/notice-publish/$noticeId'
   id:
@@ -780,6 +804,7 @@ export interface FileRouteTypes {
     | '/test/question-form'
     | '/test/rating-face'
     | '/test/recruiting-applicants'
+    | '/test/recruiting-application-detail'
     | '/test/social-button'
     | '/test/text-button'
     | '/test/text-field'
@@ -808,6 +833,7 @@ export interface FileRouteTypes {
     | '/matching/projects/'
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/edit/$projectId'
+    | '/recruiting/evaluations/document/$applicationId'
     | '/matching/projects/announce/'
     | '/matching/projects/announce/notice-publish/$noticeId'
   fileRoutesById: FileRoutesById
@@ -844,6 +870,7 @@ export interface RootRouteChildren {
   TestQuestionFormRoute: typeof TestQuestionFormRoute
   TestRatingFaceRoute: typeof TestRatingFaceRoute
   TestRecruitingApplicantsRoute: typeof TestRecruitingApplicantsRoute
+  TestRecruitingApplicationDetailRoute: typeof TestRecruitingApplicationDetailRoute
   TestSocialButtonRoute: typeof TestSocialButtonRoute
   TestTextButtonRoute: typeof TestTextButtonRoute
   TestTextFieldRoute: typeof TestTextFieldRoute
@@ -1020,6 +1047,13 @@ declare module '@tanstack/react-router' {
       path: '/test/social-button'
       fullPath: '/test/social-button'
       preLoaderRoute: typeof TestSocialButtonRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/test/recruiting-application-detail': {
+      id: '/test/recruiting-application-detail'
+      path: '/test/recruiting-application-detail'
+      fullPath: '/test/recruiting-application-detail'
+      preLoaderRoute: typeof TestRecruitingApplicationDetailRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/test/recruiting-applicants': {
@@ -1295,6 +1329,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MatchingProjectsAnnounceIndexRouteImport
       parentRoute: typeof MatchingProjectsAnnounceRouteRoute
     }
+    '/recruiting/evaluations/document/$applicationId': {
+      id: '/recruiting/evaluations/document/$applicationId'
+      path: '/$applicationId'
+      fullPath: '/recruiting/evaluations/document/$applicationId'
+      preLoaderRoute: typeof RecruitingEvaluationsDocumentApplicationIdRouteImport
+      parentRoute: typeof RecruitingEvaluationsDocumentRoute
+    }
     '/matching/projects/edit/$projectId': {
       id: '/matching/projects/edit/$projectId'
       path: '/projects/edit/$projectId'
@@ -1411,14 +1452,30 @@ const MatchingRouteRouteWithChildren = MatchingRouteRoute._addFileChildren(
   MatchingRouteRouteChildren,
 )
 
+interface RecruitingEvaluationsDocumentRouteChildren {
+  RecruitingEvaluationsDocumentApplicationIdRoute: typeof RecruitingEvaluationsDocumentApplicationIdRoute
+}
+
+const RecruitingEvaluationsDocumentRouteChildren: RecruitingEvaluationsDocumentRouteChildren =
+  {
+    RecruitingEvaluationsDocumentApplicationIdRoute:
+      RecruitingEvaluationsDocumentApplicationIdRoute,
+  }
+
+const RecruitingEvaluationsDocumentRouteWithChildren =
+  RecruitingEvaluationsDocumentRoute._addFileChildren(
+    RecruitingEvaluationsDocumentRouteChildren,
+  )
+
 interface RecruitingRouteRouteChildren {
-  RecruitingEvaluationsDocumentRoute: typeof RecruitingEvaluationsDocumentRoute
+  RecruitingEvaluationsDocumentRoute: typeof RecruitingEvaluationsDocumentRouteWithChildren
   RecruitingEvaluationsFinalRoute: typeof RecruitingEvaluationsFinalRoute
   RecruitingEvaluationsInterviewRoute: typeof RecruitingEvaluationsInterviewRoute
 }
 
 const RecruitingRouteRouteChildren: RecruitingRouteRouteChildren = {
-  RecruitingEvaluationsDocumentRoute: RecruitingEvaluationsDocumentRoute,
+  RecruitingEvaluationsDocumentRoute:
+    RecruitingEvaluationsDocumentRouteWithChildren,
   RecruitingEvaluationsFinalRoute: RecruitingEvaluationsFinalRoute,
   RecruitingEvaluationsInterviewRoute: RecruitingEvaluationsInterviewRoute,
 }
@@ -1471,6 +1528,7 @@ const rootRouteChildren: RootRouteChildren = {
   TestQuestionFormRoute: TestQuestionFormRoute,
   TestRatingFaceRoute: TestRatingFaceRoute,
   TestRecruitingApplicantsRoute: TestRecruitingApplicantsRoute,
+  TestRecruitingApplicationDetailRoute: TestRecruitingApplicationDetailRoute,
   TestSocialButtonRoute: TestSocialButtonRoute,
   TestTextButtonRoute: TestTextButtonRoute,
   TestTextFieldRoute: TestTextFieldRoute,

--- a/src/routes/recruiting/evaluations/document.$applicationId.tsx
+++ b/src/routes/recruiting/evaluations/document.$applicationId.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { ApplicationEvaluationDetailPage } from "@/features/recruiting"
+
+export const Route = createFileRoute(
+  "/recruiting/evaluations/document/$applicationId",
+)({
+  component: DocumentEvaluationDetailRoute,
+})
+
+function DocumentEvaluationDetailRoute() {
+  const { applicationId } = Route.useParams()
+  return (
+    <ApplicationEvaluationDetailPage
+      stage="document"
+      applicationId={applicationId}
+    />
+  )
+}

--- a/src/routes/recruiting/evaluations/document.$applicationId.tsx
+++ b/src/routes/recruiting/evaluations/document.$applicationId.tsx
@@ -12,6 +12,7 @@ function DocumentEvaluationDetailRoute() {
   const { applicationId } = Route.useParams()
   return (
     <ApplicationEvaluationDetailPage
+      key={applicationId}
       stage="document"
       applicationId={applicationId}
     />

--- a/src/routes/recruiting/evaluations/document.tsx
+++ b/src/routes/recruiting/evaluations/document.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, Outlet, useMatchRoute } from "@tanstack/react-router"
 
 import { ApplicantListPage } from "@/features/recruiting"
 
@@ -7,5 +7,10 @@ export const Route = createFileRoute("/recruiting/evaluations/document")({
 })
 
 function DocumentEvaluationListPage() {
+  const matchRoute = useMatchRoute()
+  const isDetail = Boolean(
+    matchRoute({ to: "/recruiting/evaluations/document/$applicationId" }),
+  )
+  if (isDetail) return <Outlet />
   return <ApplicantListPage stage="document" />
 }

--- a/src/routes/test/recruiting-application-detail.tsx
+++ b/src/routes/test/recruiting-application-detail.tsx
@@ -16,12 +16,14 @@ function parseStage(value: unknown): EvaluationStage {
 export const Route = createFileRoute("/test/recruiting-application-detail")({
   validateSearch: (search: Record<string, unknown>) => ({
     stage: parseStage(search.stage),
+    applicationId:
+      search.applicationId != null ? String(search.applicationId) : "101",
   }),
   component: RecruitingApplicationDetailTestPage,
 })
 
 function RecruitingApplicationDetailTestPage() {
-  const { stage } = Route.useSearch()
+  const { stage, applicationId } = Route.useSearch()
   const activePathname = `/recruiting/evaluations/${stage}`
 
   return (
@@ -32,8 +34,9 @@ function RecruitingApplicationDetailTestPage() {
         <div className="flex min-w-0 flex-1 flex-col">
           <div className="min-h-200 px-8 pt-10 pb-20">
             <ApplicationEvaluationDetailPage
+              key={applicationId}
               stage={stage}
-              applicationId="app-101"
+              applicationId={applicationId}
             />
           </div>
         </div>

--- a/src/routes/test/recruiting-application-detail.tsx
+++ b/src/routes/test/recruiting-application-detail.tsx
@@ -1,0 +1,44 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import {
+  ApplicationEvaluationDetailPage,
+  EVALUATION_STAGES,
+  type EvaluationStage,
+} from "@/features/recruiting"
+import Footer from "@/widgets/footer/Footer"
+import Header from "@/widgets/navigation/header/Header"
+import RecruitingSideBar from "@/widgets/navigation/sidebar/RecruitingSideBar"
+
+function parseStage(value: unknown): EvaluationStage {
+  return EVALUATION_STAGES.find((stage) => stage === value) ?? "document"
+}
+
+export const Route = createFileRoute("/test/recruiting-application-detail")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    stage: parseStage(search.stage),
+  }),
+  component: RecruitingApplicationDetailTestPage,
+})
+
+function RecruitingApplicationDetailTestPage() {
+  const { stage } = Route.useSearch()
+  const activePathname = `/recruiting/evaluations/${stage}`
+
+  return (
+    <main className="flex h-full min-h-screen w-full flex-col">
+      <Header activePathname={activePathname} />
+      <div className="flex w-full flex-1">
+        <RecruitingSideBar activePathname={activePathname} />
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="min-h-200 px-8 pt-10 pb-20">
+            <ApplicationEvaluationDetailPage
+              stage={stage}
+              applicationId="app-101"
+            />
+          </div>
+        </div>
+      </div>
+      <Footer />
+    </main>
+  )
+}


### PR DESCRIPTION
## 📸 작업 내용

리크루팅 **서류 평가 상세 페이지**를 구현했습니다 (Phase 4 1차, 에픽 #602). 지원자 목록(서류 전형)에서 행 클릭으로 진입하며, 좌측 읽기전용 지원서 + 우측 평가 패널 구조입니다. mock 기반이며 도메인 모델은 향후 API 응답 스펙으로 치환하기 쉽게 정의했습니다.

- 상세 라우트 `/recruiting/evaluations/document/$applicationId` 추가, `document.tsx`를 `useMatchRoute`+`Outlet` 분기(목록/상세)로 전환
- 목록 행 클릭·키보드(Enter/Space) → 상세 진입 (서류 전형만; 면접·최종 라우트는 후속 PR)
- 좌측 읽기전용 지원서: 질문 타입별 렌더(단일/다중 선택 옵션 표시, 텍스트, 파일/포트폴리오)
- 우측: 전형 스테퍼(서류 active·면접 disabled) / 내 서류 평가(합·불 토글 + 코멘트 + 평가 완료) / 운영진 평가 리스트(내 평가 등록 후 노출)
- 평가 완료 시 운영진 리스트 잠금 해제 + 카운트 증가(2/5 → 3/5)
- 검증용 test 라우트 `/test/recruiting-application-detail` 추가 (목록 test 라우트와 동일 패턴)

## 🎞️ 주요 코드 설명

### 전형별 상세 재사용 구조

`ApplicationEvaluationDetailPage({ stage, applicationId })` 공통 페이지에 `stage` prop을 주입해 서류/면접/최종 상세를 재사용합니다(목록의 `stage` prop 패턴 연장). 상세 라우트는 얇게 두고 스테퍼가 전형 간 이동을 담당합니다.

### 합/불 토글 — 전용 컴포넌트

시안(`11067:152356`)의 결과 토글은 컨테이너·선택 스타일·체크 아이콘이 기존 `SegmentButton`과 충분히 달라, 공용 컴포넌트 확장 대신 전용 `EvaluationResultToggle`로 분리했습니다(공용 SegmentButton 회귀 위험 회피). 전형 스테퍼는 기존 `SegmentButton`(type=number)을 그대로 재사용합니다.

### 읽기전용 지원서 렌더러

`shared/ui`의 `QuestionItemTitle`·`QuestionFieldBox`·`RadioIndicator`·`CheckboxIndicator`를 조합해 질문 타입별 읽기전용 렌더러를 구성했습니다(전체 옵션 + 선택 상태 표시).

## 🖥️ 구현화면

> localhost 1440px 캡처

|           서류 평가 상세 (입력)            |           평가 완료 후 (운영진 리스트 노출)            |
| :-------------------------: | :-------------------------: |
| <img src = "" width ="250"> | <img src = "" width ="250"> |

## 🔗 연결된 이슈

- Connected: #602
- Closes #602

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 지원자 지원서의 상세 내용을 읽기 전용으로 확인할 수 있습니다.
  * 서류 전형 평가 결과와 코멘트를 입력하고 완료 처리할 수 있습니다.
  * 평가 단계별 진행 상태와 다른 평가자들의 평가 결과를 확인할 수 있습니다.
  * 지원자 목록에서 해당 지원자의 평가 상세 화면으로 이동할 수 있습니다.
  * 질문 유형별 답변, 선택 항목, 첨부 파일을 상세 화면에서 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->