### PR TITLE
✨ feat: 리크루팅 지원서 면접 평가 상세 화면 구현

### DIFF
--- a/src/features/recruiting/model/applicationDetail.mock.ts
+++ b/src/features/recruiting/model/applicationDetail.mock.ts
@@ -13,6 +13,7 @@ import type { PartTag } from "@/shared/model/domain"
 import type {
   ApplicationDetail,
   ApplicationSection,
+  InterviewContent,
   OperatorEvaluation,
   StageEvaluationDetail,
 } from "./applicationDetail"
@@ -228,9 +229,65 @@ function buildStageDetail(
   }
 }
 
+function buildInterviewContent(row: ApplicantRow): InterviewContent {
+  const interviewEvaluation = getStageEvaluation(row, "interview")
+  const totalCountLabel = interviewEvaluation
+    ? `총 ${interviewEvaluation.totalCount}명`
+    : undefined
+  return {
+    blocks: [
+      {
+        group: "common",
+        title: "공통 질문",
+        totalCountLabel,
+        timestampLabel: "26-07-04 02:48 기준",
+        questions: [
+          { text: "UMC는 어떻게 알게 되셨나요?" },
+          { text: "재학 중이신가요, 휴학 중이신가요?" },
+          { text: "무슨 노래 좋아하세요?" },
+          { text: "MBTI가 어떻게 되세요?" },
+        ],
+        answers: [
+          {
+            sessionLabel: "이방토/이예원",
+            submittedAt: "26-07-04 02:48 기준",
+            text: "1. 학교 카톡 공지방에서 봄\n2. 휴학 중\n3. 엑스지 좋아해요\n4. 궁금하면 오백원",
+          },
+          {
+            sessionLabel: "벨라/황지원",
+            submittedAt: "26-07-04 03:04 기준",
+            text: "1. 학교 카톡 공지방에서 봤다고 함\n2. 첫 휴학 학기\n3. 엑스지 좋아한다심\n4. 궁금하면 오백원이라심",
+          },
+        ],
+      },
+      {
+        group: "individual",
+        title: "개별 질문",
+        questions: [
+          { text: "전공이 어떻게 되시나요?" },
+          { text: "오프라인 참여도 가능하신가요?" },
+          {
+            text: "포트폴리오에서 OOO 프로젝트는 무엇인가요? 참여 비율은 어떻게 되나요?",
+          },
+          { text: "개발자와 협업해 보신 경험이 있으신가요?" },
+          { text: "서비스 배포 경험이 있으신가요?" },
+        ],
+        answers: [
+          {
+            sessionLabel: "이방토/이예원",
+            submittedAt: null,
+            text: "1. 커뮤니케이션 디자인학과\n2. 네\n3. 60% 정도입니다. 사용자 기반 앱 분석 UX Research이고 실 사용자 조사로 뽑아낸 Painpoint로 개선 접근해 리뉴얼을 진행한 것입니다.\n4. ㅇㅇ 4번\n5. ㅇㅇ 3번 했어요",
+          },
+        ],
+      },
+    ],
+  }
+}
+
 const STAGES: EvaluationStage[] = ["document", "interview", "final"]
 
 function buildDetailFromRow(row: ApplicantRow): ApplicationDetail {
+  const reachedStages = STAGES.filter((stage) => getStageEvaluation(row, stage))
   return {
     applicationId: row.applicationId,
     applicantName: row.applicantName,
@@ -238,12 +295,15 @@ function buildDetailFromRow(row: ApplicantRow): ApplicationDetail {
     school: row.school,
     recruitmentLabel: `${row.school} ${RECRUITING_TARGET_GISU_LABEL_MOCK} ${formatRecruitmentType(row)} 모집`,
     parts: row.parts,
-    reachedStages: STAGES.filter((stage) => getStageEvaluation(row, stage)),
+    reachedStages,
     finalResult: getStageEvaluation(row, "final")?.result ?? null,
     sections: [
       buildBasicSection(row),
       ...row.parts.map((part) => buildPartSection(row, part)),
     ],
+    interview: reachedStages.includes("interview")
+      ? buildInterviewContent(row)
+      : null,
     evaluations: {
       document: buildStageDetail(row, "document"),
       interview: buildStageDetail(row, "interview"),

--- a/src/features/recruiting/model/applicationDetail.ts
+++ b/src/features/recruiting/model/applicationDetail.ts
@@ -60,6 +60,25 @@ export interface StageEvaluationDetail {
   operators: OperatorEvaluation[]
 }
 
+export interface InterviewAnswerSession {
+  sessionLabel: string
+  submittedAt: string | null
+  text: string
+}
+
+export interface InterviewQuestionBlock {
+  group: "common" | "individual"
+  title: string
+  totalCountLabel?: string
+  timestampLabel?: string
+  questions: { text: string }[]
+  answers: InterviewAnswerSession[]
+}
+
+export interface InterviewContent {
+  blocks: InterviewQuestionBlock[]
+}
+
 export interface ApplicationDetail {
   applicationId: string
   applicantName: string
@@ -70,6 +89,7 @@ export interface ApplicationDetail {
   reachedStages: EvaluationStage[]
   finalResult: EvaluationResult | null
   sections: ApplicationSection[]
+  interview: InterviewContent | null
   evaluations: Record<EvaluationStage, StageEvaluationDetail | null>
 }
 

--- a/src/features/recruiting/ui/ApplicantRow.tsx
+++ b/src/features/recruiting/ui/ApplicantRow.tsx
@@ -41,14 +41,21 @@ export function ApplicantRow({ row, stage, columns }: ApplicantRowProps) {
   const visibleColumns = new Set(getVisibleApplicantColumns(stage, columns))
   const timeAt = stage === "interview" ? row.interviewAt : row.appliedAt
   const timestamp = timeAt ? formatAppliedAtParts(timeAt) : null
-  const navigable = stage === "document"
+  const navigable = stage === "document" || stage === "interview"
 
   const openDetail = () => {
-    if (!navigable) return
-    navigate({
-      to: "/recruiting/evaluations/document/$applicationId",
-      params: { applicationId: row.applicationId },
-    })
+    const params = { applicationId: row.applicationId }
+    if (stage === "document") {
+      navigate({
+        to: "/recruiting/evaluations/document/$applicationId",
+        params,
+      })
+    } else if (stage === "interview") {
+      navigate({
+        to: "/recruiting/evaluations/interview/$applicationId",
+        params,
+      })
+    }
   }
 
   return (

--- a/src/features/recruiting/ui/detail/ApplicationEvaluationDetailPage.tsx
+++ b/src/features/recruiting/ui/detail/ApplicationEvaluationDetailPage.tsx
@@ -11,7 +11,9 @@ import {
   type EvaluationStage,
 } from "../../model/evaluationStage"
 import { ApplicationFormReadonly } from "./ApplicationFormReadonly"
+import { EvaluationResultToggle } from "./EvaluationResultToggle"
 import { EvaluationStepper } from "./EvaluationStepper"
+import { InterviewAnswerCards } from "./InterviewAnswerCards"
 import { MyStageEvaluationPanel } from "./MyStageEvaluationPanel"
 import { OperatorEvaluationList } from "./OperatorEvaluationList"
 
@@ -35,8 +37,14 @@ export function ApplicationEvaluationDetailPage({
   const [detail, setDetail] = useState(() =>
     getApplicationDetailMock(applicationId),
   )
+  const [finalResult, setFinalResult] = useState<EvaluationResult | null>(
+    detail.finalResult,
+  )
   const evaluation = detail.evaluations[stage]
   const listPath = STAGE_LIST_PATH[stage]
+  const showFinalResult = stage !== "document"
+  const finalResultLabel =
+    stage === "final" ? "지원자 최종 평가" : "지원자 최종 결과"
 
   const handleComplete = (result: EvaluationResult, comment: string) => {
     setDetail((prev) => {
@@ -103,6 +111,9 @@ export function ApplicationEvaluationDetailPage({
             stage={stage}
             reachedStages={detail.reachedStages}
           />
+          {stage === "interview" && detail.interview && (
+            <InterviewAnswerCards content={detail.interview} />
+          )}
           {evaluation && (
             <>
               <MyStageEvaluationPanel
@@ -112,6 +123,20 @@ export function ApplicationEvaluationDetailPage({
               />
               <OperatorEvaluationList evaluation={evaluation} />
             </>
+          )}
+          {showFinalResult && (
+            <div className="flex items-center justify-center gap-4 pt-2">
+              <span className="text-heading-7-semibold text-teal-gray-800">
+                {finalResultLabel}
+              </span>
+              <EvaluationResultToggle
+                value={finalResult}
+                onChange={setFinalResult}
+                variant="strong"
+                failLabel="최종 불합격"
+                passLabel="최종 합격"
+              />
+            </div>
           )}
         </div>
       </div>

--- a/src/features/recruiting/ui/detail/EvaluationResultToggle.tsx
+++ b/src/features/recruiting/ui/detail/EvaluationResultToggle.tsx
@@ -8,6 +8,7 @@ interface EvaluationResultToggleProps {
   onChange: (value: EvaluationResult) => void
   failLabel?: string
   passLabel?: string
+  variant?: "weak" | "strong"
   disabled?: boolean
   className?: string
 }
@@ -25,9 +26,14 @@ export function EvaluationResultToggle({
   onChange,
   failLabel = "불합격",
   passLabel = "합격",
+  variant = "weak",
   disabled = false,
   className,
 }: EvaluationResultToggleProps) {
+  const selectedClass =
+    variant === "strong"
+      ? "bg-teal-600 text-white"
+      : "border border-teal-200 bg-teal-100 text-teal-500"
   return (
     <div
       role="radiogroup"
@@ -51,9 +57,7 @@ export function EvaluationResultToggle({
             className={cn(
               "text-subtitle-3-semibold flex h-11 min-w-22 items-center justify-center gap-1.5 px-7 py-1 transition-colors",
               side === "left" ? "rounded-l-[8px]" : "rounded-r-[8px]",
-              selected
-                ? "border border-teal-200 bg-teal-100 text-teal-500"
-                : "text-teal-gray-700 bg-white",
+              selected ? selectedClass : "text-teal-gray-700 bg-white",
               !disabled && !selected && "hover:bg-teal-gray-50",
               disabled && "cursor-not-allowed",
             )}

--- a/src/features/recruiting/ui/detail/EvaluationStepper.tsx
+++ b/src/features/recruiting/ui/detail/EvaluationStepper.tsx
@@ -15,7 +15,7 @@ interface EvaluationStepperProps {
   className?: string
 }
 
-const NAVIGABLE_STAGES: EvaluationStage[] = ["document"]
+const NAVIGABLE_STAGES: EvaluationStage[] = ["document", "interview"]
 
 export function EvaluationStepper({
   applicationId,
@@ -37,10 +37,16 @@ export function EvaluationStepper({
       items={items}
       value={stage}
       onValueChange={(next) => {
+        const params = { applicationId }
         if (next === "document") {
           navigate({
             to: "/recruiting/evaluations/document/$applicationId",
-            params: { applicationId },
+            params,
+          })
+        } else if (next === "interview") {
+          navigate({
+            to: "/recruiting/evaluations/interview/$applicationId",
+            params,
           })
         }
       }}

--- a/src/features/recruiting/ui/detail/InterviewAnswerCards.tsx
+++ b/src/features/recruiting/ui/detail/InterviewAnswerCards.tsx
@@ -1,0 +1,125 @@
+import { useState } from "react"
+
+import { cn } from "@/shared/lib/utils"
+
+import type {
+  InterviewContent,
+  InterviewQuestionBlock,
+} from "../../model/applicationDetail"
+
+interface InterviewAnswerCardsProps {
+  content: InterviewContent
+}
+
+function CollapseChevron({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      className={cn(
+        "text-teal-gray-400 transition-transform",
+        expanded ? "" : "-rotate-90",
+      )}
+    >
+      <path
+        d="M6 9.5 12 15l6-5.5"
+        stroke="currentColor"
+        strokeWidth={1.6}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+function InterviewBlockCard({ block }: { block: InterviewQuestionBlock }) {
+  const [expanded, setExpanded] = useState(true)
+  const hasMeta = Boolean(block.timestampLabel || block.totalCountLabel)
+
+  return (
+    <section className="border-teal-gray-100 flex flex-col rounded-[16px] border bg-white p-6">
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center justify-between">
+          <h3 className="text-heading-6-semibold text-teal-gray-800">
+            {block.title}
+          </h3>
+          <button
+            type="button"
+            aria-expanded={expanded}
+            aria-label={`${block.title} 펼치기 접기`}
+            onClick={() => setExpanded((prev) => !prev)}
+            className="text-teal-gray-400 hover:text-teal-gray-600 flex size-6.5 shrink-0 items-center justify-center"
+          >
+            <CollapseChevron expanded={expanded} />
+          </button>
+        </div>
+        {hasMeta && (
+          <div className="text-body-2-regular text-teal-gray-500 flex items-center gap-2">
+            {block.timestampLabel && <span>{block.timestampLabel}</span>}
+            {block.timestampLabel && block.totalCountLabel && (
+              <span className="text-teal-gray-300">|</span>
+            )}
+            {block.totalCountLabel && <span>{block.totalCountLabel}</span>}
+          </div>
+        )}
+      </div>
+
+      {expanded && (
+        <div className="mt-5 flex flex-col gap-6">
+          <ol className="flex flex-col gap-3">
+            {block.questions.map((question, index) => (
+              <li
+                key={question.text}
+                className="text-body-1-regular text-teal-gray-800 flex gap-2"
+              >
+                <span className="text-teal-gray-500 shrink-0">
+                  {index + 1}.
+                </span>
+                <span>{question.text}</span>
+              </li>
+            ))}
+          </ol>
+
+          <div className="flex flex-col gap-4">
+            <h4 className="text-heading-7-semibold text-teal-gray-800">
+              지원자 답변
+            </h4>
+            {block.answers.map((answer) => (
+              <div key={answer.sessionLabel} className="flex flex-col gap-2">
+                <div className="text-body-2-medium text-teal-gray-700 flex items-center gap-2">
+                  <span>면접자: {answer.sessionLabel}</span>
+                  {answer.submittedAt && (
+                    <>
+                      <span className="text-teal-gray-300">|</span>
+                      <span className="text-teal-gray-500">
+                        {answer.submittedAt}
+                      </span>
+                    </>
+                  )}
+                </div>
+                <div className="border-teal-gray-100 rounded-[12px] border bg-white px-5 py-4">
+                  <p className="text-body-1-regular text-teal-gray-900 whitespace-pre-wrap">
+                    {answer.text}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+export function InterviewAnswerCards({ content }: InterviewAnswerCardsProps) {
+  return (
+    <div className="flex flex-col gap-5">
+      {content.blocks.map((block) => (
+        <InterviewBlockCard key={block.group} block={block} />
+      ))}
+    </div>
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -73,6 +73,7 @@ import { Route as AdminChallengerRecordsRouteImport } from './routes/admin/chall
 import { Route as AdminChallengerPointsRouteImport } from './routes/admin/challenger/points'
 import { Route as MatchingProjectsAnnounceRouteRouteImport } from './routes/matching/projects/announce/route'
 import { Route as MatchingProjectsAnnounceIndexRouteImport } from './routes/matching/projects/announce/index'
+import { Route as RecruitingEvaluationsInterviewApplicationIdRouteImport } from './routes/recruiting/evaluations/interview.$applicationId'
 import { Route as RecruitingEvaluationsDocumentApplicationIdRouteImport } from './routes/recruiting/evaluations/document.$applicationId'
 import { Route as MatchingProjectsEditProjectIdRouteImport } from './routes/matching/projects/edit.$projectId'
 import { Route as MatchingProjectsAnnounceNoticePublishRouteImport } from './routes/matching/projects/announce/notice-publish'
@@ -409,6 +410,12 @@ const MatchingProjectsAnnounceIndexRoute =
     path: '/',
     getParentRoute: () => MatchingProjectsAnnounceRouteRoute,
   } as any)
+const RecruitingEvaluationsInterviewApplicationIdRoute =
+  RecruitingEvaluationsInterviewApplicationIdRouteImport.update({
+    id: '/$applicationId',
+    path: '/$applicationId',
+    getParentRoute: () => RecruitingEvaluationsInterviewRoute,
+  } as any)
 const RecruitingEvaluationsDocumentApplicationIdRoute =
   RecruitingEvaluationsDocumentApplicationIdRouteImport.update({
     id: '/$applicationId',
@@ -496,11 +503,12 @@ export interface FileRoutesByFullPath {
   '/oauth/kakao/callback': typeof OauthKakaoCallbackRoute
   '/recruiting/evaluations/document': typeof RecruitingEvaluationsDocumentRouteWithChildren
   '/recruiting/evaluations/final': typeof RecruitingEvaluationsFinalRoute
-  '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRoute
+  '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRouteWithChildren
   '/matching/projects/': typeof MatchingProjectsIndexRoute
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/edit/$projectId': typeof MatchingProjectsEditProjectIdRoute
   '/recruiting/evaluations/document/$applicationId': typeof RecruitingEvaluationsDocumentApplicationIdRoute
+  '/recruiting/evaluations/interview/$applicationId': typeof RecruitingEvaluationsInterviewApplicationIdRoute
   '/matching/projects/announce/': typeof MatchingProjectsAnnounceIndexRoute
   '/matching/projects/announce/notice-publish/$noticeId': typeof MatchingProjectsAnnounceNoticePublishNoticeIdRoute
 }
@@ -562,11 +570,12 @@ export interface FileRoutesByTo {
   '/oauth/kakao/callback': typeof OauthKakaoCallbackRoute
   '/recruiting/evaluations/document': typeof RecruitingEvaluationsDocumentRouteWithChildren
   '/recruiting/evaluations/final': typeof RecruitingEvaluationsFinalRoute
-  '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRoute
+  '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRouteWithChildren
   '/matching/projects': typeof MatchingProjectsIndexRoute
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/edit/$projectId': typeof MatchingProjectsEditProjectIdRoute
   '/recruiting/evaluations/document/$applicationId': typeof RecruitingEvaluationsDocumentApplicationIdRoute
+  '/recruiting/evaluations/interview/$applicationId': typeof RecruitingEvaluationsInterviewApplicationIdRoute
   '/matching/projects/announce': typeof MatchingProjectsAnnounceIndexRoute
   '/matching/projects/announce/notice-publish/$noticeId': typeof MatchingProjectsAnnounceNoticePublishNoticeIdRoute
 }
@@ -633,11 +642,12 @@ export interface FileRoutesById {
   '/oauth/kakao/callback': typeof OauthKakaoCallbackRoute
   '/recruiting/evaluations/document': typeof RecruitingEvaluationsDocumentRouteWithChildren
   '/recruiting/evaluations/final': typeof RecruitingEvaluationsFinalRoute
-  '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRoute
+  '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRouteWithChildren
   '/matching/projects/': typeof MatchingProjectsIndexRoute
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/edit/$projectId': typeof MatchingProjectsEditProjectIdRoute
   '/recruiting/evaluations/document/$applicationId': typeof RecruitingEvaluationsDocumentApplicationIdRoute
+  '/recruiting/evaluations/interview/$applicationId': typeof RecruitingEvaluationsInterviewApplicationIdRoute
   '/matching/projects/announce/': typeof MatchingProjectsAnnounceIndexRoute
   '/matching/projects/announce/notice-publish/$noticeId': typeof MatchingProjectsAnnounceNoticePublishNoticeIdRoute
 }
@@ -710,6 +720,7 @@ export interface FileRouteTypes {
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/edit/$projectId'
     | '/recruiting/evaluations/document/$applicationId'
+    | '/recruiting/evaluations/interview/$applicationId'
     | '/matching/projects/announce/'
     | '/matching/projects/announce/notice-publish/$noticeId'
   fileRoutesByTo: FileRoutesByTo
@@ -776,6 +787,7 @@ export interface FileRouteTypes {
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/edit/$projectId'
     | '/recruiting/evaluations/document/$applicationId'
+    | '/recruiting/evaluations/interview/$applicationId'
     | '/matching/projects/announce'
     | '/matching/projects/announce/notice-publish/$noticeId'
   id:
@@ -846,6 +858,7 @@ export interface FileRouteTypes {
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/edit/$projectId'
     | '/recruiting/evaluations/document/$applicationId'
+    | '/recruiting/evaluations/interview/$applicationId'
     | '/matching/projects/announce/'
     | '/matching/projects/announce/notice-publish/$noticeId'
   fileRoutesById: FileRoutesById
@@ -1349,6 +1362,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MatchingProjectsAnnounceIndexRouteImport
       parentRoute: typeof MatchingProjectsAnnounceRouteRoute
     }
+    '/recruiting/evaluations/interview/$applicationId': {
+      id: '/recruiting/evaluations/interview/$applicationId'
+      path: '/$applicationId'
+      fullPath: '/recruiting/evaluations/interview/$applicationId'
+      preLoaderRoute: typeof RecruitingEvaluationsInterviewApplicationIdRouteImport
+      parentRoute: typeof RecruitingEvaluationsInterviewRoute
+    }
     '/recruiting/evaluations/document/$applicationId': {
       id: '/recruiting/evaluations/document/$applicationId'
       path: '/$applicationId'
@@ -1487,17 +1507,33 @@ const RecruitingEvaluationsDocumentRouteWithChildren =
     RecruitingEvaluationsDocumentRouteChildren,
   )
 
+interface RecruitingEvaluationsInterviewRouteChildren {
+  RecruitingEvaluationsInterviewApplicationIdRoute: typeof RecruitingEvaluationsInterviewApplicationIdRoute
+}
+
+const RecruitingEvaluationsInterviewRouteChildren: RecruitingEvaluationsInterviewRouteChildren =
+  {
+    RecruitingEvaluationsInterviewApplicationIdRoute:
+      RecruitingEvaluationsInterviewApplicationIdRoute,
+  }
+
+const RecruitingEvaluationsInterviewRouteWithChildren =
+  RecruitingEvaluationsInterviewRoute._addFileChildren(
+    RecruitingEvaluationsInterviewRouteChildren,
+  )
+
 interface RecruitingRouteRouteChildren {
   RecruitingEvaluationsDocumentRoute: typeof RecruitingEvaluationsDocumentRouteWithChildren
   RecruitingEvaluationsFinalRoute: typeof RecruitingEvaluationsFinalRoute
-  RecruitingEvaluationsInterviewRoute: typeof RecruitingEvaluationsInterviewRoute
+  RecruitingEvaluationsInterviewRoute: typeof RecruitingEvaluationsInterviewRouteWithChildren
 }
 
 const RecruitingRouteRouteChildren: RecruitingRouteRouteChildren = {
   RecruitingEvaluationsDocumentRoute:
     RecruitingEvaluationsDocumentRouteWithChildren,
   RecruitingEvaluationsFinalRoute: RecruitingEvaluationsFinalRoute,
-  RecruitingEvaluationsInterviewRoute: RecruitingEvaluationsInterviewRoute,
+  RecruitingEvaluationsInterviewRoute:
+    RecruitingEvaluationsInterviewRouteWithChildren,
 }
 
 const RecruitingRouteRouteWithChildren = RecruitingRouteRoute._addFileChildren(

--- a/src/routes/recruiting/evaluations/interview.$applicationId.tsx
+++ b/src/routes/recruiting/evaluations/interview.$applicationId.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { ApplicationEvaluationDetailPage } from "@/features/recruiting"
+
+export const Route = createFileRoute(
+  "/recruiting/evaluations/interview/$applicationId",
+)({
+  component: InterviewEvaluationDetailRoute,
+})
+
+function InterviewEvaluationDetailRoute() {
+  const { applicationId } = Route.useParams()
+  return (
+    <ApplicationEvaluationDetailPage
+      key={applicationId}
+      stage="interview"
+      applicationId={applicationId}
+    />
+  )
+}

--- a/src/routes/recruiting/evaluations/interview.tsx
+++ b/src/routes/recruiting/evaluations/interview.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, Outlet, useMatchRoute } from "@tanstack/react-router"
 
 import { ApplicantListPage } from "@/features/recruiting"
 
@@ -7,5 +7,10 @@ export const Route = createFileRoute("/recruiting/evaluations/interview")({
 })
 
 function InterviewEvaluationListPage() {
+  const matchRoute = useMatchRoute()
+  const isDetail = Boolean(
+    matchRoute({ to: "/recruiting/evaluations/interview/$applicationId" }),
+  )
+  if (isDetail) return <Outlet />
   return <ApplicantListPage stage="interview" />
 }


### PR DESCRIPTION
## 📸 작업 내용

> 지원서 면접 평가 상세 화면을 mock 기반으로 구현했습니다. (서류 평가 상세 후속)

- `interview.$applicationId` 상세 라우트 + `interview.tsx` Outlet 패턴, 스테퍼 면접 전형 이동, 지원자 목록 면접 행 클릭 → 상세 진입 배선
- 면접 본문: 공통/개별 질문 2카드(접기 토글) + 면접자 조별 복수 답변 표시. 내 면접 평가·운영진 평가 리스트는 서류 상세 컴포넌트 재사용
- 하단 지원자 최종 결과 토글(선택 시 solid teal) 추가 + `EvaluationResultToggle`에 weak/strong variant 확장(공용 SegmentButton 미변경). 서류 상세에는 노출되지 않도록 게이팅
- 데이터는 mock 우선, 실제 연동은 후속(Phase 6)

## 🎞️ 주요 코드 설명

### 평가 결과 토글 variant

```TypeScript
// EvaluationResultToggle
const selectedClass =
  variant === "strong"
    ? "bg-teal-600 text-white"
    : "border border-teal-200 bg-teal-100 text-teal-500"
```

- 합/불 평가는 weak(연한 teal), 지원자 최종 결과는 strong(solid teal)으로 사용

### 상세 페이지 전형 분기

```TypeScript
{stage === "interview" && detail.interview && (
  <InterviewAnswerCards content={detail.interview} />
)}
{showFinalResult && ( /* stage !== "document" */
  <EvaluationResultToggle variant="strong" ... />
)}
```

- 면접 전형일 때 공통/개별 질문·면접자 답변을 렌더하고, 서류 상세에는 최종 결과 토글을 노출하지 않음

## 🖥️ 구현화면

> 로컬 캡처 첨부 예정 (면접 평가 상세 / 최종 결과 토글)

|           면접 평가 상세            |           최종 결과 토글            |
| :-------------------------: | :-------------------------: |
| <img src = "" width ="250"> | <img src = "" width ="250"> |

## 🔗 연결된 이슈

- Connected: #616
- Closes #616

## 📚 참고자료

- Figma 면접 평가 상세 `10659:155943`, 평가 결과 토글 `9996:49934`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 지원자의 면접 평가 상세 화면을 추가했습니다.
  * 면접 질문과 답변을 블록별 카드로 확인하고 접거나 펼칠 수 있습니다.
  * 문서 평가와 면접 평가 간 이동을 지원합니다.
  * 면접 및 최종 평가 결과를 확인하고 변경할 수 있습니다.

* **개선 사항**
  * 지원자 목록에서 면접 단계 항목을 선택해 상세 평가로 이동할 수 있습니다.
  * 면접 결과가 있는 지원서에만 관련 질문과 답변이 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->