### PR TITLE
feat: 평가 인원 배정 페이지 UI 구현

### DIFF
--- a/src/features/recruiting/index.ts
+++ b/src/features/recruiting/index.ts
@@ -11,5 +11,6 @@ export {
 export { ApplicantListPage } from "./ui/ApplicantListPage"
 export { RecruitingApplyForm } from "./ui/apply/RecruitingApplyForm"
 export { ApplicationEvaluationDetailPage } from "./ui/detail/ApplicationEvaluationDetailPage"
+export { EvaluatorAllocationPage } from "./ui/evaluations/EvaluatorAllocationPage"
 export { RecruitingApplicationCard } from "./ui/RecruitingApplicationCard"
 export type { RecruitingApplication } from "./ui/RecruitingApplicationCard"

--- a/src/features/recruiting/model/evaluatorAllocation.ts
+++ b/src/features/recruiting/model/evaluatorAllocation.ts
@@ -1,0 +1,12 @@
+export interface Staff {
+  id: string
+  nickname: string
+  name: string
+}
+
+export const SCHOOL_STAFF_LIST: Staff[] = [
+  { id: "staff-1", nickname: "이삭", name: "강지훈" },
+  { id: "staff-2", nickname: "헤일리", name: "한현서" },
+  { id: "staff-3", nickname: "주디", name: "양혜원" },
+  { id: "staff-4", nickname: "준오", name: "오창준" },
+]

--- a/src/features/recruiting/ui/evaluations/AssignedStaffChip.tsx
+++ b/src/features/recruiting/ui/evaluations/AssignedStaffChip.tsx
@@ -1,0 +1,41 @@
+import HamburgerIcon from "@/shared/assets/icon/hamburger/HamburgerIcon"
+import { cn } from "@/shared/lib/utils"
+
+import type { Staff } from "../../model/evaluatorAllocation"
+
+interface AssignedStaffChipProps {
+  staff: Staff
+  isSelected: boolean
+  onSelect: (id: string | null) => void
+}
+
+export function AssignedStaffChip({
+  staff,
+  isSelected,
+  onSelect,
+}: AssignedStaffChipProps) {
+  const textColorClass = isSelected
+    ? "text-teal-gray-400"
+    : "text-role-product-600"
+
+  return (
+    <div
+      onClick={(e) => {
+        e.stopPropagation()
+        onSelect(isSelected ? null : staff.id)
+      }}
+      className="bg-role-product-200 flex w-fit cursor-pointer items-center gap-[7px] rounded-[8px] px-[9px] py-[2.5px] select-none"
+    >
+      <HamburgerIcon className={cn("h-4 w-4", textColorClass)} />
+      <div className="flex items-center gap-0.5">
+        <span className={cn("text-subtitle-2-medium", textColorClass)}>
+          {staff.nickname}
+        </span>
+        <span className={cn("text-subtitle-2-medium", textColorClass)}>/</span>
+        <span className={cn("text-subtitle-2-medium", textColorClass)}>
+          {staff.name}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/features/recruiting/ui/evaluations/DraggableStaffChip.tsx
+++ b/src/features/recruiting/ui/evaluations/DraggableStaffChip.tsx
@@ -1,0 +1,41 @@
+import { useDraggable } from "@dnd-kit/core"
+
+import HamburgerIcon from "@/shared/assets/icon/hamburger/HamburgerIcon"
+import { cn } from "@/shared/lib/utils"
+
+import type { Staff } from "../../model/evaluatorAllocation"
+
+interface DraggableStaffChipProps {
+  staff: Staff
+}
+
+export function DraggableStaffChip({ staff }: DraggableStaffChipProps) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: staff.id,
+    data: staff,
+  })
+
+  const textColorClass = isDragging
+    ? "text-teal-gray-400"
+    : "text-role-product-600"
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      className="bg-role-product-200 flex w-fit cursor-grab items-center gap-[7px] rounded-[8px] px-[9px] py-[2.5px] select-none active:cursor-grabbing"
+    >
+      <HamburgerIcon className={cn("h-4 w-4", textColorClass)} />
+      <div className="flex items-center gap-0.5">
+        <span className={cn("text-subtitle-2-medium", textColorClass)}>
+          {staff.nickname}
+        </span>
+        <span className={cn("text-subtitle-2-medium", textColorClass)}>/</span>
+        <span className={cn("text-subtitle-2-medium", textColorClass)}>
+          {staff.name}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/features/recruiting/ui/evaluations/DroppableRecruitmentBox.tsx
+++ b/src/features/recruiting/ui/evaluations/DroppableRecruitmentBox.tsx
@@ -1,0 +1,97 @@
+import { useDroppable } from "@dnd-kit/core"
+
+import ResetIcon from "@/shared/assets/icon/reset/ResetIcon"
+
+import { AssignedStaffChip } from "./AssignedStaffChip"
+
+import type { Staff } from "../../model/evaluatorAllocation"
+
+interface DroppableRecruitmentBoxProps {
+  id: string
+  assignedEvaluators: Staff[]
+  selectedChipId: string | null
+  onSelectChip: (id: string | null) => void
+  onClear: () => void
+}
+
+export function DroppableRecruitmentBox({
+  id,
+  assignedEvaluators,
+  selectedChipId,
+  onSelectChip,
+  onClear,
+}: DroppableRecruitmentBoxProps) {
+  const { setNodeRef } = useDroppable({ id })
+
+  return (
+    <div
+      ref={setNodeRef}
+      className="shadow-drop-neutral-3 border-teal-gray-100 box-border flex h-68.5 w-full flex-col gap-5 rounded-[12px] border bg-white px-8 pt-7 pb-7.5"
+    >
+      <div className="flex h-19 w-full justify-between">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-1.5">
+            <span className="text-heading-6-semibold text-teal-700">
+              정규 모집
+            </span>
+            <span className="text-heading-6-semibold text-teal-gray-800">
+              평가 담당자
+            </span>
+          </div>
+
+          <div className="flex flex-col gap-0.5">
+            <div className="flex items-center gap-2">
+              <p className="text-body-2-regular text-teal-gray-400">
+                서류 모집 마감: 2026-07-07 12:00
+              </p>
+              <div className="bg-teal-gray-200 h-3 w-[1px] rounded-[0.5px]" />
+              <p className="text-body-2-regular text-teal-gray-400">
+                결과 발표: 2026-07-07 12:00
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <p className="text-body-2-regular text-teal-gray-400">
+                면접 진행 기간: 2026-07-07 12:00 ~ 2026-07-07 12:00
+              </p>
+              <div className="bg-teal-gray-200 h-3 w-[1px] rounded-[0.5px]" />
+              <p className="text-body-2-regular text-teal-gray-400">
+                결과 발표: 2026-07-07 12:00
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="pt-[15px] pb-[27px]">
+          <button
+            onClick={onClear}
+            className="hover:shadow-inner-neutral-2 flex h-8.5 items-center gap-1 rounded-[10px] bg-white py-1 pr-3 pl-2.5"
+          >
+            <ResetIcon className="h-4 w-4" />
+            <span className="text-label-1-medium text-teal-gray-700">
+              비우기
+            </span>
+          </button>
+        </div>
+      </div>
+
+      {assignedEvaluators.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center overflow-y-auto">
+          <span className="text-body-2-medium text-teal-gray-400">
+            배정된 평가 담당자가 없습니다.
+          </span>
+        </div>
+      ) : (
+        <div className="flex flex-1 flex-wrap content-start gap-3 overflow-y-auto">
+          {assignedEvaluators.map((staff) => (
+            <AssignedStaffChip
+              key={staff.id}
+              staff={staff}
+              isSelected={selectedChipId === staff.id}
+              onSelect={onSelectChip}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
+++ b/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
@@ -1,0 +1,169 @@
+import {
+  DndContext,
+  type DragEndEvent,
+  DragOverlay,
+  type DragStartEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core"
+import { useEffect, useState } from "react"
+
+import HamburgerIcon from "@/shared/assets/icon/hamburger/HamburgerIcon"
+import ResetIcon from "@/shared/assets/icon/reset/ResetIcon"
+import { Button } from "@/shared/ui/Button"
+import { PageLabel } from "@/shared/ui/page-label/PageLabel"
+
+import { SCHOOL_STAFF_LIST, type Staff } from "../../model/evaluatorAllocation"
+import { DroppableRecruitmentBox } from "./DroppableRecruitmentBox"
+import { EvaluatorSharedNote } from "./EvaluatorSharedNote"
+import { SchoolStaffPanel } from "./SchoolStaffPanel"
+
+export function EvaluatorAllocationPage() {
+  const [assignedEvaluators, setAssignedEvaluators] = useState<Staff[]>([])
+  const [selectedChipId, setSelectedChipId] = useState<string | null>(null)
+  const [activeStaff, setActiveStaff] = useState<Staff | null>(null)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 5 },
+    }),
+  )
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (
+        document.activeElement?.tagName === "INPUT" ||
+        document.activeElement?.tagName === "TEXTAREA"
+      ) {
+        return
+      }
+
+      if (selectedChipId && (e.key === "Delete" || e.key === "Backspace")) {
+        setAssignedEvaluators((prev) =>
+          prev.filter((staff) => staff.id !== selectedChipId),
+        )
+        setSelectedChipId(null)
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [selectedChipId])
+
+  function handleDragStart(event: DragStartEvent) {
+    const staff = event.active.data.current as Staff | undefined
+    if (staff) {
+      setActiveStaff(staff)
+    }
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    setActiveStaff(null)
+
+    if (over && over.id === "regular-recruitment-box") {
+      const staff = active.data.current as Staff | undefined
+      if (staff) {
+        setAssignedEvaluators((prev) => {
+          if (prev.some((item) => item.id === staff.id)) return prev
+          return [...prev, staff]
+        })
+      }
+    }
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <div
+        className="flex w-full max-w-286.5 flex-col gap-8"
+        onClick={() => setSelectedChipId(null)}
+      >
+        <PageLabel
+          breadcrumb={[
+            { id: "recruiting", label: "리크루팅" },
+            { id: "evaluation-management", label: "평가 관리" },
+            { id: "evaluator-assignment", label: "평가 담당자 배정" },
+          ]}
+          title="평가 담당자 배정"
+          description="교내 운영진을 각 모집의 평가 담당자로 배정합니다."
+          className="pl-3"
+        />
+
+        <div className="relative flex w-full flex-col gap-4">
+          <div className="absolute -top-10.5 right-0.5 flex gap-2">
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                setAssignedEvaluators([])
+                setSelectedChipId(null)
+              }}
+              className="border-teal-gray-400/15 box-border flex h-8.5 items-center gap-1 rounded-[10px] border bg-white px-3 py-1 pl-2.5"
+            >
+              <ResetIcon className="h-4 w-4" />
+              <span className="text-label-1-medium text-teal-gray-700">
+                전체 비우기
+              </span>
+            </button>
+
+            <Button
+              size="xs"
+              color="primary"
+              variant="fill"
+              className="w-fit rounded-[8px] px-3 py-1.5"
+            >
+              저장하기
+            </Button>
+          </div>
+
+          <div className="flex h-197.5 w-full gap-4">
+            <SchoolStaffPanel
+              schoolName="중앙대학교"
+              staffList={SCHOOL_STAFF_LIST}
+            />
+
+            {/* 공고 */}
+            <div className="flex flex-1 flex-col gap-4 overflow-y-auto">
+              <DroppableRecruitmentBox
+                id="regular-recruitment-box"
+                assignedEvaluators={assignedEvaluators}
+                selectedChipId={selectedChipId}
+                onSelectChip={setSelectedChipId}
+                onClear={() => {
+                  setAssignedEvaluators([])
+                  setSelectedChipId(null)
+                }}
+              />
+            </div>
+          </div>
+
+          {/* 공유 메모 */}
+          <EvaluatorSharedNote />
+        </div>
+      </div>
+
+      {activeStaff && (
+        <DragOverlay>
+          <div className="bg-role-product-200 flex w-fit items-center gap-[7px] rounded-[8px] px-[9px] py-[2.5px] shadow-md select-none">
+            <HamburgerIcon className="text-teal-gray-400 h-4 w-4" />
+            <div className="flex items-center gap-0.5">
+              <span className="text-subtitle-2-medium text-teal-gray-400">
+                {activeStaff.nickname}
+              </span>
+              <span className="text-subtitle-2-medium text-teal-gray-400">
+                /
+              </span>
+              <span className="text-subtitle-2-medium text-teal-gray-400">
+                {activeStaff.name}
+              </span>
+            </div>
+          </div>
+        </DragOverlay>
+      )}
+    </DndContext>
+  )
+}

--- a/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
+++ b/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
@@ -58,6 +58,10 @@ export function EvaluatorAllocationPage() {
     }
   }
 
+  function handleDragCancel() {
+    setActiveStaff(null)
+  }
+
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event
     setActiveStaff(null)
@@ -78,6 +82,7 @@ export function EvaluatorAllocationPage() {
       sensors={sensors}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
     >
       <div
         className="flex w-full max-w-286.5 flex-col gap-8"

--- a/src/features/recruiting/ui/evaluations/EvaluatorSharedNote.tsx
+++ b/src/features/recruiting/ui/evaluations/EvaluatorSharedNote.tsx
@@ -1,0 +1,22 @@
+export function EvaluatorSharedNote() {
+  return (
+    <div className="border-teal-gray-100 shadow-drop-neutral-3 box-border flex h-68.5 flex-col gap-5 rounded-[12px] border bg-white px-8 pt-7 pb-7.5">
+      <div className="flex flex-col gap-1">
+        <span className="text-heading-6-semibold text-teal-gray-800">
+          공유 메모
+        </span>
+
+        <p className="text-body-2-regular text-teal-gray-500">
+          교내 운영진과 내용이 공유됩니다.
+        </p>
+      </div>
+
+      <textarea
+        placeholder={
+          "평가 담당자 배정과 관련된 메모를 남길 수 있습니다.\nex. 윰씨/유엠씨 7/7~12 2시부터 면접 가능"
+        }
+        className="text-tealgray-900 text-body-1-regular bg-teal-gray-50 placeholder:text-teal-gray-400 shadow-inner-neutral-3 resize-none overflow-y-auto rounded-[12px] px-8 pt-6 pb-[67px] outline-none"
+      />
+    </div>
+  )
+}

--- a/src/features/recruiting/ui/evaluations/EvaluatorSharedNote.tsx
+++ b/src/features/recruiting/ui/evaluations/EvaluatorSharedNote.tsx
@@ -1,6 +1,13 @@
+import { useState } from "react"
+
+import { CounterLabel } from "@/shared/ui/CounterLabel"
+
 export function EvaluatorSharedNote() {
+  const [note, setNote] = useState("")
+  const maxLength = 1000
+
   return (
-    <div className="border-teal-gray-100 shadow-drop-neutral-3 box-border flex h-68.5 flex-col gap-5 rounded-[12px] border bg-white px-8 pt-7 pb-7.5">
+    <div className="border-teal-gray-100 shadow-drop-neutral-3 relative box-border flex h-68.5 flex-col gap-5 rounded-[12px] border bg-white px-8 pt-7 pb-7.5">
       <div className="flex flex-col gap-1">
         <span className="text-heading-6-semibold text-teal-gray-800">
           공유 메모
@@ -12,10 +19,20 @@ export function EvaluatorSharedNote() {
       </div>
 
       <textarea
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+        maxLength={maxLength}
         placeholder={
           "평가 담당자 배정과 관련된 메모를 남길 수 있습니다.\nex. 윰씨/유엠씨 7/7~12 2시부터 면접 가능"
         }
-        className="text-tealgray-900 text-body-1-regular bg-teal-gray-50 placeholder:text-teal-gray-400 shadow-inner-neutral-3 resize-none overflow-y-auto rounded-[12px] px-8 pt-6 pb-[67px] outline-none"
+        className="text-tealgray-900 text-body-1-regular bg-teal-gray-50 placeholder:text-teal-gray-400 shadow-inner-neutral-3 flex-1 resize-none overflow-y-auto rounded-[12px] px-8 pt-6 pb-[67px] outline-none"
+      />
+
+      <CounterLabel
+        current={note.length}
+        total={maxLength}
+        size="sm"
+        className="text-teal-gray-400 absolute right-16 bottom-15"
       />
     </div>
   )

--- a/src/features/recruiting/ui/evaluations/SchoolStaffPanel.tsx
+++ b/src/features/recruiting/ui/evaluations/SchoolStaffPanel.tsx
@@ -1,0 +1,33 @@
+import { DraggableStaffChip } from "./DraggableStaffChip"
+
+import type { Staff } from "../../model/evaluatorAllocation"
+
+interface SchoolStaffPanelProps {
+  schoolName: string
+  staffList: Staff[]
+}
+
+export function SchoolStaffPanel({
+  schoolName,
+  staffList,
+}: SchoolStaffPanelProps) {
+  return (
+    <div className="border-teal-gray-100 shadow-drop-neutral-3 box-border flex w-70 flex-col gap-[23px] rounded-[12px] border bg-white px-8 py-7">
+      <div className="flex flex-col gap-0.5">
+        <p className="text-heading-6-semibold text-teal-700">{schoolName}</p>
+        <p className="text-body-2-regular text-teal-gray-500">
+          드래그 앤 드롭으로 이동할 수 있습니다
+        </p>
+      </div>
+      <div className="flex flex-col gap-2.5">
+        <p className="text-body-2-regular text-teal-gray-500">교내 운영진</p>
+
+        <div className="flex flex-col gap-4">
+          {staffList.map((staff) => (
+            <DraggableStaffChip key={staff.id} staff={staff} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -64,6 +64,7 @@ import { Route as MatchingRoundsRouteImport } from './routes/matching/rounds'
 import { Route as MatchingNoticePublishRouteImport } from './routes/matching/notice-publish'
 import { Route as MatchingApplicationsRouteImport } from './routes/matching/applications'
 import { Route as LoginDefaultRouteImport } from './routes/login/default'
+import { Route as RecruitingEvaluationsIndexRouteImport } from './routes/recruiting/evaluations/index'
 import { Route as ProjectsApplicationIndexRouteImport } from './routes/projects/application/index'
 import { Route as MatchingProjectsIndexRouteImport } from './routes/matching/projects/index'
 import { Route as RecruitingEvaluationsInterviewRouteImport } from './routes/recruiting/evaluations/interview'
@@ -364,6 +365,12 @@ const LoginDefaultRoute = LoginDefaultRouteImport.update({
   path: '/login/default',
   getParentRoute: () => rootRouteImport,
 } as any)
+const RecruitingEvaluationsIndexRoute =
+  RecruitingEvaluationsIndexRouteImport.update({
+    id: '/evaluations/',
+    path: '/evaluations/',
+    getParentRoute: () => RecruitingRouteRoute,
+  } as any)
 const ProjectsApplicationIndexRoute =
   ProjectsApplicationIndexRouteImport.update({
     id: '/application/',
@@ -549,6 +556,7 @@ export interface FileRoutesByFullPath {
   '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRouteWithChildren
   '/matching/projects/': typeof MatchingProjectsIndexRoute
   '/projects/application/': typeof ProjectsApplicationIndexRoute
+  '/recruiting/evaluations/': typeof RecruitingEvaluationsIndexRoute
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/edit/$projectId': typeof MatchingProjectsEditProjectIdRoute
   '/recruiting/evaluations/document/$applicationId': typeof RecruitingEvaluationsDocumentApplicationIdRoute
@@ -621,6 +629,7 @@ export interface FileRoutesByTo {
   '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRouteWithChildren
   '/matching/projects': typeof MatchingProjectsIndexRoute
   '/projects/application': typeof ProjectsApplicationIndexRoute
+  '/recruiting/evaluations': typeof RecruitingEvaluationsIndexRoute
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/edit/$projectId': typeof MatchingProjectsEditProjectIdRoute
   '/recruiting/evaluations/document/$applicationId': typeof RecruitingEvaluationsDocumentApplicationIdRoute
@@ -699,6 +708,7 @@ export interface FileRoutesById {
   '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRouteWithChildren
   '/matching/projects/': typeof MatchingProjectsIndexRoute
   '/projects/application/': typeof ProjectsApplicationIndexRoute
+  '/recruiting/evaluations/': typeof RecruitingEvaluationsIndexRoute
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/edit/$projectId': typeof MatchingProjectsEditProjectIdRoute
   '/recruiting/evaluations/document/$applicationId': typeof RecruitingEvaluationsDocumentApplicationIdRoute
@@ -778,6 +788,7 @@ export interface FileRouteTypes {
     | '/recruiting/evaluations/interview'
     | '/matching/projects/'
     | '/projects/application/'
+    | '/recruiting/evaluations/'
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/edit/$projectId'
     | '/recruiting/evaluations/document/$applicationId'
@@ -850,6 +861,7 @@ export interface FileRouteTypes {
     | '/recruiting/evaluations/interview'
     | '/matching/projects'
     | '/projects/application'
+    | '/recruiting/evaluations'
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/edit/$projectId'
     | '/recruiting/evaluations/document/$applicationId'
@@ -927,6 +939,7 @@ export interface FileRouteTypes {
     | '/recruiting/evaluations/interview'
     | '/matching/projects/'
     | '/projects/application/'
+    | '/recruiting/evaluations/'
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/edit/$projectId'
     | '/recruiting/evaluations/document/$applicationId'
@@ -1372,6 +1385,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LoginDefaultRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/recruiting/evaluations/': {
+      id: '/recruiting/evaluations/'
+      path: '/evaluations'
+      fullPath: '/recruiting/evaluations/'
+      preLoaderRoute: typeof RecruitingEvaluationsIndexRouteImport
+      parentRoute: typeof RecruitingRouteRoute
+    }
     '/projects/application/': {
       id: '/projects/application/'
       path: '/application'
@@ -1661,6 +1681,7 @@ interface RecruitingRouteRouteChildren {
   RecruitingEvaluationsDocumentRoute: typeof RecruitingEvaluationsDocumentRouteWithChildren
   RecruitingEvaluationsFinalRoute: typeof RecruitingEvaluationsFinalRoute
   RecruitingEvaluationsInterviewRoute: typeof RecruitingEvaluationsInterviewRouteWithChildren
+  RecruitingEvaluationsIndexRoute: typeof RecruitingEvaluationsIndexRoute
 }
 
 const RecruitingRouteRouteChildren: RecruitingRouteRouteChildren = {
@@ -1669,6 +1690,7 @@ const RecruitingRouteRouteChildren: RecruitingRouteRouteChildren = {
   RecruitingEvaluationsFinalRoute: RecruitingEvaluationsFinalRoute,
   RecruitingEvaluationsInterviewRoute:
     RecruitingEvaluationsInterviewRouteWithChildren,
+  RecruitingEvaluationsIndexRoute: RecruitingEvaluationsIndexRoute,
 }
 
 const RecruitingRouteRouteWithChildren = RecruitingRouteRoute._addFileChildren(

--- a/src/routes/recruiting/evaluations/index.tsx
+++ b/src/routes/recruiting/evaluations/index.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { PageLabel } from "@/shared/ui/page-label/PageLabel"
+
+export const Route = createFileRoute("/recruiting/evaluations/")({
+  component: EvaluatorAllocationPage,
+})
+
+function EvaluatorAllocationPage() {
+  return (
+    <div className="flex w-full max-w-286.5 flex-col">
+      <PageLabel
+        breadcrumb={[
+          { id: "recruiting", label: "리크루팅" },
+          { id: "evaluation-management", label: "평가 관리" },
+          { id: "evaluator-assignment", label: "평가 담당자 배정" },
+        ]}
+        title="평가 담당자 배정"
+        description="교내 운영진을 각 모집의 평가 담당자로 배정합니다."
+        className="pl-3"
+      />
+    </div>
+  )
+}

--- a/src/routes/recruiting/evaluations/index.tsx
+++ b/src/routes/recruiting/evaluations/index.tsx
@@ -1,24 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 
-import { PageLabel } from "@/shared/ui/page-label/PageLabel"
+import { EvaluatorAllocationPage } from "@/features/recruiting"
 
 export const Route = createFileRoute("/recruiting/evaluations/")({
   component: EvaluatorAllocationPage,
 })
-
-function EvaluatorAllocationPage() {
-  return (
-    <div className="flex w-full max-w-286.5 flex-col">
-      <PageLabel
-        breadcrumb={[
-          { id: "recruiting", label: "리크루팅" },
-          { id: "evaluation-management", label: "평가 관리" },
-          { id: "evaluator-assignment", label: "평가 담당자 배정" },
-        ]}
-        title="평가 담당자 배정"
-        description="교내 운영진을 각 모집의 평가 담당자로 배정합니다."
-        className="pl-3"
-      />
-    </div>
-  )
-}

--- a/src/shared/config/recruitingNavigation.ts
+++ b/src/shared/config/recruitingNavigation.ts
@@ -56,7 +56,7 @@ export const RECRUITING_SIDEBAR_ITEMS: RecruitingSideBarSection[] = [
       {
         id: "recruiting-evaluations-assignment",
         title: "평가 담당자 배정",
-        to: "/recruiting/evaluations/assignment",
+        to: "/recruiting/evaluations/",
       },
       {
         id: "recruiting-evaluations-document",


### PR DESCRIPTION
## 📸 작업 내용

평가 담당자 배정 페이지 구현, 라우트 변경, PageLabel 적용 및 드래그 앤 드롭 기반 칩 배정/삭제 기능을 구현하였습니다.

- **라우트 변경 & PageLabel 적용**:
  - 사이드바 "평가 담당자 배정" 메뉴 경로를 `/recruiting/evaluations/`로 변경
  - `/recruiting/evaluations/` 라우트에 `PageLabel` 컴포넌트 연동 (Breadcrumb, 타이틀 및 설명 추가)
- **드래그 앤 드롭 (DndKit 연동)**:
  - `@dnd-kit/core` 기반으로 교내 운영진 칩을 정규 모집 평가 담당자 박스로 이동할 수 있도록 구현
  - 옮겨진 이후에도 중앙대학교 박스의 원본 칩은 유지되도록 처리 (여러 모집 박스 배정 지원)
  - 옮겨진 칩들은 12px(`gap-3`) 간격 및 자동 줄바꿈(`flex-wrap`) 처리되며 `overflow-y-auto`로 스크롤 가능
- **칩 상태별 스타일 & 키보드 삭제 기능**:
  - 드래그 중(pressed)이거나 선택(selected)된 칩의 텍스트 색상을 `text-teal-gray-400`으로 변경
  - 배정된 칩을 선택한 후 `Delete` / `Backspace` 키 조작 시 해당 박스에서 칩 삭제 (입력 폼 필드 입력 중에는 제어)
- **Empty State & Shared Note**:
  - 배정된 평가 담당자가 없을 시 영역 가로/세로 정중앙에 `"배정된 평가 담당자가 없습니다."` 텍스트 표시
  - 공유 메모 textarea의 placeholder에 줄바꿈(`\n`) 적용
- **FSD 레이어 컴포넌트화**:
  - `src/features/recruiting/ui/evaluations/` 하위로 역할별 단위 컴포넌트(`DraggableStaffChip`, `AssignedStaffChip`, `SchoolStaffPanel`, `DroppableRecruitmentBox`, `EvaluatorSharedNote`, `EvaluatorAllocationPage`) 분리 및 리팩토링

## 🎞️ 주요 코드 설명

### 주제 1: @dnd-kit/core 기반 드래그 앤 드롭

```typescript
function handleDragEnd(event: DragEndEvent) {
  const { active, over } = event
  setActiveStaff(null)

  if (over && over.id === "regular-recruitment-box") {
    const staff = active.data.current as Staff | undefined
    if (staff) {
      setAssignedEvaluators((prev) => {
        if (prev.some((item) => item.id === staff.id)) return prev
        return [...prev, staff]
      })
    }
  }
}
```

- `<DndContext>`의 `onDragEnd` 이벤트를 수신하여 드롭 타겟(`over.id === "regular-recruitment-box"`)에 도달 시, 원본 운영진 데이터는 유지한 채 배정 목록 state만 업데이트합니다.
- `PointerSensor`에 `activationConstraint: { distance: 5 }` 옵션을 추가하여 단순 클릭 시 실수로 드래그되는 현상을 방지했습니다.

### 주제 2: 선택된 칩 키보드 Delete/Backspace 삭제 이벤트

```typescript
useEffect(() => {
  function handleKeyDown(e: KeyboardEvent) {
    if (
      document.activeElement?.tagName === "INPUT" ||
      document.activeElement?.tagName === "TEXTAREA"
    ) {
      return
    }

    if (selectedChipId && (e.key === "Delete" || e.key === "Backspace")) {
      setAssignedEvaluators((prev) =>
        prev.filter((staff) => staff.id !== selectedChipId),
      )
      setSelectedChipId(null)
    }
  }

  window.addEventListener("keydown", handleKeyDown)
  return () => window.removeEventListener("keydown", handleKeyDown)
}, [selectedChipId])
```

- 배정된 칩을 클릭하여 `selectedChipId`가 설정된 상태에서 `Delete` 또는 `Backspace` 키를 누르면 해당 칩이 삭제됩니다.
- 입력창(`INPUT`, `TEXTAREA`)에 포커스가 되어 있을 때는 글자 삭제 작업에 영향을 주지 않도록 포커스 검사를 수행합니다.

## 🖥️ 구현화면

<img width="50%" alt="screencapture-localhost-5173-recruiting-evaluations-2026-07-23-02_03_38" src="https://github.com/user-attachments/assets/cdabc0f5-1dd4-4b62-afeb-54814db9bb82" />

<img width="50%" alt="screencapture-localhost-5173-recruiting-evaluations-2026-07-23-02_03_53" src="https://github.com/user-attachments/assets/ffdd2904-5548-4f47-a0c7-32a8ec0ced03" />

## 🔗 연결된 이슈

- Connected: #619 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 평가 담당자 배정 페이지를 추가했습니다.
  * 담당자를 드래그 앤 드롭으로 모집 일정에 배정할 수 있습니다.
  * 담당자 선택, 개별 삭제, 전체 비우기 기능을 제공합니다.
  * 공유 메모 입력 영역을 추가했습니다.
  * 리쿠르팅 메뉴에서 평가 담당자 배정 화면으로 이동할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->