### PR TITLE
✨ feat: 공용 Button 컴포넌트 red 색상 추가

### DIFF
--- a/src/routes/test/button.tsx
+++ b/src/routes/test/button.tsx
@@ -9,7 +9,7 @@ export const Route = createFileRoute("/test/button")({
 })
 
 const VARIANTS = ["fill", "weak"] as const
-const COLORS = ["primary", "neutral"] as const
+const COLORS = ["primary", "neutral", "red"] as const
 const SIZES = ["xs", "s", "m", "lg", "xl"] as const
 
 function Section({

--- a/src/shared/ui/Button.test.tsx
+++ b/src/shared/ui/Button.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { Button } from "./Button"
+
+describe("Button", () => {
+  it("variant 생략 시 red loading 버튼도 기본값(fill)을 해석해 loading 배경을 적용한다", () => {
+    render(
+      <Button color="red" isLoading>
+        버튼
+      </Button>,
+    )
+
+    expect(screen.getByRole("button")).toHaveClass("bg-error-700")
+  })
+
+  it("weak red loading 버튼은 bg-error-200 loading 배경을 적용한다", () => {
+    render(
+      <Button color="red" variant="weak" isLoading>
+        버튼
+      </Button>,
+    )
+
+    expect(screen.getByRole("button")).toHaveClass("bg-error-200")
+  })
+
+  it("variant/color 생략 시 기본 primary fill loading 배경을 적용한다", () => {
+    render(<Button isLoading>버튼</Button>)
+
+    expect(screen.getByRole("button")).toHaveClass("bg-teal-700")
+  })
+})

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -17,6 +17,7 @@ const buttonVariants = cva(
         primary: "",
         neutral: "",
         white: "",
+        red: "",
       },
       size: {
         xl: "h-14 min-h-14 min-w-24 py-1 px-8 gap-2.5 text-heading-7-semibold",
@@ -50,6 +51,18 @@ const buttonVariants = cva(
         color: "neutral",
         className:
           "bg-teal-gray-150 text-teal-gray-600 hover:bg-teal-gray-200 disabled:bg-teal-gray-100 disabled:text-teal-gray-300",
+      },
+      {
+        variant: "fill",
+        color: "red",
+        className:
+          "bg-error-600 text-white hover:bg-error-700 disabled:bg-error-300 disabled:text-teal-gray-50",
+      },
+      {
+        variant: "weak",
+        color: "red",
+        className:
+          "bg-error-100 text-error-600 hover:bg-error-200 disabled:bg-error-100 disabled:text-error-300",
       },
       {
         variant: "fill",
@@ -145,6 +158,8 @@ export function Button({
           variant === "weak" &&
           color === "neutral" &&
           "bg-teal-gray-200",
+        isLoading && variant === "fill" && color === "red" && "bg-error-700",
+        isLoading && variant === "weak" && color === "red" && "bg-error-200",
         className,
       )}
       {...props}

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -110,6 +110,9 @@ export function Button({
 }: ButtonProps) {
   const Comp = asChild ? Slot.Root : "button"
 
+  const resolvedVariant = variant ?? "fill"
+  const resolvedColor = color ?? "primary"
+
   const leftIcon = (() => {
     if (!icon) return null
     if (size === "xs") {
@@ -148,18 +151,30 @@ export function Button({
         icon && size === "s" && "min-h-10 rounded-[10px] py-1 pr-4 pl-2.5",
         icon && size === "m" && "min-h-11 min-w-19 py-1 pr-4 pl-3",
         isLoading && "pointer-events-none cursor-default select-none",
-        isLoading && variant === "fill" && color === "primary" && "bg-teal-700",
-        isLoading && variant === "weak" && color === "primary" && "bg-teal-200",
         isLoading &&
-          variant === "fill" &&
-          color === "neutral" &&
+          resolvedVariant === "fill" &&
+          resolvedColor === "primary" &&
+          "bg-teal-700",
+        isLoading &&
+          resolvedVariant === "weak" &&
+          resolvedColor === "primary" &&
+          "bg-teal-200",
+        isLoading &&
+          resolvedVariant === "fill" &&
+          resolvedColor === "neutral" &&
           "bg-teal-gray-700",
         isLoading &&
-          variant === "weak" &&
-          color === "neutral" &&
+          resolvedVariant === "weak" &&
+          resolvedColor === "neutral" &&
           "bg-teal-gray-200",
-        isLoading && variant === "fill" && color === "red" && "bg-error-700",
-        isLoading && variant === "weak" && color === "red" && "bg-error-200",
+        isLoading &&
+          resolvedVariant === "fill" &&
+          resolvedColor === "red" &&
+          "bg-error-700",
+        isLoading &&
+          resolvedVariant === "weak" &&
+          resolvedColor === "red" &&
+          "bg-error-200",
         className,
       )}
       {...props}


### PR DESCRIPTION
## 📸 작업 내용

- Figma Button 디자인 시스템(node `741:15571`)을 현재 코드와 전면 대조한 결과 **유일한 누락 항목이던 `Red` 색상**을 공용 `Button` 컴포넌트에 추가했습니다.
- `color="red"`를 `fill` / `weak` 두 variant로 지원하며, default·hover·disabled·loading 상태를 기존 `primary`/`neutral` 패턴 그대로 배선했습니다.
- 이미 정의·등록되어 있던 `error-*` 디자인 토큰을 사용하므로 **신규 색상 토큰 추가는 없습니다**(순수 CVA 추가).
- 색상 키 명명은 기존 `Tag` 컴포넌트의 `red` 관례 및 Figma `Red` 변형명과 일치시켰습니다.

## 🎞️ 주요 코드 설명

### `color` variant에 red 추가 + compoundVariant 배선

```TypeScript
// fill/red
"bg-error-600 text-white hover:bg-error-700 disabled:bg-error-300 disabled:text-teal-gray-50"
// weak/red
"bg-error-100 text-error-600 hover:bg-error-200 disabled:bg-error-100 disabled:text-error-300"
// loading 상태
isLoading && variant === "fill" && color === "red" && "bg-error-700",
isLoading && variant === "weak" && color === "red" && "bg-error-200",
```

`VariantProps`가 `color` 유니온을 자동 확장하므로 `ButtonProps` 타입·기존 소비처는 변경하지 않았습니다(순수 opt-in).

## 🖥️ 구현화면

> 현재 red 색상을 사용하는 소비처가 없어 화면 캡처는 생략합니다. `tsc -b`·`pnpm build` 통과 및 빌드 산출 CSS에 `bg-error-*`/`text-error-*` 유틸리티가 정상 생성됨을 확인했습니다. 토큰 값은 Figma와 정확히 일치합니다(error-600 `#c21f14`, error-700 `#b00303`).

## 🔗 연결된 이슈

- Connected: #620
- Closes #620

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 버튼에 빨간색(`red`) 색상 옵션을 추가했습니다.
  - 채워진 버튼과 약한 강조 버튼 조합에서 빨간색 스타일을 지원합니다.
  - 빨간색 버튼의 로딩 상태에서도 일관된 오류 색상 팔레트가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->