### PR TITLE
✨ feat: 리크루팅 지원 폼 모달 구현

### DIFF
--- a/src/features/recruiting/index.ts
+++ b/src/features/recruiting/index.ts
@@ -9,4 +9,5 @@ export {
   type RecruitingListRole,
 } from "./model/recruitingListRole"
 export { ApplicantListPage } from "./ui/ApplicantListPage"
+export { RecruitingApplyForm } from "./ui/apply/RecruitingApplyForm"
 export { ApplicationEvaluationDetailPage } from "./ui/detail/ApplicationEvaluationDetailPage"

--- a/src/features/recruiting/model/applyForm.mock.ts
+++ b/src/features/recruiting/model/applyForm.mock.ts
@@ -1,0 +1,150 @@
+import type { ApplicationSection } from "./applicationDetail"
+import type { ApplyFormConfig } from "./applyForm"
+
+export const RECRUITING_APPLY_CODE_MOCK = "A3F9K2"
+
+const PART_OPTION_IDS = {
+  pm: "opt-part-pm",
+  design: "opt-part-design",
+  web: "opt-part-web",
+  mobile: "opt-part-mobile",
+} as const
+
+const PART_OPTIONS = [
+  { optionId: PART_OPTION_IDS.pm, content: "PM" },
+  { optionId: PART_OPTION_IDS.design, content: "Design" },
+  { optionId: PART_OPTION_IDS.web, content: "Web Product Engineering" },
+  { optionId: PART_OPTION_IDS.mobile, content: "Mobile Product Engineering" },
+]
+
+const BASIC_SECTION: ApplicationSection = {
+  sectionId: "sec-basic",
+  type: "common",
+  title: "기본 문항",
+  questions: [
+    {
+      questionId: "q-basic-1",
+      type: "radio",
+      title: "신규 지원자이신가요?",
+      required: true,
+      options: [
+        { optionId: "opt-basic-1-1", content: "네, 신규 지원자입니다" },
+        { optionId: "opt-basic-1-2", content: "아니요, 기존 챌린저입니다" },
+      ],
+      textValue: null,
+      selectedOptionIds: [],
+      files: [],
+    },
+    {
+      questionId: "q-basic-2",
+      type: "shortText",
+      title: "지원자님의 성함을 알려주세요.",
+      required: true,
+      options: [],
+      textValue: null,
+      selectedOptionIds: [],
+      files: [],
+    },
+    {
+      questionId: "q-basic-3",
+      type: "radio",
+      title: "1지망 지원 파트를 알려주세요.",
+      required: true,
+      options: PART_OPTIONS,
+      textValue: null,
+      selectedOptionIds: [],
+      files: [],
+    },
+    {
+      questionId: "q-basic-4",
+      type: "radio",
+      title: "2지망 지원 파트를 알려주세요.",
+      required: true,
+      options: PART_OPTIONS,
+      textValue: null,
+      selectedOptionIds: [],
+      files: [],
+    },
+    {
+      questionId: "q-basic-5",
+      type: "shortText",
+      title: "이메일 주소를 입력해 주세요.",
+      description:
+        "모든 전형 안내는 입력하신 메일 주소로 발송되오니, 정확한 주소를 기재해 주시기 바랍니다.",
+      required: true,
+      options: [],
+      textValue: null,
+      selectedOptionIds: [],
+      files: [],
+    },
+  ],
+}
+
+function buildPartSection(
+  sectionId: string,
+  title: string,
+  stackOptions: string[],
+): ApplicationSection {
+  return {
+    sectionId,
+    type: "part",
+    title,
+    questions: [
+      {
+        questionId: `${sectionId}-stack`,
+        type: "checkbox",
+        title: "사용 가능한 기술 스택을 선택하세요.",
+        required: true,
+        options: stackOptions.map((content, index) => ({
+          optionId: `${sectionId}-stack-${index}`,
+          content,
+        })),
+        textValue: null,
+        selectedOptionIds: [],
+        files: [],
+      },
+      {
+        questionId: `${sectionId}-portfolio`,
+        type: "portfolio",
+        title: "포트폴리오를 링크 혹은 PDF 파일의 형태로 제출하세요.",
+        required: true,
+        options: [],
+        textValue: null,
+        selectedOptionIds: [],
+        files: [],
+      },
+    ],
+  }
+}
+
+export const RECRUITING_APPLY_FORM_MOCK: ApplyFormConfig = {
+  recruitment: {
+    recruitmentId: "recruitment-1",
+    title: "UMC 11기 2차 정규 모집",
+    school: "한양대학교 ERICA",
+    notice:
+      "모집 공지 모집 공지 모집 공지 모집 공지 모집 공지\n모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지 모집 공지",
+    logoUrl: null,
+  },
+  sections: [
+    BASIC_SECTION,
+    buildPartSection("sec-part-pm", "PM", ["Notion", "Slack"]),
+    buildPartSection("sec-part-design", "Design", ["Figma", "illustration"]),
+    buildPartSection("sec-part-web", "Web Product Engineering", [
+      "Figma",
+      "Github",
+    ]),
+    buildPartSection("sec-part-mobile", "Mobile Product Engineering", [
+      "Swift",
+      "Kotlin",
+    ]),
+  ],
+  partQuestionIds: ["q-basic-3", "q-basic-4"],
+  nameQuestionId: "q-basic-2",
+  partOptionSectionMap: {
+    [PART_OPTION_IDS.pm]: "sec-part-pm",
+    [PART_OPTION_IDS.design]: "sec-part-design",
+    [PART_OPTION_IDS.web]: "sec-part-web",
+    [PART_OPTION_IDS.mobile]: "sec-part-mobile",
+  },
+}

--- a/src/features/recruiting/model/applyForm.ts
+++ b/src/features/recruiting/model/applyForm.ts
@@ -1,0 +1,187 @@
+import { z } from "zod"
+
+import type { PortfolioValue } from "@/shared/ui/question-field/PortfolioField"
+
+import type {
+  ApplicationQuestion,
+  ApplicationSection,
+} from "./applicationDetail"
+
+export const APPLY_SHORT_TEXT_MAX = 200
+export const APPLY_LONG_TEXT_MAX = 500
+
+export interface ApplyUploadedFile {
+  name: string
+}
+
+export type ApplyAnswerValue =
+  | string
+  | string[]
+  | PortfolioValue
+  | ApplyUploadedFile
+  | null
+
+export interface ApplyRecruitmentInfo {
+  recruitmentId: string
+  title: string
+  school: string
+  notice: string
+  logoUrl: string | null
+}
+
+export interface ApplyFormConfig {
+  recruitment: ApplyRecruitmentInfo
+  sections: ApplicationSection[]
+  partQuestionIds: string[]
+  partOptionSectionMap: Record<string, string>
+  nameQuestionId?: string
+}
+
+export function isApplyUploadedFile(
+  value: ApplyAnswerValue,
+): value is ApplyUploadedFile {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "name" in value &&
+    !("kind" in value)
+  )
+}
+
+export function isApplyPortfolioValue(
+  value: ApplyAnswerValue,
+): value is PortfolioValue {
+  return typeof value === "object" && value !== null && "kind" in value
+}
+
+export function buildDefaultApplyValues(sections: ApplicationSection[]) {
+  const values: Record<string, ApplyAnswerValue> = {}
+  sections.forEach((section) => {
+    section.questions.forEach((question) => {
+      if (question.type === "checkbox") {
+        values[question.questionId] = []
+        return
+      }
+      if (question.type === "file" || question.type === "portfolio") {
+        values[question.questionId] = null
+        return
+      }
+      values[question.questionId] = ""
+    })
+  })
+  return values
+}
+
+export function resolveEnabledSectionIds(
+  config: ApplyFormConfig,
+  values: Record<string, unknown>,
+) {
+  const enabled = new Set<string>()
+  config.sections.forEach((section) => {
+    if (section.type === "common") enabled.add(section.sectionId)
+  })
+  config.partQuestionIds.forEach((questionId) => {
+    const value = values[questionId]
+    if (typeof value !== "string" || !value) return
+    const sectionId = config.partOptionSectionMap[value]
+    if (sectionId) enabled.add(sectionId)
+  })
+  return enabled
+}
+
+const portfolioValueSchema = z.union([
+  z.object({
+    kind: z.literal("link"),
+    url: z
+      .string()
+      .url("유효한 URL을 입력해 주세요. (예: https://example.com)"),
+  }),
+  z.object({
+    kind: z.literal("file"),
+    name: z.string().min(1),
+    file: z.instanceof(File).optional(),
+  }),
+])
+
+const uploadedFileValueSchema = z.object({ name: z.string().min(1) })
+
+function questionSchema(
+  question: ApplicationQuestion,
+  enabled: boolean,
+): z.ZodTypeAny {
+  const required = question.required && enabled
+  switch (question.type) {
+    case "shortText": {
+      const base = z
+        .string()
+        .max(
+          APPLY_SHORT_TEXT_MAX,
+          `${APPLY_SHORT_TEXT_MAX}자 이내로 입력해 주세요.`,
+        )
+      return required ? base.min(1, "필수 항목입니다.") : base
+    }
+    case "longText": {
+      const base = z
+        .string()
+        .max(
+          APPLY_LONG_TEXT_MAX,
+          `${APPLY_LONG_TEXT_MAX}자 이내로 입력해 주세요.`,
+        )
+      return required ? base.min(1, "필수 항목입니다.") : base
+    }
+    case "radio":
+    case "dropdown":
+      return required ? z.string().min(1, "선택해 주세요.") : z.string()
+    case "checkbox":
+      return required
+        ? z.array(z.string()).min(1, "한 개 이상 선택해 주세요.")
+        : z.array(z.string())
+    case "file":
+      if (required) {
+        return z.unknown().superRefine((value, ctx) => {
+          if (!uploadedFileValueSchema.safeParse(value).success) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: "파일을 첨부해 주세요.",
+            })
+          }
+        })
+      }
+      return uploadedFileValueSchema.nullable().optional()
+    case "portfolio":
+      if (required) {
+        return z.unknown().superRefine((value, ctx) => {
+          if (value === null || value === undefined) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: "포트폴리오를 제출해 주세요.",
+            })
+            return
+          }
+          const parsed = portfolioValueSchema.safeParse(value)
+          if (!parsed.success) {
+            const [firstIssue] = parsed.error.issues
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: firstIssue?.message ?? "포트폴리오를 확인해 주세요.",
+            })
+          }
+        })
+      }
+      return portfolioValueSchema.nullable().optional()
+  }
+}
+
+export function buildRecruitingAnswersSchema(
+  sections: ApplicationSection[],
+  enabledSectionIds: Set<string>,
+) {
+  const shape: Record<string, z.ZodTypeAny> = {}
+  sections.forEach((section) => {
+    const enabled = enabledSectionIds.has(section.sectionId)
+    section.questions.forEach((question) => {
+      shape[question.questionId] = questionSchema(question, enabled)
+    })
+  })
+  return z.object(shape)
+}

--- a/src/features/recruiting/ui/apply/ApplyAnswerField.tsx
+++ b/src/features/recruiting/ui/apply/ApplyAnswerField.tsx
@@ -34,10 +34,14 @@ function FileAnswerField({
   value,
   onChange,
   error,
+  ariaLabel,
+  ariaRequired,
 }: {
   value: ApplyAnswerValue
   onChange: (value: ApplyAnswerValue) => void
   error?: string
+  ariaLabel?: string
+  ariaRequired?: boolean
 }) {
   const inputRef = useRef<HTMLInputElement>(null)
   const fileName = isApplyUploadedFile(value) ? value.name : null
@@ -48,6 +52,8 @@ function FileAnswerField({
         ref={inputRef}
         type="file"
         className="hidden"
+        aria-label={ariaLabel}
+        aria-required={ariaRequired || undefined}
         onChange={(event) => {
           const file = event.target.files?.[0]
           if (file) onChange({ name: file.name })
@@ -57,6 +63,7 @@ function FileAnswerField({
       <FileUploadField
         fileName={fileName}
         error={error}
+        ariaLabel={ariaLabel}
         onUpload={() => inputRef.current?.click()}
         onDelete={() => onChange(null)}
       />
@@ -176,6 +183,14 @@ export function ApplyAnswerField({
         />
       )
     case "file":
-      return <FileAnswerField value={value} onChange={onChange} error={error} />
+      return (
+        <FileAnswerField
+          value={value}
+          onChange={onChange}
+          error={error}
+          ariaLabel={question.title}
+          ariaRequired={question.required}
+        />
+      )
   }
 }

--- a/src/features/recruiting/ui/apply/ApplyAnswerField.tsx
+++ b/src/features/recruiting/ui/apply/ApplyAnswerField.tsx
@@ -1,0 +1,181 @@
+import { useRef } from "react"
+
+import { Dropdown } from "@/shared/ui/Dropdown"
+import { CheckboxList } from "@/shared/ui/input/checkbox/CheckboxList"
+import { OPTION_LIST_CLASS } from "@/shared/ui/input/optionList"
+import { RadioList } from "@/shared/ui/input/radio/RadioList"
+import { FileUploadField } from "@/shared/ui/question-field/FileUploadField"
+import { PortfolioField } from "@/shared/ui/question-field/PortfolioField"
+import { TextQuestionField } from "@/shared/ui/question-field/TextQuestionField"
+
+import {
+  APPLY_LONG_TEXT_MAX,
+  APPLY_SHORT_TEXT_MAX,
+  type ApplyAnswerValue,
+  isApplyPortfolioValue,
+  isApplyUploadedFile,
+} from "../../model/applyForm"
+
+import type { ApplicationQuestion } from "../../model/applicationDetail"
+
+interface ApplyAnswerFieldProps {
+  question: ApplicationQuestion
+  value: ApplyAnswerValue
+  onChange: (value: ApplyAnswerValue) => void
+  error?: string
+}
+
+function OptionError({ error }: { error?: string }) {
+  if (!error) return null
+  return <p className="text-caption-2-regular text-error-600 px-1">{error}</p>
+}
+
+function FileAnswerField({
+  value,
+  onChange,
+  error,
+}: {
+  value: ApplyAnswerValue
+  onChange: (value: ApplyAnswerValue) => void
+  error?: string
+}) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const fileName = isApplyUploadedFile(value) ? value.name : null
+
+  return (
+    <>
+      <input
+        ref={inputRef}
+        type="file"
+        className="hidden"
+        onChange={(event) => {
+          const file = event.target.files?.[0]
+          if (file) onChange({ name: file.name })
+          event.target.value = ""
+        }}
+      />
+      <FileUploadField
+        fileName={fileName}
+        error={error}
+        onUpload={() => inputRef.current?.click()}
+        onDelete={() => onChange(null)}
+      />
+    </>
+  )
+}
+
+export function ApplyAnswerField({
+  question,
+  value,
+  onChange,
+  error,
+}: ApplyAnswerFieldProps) {
+  switch (question.type) {
+    case "shortText":
+      return (
+        <TextQuestionField
+          value={typeof value === "string" ? value : ""}
+          onChange={onChange}
+          maxLength={APPLY_SHORT_TEXT_MAX}
+          size="md"
+          error={error}
+          ariaLabel={question.title}
+          ariaRequired={question.required}
+        />
+      )
+    case "longText":
+      return (
+        <TextQuestionField
+          value={typeof value === "string" ? value : ""}
+          onChange={onChange}
+          maxLength={APPLY_LONG_TEXT_MAX}
+          size="lg"
+          error={error}
+          ariaLabel={question.title}
+          ariaRequired={question.required}
+        />
+      )
+    case "radio":
+      return (
+        <div className="flex flex-col gap-1">
+          <div
+            role="radiogroup"
+            aria-label={question.title}
+            aria-required={question.required || undefined}
+            className={OPTION_LIST_CLASS}
+          >
+            {question.options.map((option) => (
+              <RadioList
+                key={option.optionId}
+                checked={value === option.optionId}
+                onChange={(checked) => {
+                  onChange(checked ? option.optionId : "")
+                }}
+              >
+                {option.content}
+              </RadioList>
+            ))}
+          </div>
+          <OptionError error={error} />
+        </div>
+      )
+    case "checkbox":
+      return (
+        <div className="flex flex-col gap-1">
+          <div
+            role="group"
+            aria-label={question.title}
+            className={OPTION_LIST_CLASS}
+          >
+            {question.options.map((option) => {
+              const current = Array.isArray(value) ? value : []
+              return (
+                <CheckboxList
+                  key={option.optionId}
+                  checked={current.includes(option.optionId)}
+                  onChange={(checked) => {
+                    onChange(
+                      checked
+                        ? [...current, option.optionId]
+                        : current.filter((id) => id !== option.optionId),
+                    )
+                  }}
+                >
+                  {option.content}
+                </CheckboxList>
+              )
+            })}
+          </div>
+          <OptionError error={error} />
+        </div>
+      )
+    case "dropdown":
+      return (
+        <div className="flex flex-col gap-1">
+          <Dropdown
+            value={typeof value === "string" && value ? value : undefined}
+            onChange={onChange}
+            options={question.options.map((option) => ({
+              value: option.optionId,
+              label: option.content,
+            }))}
+            placeholder="선택해 주세요."
+            error={Boolean(error)}
+          />
+          <OptionError error={error} />
+        </div>
+      )
+    case "portfolio":
+      return (
+        <PortfolioField
+          value={isApplyPortfolioValue(value) ? value : null}
+          onChange={onChange}
+          error={error}
+          ariaLabel={question.title}
+          ariaRequired={question.required}
+        />
+      )
+    case "file":
+      return <FileAnswerField value={value} onChange={onChange} error={error} />
+  }
+}

--- a/src/features/recruiting/ui/apply/RecruitingApplyForm.tsx
+++ b/src/features/recruiting/ui/apply/RecruitingApplyForm.tsx
@@ -1,0 +1,368 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useBlocker } from "@tanstack/react-router"
+import { useMemo, useRef, useState } from "react"
+import { Controller, useForm, useWatch } from "react-hook-form"
+
+import { cn } from "@/shared/lib/utils"
+import { Button } from "@/shared/ui/Button"
+import { CtaModal } from "@/shared/ui/modal/CtaModal"
+import { QuestionItemTitle } from "@/shared/ui/question-field/QuestionItemTitle"
+import { useToastStore } from "@/shared/ui/toast/useToastStore"
+
+import {
+  type ApplyAnswerValue,
+  type ApplyFormConfig,
+  buildDefaultApplyValues,
+  buildRecruitingAnswersSchema,
+  resolveEnabledSectionIds,
+} from "../../model/applyForm"
+import { RECRUITING_APPLY_CODE_MOCK } from "../../model/applyForm.mock"
+import { ApplyAnswerField } from "./ApplyAnswerField"
+
+import type { Resolver } from "react-hook-form"
+
+import type { ApplicationSection } from "../../model/applicationDetail"
+
+type ApplyModalKind = "draftSaved" | "leave" | "submitConfirm" | "complete"
+
+interface RecruitingApplyFormProps {
+  config: ApplyFormConfig
+  initialValues?: Partial<Record<string, ApplyAnswerValue>>
+  onExit?: () => void
+  className?: string
+}
+
+function FolderTabHeader({ title, school }: { title: string; school: string }) {
+  return (
+    <div className="flex items-end">
+      <div
+        className="flex h-21 w-113.5 shrink-0 items-center gap-5 bg-teal-100 pt-3 pb-2.5 pl-4"
+        style={{
+          clipPath: "polygon(0 0, calc(100% - 62px) 0, 100% 100%, 0 100%)",
+          borderTopLeftRadius: 17,
+        }}
+      >
+        <div className="text-heading-7-semibold flex size-12.5 shrink-0 items-center justify-center rounded-[8px] bg-white text-teal-600">
+          {school.slice(0, 1)}
+        </div>
+        <div className="flex min-w-0 flex-col gap-1">
+          <span className="text-heading-6-semibold text-teal-gray-800 truncate">
+            {title}
+          </span>
+          <span className="text-body-2-medium text-teal-gray-600 truncate">
+            {school}
+          </span>
+        </div>
+      </div>
+      <div className="h-2.5 min-w-0 flex-1 rounded-tr-[17px] bg-teal-100" />
+    </div>
+  )
+}
+
+function FormSection({
+  section,
+  renderQuestion,
+}: {
+  section: ApplicationSection
+  renderQuestion: (
+    question: ApplicationSection["questions"][number],
+    index: number,
+  ) => React.ReactNode
+}) {
+  return (
+    <section className="flex flex-col">
+      <h3 className="text-heading-7-semibold rounded-t-[12px] border-x border-t border-teal-300 bg-teal-100 py-2 pr-5 pl-7.5 text-teal-600">
+        {section.title}
+      </h3>
+      <div className="flex flex-col gap-8 rounded-b-[12px] border-x border-b border-teal-300 bg-white px-5 py-8.5">
+        {section.questions.map((question, index) =>
+          renderQuestion(question, index),
+        )}
+      </div>
+    </section>
+  )
+}
+
+export function RecruitingApplyForm({
+  config,
+  initialValues,
+  onExit,
+  className,
+}: RecruitingApplyFormProps) {
+  const addToast = useToastStore((state) => state.addToast)
+  const [openModal, setOpenModal] = useState<ApplyModalKind | null>(null)
+
+  const defaultValues = useMemo(
+    () => ({
+      ...buildDefaultApplyValues(config.sections),
+      ...initialValues,
+    }),
+    [config.sections, initialValues],
+  )
+  const snapshotRef = useRef(JSON.stringify(defaultValues))
+
+  const schemaRef = useRef(
+    buildRecruitingAnswersSchema(
+      config.sections,
+      resolveEnabledSectionIds(config, defaultValues),
+    ),
+  )
+  const resolverRef = useRef<Resolver<Record<string, ApplyAnswerValue>>>(
+    (values, context, options) =>
+      (
+        zodResolver(schemaRef.current) as Resolver<
+          Record<string, ApplyAnswerValue>
+        >
+      )(values, context, options),
+  )
+
+  const { control, getValues, handleSubmit } = useForm<
+    Record<string, ApplyAnswerValue>
+  >({
+    resolver: resolverRef.current,
+    mode: "onChange",
+    defaultValues,
+  })
+
+  const watchedValues = useWatch({ control })
+
+  const enabledSectionIds = useMemo(
+    () =>
+      resolveEnabledSectionIds(config, {
+        ...defaultValues,
+        ...watchedValues,
+      }),
+    [config, defaultValues, watchedValues],
+  )
+
+  const visibleSections = config.sections.filter((section) =>
+    enabledSectionIds.has(section.sectionId),
+  )
+
+  schemaRef.current = useMemo(
+    () => buildRecruitingAnswersSchema(config.sections, enabledSectionIds),
+    [config.sections, enabledSectionIds],
+  )
+
+  const isDirtyNow = () => JSON.stringify(getValues()) !== snapshotRef.current
+
+  const {
+    proceed: proceedLeave,
+    reset: resetLeave,
+    status: leaveStatus,
+  } = useBlocker({
+    shouldBlockFn: () => isDirtyNow(),
+    withResolver: true,
+  })
+
+  const applicantName = (() => {
+    const raw = config.nameQuestionId
+      ? getValues()[config.nameQuestionId]
+      : null
+    return typeof raw === "string" && raw.trim() ? raw.trim() : "지원자"
+  })()
+
+  const submitWithValidation = (onValid: () => void) =>
+    handleSubmit(
+      () => onValid(),
+      (errors) => handleInvalid(errors),
+    )
+
+  const handleInvalid = (
+    errors: Record<string, { message?: string } | undefined>,
+  ) => {
+    const firstQuestionId = config.sections
+      .filter((section) => enabledSectionIds.has(section.sectionId))
+      .flatMap((section) => section.questions)
+      .find((question) => errors[question.questionId])?.questionId
+    addToast({
+      message: "필수 항목을 확인해 주세요.",
+      color: "red",
+      variant: "deep",
+      type: "default",
+      duration: 3000,
+    })
+    if (firstQuestionId) {
+      document
+        .querySelector(`[data-question-id="${firstQuestionId}"]`)
+        ?.scrollIntoView({ behavior: "smooth", block: "center" })
+    }
+  }
+
+  const handleSaveDraft = () => {
+    snapshotRef.current = JSON.stringify(getValues())
+    setOpenModal("draftSaved")
+  }
+
+  const handleExit = () => {
+    snapshotRef.current = JSON.stringify(getValues())
+    setOpenModal(null)
+    onExit?.()
+  }
+
+  return (
+    <div className={cn("flex w-full flex-col", className)}>
+      <FolderTabHeader
+        title={config.recruitment.title}
+        school={config.recruitment.school}
+      />
+      <div className="flex flex-col gap-9 rounded-b-[17px] border-x border-b border-teal-100 bg-white px-11.5 pt-9 pb-12">
+        <p className="text-body-1-regular text-teal-gray-700 whitespace-pre-wrap">
+          {config.recruitment.notice}
+        </p>
+        <div className="flex flex-col gap-8">
+          {visibleSections.map((section) => (
+            <FormSection
+              key={section.sectionId}
+              section={section}
+              renderQuestion={(question, index) => (
+                <div
+                  key={question.questionId}
+                  data-question-id={question.questionId}
+                  className="flex flex-col gap-3 px-1"
+                >
+                  <QuestionItemTitle
+                    index={String(index + 1).padStart(2, "0")}
+                    title={question.title}
+                    caption={question.description}
+                    required={question.required}
+                  />
+                  <div className="pl-8.5">
+                    <Controller
+                      control={control}
+                      name={question.questionId}
+                      render={({ field, fieldState }) => (
+                        <ApplyAnswerField
+                          question={question}
+                          value={field.value ?? null}
+                          onChange={field.onChange}
+                          error={fieldState.error?.message}
+                        />
+                      )}
+                    />
+                  </div>
+                </div>
+              )}
+            />
+          ))}
+        </div>
+        <div className="mt-3 flex items-center justify-center gap-4">
+          <Button
+            type="button"
+            variant="weak"
+            color="neutral"
+            size="xl"
+            className="w-50"
+            onClick={handleSaveDraft}
+          >
+            임시저장 후 나가기
+          </Button>
+          <Button
+            type="button"
+            size="xl"
+            className="w-50"
+            onClick={submitWithValidation(() => setOpenModal("submitConfirm"))}
+          >
+            제출하기
+          </Button>
+        </div>
+      </div>
+
+      <CtaModal
+        open={openModal === "draftSaved"}
+        variant="success"
+        title="지원서가 임시저장되었습니다"
+        content={
+          <span className="whitespace-pre-line">
+            {applicantName}님의 지원 코드는{" "}
+            <span className="text-teal-600">{RECRUITING_APPLY_CODE_MOCK}</span>
+            입니다.
+            {"\n"}
+            <span className="underline underline-offset-2">내 지원서</span>에서
+            이어서 작성할 수 있습니다.
+            {"\n"}마감 전까지 제출을 완료해 주세요.
+            {"\n\n"}이메일과 지원 코드를 알면 누구나 지원서를 확인하고 수정할 수
+            있습니다.
+            {"\n"}지원 코드가 다른 사람에게 보이지 않도록 주의해 주세요.
+          </span>
+        }
+        cancelText="계속 작성하기"
+        confirmText="나가기"
+        onOpenChange={(open) => {
+          if (!open) setOpenModal(null)
+        }}
+        onCancel={() => setOpenModal(null)}
+        onConfirm={handleExit}
+      />
+
+      <CtaModal
+        open={leaveStatus === "blocked"}
+        variant="warning"
+        title="페이지를 나가시겠습니까?"
+        content={
+          <span className="whitespace-pre-line">
+            작성 중인 내용이 있습니다.
+            {"\n"}페이지를 나가면 저장하지 않은 내용은 사라집니다.
+          </span>
+        }
+        cancelText="계속 작성하기"
+        confirmText="나가기"
+        onOpenChange={(open) => {
+          if (!open) resetLeave?.()
+        }}
+        onCancel={() => resetLeave?.()}
+        onConfirm={() => proceedLeave?.()}
+      />
+
+      <CtaModal
+        open={openModal === "submitConfirm" && leaveStatus !== "blocked"}
+        variant="warning"
+        title="지원서를 제출할까요?"
+        content={
+          <span className="whitespace-pre-line">
+            제출 후에도 모집 마감 전까지 수정할 수 있습니다.
+            {"\n"}마감 전 마지막으로 저장한 내용이 최종 반영됩니다.
+          </span>
+        }
+        cancelText="계속 작성하기"
+        confirmText="제출하기"
+        onOpenChange={(open) => {
+          if (!open) setOpenModal(null)
+        }}
+        onCancel={() => setOpenModal(null)}
+        onConfirm={() => {
+          snapshotRef.current = JSON.stringify(getValues())
+          setOpenModal("complete")
+        }}
+      />
+
+      <CtaModal
+        open={openModal === "complete"}
+        variant="success"
+        title="제출 완료"
+        content={
+          <span className="whitespace-pre-line">
+            {applicantName}님의 지원 번호는{" "}
+            <span className="text-teal-600">{RECRUITING_APPLY_CODE_MOCK}</span>
+            입니다.
+            {"\n"}발급된 번호로{" "}
+            <span className="underline underline-offset-2">내 지원서</span>{" "}
+            페이지에서 모집 마감 전까지 수정할 수 있습니다.
+            {"\n\n"}지원 코드와 향후 합격 여부를 포함한 모든 모집 안내는 입력한
+            이메일로 보내드리니, 모집 기간 동안 이메일 수신함을 자주 확인해
+            주시기 바랍니다.
+            {"\n\n"}지원해 주셔서 감사합니다!
+          </span>
+        }
+        cancelText="나가기"
+        confirmText="내 지원서 확인하기"
+        cancelOnDismiss={false}
+        onOpenChange={(open) => {
+          if (!open) setOpenModal(null)
+        }}
+        onCancel={handleExit}
+        onConfirm={handleExit}
+      />
+    </div>
+  )
+}

--- a/src/features/recruiting/ui/apply/RecruitingApplyForm.tsx
+++ b/src/features/recruiting/ui/apply/RecruitingApplyForm.tsx
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useBlocker } from "@tanstack/react-router"
-import { useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { Controller, useForm, useWatch } from "react-hook-form"
 
 import { cn } from "@/shared/lib/utils"
@@ -139,10 +139,14 @@ export function RecruitingApplyForm({
     enabledSectionIds.has(section.sectionId),
   )
 
-  schemaRef.current = useMemo(
+  const schema = useMemo(
     () => buildRecruitingAnswersSchema(config.sections, enabledSectionIds),
     [config.sections, enabledSectionIds],
   )
+
+  useEffect(() => {
+    schemaRef.current = schema
+  }, [schema])
 
   const isDirtyNow = () => JSON.stringify(getValues()) !== snapshotRef.current
 

--- a/src/features/recruiting/ui/apply/RecruitingApplyForm.tsx
+++ b/src/features/recruiting/ui/apply/RecruitingApplyForm.tsx
@@ -29,6 +29,7 @@ interface RecruitingApplyFormProps {
   config: ApplyFormConfig
   initialValues?: Partial<Record<string, ApplyAnswerValue>>
   onExit?: () => void
+  onViewApplication?: () => void
   className?: string
 }
 
@@ -87,6 +88,7 @@ export function RecruitingApplyForm({
   config,
   initialValues,
   onExit,
+  onViewApplication,
   className,
 }: RecruitingApplyFormProps) {
   const addToast = useToastStore((state) => state.addToast)
@@ -202,6 +204,12 @@ export function RecruitingApplyForm({
     snapshotRef.current = JSON.stringify(getValues())
     setOpenModal(null)
     onExit?.()
+  }
+
+  const handleViewApplication = () => {
+    snapshotRef.current = JSON.stringify(getValues())
+    setOpenModal(null)
+    ;(onViewApplication ?? onExit)?.()
   }
 
   return (
@@ -365,7 +373,7 @@ export function RecruitingApplyForm({
           if (!open) setOpenModal(null)
         }}
         onCancel={handleExit}
-        onConfirm={handleExit}
+        onConfirm={handleViewApplication}
       />
     </div>
   )

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -32,6 +32,7 @@ import { Route as TestToastRouteImport } from './routes/test/toast'
 import { Route as TestTextFieldRouteImport } from './routes/test/text-field'
 import { Route as TestTextButtonRouteImport } from './routes/test/text-button'
 import { Route as TestSocialButtonRouteImport } from './routes/test/social-button'
+import { Route as TestRecruitingApplyRouteImport } from './routes/test/recruiting-apply'
 import { Route as TestRecruitingApplicationDetailRouteImport } from './routes/test/recruiting-application-detail'
 import { Route as TestRecruitingApplicantsRouteImport } from './routes/test/recruiting-applicants'
 import { Route as TestRatingFaceRouteImport } from './routes/test/rating-face'
@@ -190,6 +191,11 @@ const TestTextButtonRoute = TestTextButtonRouteImport.update({
 const TestSocialButtonRoute = TestSocialButtonRouteImport.update({
   id: '/test/social-button',
   path: '/test/social-button',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const TestRecruitingApplyRoute = TestRecruitingApplyRouteImport.update({
+  id: '/test/recruiting-apply',
+  path: '/test/recruiting-apply',
   getParentRoute: () => rootRouteImport,
 } as any)
 const TestRecruitingApplicationDetailRoute =
@@ -465,6 +471,7 @@ export interface FileRoutesByFullPath {
   '/test/rating-face': typeof TestRatingFaceRoute
   '/test/recruiting-applicants': typeof TestRecruitingApplicantsRoute
   '/test/recruiting-application-detail': typeof TestRecruitingApplicationDetailRoute
+  '/test/recruiting-apply': typeof TestRecruitingApplyRoute
   '/test/social-button': typeof TestSocialButtonRoute
   '/test/text-button': typeof TestTextButtonRoute
   '/test/text-field': typeof TestTextFieldRoute
@@ -531,6 +538,7 @@ export interface FileRoutesByTo {
   '/test/rating-face': typeof TestRatingFaceRoute
   '/test/recruiting-applicants': typeof TestRecruitingApplicantsRoute
   '/test/recruiting-application-detail': typeof TestRecruitingApplicationDetailRoute
+  '/test/recruiting-apply': typeof TestRecruitingApplyRoute
   '/test/social-button': typeof TestSocialButtonRoute
   '/test/text-button': typeof TestTextButtonRoute
   '/test/text-field': typeof TestTextFieldRoute
@@ -600,6 +608,7 @@ export interface FileRoutesById {
   '/test/rating-face': typeof TestRatingFaceRoute
   '/test/recruiting-applicants': typeof TestRecruitingApplicantsRoute
   '/test/recruiting-application-detail': typeof TestRecruitingApplicationDetailRoute
+  '/test/recruiting-apply': typeof TestRecruitingApplyRoute
   '/test/social-button': typeof TestSocialButtonRoute
   '/test/text-button': typeof TestTextButtonRoute
   '/test/text-field': typeof TestTextFieldRoute
@@ -671,6 +680,7 @@ export interface FileRouteTypes {
     | '/test/rating-face'
     | '/test/recruiting-applicants'
     | '/test/recruiting-application-detail'
+    | '/test/recruiting-apply'
     | '/test/social-button'
     | '/test/text-button'
     | '/test/text-field'
@@ -737,6 +747,7 @@ export interface FileRouteTypes {
     | '/test/rating-face'
     | '/test/recruiting-applicants'
     | '/test/recruiting-application-detail'
+    | '/test/recruiting-apply'
     | '/test/social-button'
     | '/test/text-button'
     | '/test/text-field'
@@ -805,6 +816,7 @@ export interface FileRouteTypes {
     | '/test/rating-face'
     | '/test/recruiting-applicants'
     | '/test/recruiting-application-detail'
+    | '/test/recruiting-apply'
     | '/test/social-button'
     | '/test/text-button'
     | '/test/text-field'
@@ -871,6 +883,7 @@ export interface RootRouteChildren {
   TestRatingFaceRoute: typeof TestRatingFaceRoute
   TestRecruitingApplicantsRoute: typeof TestRecruitingApplicantsRoute
   TestRecruitingApplicationDetailRoute: typeof TestRecruitingApplicationDetailRoute
+  TestRecruitingApplyRoute: typeof TestRecruitingApplyRoute
   TestSocialButtonRoute: typeof TestSocialButtonRoute
   TestTextButtonRoute: typeof TestTextButtonRoute
   TestTextFieldRoute: typeof TestTextFieldRoute
@@ -1047,6 +1060,13 @@ declare module '@tanstack/react-router' {
       path: '/test/social-button'
       fullPath: '/test/social-button'
       preLoaderRoute: typeof TestSocialButtonRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/test/recruiting-apply': {
+      id: '/test/recruiting-apply'
+      path: '/test/recruiting-apply'
+      fullPath: '/test/recruiting-apply'
+      preLoaderRoute: typeof TestRecruitingApplyRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/test/recruiting-application-detail': {
@@ -1529,6 +1549,7 @@ const rootRouteChildren: RootRouteChildren = {
   TestRatingFaceRoute: TestRatingFaceRoute,
   TestRecruitingApplicantsRoute: TestRecruitingApplicantsRoute,
   TestRecruitingApplicationDetailRoute: TestRecruitingApplicationDetailRoute,
+  TestRecruitingApplyRoute: TestRecruitingApplyRoute,
   TestSocialButtonRoute: TestSocialButtonRoute,
   TestTextButtonRoute: TestTextButtonRoute,
   TestTextFieldRoute: TestTextFieldRoute,

--- a/src/routes/test/recruiting-apply.tsx
+++ b/src/routes/test/recruiting-apply.tsx
@@ -1,0 +1,67 @@
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
+
+import { RecruitingApplyForm } from "@/features/recruiting"
+import { RECRUITING_APPLY_FORM_MOCK } from "@/features/recruiting/model/applyForm.mock"
+import PersonIcon from "@/shared/assets/icon/people/PersonIcon"
+import { PageLabel } from "@/shared/ui/page-label/PageLabel"
+import Footer from "@/widgets/footer/Footer"
+import Header from "@/widgets/navigation/header/Header"
+
+const APPLICANT_SIDEBAR_ITEMS = ["지원 방법", "모집 공고", "내 지원서"]
+
+export const Route = createFileRoute("/test/recruiting-apply")({
+  component: RecruitingApplyTestPage,
+})
+
+function RecruitingApplyTestPage() {
+  const navigate = useNavigate()
+
+  return (
+    <main className="flex h-full min-h-screen w-full flex-col">
+      <Header activePathname="/recruiting" />
+      <div className="flex w-full flex-1">
+        <aside className="border-teal-gray-100 w-55 shrink-0 border-r bg-white px-4 pt-8">
+          <span className="text-caption-1-medium text-teal-gray-400 px-2">
+            UMC 10th
+          </span>
+          <nav className="mt-4 flex flex-col gap-0.5">
+            {APPLICANT_SIDEBAR_ITEMS.map((label, index) => (
+              <span
+                key={label}
+                className={
+                  index === 0
+                    ? "text-body-2-medium flex h-12 items-center gap-2 rounded-[10px] bg-teal-50 px-3 text-teal-700"
+                    : "text-body-2-medium text-teal-gray-500 flex h-12 items-center gap-2 px-3"
+                }
+              >
+                <PersonIcon className="size-5 shrink-0" />
+                {label}
+              </span>
+            ))}
+          </nav>
+        </aside>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="min-h-200 px-8 pt-10 pb-20">
+            <div className="flex w-full max-w-265 flex-col">
+              <PageLabel
+                breadcrumb={[
+                  { id: "recruiting", label: "리크루팅" },
+                  { id: "apply", label: "지원하기" },
+                  { id: "guide", label: "지원 방법" },
+                ]}
+                title="모집 공고"
+                className="pl-3"
+              />
+              <RecruitingApplyForm
+                config={RECRUITING_APPLY_FORM_MOCK}
+                onExit={() => navigate({ to: "/test" })}
+                className="mt-8"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <Footer />
+    </main>
+  )
+}

--- a/src/shared/ui/question-field/FileUploadField.tsx
+++ b/src/shared/ui/question-field/FileUploadField.tsx
@@ -11,6 +11,7 @@ interface FileUploadFieldProps extends Omit<ComponentProps<"div">, "children"> {
   onUpload: () => void
   onDelete: () => void
   error?: string
+  ariaLabel?: string
 }
 
 export function FileUploadField({
@@ -20,6 +21,7 @@ export function FileUploadField({
   onUpload,
   onDelete,
   error,
+  ariaLabel,
   className,
   ...props
 }: FileUploadFieldProps) {
@@ -50,6 +52,7 @@ export function FileUploadField({
               size="xs"
               color="primary"
               onClick={onUpload}
+              aria-label={ariaLabel ? `${ariaLabel} 파일 업로드` : undefined}
               className="w-auto min-w-fit px-3"
             >
               파일 업로드
@@ -68,7 +71,12 @@ export function FileUploadField({
                 {fileName}
               </span>
             </div>
-            <Button size="xs" color="neutral" onClick={onDelete}>
+            <Button
+              size="xs"
+              color="neutral"
+              onClick={onDelete}
+              aria-label={ariaLabel ? `${ariaLabel} 파일 삭제` : undefined}
+            >
               삭제
             </Button>
           </>

--- a/src/shared/ui/question-field/PortfolioField.tsx
+++ b/src/shared/ui/question-field/PortfolioField.tsx
@@ -24,6 +24,8 @@ interface PortfolioFieldProps {
   onChange?: (value: PortfolioValue | null) => void
   error?: string
   className?: string
+  ariaLabel?: string
+  ariaRequired?: boolean
 }
 
 export function PortfolioField({
@@ -31,6 +33,8 @@ export function PortfolioField({
   onChange,
   error: errorProp,
   className,
+  ariaLabel,
+  ariaRequired,
 }: PortfolioFieldProps) {
   const [link, setLink] = useState(value?.kind === "link" ? value.url : "")
   const [linkError, setLinkError] = useState("")
@@ -44,7 +48,11 @@ export function PortfolioField({
     const val = e.target.value
     setLink(val)
     setLinkError("")
-    if (!val) onChange?.(null)
+    if (val && isValidUrl(val)) {
+      onChange?.({ kind: "link", url: val })
+    } else {
+      onChange?.(null)
+    }
   }
 
   function handleLinkBlur() {
@@ -113,6 +121,8 @@ export function PortfolioField({
               value={link}
               onChange={handleLinkChange}
               onBlur={handleLinkBlur}
+              aria-label={ariaLabel}
+              aria-required={ariaRequired || undefined}
               placeholder="링크를 입력하거나 파일을 첨부해 주세요. 150MB 이하의 PDF 파일만 업로드 가능합니다."
               className={cn(
                 "text-body-1-medium placeholder:text-body-1-regular placeholder:text-teal-gray-400 min-w-0 flex-1 bg-transparent outline-none",

--- a/src/shared/ui/question-field/QuestionItemTitle.tsx
+++ b/src/shared/ui/question-field/QuestionItemTitle.tsx
@@ -27,7 +27,11 @@ export function QuestionItemTitle({
           ) : (
             <span className="text-teal-gray-400">질문을 작성하세요</span>
           )}
-          {required && <span className="text-error-600 ml-1">*</span>}
+          {required && (
+            <span aria-hidden="true" className="text-error-600 ml-1">
+              *
+            </span>
+          )}
         </span>
         {caption !== undefined && caption !== "" && (
           <span className="text-body-2-regular text-teal-gray-600 break-keep whitespace-pre-wrap">

--- a/src/shared/ui/question-field/TextQuestionField.tsx
+++ b/src/shared/ui/question-field/TextQuestionField.tsx
@@ -14,6 +14,8 @@ interface TextQuestionFieldProps {
   size?: "lg" | "md"
   error?: string
   className?: string
+  ariaLabel?: string
+  ariaRequired?: boolean
   onKeyDown?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void
   textareaRef?: React.RefObject<HTMLTextAreaElement | null>
 }
@@ -27,6 +29,8 @@ export function TextQuestionField({
   size = "lg",
   error,
   className,
+  ariaLabel,
+  ariaRequired,
   onKeyDown,
   textareaRef: externalTextareaRef,
 }: TextQuestionFieldProps) {
@@ -61,6 +65,8 @@ export function TextQuestionField({
           value={value}
           maxLength={maxLength}
           placeholder={placeholder}
+          aria-label={ariaLabel}
+          aria-required={ariaRequired || undefined}
           onChange={(e) => onChange(e.target.value)}
           onFocus={() => setFocused(true)}
           onBlur={() => setFocused(false)}


### PR DESCRIPTION
## 📸 작업 내용

리크루팅 **지원 폼 모달**(챌린저가 모집 공고에서 지원서를 작성·임시저장·제출하는 화면)을 구현했습니다. 배경 공고 페이지는 타 팀원 담당·미구현이라, 폼 모달 + 서브모달 4종을 독립 컴포넌트로 구현·export하고 `/test` 라우트로 검증합니다. mock 기반이며 도메인 모델은 향후 API 응답 스펙으로 치환하기 쉽게 정의했습니다.

- 질문 타입 7종 입력 필드(단답/장문/라디오/체크박스/드롭다운/포트폴리오/파일) — 공용 `TextQuestionField`·`RadioList`·`CheckboxList`·`Dropdown`·`PortfolioField`·`FileUploadField` 재사용
- **1·2지망 파트 선택에 따라 해당 파트 섹션이 동적으로 노출**(선택 순서대로)
- 서브모달 4종: 임시저장 완료(지원 코드 안내) / 페이지 이탈 / 제출 확인 / 제출 완료 — 공용 `CtaModal` 재사용, 문구 시안 준수
- 값 JSON 스냅샷 비교로 dirty 감지 + `useBlocker` 이탈 가드
- 적대적 검증 반영: 공용 폼 필드 접근성(radiogroup/aria-label/aria-required, 필수 표시 aria-hidden)·포트폴리오 링크 입력 실시간 검증 동기화

## 🎞️ 주요 코드 설명

### 동적 파트 섹션 + 동적 검증 스키마

`resolveEnabledSectionIds`가 1·2지망 선택값으로 활성 파트 섹션을 계산하고, `buildRecruitingAnswersSchema`가 활성 섹션만 필수 검증합니다. RHF resolver를 ref 기반으로 두어 파트 섹션 활성 변화가 제출 검증에 정확히 반영되도록 했습니다.

### 값 스냅샷 dirty 감지

이 폼 계열은 `isDirty`/`dirtyFields`가 불안정해(기존 `ProjectApplyModal` 선례), `JSON.stringify(getValues())` 스냅샷 비교로 변경을 감지하고 `useBlocker`로 이탈을 가드합니다. 임시저장/제출 시 스냅샷을 갱신합니다.

### 공용 폼 필드 보강(적대적 검증)

`PortfolioField`의 링크 입력을 실시간으로 폼 상태에 동기화해, 무효 URL이 남은 stale 값으로 검증을 통과하던 문제를 수정했습니다. 공용 필드에 `aria-label`/`aria-required` 옵션을 추가(기존 사용처 무영향)해 지원 폼에서 질문 제목을 접근성 이름으로 연결했습니다.

## 🖥️ 구현화면

> localhost 1440px 캡처

|           지원 폼 (디폴트)            |           1·2지망 선택 → 파트 섹션 노출            |
| :-------------------------: | :-------------------------: |
| <img src = "" width ="250"> | <img src = "" width ="250"> |

## 🔗 연결된 이슈

- Connected: #603
- Closes #603

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 모집 지원서 작성 폼을 추가했습니다.
  * 단답형, 장문형, 선택형, 파일 및 포트폴리오 질문을 지원합니다.
  * 필수 항목 검증, 조건부 섹션 표시, 임시저장 및 제출 확인 흐름을 제공합니다.
  * 지원서 테스트 페이지를 추가했습니다.

* **버그 수정**
  * 포트폴리오 링크 입력 시 유효한 URL만 저장되도록 개선했습니다.

* **접근성**
  * 입력 필드에 접근성 라벨과 필수 상태 정보를 지원합니다.
  * 필수 항목 표시가 보조 기술에서 올바르게 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->