### PR TITLE
✨ feat: 지원자 평가 상세 조회 API 연동

### DIFF
--- a/src/features/recruiting/api/queryKeys.ts
+++ b/src/features/recruiting/api/queryKeys.ts
@@ -1,16 +1,15 @@
 import type { EvaluationStage } from "../model/evaluationStage"
-import type { ApiEvaluationStage, RecruitingRoundsQuery } from "./types"
+import type { ApiEvaluationStage } from "./types"
 
 export const recruitingKeys = {
   all: ["recruiting"] as const,
 
   rounds: () => [...recruitingKeys.all, "rounds"] as const,
 
-  roundList: (params: RecruitingRoundsQuery) =>
-    [...recruitingKeys.rounds(), params] as const,
+  roundList: (gisuId: string) => [...recruitingKeys.rounds(), gisuId] as const,
 
-  publicRound: (gisuId: string, roundId: string) =>
-    [...recruitingKeys.rounds(), "public", gisuId, roundId] as const,
+  round: (gisuId: string, roundId: string) =>
+    [...recruitingKeys.rounds(), gisuId, roundId] as const,
 
   applications: () => [...recruitingKeys.all, "applications"] as const,
 

--- a/src/features/recruiting/api/queryKeys.ts
+++ b/src/features/recruiting/api/queryKeys.ts
@@ -49,4 +49,7 @@ export const recruitingKeys = {
 
   evaluators: (roundId: string) =>
     [...recruitingKeys.all, "evaluators", roundId] as const,
+
+  evaluatorProfiles: (memberIds: string[]) =>
+    [...recruitingKeys.all, "evaluator-profiles", memberIds] as const,
 }

--- a/src/features/recruiting/api/queryKeys.ts
+++ b/src/features/recruiting/api/queryKeys.ts
@@ -1,5 +1,5 @@
 import type { EvaluationStage } from "../model/evaluationStage"
-import type { RecruitingRoundsQuery } from "./types"
+import type { ApiEvaluationStage, RecruitingRoundsQuery } from "./types"
 
 export const recruitingKeys = {
   all: ["recruiting"] as const,
@@ -9,8 +9,45 @@ export const recruitingKeys = {
   roundList: (params: RecruitingRoundsQuery) =>
     [...recruitingKeys.rounds(), params] as const,
 
+  publicRound: (gisuId: string, roundId: string) =>
+    [...recruitingKeys.rounds(), "public", gisuId, roundId] as const,
+
   applications: () => [...recruitingKeys.all, "applications"] as const,
 
   schoolApplications: (roundIds: string[], stage: EvaluationStage) =>
     [...recruitingKeys.applications(), [...roundIds].sort(), stage] as const,
+
+  applicationDetail: (roundId: string, applicationId: string) =>
+    [
+      ...recruitingKeys.applications(),
+      "detail",
+      roundId,
+      applicationId,
+    ] as const,
+
+  forms: () => [...recruitingKeys.all, "forms"] as const,
+
+  formStructure: (
+    applicationFormId: string,
+    firstChoice: string,
+    secondChoice: string | null,
+  ) =>
+    [
+      ...recruitingKeys.forms(),
+      applicationFormId,
+      firstChoice,
+      secondChoice,
+    ] as const,
+
+  evaluations: () => [...recruitingKeys.all, "evaluations"] as const,
+
+  stageEvaluations: (
+    roundId: string,
+    applicationId: string,
+    stage: ApiEvaluationStage,
+  ) =>
+    [...recruitingKeys.evaluations(), roundId, applicationId, stage] as const,
+
+  evaluators: (roundId: string) =>
+    [...recruitingKeys.all, "evaluators", roundId] as const,
 }

--- a/src/features/recruiting/api/recruitingApi.test.ts
+++ b/src/features/recruiting/api/recruitingApi.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+
+import { mergeRoundGroups } from "./recruitingApi"
+
+import type { RecruitingRound, RecruitingRoundGroup } from "./types"
+
+function round(roundId: string): RecruitingRound {
+  return {
+    roundId,
+    title: `차수 ${roundId}`,
+    type: "REGULAR",
+    roundNo: 1,
+    recruitableTracks: [],
+    secondChoiceEnabled: false,
+    documentStartAt: null,
+    documentEndAt: null,
+    documentResultPublishedAt: null,
+    interviewRequired: true,
+    interviewStartAt: null,
+    interviewEndAt: null,
+    finalResultPublishedAt: null,
+    announcement: null,
+    applicationFormId: "9",
+    formId: "9",
+    applicationOpen: false,
+  }
+}
+
+function group(
+  seasonId: string,
+  rounds: RecruitingRound[],
+): RecruitingRoundGroup {
+  return {
+    seasonId,
+    gisuId: "5",
+    chapterId: "1",
+    chapterName: "서울",
+    schoolId: "2",
+    schoolName: "중앙대학교",
+    rounds,
+  }
+}
+
+describe("mergeRoundGroups", () => {
+  it("같은 시즌의 차수를 한 그룹으로 합친다", () => {
+    const merged = mergeRoundGroups([
+      group("100", [round("1")]),
+      group("100", [round("2")]),
+    ])
+
+    expect(merged).toHaveLength(1)
+    expect(merged[0]?.rounds.map((item) => item.roundId)).toEqual(["1", "2"])
+  })
+
+  it("두 구간에 겹쳐 나온 차수를 중복으로 남기지 않는다", () => {
+    const merged = mergeRoundGroups([
+      group("100", [round("1"), round("2")]),
+      group("100", [round("2"), round("3")]),
+    ])
+
+    expect(merged[0]?.rounds.map((item) => item.roundId)).toEqual([
+      "1",
+      "2",
+      "3",
+    ])
+  })
+
+  it("시즌이 다르면 그룹을 나눠 둔다", () => {
+    const merged = mergeRoundGroups([
+      group("100", [round("1")]),
+      group("200", [round("2")]),
+    ])
+
+    expect(merged.map((item) => item.seasonId)).toEqual(["100", "200"])
+  })
+
+  it("빈 입력은 빈 결과가 된다", () => {
+    expect(mergeRoundGroups([])).toEqual([])
+  })
+})

--- a/src/features/recruiting/api/recruitingApi.ts
+++ b/src/features/recruiting/api/recruitingApi.ts
@@ -3,9 +3,18 @@ import { api } from "@/shared/lib/axios"
 import type { ApiResponse } from "@/shared/lib/apiResponse"
 
 import type {
+  ApiEvaluationStage,
+  FormStructureQuery,
+  PublicRoundsQuery,
+  RecruitingApplicationDetail,
   RecruitingApplicationPage,
   RecruitingApplicationSummary,
+  RecruitingEvaluation,
+  RecruitingFormStructure,
+  RecruitingPublicRoundGroup,
+  RecruitingRoundEvaluator,
   RecruitingRoundGroup,
+  RecruitingRoundPhase,
   RecruitingRoundsQuery,
   RoundApplicationsQuery,
 } from "./types"
@@ -20,6 +29,33 @@ export async function getRecruitingRounds(
     { params },
   )
   return data.result
+}
+
+// 관리자용 차수 목록(ADMIN-011)은 학교 회장단 이상만 조회할 수 있다. 평가자로만
+// 등록된 운영진도 차수 정보가 필요하므로 공개 목록을 쓴다.
+export async function getPublicRounds(
+  params: PublicRoundsQuery,
+): Promise<RecruitingPublicRoundGroup[]> {
+  const { data } = await api.get<ApiResponse<RecruitingPublicRoundGroup[]>>(
+    "/v1/recruiting/public/rounds",
+    { params, paramsSerializer: { indexes: null } },
+  )
+  return data.result
+}
+
+// phase 는 서버에서 OPEN 이 기본값이라 마감된 차수가 빠진다. 평가는 서류 마감 후에
+// 하므로 두 구간을 모두 조회해 합친다.
+export async function findPublicRound(
+  gisuId: string,
+  roundId: string,
+): Promise<RecruitingPublicRoundGroup[]> {
+  const phases: RecruitingRoundPhase[] = ["PAST", "OPEN"]
+  const perPhase = await Promise.all(
+    phases.map((phase) =>
+      getPublicRounds({ gisuId, roundIds: [roundId], phase }),
+    ),
+  )
+  return perPhase.flat()
 }
 
 export async function getRoundApplications(
@@ -50,4 +86,45 @@ export async function getAllRoundApplications(
     if (!result.hasNext) return collected
     page += 1
   }
+}
+
+export async function getApplicationDetail(
+  roundId: string,
+  applicationId: string,
+): Promise<RecruitingApplicationDetail> {
+  const { data } = await api.get<ApiResponse<RecruitingApplicationDetail>>(
+    `/v1/recruiting/rounds/${roundId}/applications/${applicationId}`,
+  )
+  return data.result
+}
+
+export async function getFormStructure(
+  applicationFormId: string,
+  params: FormStructureQuery,
+): Promise<RecruitingFormStructure> {
+  const { data } = await api.get<ApiResponse<RecruitingFormStructure>>(
+    `/v1/recruiting/public/forms/${applicationFormId}/structure`,
+    { params },
+  )
+  return data.result
+}
+
+export async function getStageEvaluations(
+  roundId: string,
+  applicationId: string,
+  stage: ApiEvaluationStage,
+): Promise<RecruitingEvaluation[]> {
+  const { data } = await api.get<ApiResponse<RecruitingEvaluation[]>>(
+    `/v1/recruiting/rounds/${roundId}/applications/${applicationId}/evaluations/${stage}`,
+  )
+  return data.result
+}
+
+export async function getRoundEvaluators(
+  roundId: string,
+): Promise<RecruitingRoundEvaluator[]> {
+  const { data } = await api.get<ApiResponse<RecruitingRoundEvaluator[]>>(
+    `/v1/recruiting/admin/rounds/${roundId}/evaluators`,
+  )
+  return data.result
 }

--- a/src/features/recruiting/api/recruitingApi.ts
+++ b/src/features/recruiting/api/recruitingApi.ts
@@ -11,51 +11,58 @@ import type {
   RecruitingApplicationSummary,
   RecruitingEvaluation,
   RecruitingFormStructure,
-  RecruitingPublicRoundGroup,
   RecruitingRoundEvaluator,
   RecruitingRoundGroup,
   RecruitingRoundPhase,
-  RecruitingRoundsQuery,
   RoundApplicationsQuery,
 } from "./types"
 
 const APPLICATIONS_PAGE_SIZE = 100
 
-export async function getRecruitingRounds(
-  params: RecruitingRoundsQuery,
-): Promise<RecruitingRoundGroup[]> {
-  const { data } = await api.get<ApiResponse<RecruitingRoundGroup[]>>(
-    "/v1/recruiting/admin/rounds",
-    { params },
-  )
-  return data.result
-}
-
-// 관리자용 차수 목록(ADMIN-011)은 학교 회장단 이상만 조회할 수 있다. 평가자로만
-// 등록된 운영진도 차수 정보가 필요하므로 공개 목록을 쓴다.
+// 관리자용 차수 목록은 학교 회장단 이상만 조회할 수 있어 평가자 권한만 가진
+// 운영진이 403 을 받는다. 공개 목록이 같은 차수 응답을 주므로 이쪽을 쓴다.
 export async function getPublicRounds(
   params: PublicRoundsQuery,
-): Promise<RecruitingPublicRoundGroup[]> {
-  const { data } = await api.get<ApiResponse<RecruitingPublicRoundGroup[]>>(
+): Promise<RecruitingRoundGroup[]> {
+  const { data } = await api.get<ApiResponse<RecruitingRoundGroup[]>>(
     "/v1/recruiting/public/rounds",
     { params, paramsSerializer: { indexes: null } },
   )
   return data.result
 }
 
-// phase 는 서버에서 OPEN 이 기본값이라 마감된 차수가 빠진다. 평가는 서류 마감 후에
-// 하므로 두 구간을 모두 조회해 합친다.
-export async function findPublicRound(
+export function mergeRoundGroups(
+  groups: RecruitingRoundGroup[],
+): RecruitingRoundGroup[] {
+  const bySeason = new Map<string, RecruitingRoundGroup>()
+
+  groups.forEach((group) => {
+    const key = String(group.seasonId)
+    const merged = bySeason.get(key)
+    if (!merged) {
+      bySeason.set(key, { ...group, rounds: [...group.rounds] })
+      return
+    }
+    const seen = new Set(merged.rounds.map((round) => String(round.roundId)))
+    merged.rounds.push(
+      ...group.rounds.filter((round) => !seen.has(String(round.roundId))),
+    )
+  })
+
+  return [...bySeason.values()]
+}
+
+// phase 는 서버에서 OPEN 이 기본값이라 마감된 차수가 빠진다. 값이 두 개뿐이라
+// 한쪽으로는 전 구간을 덮을 수 없어 둘 다 조회해 합친다.
+export async function getAllPublicRounds(
   gisuId: string,
-  roundId: string,
-): Promise<RecruitingPublicRoundGroup[]> {
+  roundIds?: string[],
+): Promise<RecruitingRoundGroup[]> {
   const phases: RecruitingRoundPhase[] = ["PAST", "OPEN"]
   const perPhase = await Promise.all(
-    phases.map((phase) =>
-      getPublicRounds({ gisuId, roundIds: [roundId], phase }),
-    ),
+    phases.map((phase) => getPublicRounds({ gisuId, roundIds, phase })),
   )
-  return perPhase.flat()
+  return mergeRoundGroups(perPhase.flat())
 }
 
 export async function getRoundApplications(

--- a/src/features/recruiting/api/types.ts
+++ b/src/features/recruiting/api/types.ts
@@ -46,7 +46,6 @@ export interface RecruitingRoundGroup {
   chapterName: string
   schoolId: string
   schoolName: string
-  memo: string | null
   rounds: RecruitingRound[]
 }
 
@@ -75,14 +74,8 @@ export interface RecruitingApplicationPage {
   hasPrevious: boolean
 }
 
-export interface RecruitingRoundsQuery {
-  gisuId: string
-  chapterId?: string
-  schoolId?: string
-}
-
 // 공개 목록은 지원 기간이 열린 차수(OPEN)와 마감된 차수(PAST)를 따로 조회한다.
-// 파라미터를 생략하면 서버가 OPEN 으로 간주해 평가 대상 차수가 빠진다.
+// 파라미터를 생략하면 서버가 OPEN 으로 간주해 마감된 차수가 빠진다.
 export type RecruitingRoundPhase = "OPEN" | "PAST"
 
 export interface PublicRoundsQuery {
@@ -90,9 +83,6 @@ export interface PublicRoundsQuery {
   roundIds?: string[]
   phase?: RecruitingRoundPhase
 }
-
-// 공개 응답에는 운영진 전용 필드(memo)가 없다.
-export type RecruitingPublicRoundGroup = Omit<RecruitingRoundGroup, "memo">
 
 export interface RoundApplicationsQuery {
   statuses?: RecruitingApplicationStatus[]

--- a/src/features/recruiting/api/types.ts
+++ b/src/features/recruiting/api/types.ts
@@ -81,9 +81,113 @@ export interface RecruitingRoundsQuery {
   schoolId?: string
 }
 
+// 공개 목록은 지원 기간이 열린 차수(OPEN)와 마감된 차수(PAST)를 따로 조회한다.
+// 파라미터를 생략하면 서버가 OPEN 으로 간주해 평가 대상 차수가 빠진다.
+export type RecruitingRoundPhase = "OPEN" | "PAST"
+
+export interface PublicRoundsQuery {
+  gisuId: string
+  roundIds?: string[]
+  phase?: RecruitingRoundPhase
+}
+
+// 공개 응답에는 운영진 전용 필드(memo)가 없다.
+export type RecruitingPublicRoundGroup = Omit<RecruitingRoundGroup, "memo">
+
 export interface RoundApplicationsQuery {
   statuses?: RecruitingApplicationStatus[]
   tracks?: RecruitingTrack[]
   page?: number
   size?: number
+}
+
+export type RecruitingQuestionType =
+  | "SHORT_TEXT"
+  | "LONG_TEXT"
+  | "RADIO"
+  | "CHECKBOX"
+  | "DROPDOWN"
+  | "SCHEDULE"
+  | "FILE"
+  | "PORTFOLIO"
+
+export interface RecruitingFormOption {
+  optionId: string
+  content: string
+  orderNo: number
+  other: boolean
+  nextSectionId: string | null
+}
+
+export interface RecruitingFormQuestion {
+  questionId: string
+  title: string
+  description: string | null
+  type: RecruitingQuestionType
+  required: boolean
+  orderNo: number
+  options: RecruitingFormOption[]
+}
+
+export interface RecruitingFormSection {
+  sectionId: string
+  title: string
+  description: string | null
+  orderNo: number
+  questions: RecruitingFormQuestion[]
+}
+
+export interface RecruitingFormStructure {
+  formId: string
+  title: string
+  description: string | null
+  sections: RecruitingFormSection[]
+}
+
+export interface RecruitingSelectedOption {
+  questionOptionId: string | null
+  answeredAsContent: string | null
+}
+
+// 서버가 선택지 답변을 id 배열에서 객체 배열로 옮기는 중이다. dev 는 아직
+// selectedOptionIds 를 주고 원본은 selectedOptions 로 바뀌어 있어 둘 다 받는다.
+export interface RecruitingApplicationAnswer {
+  questionId: string
+  type?: RecruitingQuestionType
+  textValue: string | null
+  selectedOptionIds?: string[]
+  selectedOptions?: RecruitingSelectedOption[]
+  fileIds: string[]
+  times: string[]
+}
+
+export interface RecruitingApplicationDetail {
+  application: RecruitingApplicationSummary
+  formResponseId: string
+  answers: RecruitingApplicationAnswer[]
+}
+
+export interface FormStructureQuery {
+  firstChoice: RecruitingTrack
+  secondChoice?: RecruitingTrack
+}
+
+export type ApiEvaluationStage = "DOCUMENT" | "INTERVIEW"
+
+export type RecruitingEvaluationDecision = "APPROVED" | "REJECTED"
+
+export interface RecruitingEvaluation {
+  id: string
+  applicationId: string
+  evaluatorMemberId: string
+  stage: ApiEvaluationStage
+  decision: RecruitingEvaluationDecision
+  comment: string | null
+  submittedAt: string | null
+}
+
+export interface RecruitingRoundEvaluator {
+  id: string
+  roundId: string
+  memberId: string
 }

--- a/src/features/recruiting/hooks/useApplicationDetail.ts
+++ b/src/features/recruiting/hooks/useApplicationDetail.ts
@@ -1,0 +1,123 @@
+import { useQuery } from "@tanstack/react-query"
+import { useMemo } from "react"
+
+import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
+
+import { recruitingKeys } from "../api/queryKeys"
+import {
+  findPublicRound,
+  getApplicationDetail,
+  getFormStructure,
+} from "../api/recruitingApi"
+import {
+  toApplicationDetail,
+  toApplicationSections,
+} from "../model/applicationDetailMapper"
+
+import type { RecruitingPublicRoundGroup, RecruitingRound } from "../api/types"
+
+interface RoundLocation {
+  group: RecruitingPublicRoundGroup
+  round: RecruitingRound
+}
+
+function locateRound(
+  groups: RecruitingPublicRoundGroup[],
+  roundId: string | undefined,
+): RoundLocation | null {
+  if (!roundId) return null
+  for (const group of groups) {
+    const round = group.rounds.find(
+      (candidate) => String(candidate.roundId) === roundId,
+    )
+    if (round) return { group, round }
+  }
+  return null
+}
+
+export function useApplicationDetail(
+  applicationId: string,
+  roundId: string | undefined,
+) {
+  const gisuQuery = useActiveGisu()
+  const gisuId =
+    gisuQuery.data?.gisuId != null ? String(gisuQuery.data.gisuId) : null
+
+  // 차수의 applicationFormId 와 지부·학교명이 필요하다. 관리자 목록은 학교
+  // 회장단 이상만 볼 수 있어, 평가자로만 등록된 운영진도 쓸 수 있는 공개 목록에서
+  // 해당 차수 하나만 가져온다.
+  const roundQuery = useQuery({
+    queryKey: recruitingKeys.publicRound(gisuId ?? "", roundId ?? ""),
+    queryFn: () => findPublicRound(gisuId!, roundId!),
+    enabled: gisuId != null && roundId != null,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const location = useMemo(
+    () => locateRound(roundQuery.data ?? [], roundId),
+    [roundQuery.data, roundId],
+  )
+
+  const detailQuery = useQuery({
+    queryKey: recruitingKeys.applicationDetail(roundId ?? "", applicationId),
+    queryFn: () => getApplicationDetail(roundId!, applicationId),
+    enabled: roundId != null,
+    staleTime: 60 * 1000,
+  })
+
+  const application = detailQuery.data?.application
+  const applicationFormId = location?.round.applicationFormId ?? null
+
+  const structureQuery = useQuery({
+    queryKey: recruitingKeys.formStructure(
+      applicationFormId ?? "",
+      application?.firstChoice ?? "",
+      application?.secondChoice ?? null,
+    ),
+    queryFn: () =>
+      getFormStructure(applicationFormId!, {
+        firstChoice: application!.firstChoice,
+        secondChoice: application?.secondChoice ?? undefined,
+      }),
+    enabled: applicationFormId != null && application != null,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const detail = useMemo(() => {
+    const answers = detailQuery.data?.answers
+    const structure = structureQuery.data
+    if (!application || !answers || !structure || !location) return null
+
+    return toApplicationDetail(
+      application,
+      toApplicationSections(structure, answers, application),
+      location.group,
+      location.round,
+    )
+  }, [application, detailQuery.data?.answers, structureQuery.data, location])
+
+  const isLoading =
+    gisuQuery.isLoading ||
+    roundQuery.isLoading ||
+    detailQuery.isLoading ||
+    structureQuery.isLoading
+
+  // roundId 가 없거나 그 차수를 찾지 못하면 문항 구조를 조회할 수 없다.
+  // 조회가 끝났는데도 조립할 수 없는 상태는 에러로 다룬다.
+  const unresolvable =
+    !isLoading &&
+    (roundId == null ||
+      (roundQuery.isSuccess && location == null) ||
+      (location != null && applicationFormId == null))
+
+  return {
+    detail,
+    round: location?.round ?? null,
+    isError:
+      gisuQuery.isError ||
+      roundQuery.isError ||
+      detailQuery.isError ||
+      structureQuery.isError ||
+      unresolvable,
+  }
+}

--- a/src/features/recruiting/hooks/useApplicationDetail.ts
+++ b/src/features/recruiting/hooks/useApplicationDetail.ts
@@ -5,7 +5,7 @@ import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
 
 import { recruitingKeys } from "../api/queryKeys"
 import {
-  findPublicRound,
+  getAllPublicRounds,
   getApplicationDetail,
   getFormStructure,
 } from "../api/recruitingApi"
@@ -14,15 +14,15 @@ import {
   toApplicationSections,
 } from "../model/applicationDetailMapper"
 
-import type { RecruitingPublicRoundGroup, RecruitingRound } from "../api/types"
+import type { RecruitingRound, RecruitingRoundGroup } from "../api/types"
 
 interface RoundLocation {
-  group: RecruitingPublicRoundGroup
+  group: RecruitingRoundGroup
   round: RecruitingRound
 }
 
 function locateRound(
-  groups: RecruitingPublicRoundGroup[],
+  groups: RecruitingRoundGroup[],
   roundId: string | undefined,
 ): RoundLocation | null {
   if (!roundId) return null
@@ -47,8 +47,8 @@ export function useApplicationDetail(
   // 회장단 이상만 볼 수 있어, 평가자로만 등록된 운영진도 쓸 수 있는 공개 목록에서
   // 해당 차수 하나만 가져온다.
   const roundQuery = useQuery({
-    queryKey: recruitingKeys.publicRound(gisuId ?? "", roundId ?? ""),
-    queryFn: () => findPublicRound(gisuId!, roundId!),
+    queryKey: recruitingKeys.round(gisuId ?? "", roundId ?? ""),
+    queryFn: () => getAllPublicRounds(gisuId!, [roundId!]),
     enabled: gisuId != null && roundId != null,
     staleTime: 5 * 60 * 1000,
   })

--- a/src/features/recruiting/hooks/useRecruitingRounds.ts
+++ b/src/features/recruiting/hooks/useRecruitingRounds.ts
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query"
 import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
 
 import { recruitingKeys } from "../api/queryKeys"
-import { getRecruitingRounds } from "../api/recruitingApi"
+import { getAllPublicRounds } from "../api/recruitingApi"
 
 export function useRecruitingRounds() {
   const gisuQuery = useActiveGisu()
@@ -11,8 +11,8 @@ export function useRecruitingRounds() {
     gisuQuery.data?.gisuId != null ? String(gisuQuery.data.gisuId) : null
 
   const roundsQuery = useQuery({
-    queryKey: recruitingKeys.roundList({ gisuId: gisuId ?? "" }),
-    queryFn: () => getRecruitingRounds({ gisuId: gisuId! }),
+    queryKey: recruitingKeys.roundList(gisuId ?? ""),
+    queryFn: () => getAllPublicRounds(gisuId!),
     enabled: gisuId != null,
     staleTime: 5 * 60 * 1000,
   })

--- a/src/features/recruiting/hooks/useStageEvaluations.ts
+++ b/src/features/recruiting/hooks/useStageEvaluations.ts
@@ -1,0 +1,124 @@
+import { useQuery } from "@tanstack/react-query"
+import { isAxiosError } from "axios"
+import { useMemo } from "react"
+
+import { getMemberProfile } from "@/entities/member/api/member"
+import { useMe } from "@/entities/member/hooks/useMe"
+
+import { recruitingKeys } from "../api/queryKeys"
+import { getRoundEvaluators, getStageEvaluations } from "../api/recruitingApi"
+import {
+  toApiStage,
+  toOperatorEvaluations,
+  toStageEvaluationDetail,
+} from "../model/evaluatorMapper"
+
+import type { EvaluationStage } from "../model/evaluationStage"
+
+export function useStageEvaluations(
+  applicationId: string,
+  roundId: string | undefined,
+  stage: EvaluationStage,
+) {
+  const { data: me } = useMe()
+  const apiStage = toApiStage(stage)
+  const enabled = roundId != null && apiStage != null
+
+  // 평가자 명단은 모집 관리 권한이 있어야 조회할 수 있다. 평가자 whitelist 에만
+  // 올라간 운영진은 403 을 받으므로, 실패해도 평가 목록은 그대로 보여준다.
+  // 403 은 권한이 없다는 확정 답이라 재시도하지 않고, 나머지 오류만 재시도해
+  // 일시적 실패가 권한 없음으로 오인되지 않게 한다.
+  const evaluatorsQuery = useQuery({
+    queryKey: recruitingKeys.evaluators(roundId ?? ""),
+    queryFn: () => getRoundEvaluators(roundId!),
+    enabled,
+    retry: (failureCount, error) =>
+      !(isAxiosError(error) && error.response?.status === 403) &&
+      failureCount < 2,
+    staleTime: 5 * 60 * 1000,
+  })
+  const roster = useMemo(
+    () => evaluatorsQuery.data ?? [],
+    [evaluatorsQuery.data],
+  )
+  const rosterKnown = evaluatorsQuery.isSuccess
+  // 명단 조회가 끝나기 전에는 관리 권한 유무를 알 수 없다. 그 사이에 비운영진
+  // 화면을 보였다가 뒤바뀌지 않도록 결과가 확정된 뒤에 조립한다.
+  const rosterSettled = evaluatorsQuery.isSuccess || evaluatorsQuery.isError
+
+  const evaluationsQuery = useQuery({
+    queryKey: recruitingKeys.stageEvaluations(
+      roundId ?? "",
+      applicationId,
+      apiStage ?? "DOCUMENT",
+    ),
+    queryFn: () => getStageEvaluations(roundId!, applicationId, apiStage!),
+    enabled,
+    staleTime: 60 * 1000,
+  })
+
+  const memberIds = useMemo(() => {
+    const ids = [
+      ...roster.map((evaluator) => String(evaluator.memberId)),
+      ...(evaluationsQuery.data ?? []).map((evaluation) =>
+        String(evaluation.evaluatorMemberId),
+      ),
+    ]
+    return [...new Set(ids)].sort()
+  }, [roster, evaluationsQuery.data])
+
+  const profilesQuery = useQuery({
+    queryKey: [...recruitingKeys.all, "evaluator-profiles", memberIds] as const,
+    queryFn: async () => {
+      // 탈퇴·권한 문제로 한 명이 실패해도 나머지 이름은 살린다.
+      const settled = await Promise.allSettled(
+        memberIds.map((memberId) => getMemberProfile(memberId)),
+      )
+      return new Map(
+        settled
+          .filter((result) => result.status === "fulfilled")
+          .map((result) => [
+            String(result.value.id),
+            result.value.name || result.value.nickname,
+          ]),
+      )
+    },
+    enabled: memberIds.length > 0,
+    staleTime: 10 * 60 * 1000,
+  })
+
+  const evaluation = useMemo(() => {
+    if (!enabled || !me || !rosterSettled) return null
+    const evaluations = evaluationsQuery.data
+    if (!evaluations) return null
+
+    return toStageEvaluationDetail(
+      toOperatorEvaluations(
+        roster,
+        evaluations,
+        profilesQuery.data ?? new Map(),
+        stage,
+      ),
+      stage,
+      String(me.id),
+      // 평가 등록 mutation 은 후속 작업이라 이번에는 읽기 전용으로 둔다.
+      true,
+    )
+  }, [
+    enabled,
+    me,
+    rosterSettled,
+    roster,
+    evaluationsQuery.data,
+    profilesQuery.data,
+    stage,
+  ])
+
+  return {
+    evaluation,
+    // 명단을 못 받으면 아직 평가하지 않은 운영진을 알 수 없어 총원을 셀 수 없다.
+    rosterKnown,
+    isLoading: evaluationsQuery.isLoading,
+    isError: evaluationsQuery.isError,
+  }
+}

--- a/src/features/recruiting/hooks/useStageEvaluations.ts
+++ b/src/features/recruiting/hooks/useStageEvaluations.ts
@@ -68,7 +68,7 @@ export function useStageEvaluations(
   }, [roster, evaluationsQuery.data])
 
   const profilesQuery = useQuery({
-    queryKey: [...recruitingKeys.all, "evaluator-profiles", memberIds] as const,
+    queryKey: recruitingKeys.evaluatorProfiles(memberIds),
     queryFn: async () => {
       // 탈퇴·권한 문제로 한 명이 실패해도 나머지 이름은 살린다.
       const settled = await Promise.allSettled(

--- a/src/features/recruiting/model/applicationDetail.ts
+++ b/src/features/recruiting/model/applicationDetail.ts
@@ -9,6 +9,7 @@ export type ApplicationQuestionType =
   | "radio"
   | "checkbox"
   | "dropdown"
+  | "schedule"
   | "file"
   | "portfolio"
 
@@ -20,7 +21,7 @@ export interface ApplicationQuestionOption {
 export interface ApplicationQuestionFile {
   fileId: string
   name: string
-  url: string
+  url: string | null
 }
 
 export interface ApplicationQuestion {

--- a/src/features/recruiting/model/applicationDetailMapper.test.ts
+++ b/src/features/recruiting/model/applicationDetailMapper.test.ts
@@ -1,0 +1,503 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  toApplicationDetail,
+  toApplicationSections,
+  toReachedStages,
+  toRecruitmentLabel,
+} from "./applicationDetailMapper"
+
+import type {
+  RecruitingApplicationAnswer,
+  RecruitingApplicationSummary,
+  RecruitingFormQuestion,
+  RecruitingFormStructure,
+} from "../api/types"
+
+function question(
+  overrides: Partial<RecruitingFormQuestion> & { questionId: string },
+): RecruitingFormQuestion {
+  return {
+    title: "질문",
+    description: null,
+    type: "SHORT_TEXT",
+    required: false,
+    orderNo: 1,
+    options: [],
+    ...overrides,
+  }
+}
+
+function structure(
+  sections: RecruitingFormStructure["sections"],
+): RecruitingFormStructure {
+  return { formId: "1", title: "지원서", description: null, sections }
+}
+
+const CHOICES = {
+  firstChoice: "WEB_PRODUCT_ENGINEER",
+  secondChoice: null,
+} satisfies Pick<RecruitingApplicationSummary, "firstChoice" | "secondChoice">
+
+function summary(
+  overrides: Partial<RecruitingApplicationSummary> = {},
+): RecruitingApplicationSummary {
+  return {
+    applicationId: "500",
+    applicantName: "김지원",
+    email: "a@b.com",
+    applicantMemberId: "9",
+    firstChoice: "WEB_PRODUCT_ENGINEER",
+    secondChoice: null,
+    acceptedTrack: null,
+    status: "SUBMITTED",
+    registrationStatus: "NOT_READY",
+    submittedAt: "2026-07-20T10:00:00",
+    documentEvaluatedByMe: false,
+    interviewEvaluatedByMe: false,
+    ...overrides,
+  }
+}
+
+describe("toApplicationSections", () => {
+  it("questionId 로 답변을 문항에 붙인다", () => {
+    const sections = toApplicationSections(
+      structure([
+        {
+          sectionId: "1",
+          title: "기본 문항",
+          description: null,
+          orderNo: 1,
+          questions: [
+            question({ questionId: "10", title: "이름", orderNo: 1 }),
+            question({ questionId: "11", title: "각오", orderNo: 2 }),
+          ],
+        },
+      ]),
+      [
+        {
+          questionId: "11",
+          textValue: "열심히",
+          selectedOptionIds: [],
+          fileIds: [],
+          times: [],
+        },
+        {
+          questionId: "10",
+          textValue: "김지원",
+          selectedOptionIds: [],
+          fileIds: [],
+          times: [],
+        },
+      ],
+      CHOICES,
+    )
+
+    expect(sections[0]?.questions.map((q) => q.textValue)).toEqual([
+      "김지원",
+      "열심히",
+    ])
+  })
+
+  it("답변이 없는 문항도 빈 값으로 남긴다", () => {
+    const sections = toApplicationSections(
+      structure([
+        {
+          sectionId: "1",
+          title: "기본 문항",
+          description: null,
+          orderNo: 1,
+          questions: [question({ questionId: "10" })],
+        },
+      ]),
+      [],
+      CHOICES,
+    )
+
+    expect(sections[0]?.questions[0]).toMatchObject({
+      textValue: null,
+      selectedOptionIds: [],
+      files: [],
+    })
+  })
+
+  it("id 가 숫자로 와도 선택지 답변이 매칭된다", () => {
+    const answers = [
+      {
+        questionId: 10 as unknown as string,
+        textValue: null,
+        selectedOptionIds: [104 as unknown as string],
+        fileIds: [],
+        times: [],
+      },
+    ] satisfies RecruitingApplicationAnswer[]
+
+    const sections = toApplicationSections(
+      structure([
+        {
+          sectionId: "1",
+          title: "기본 문항",
+          description: null,
+          orderNo: 1,
+          questions: [
+            question({
+              questionId: 10 as unknown as string,
+              type: "RADIO",
+              options: [
+                {
+                  optionId: "104",
+                  content: "예",
+                  orderNo: 1,
+                  other: false,
+                  nextSectionId: null,
+                },
+                {
+                  optionId: "105",
+                  content: "아니오",
+                  orderNo: 2,
+                  other: false,
+                  nextSectionId: null,
+                },
+              ],
+            }),
+          ],
+        },
+      ]),
+      answers,
+      CHOICES,
+    )
+
+    expect(sections[0]?.questions[0]?.selectedOptionIds).toEqual(["104"])
+  })
+
+  it("선택지 답변이 객체 배열로 와도 매칭된다", () => {
+    const sections = toApplicationSections(
+      structure([
+        {
+          sectionId: "1",
+          title: "기본 문항",
+          description: null,
+          orderNo: 1,
+          questions: [
+            question({
+              questionId: "10",
+              type: "CHECKBOX",
+              options: [
+                {
+                  optionId: "104",
+                  content: "예",
+                  orderNo: 1,
+                  other: false,
+                  nextSectionId: null,
+                },
+                {
+                  optionId: "105",
+                  content: "아니오",
+                  orderNo: 2,
+                  other: false,
+                  nextSectionId: null,
+                },
+              ],
+            }),
+          ],
+        },
+      ]),
+      [
+        {
+          questionId: "10",
+          textValue: null,
+          selectedOptions: [
+            { questionOptionId: "105", answeredAsContent: "아니오" },
+          ],
+          fileIds: [],
+          times: [],
+        },
+      ],
+      CHOICES,
+    )
+
+    expect(sections[0]?.questions[0]?.selectedOptionIds).toEqual(["105"])
+  })
+
+  it("폼에서 지워진 선택지도 응답 시점 내용으로 되살린다", () => {
+    const sections = toApplicationSections(
+      structure([
+        {
+          sectionId: "1",
+          title: "기본 문항",
+          description: null,
+          orderNo: 1,
+          questions: [
+            question({
+              questionId: "10",
+              type: "CHECKBOX",
+              options: [
+                {
+                  optionId: "7",
+                  content: "남은 선택지",
+                  orderNo: 1,
+                  other: false,
+                  nextSectionId: null,
+                },
+              ],
+            }),
+          ],
+        },
+      ]),
+      [
+        {
+          questionId: "10",
+          textValue: null,
+          selectedOptions: [
+            { questionOptionId: null, answeredAsContent: "지워진 선택지" },
+            { questionOptionId: "7", answeredAsContent: "남은 선택지" },
+          ],
+          fileIds: [],
+          times: [],
+        },
+      ],
+      CHOICES,
+    )
+
+    const target = sections[0]?.questions[0]
+    expect(target?.options.map((option) => option.content)).toEqual([
+      "남은 선택지",
+      "지워진 선택지",
+    ])
+    expect(target?.selectedOptionIds).toHaveLength(2)
+    const removed = target?.options.find(
+      (option) => option.content === "지워진 선택지",
+    )
+    expect(target?.selectedOptionIds).toContain(removed?.optionId)
+  })
+
+  it("내용조차 없는 선택 항목은 버린다", () => {
+    const sections = toApplicationSections(
+      structure([
+        {
+          sectionId: "1",
+          title: "기본 문항",
+          description: null,
+          orderNo: 1,
+          questions: [question({ questionId: "10", type: "CHECKBOX" })],
+        },
+      ]),
+      [
+        {
+          questionId: "10",
+          textValue: null,
+          selectedOptions: [{ questionOptionId: null, answeredAsContent: "" }],
+          fileIds: [],
+          times: [],
+        },
+      ],
+      CHOICES,
+    )
+
+    expect(sections[0]?.questions[0]?.selectedOptionIds).toEqual([])
+    expect(sections[0]?.questions[0]?.options).toEqual([])
+  })
+
+  it("섹션과 선택지를 orderNo 순으로 정렬한다", () => {
+    const sections = toApplicationSections(
+      structure([
+        {
+          sectionId: "2",
+          title: "나중",
+          description: null,
+          orderNo: 2,
+          questions: [],
+        },
+        {
+          sectionId: "1",
+          title: "먼저",
+          description: null,
+          orderNo: 1,
+          questions: [
+            question({
+              questionId: "10",
+              type: "CHECKBOX",
+              options: [
+                {
+                  optionId: "2",
+                  content: "B",
+                  orderNo: 2,
+                  other: false,
+                  nextSectionId: null,
+                },
+                {
+                  optionId: "1",
+                  content: "A",
+                  orderNo: 1,
+                  other: false,
+                  nextSectionId: null,
+                },
+              ],
+            }),
+          ],
+        },
+      ]),
+      [],
+      CHOICES,
+    )
+
+    expect(sections.map((section) => section.title)).toEqual(["먼저", "나중"])
+    expect(
+      sections[0]?.questions[0]?.options.map((option) => option.content),
+    ).toEqual(["A", "B"])
+  })
+
+  it("지원 트랙 라벨이 들어간 섹션을 파트 섹션으로 본다", () => {
+    const sections = toApplicationSections(
+      structure([
+        {
+          sectionId: "1",
+          title: "기본 문항",
+          description: null,
+          orderNo: 1,
+          questions: [],
+        },
+        {
+          sectionId: "2",
+          title: "Web PE 파트 문항",
+          description: null,
+          orderNo: 2,
+          questions: [],
+        },
+      ]),
+      [],
+      CHOICES,
+    )
+
+    expect(sections.map((section) => section.type)).toEqual(["common", "part"])
+  })
+
+  it("SCHEDULE 문항은 선택한 일정을 텍스트로 보여준다", () => {
+    const sections = toApplicationSections(
+      structure([
+        {
+          sectionId: "1",
+          title: "면접 일정",
+          description: null,
+          orderNo: 1,
+          questions: [question({ questionId: "10", type: "SCHEDULE" })],
+        },
+      ]),
+      [
+        {
+          questionId: "10",
+          textValue: null,
+          selectedOptionIds: [],
+          fileIds: [],
+          times: ["2026-07-28T14:00:00"],
+        },
+      ],
+      CHOICES,
+    )
+
+    expect(sections[0]?.questions[0]?.type).toBe("schedule")
+    expect(sections[0]?.questions[0]?.textValue).toBe("26-07-28 14:00")
+  })
+
+  it("첨부 파일은 이름만 만들고 링크를 걸지 않는다", () => {
+    const sections = toApplicationSections(
+      structure([
+        {
+          sectionId: "1",
+          title: "포트폴리오",
+          description: null,
+          orderNo: 1,
+          questions: [question({ questionId: "10", type: "FILE" })],
+        },
+      ]),
+      [
+        {
+          questionId: "10",
+          textValue: null,
+          selectedOptionIds: [],
+          fileIds: ["f1", "f2"],
+          times: [],
+        },
+      ],
+      CHOICES,
+    )
+
+    expect(sections[0]?.questions[0]?.files).toEqual([
+      { fileId: "f1", name: "첨부파일 1", url: null },
+      { fileId: "f2", name: "첨부파일 2", url: null },
+    ])
+  })
+})
+
+describe("toReachedStages", () => {
+  it("서류 심사 중이면 서류 단계만 노출한다", () => {
+    expect(toReachedStages(summary({ status: "SUBMITTED" }), true)).toEqual([
+      "document",
+    ])
+  })
+
+  it("서류 불합격이면 이후 단계를 노출하지 않는다", () => {
+    expect(
+      toReachedStages(summary({ status: "DOCUMENT_FAILED" }), true),
+    ).toEqual(["document"])
+  })
+
+  it("면접 대상자는 면접 단계까지 노출한다", () => {
+    expect(
+      toReachedStages(summary({ status: "INTERVIEW_ASSIGNED" }), true),
+    ).toEqual(["document", "interview"])
+  })
+
+  it("최종 결과가 나오면 최종 단계까지 노출한다", () => {
+    expect(toReachedStages(summary({ status: "FINAL_PASSED" }), true)).toEqual([
+      "document",
+      "interview",
+      "final",
+    ])
+  })
+
+  it("면접을 건너뛴 지원자는 면접 단계를 노출하지 않는다", () => {
+    expect(
+      toReachedStages(summary({ status: "INTERVIEW_SKIPPED" }), true),
+    ).toEqual(["document", "final"])
+  })
+
+  it("면접이 없는 모집은 면접 단계를 건너뛴다", () => {
+    expect(toReachedStages(summary({ status: "FINAL_PASSED" }), false)).toEqual(
+      ["document", "final"],
+    )
+    expect(
+      toReachedStages(summary({ status: "INTERVIEW_ASSIGNED" }), false),
+    ).toEqual(["document"])
+  })
+})
+
+describe("toRecruitmentLabel", () => {
+  it("본 모집과 추가 모집을 구분한다", () => {
+    expect(toRecruitmentLabel({ type: "REGULAR", roundNo: 1 })).toBe("본 모집")
+    expect(toRecruitmentLabel({ type: "ADDITIONAL", roundNo: 2 })).toBe(
+      "2차 추가 모집",
+    )
+  })
+})
+
+describe("toApplicationDetail", () => {
+  it("지부·학교와 지원 파트를 차수 정보에서 채운다", () => {
+    const detail = toApplicationDetail(
+      summary({ status: "FINAL_PASSED", secondChoice: "PLAN" }),
+      [],
+      { chapterName: "서울", schoolName: "중앙대학교" },
+      { type: "REGULAR", roundNo: 1, interviewRequired: true },
+    )
+
+    expect(detail).toMatchObject({
+      applicationId: "500",
+      applicantName: "김지원",
+      chapter: "서울",
+      school: "중앙대학교",
+      recruitmentLabel: "본 모집",
+      parts: ["web-pe", "pm"],
+      finalResult: "pass",
+    })
+  })
+})

--- a/src/features/recruiting/model/applicationDetailMapper.ts
+++ b/src/features/recruiting/model/applicationDetailMapper.ts
@@ -1,0 +1,214 @@
+import { PART_TAG_LABEL } from "@/shared/model/domain"
+
+import { formatBaseTime } from "./applicantListTypes"
+import { toPartTags } from "./applicantMapper"
+
+import type {
+  RecruitingApplicationAnswer,
+  RecruitingApplicationSummary,
+  RecruitingFormQuestion,
+  RecruitingFormStructure,
+  RecruitingQuestionType,
+  RecruitingRound,
+  RecruitingRoundGroup,
+} from "../api/types"
+import type { EvaluationResult } from "./applicantListTypes"
+import type {
+  ApplicationDetail,
+  ApplicationQuestion,
+  ApplicationQuestionType,
+  ApplicationSection,
+} from "./applicationDetail"
+import type { EvaluationStage } from "./evaluationStage"
+
+const QUESTION_TYPE: Record<RecruitingQuestionType, ApplicationQuestionType> = {
+  SHORT_TEXT: "shortText",
+  LONG_TEXT: "longText",
+  RADIO: "radio",
+  CHECKBOX: "checkbox",
+  DROPDOWN: "dropdown",
+  SCHEDULE: "schedule",
+  FILE: "file",
+  PORTFOLIO: "portfolio",
+}
+
+function toId(value: string | number): string {
+  return String(value)
+}
+
+function scheduleText(times: string[]): string | null {
+  if (times.length === 0) return null
+  return times.map((time) => formatBaseTime(new Date(time))).join("\n")
+}
+
+const REMOVED_OPTION_PREFIX = "removed-"
+
+// 폼에서 지워진 선택지는 문항 구조에 없지만 답변에는 응답 시점 텍스트가 남는다.
+// 그대로 버리면 지원자가 무엇을 골랐는지 평가자에게 보이지 않으므로 선택지 목록
+// 끝에 되살려 붙인다.
+function resolveSelection(
+  question: RecruitingFormQuestion,
+  answer: RecruitingApplicationAnswer | undefined,
+): Pick<ApplicationQuestion, "options" | "selectedOptionIds"> {
+  const options = question.options
+    .slice()
+    .sort((a, b) => a.orderNo - b.orderNo)
+    .map((option) => ({
+      optionId: toId(option.optionId),
+      content: option.content,
+    }))
+  const knownIds = new Set(options.map((option) => option.optionId))
+
+  if (!answer?.selectedOptions) {
+    const selectedOptionIds = (answer?.selectedOptionIds ?? []).map(toId)
+    return { options, selectedOptionIds }
+  }
+
+  const selectedOptionIds: string[] = []
+  answer.selectedOptions.forEach((selected, index) => {
+    const optionId =
+      selected.questionOptionId != null ? toId(selected.questionOptionId) : null
+
+    if (optionId != null && knownIds.has(optionId)) {
+      selectedOptionIds.push(optionId)
+      return
+    }
+    if (!selected.answeredAsContent) return
+
+    const removedId = `${REMOVED_OPTION_PREFIX}${index}`
+    options.push({ optionId: removedId, content: selected.answeredAsContent })
+    selectedOptionIds.push(removedId)
+  })
+
+  return { options, selectedOptionIds }
+}
+
+function toFiles(fileIds: string[]) {
+  return fileIds.map((fileId, index) => ({
+    fileId: toId(fileId),
+    name: `첨부파일 ${index + 1}`,
+    url: null,
+  }))
+}
+
+function toQuestion(
+  question: RecruitingFormQuestion,
+  answer: RecruitingApplicationAnswer | undefined,
+): ApplicationQuestion {
+  const type = QUESTION_TYPE[question.type]
+  const times = answer?.times ?? []
+  const { options, selectedOptionIds } = resolveSelection(question, answer)
+
+  return {
+    questionId: toId(question.questionId),
+    type,
+    title: question.title,
+    description: question.description ?? undefined,
+    required: question.required,
+    options,
+    textValue:
+      type === "schedule" ? scheduleText(times) : (answer?.textValue ?? null),
+    selectedOptionIds,
+    files: toFiles(answer?.fileIds ?? []),
+  }
+}
+
+// PUBLIC-002 는 공통 섹션과 트랙 섹션을 구분해 주지 않는다. 지원 트랙의 파트
+// 라벨이 섹션 제목에 들어있으면 트랙 섹션으로 본다. 판정이 빗나가도 섹션 헤더
+// 색상만 달라진다.
+function isPartSection(title: string, partLabels: string[]): boolean {
+  const normalized = title.toLowerCase()
+  return partLabels.some((label) => normalized.includes(label.toLowerCase()))
+}
+
+export function toApplicationSections(
+  structure: RecruitingFormStructure,
+  answers: RecruitingApplicationAnswer[],
+  choices: Pick<RecruitingApplicationSummary, "firstChoice" | "secondChoice">,
+): ApplicationSection[] {
+  const answerByQuestionId = new Map(
+    answers.map((answer) => [toId(answer.questionId), answer]),
+  )
+  const partLabels = toPartTags(choices.firstChoice, choices.secondChoice).map(
+    (tag) => PART_TAG_LABEL[tag],
+  )
+
+  return structure.sections
+    .slice()
+    .sort((a, b) => a.orderNo - b.orderNo)
+    .map((section) => ({
+      sectionId: toId(section.sectionId),
+      type: isPartSection(section.title, partLabels)
+        ? ("part" as const)
+        : ("common" as const),
+      title: section.title,
+      questions: section.questions
+        .slice()
+        .sort((a, b) => a.orderNo - b.orderNo)
+        .map((question) =>
+          toQuestion(
+            question,
+            answerByQuestionId.get(toId(question.questionId)),
+          ),
+        ),
+    }))
+}
+
+const STAGE_ORDER: EvaluationStage[] = ["document", "interview", "final"]
+
+export function toReachedStages(
+  summary: RecruitingApplicationSummary,
+  interviewRequired: boolean,
+): EvaluationStage[] {
+  const { status } = summary
+  if (status === "SUBMITTED" || status === "DOCUMENT_FAILED") {
+    return ["document"]
+  }
+  if (status === "INTERVIEW_ASSIGNED") {
+    return interviewRequired ? ["document", "interview"] : ["document"]
+  }
+  // 면접을 건너뛴 지원자는 면접 평가가 존재하지 않는다. 모집 차수가 면접을
+  // 요구하더라도 단계를 노출하지 않는다.
+  if (status === "INTERVIEW_SKIPPED") {
+    return ["document", "final"]
+  }
+  if (status === "FINAL_PASSED" || status === "FINAL_FAILED") {
+    return interviewRequired ? STAGE_ORDER : ["document", "final"]
+  }
+  return ["document"]
+}
+
+function toFinalResult(
+  summary: RecruitingApplicationSummary,
+): EvaluationResult | null {
+  if (summary.status === "FINAL_PASSED") return "pass"
+  if (summary.status === "FINAL_FAILED") return "fail"
+  return null
+}
+
+export function toRecruitmentLabel(
+  round: Pick<RecruitingRound, "type" | "roundNo">,
+): string {
+  return round.type === "ADDITIONAL"
+    ? `${round.roundNo}차 추가 모집`
+    : "본 모집"
+}
+
+export function toApplicationDetail(
+  summary: RecruitingApplicationSummary,
+  sections: ApplicationSection[],
+  group: Pick<RecruitingRoundGroup, "chapterName" | "schoolName">,
+  round: Pick<RecruitingRound, "type" | "roundNo" | "interviewRequired">,
+): Omit<ApplicationDetail, "interview" | "evaluations"> {
+  return {
+    applicationId: toId(summary.applicationId),
+    applicantName: summary.applicantName,
+    chapter: group.chapterName,
+    school: group.schoolName,
+    recruitmentLabel: toRecruitmentLabel(round),
+    parts: toPartTags(summary.firstChoice, summary.secondChoice),
+    reachedStages: toReachedStages(summary, round.interviewRequired),
+    finalResult: toFinalResult(summary),
+    sections,
+  }
+}

--- a/src/features/recruiting/model/applyForm.ts
+++ b/src/features/recruiting/model/applyForm.ts
@@ -137,6 +137,10 @@ function questionSchema(
       return required
         ? z.array(z.string()).min(1, "한 개 이상 선택해 주세요.")
         : z.array(z.string())
+    // 일정 문항을 입력할 UI 가 아직 없다. 필수로 두면 채울 방법 없이 제출이
+    // 막히므로 값이 들어올 때만 문자열 배열로 받는다.
+    case "schedule":
+      return z.array(z.string()).optional()
     case "file":
       if (required) {
         return z.unknown().superRefine((value, ctx) => {

--- a/src/features/recruiting/model/evaluatorMapper.test.ts
+++ b/src/features/recruiting/model/evaluatorMapper.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest"
+
+import { toApiStage, toOperatorEvaluations } from "./evaluatorMapper"
+
+import type { RecruitingEvaluation } from "../api/types"
+
+function evaluation(
+  overrides: Partial<RecruitingEvaluation> & { evaluatorMemberId: string },
+): RecruitingEvaluation {
+  return {
+    id: "1",
+    applicationId: "500",
+    stage: "DOCUMENT",
+    decision: "APPROVED",
+    comment: null,
+    submittedAt: "2026-07-21T09:00:00",
+    ...overrides,
+  }
+}
+
+const NAMES = new Map([
+  ["7", "박운영"],
+  ["8", "최운영"],
+  ["9", "정운영"],
+])
+
+describe("toOperatorEvaluations", () => {
+  it("평가하지 않은 평가자도 목록에 남긴다", () => {
+    const operators = toOperatorEvaluations(
+      [
+        { id: "1", roundId: "3", memberId: "7" },
+        { id: "2", roundId: "3", memberId: "8" },
+      ],
+      [evaluation({ evaluatorMemberId: "7", comment: "좋습니다" })],
+      NAMES,
+      "document",
+    )
+
+    expect(operators).toEqual([
+      {
+        evaluatorId: "7",
+        evaluatorName: "박운영",
+        stage: "document",
+        progress: "done",
+        result: "pass",
+        comment: "좋습니다",
+      },
+      {
+        evaluatorId: "8",
+        evaluatorName: "최운영",
+        stage: "document",
+        progress: "before",
+        result: null,
+        comment: null,
+      },
+    ])
+  })
+
+  it("REJECTED 를 불합격으로 옮긴다", () => {
+    const [operator] = toOperatorEvaluations(
+      [{ id: "1", roundId: "3", memberId: "7" }],
+      [evaluation({ evaluatorMemberId: "7", decision: "REJECTED" })],
+      NAMES,
+      "interview",
+    )
+
+    expect(operator?.result).toBe("fail")
+  })
+
+  it("평가자 명단에서 빠졌어도 제출한 평가는 유지한다", () => {
+    const operators = toOperatorEvaluations(
+      [{ id: "1", roundId: "3", memberId: "7" }],
+      [
+        evaluation({ evaluatorMemberId: "7" }),
+        evaluation({ evaluatorMemberId: "9", id: "2" }),
+      ],
+      NAMES,
+      "document",
+    )
+
+    expect(operators.map((operator) => operator.evaluatorId)).toEqual([
+      "7",
+      "9",
+    ])
+  })
+
+  it("memberId 가 숫자로 와도 평가를 붙인다", () => {
+    const [operator] = toOperatorEvaluations(
+      [{ id: "1", roundId: "3", memberId: 7 as unknown as string }],
+      [evaluation({ evaluatorMemberId: 7 as unknown as string })],
+      NAMES,
+      "document",
+    )
+
+    expect(operator).toMatchObject({ evaluatorId: "7", progress: "done" })
+  })
+
+  it("프로필을 못 받은 평가자는 대체 이름을 쓴다", () => {
+    const [operator] = toOperatorEvaluations(
+      [{ id: "1", roundId: "3", memberId: "99" }],
+      [],
+      NAMES,
+      "document",
+    )
+
+    expect(operator?.evaluatorName).toBe("이름 없음")
+  })
+})
+
+describe("toApiStage", () => {
+  it("최종 단계에는 평가 API 가 없다", () => {
+    expect(toApiStage("document")).toBe("DOCUMENT")
+    expect(toApiStage("interview")).toBe("INTERVIEW")
+    expect(toApiStage("final")).toBeUndefined()
+  })
+})

--- a/src/features/recruiting/model/evaluatorMapper.ts
+++ b/src/features/recruiting/model/evaluatorMapper.ts
@@ -1,0 +1,76 @@
+import type {
+  ApiEvaluationStage,
+  RecruitingEvaluation,
+  RecruitingRoundEvaluator,
+} from "../api/types"
+import type { EvaluationResult } from "./applicantListTypes"
+import type {
+  OperatorEvaluation,
+  StageEvaluationDetail,
+} from "./applicationDetail"
+import type { EvaluationStage } from "./evaluationStage"
+
+const API_STAGE: Partial<Record<EvaluationStage, ApiEvaluationStage>> = {
+  document: "DOCUMENT",
+  interview: "INTERVIEW",
+}
+
+export function toApiStage(
+  stage: EvaluationStage,
+): ApiEvaluationStage | undefined {
+  return API_STAGE[stage]
+}
+
+function toResult(
+  decision: RecruitingEvaluation["decision"],
+): EvaluationResult {
+  return decision === "APPROVED" ? "pass" : "fail"
+}
+
+// EVALUATION-002 는 제출된 평가만 준다. 평가자 명단(ADMIN-033)과 합쳐야
+// 아직 평가하지 않은 운영진이 목록에 나온다.
+export function toOperatorEvaluations(
+  evaluators: RecruitingRoundEvaluator[],
+  evaluations: RecruitingEvaluation[],
+  memberNames: Map<string, string>,
+  stage: EvaluationStage,
+): OperatorEvaluation[] {
+  const evaluationByMemberId = new Map(
+    evaluations.map((evaluation) => [
+      String(evaluation.evaluatorMemberId),
+      evaluation,
+    ]),
+  )
+  const memberIds = [
+    ...new Set([
+      ...evaluators.map((evaluator) => String(evaluator.memberId)),
+      ...evaluationByMemberId.keys(),
+    ]),
+  ]
+
+  return memberIds.map((memberId) => {
+    const evaluation = evaluationByMemberId.get(memberId)
+    return {
+      evaluatorId: memberId,
+      evaluatorName: memberNames.get(memberId) ?? "이름 없음",
+      stage,
+      progress: evaluation ? "done" : "before",
+      result: evaluation ? toResult(evaluation.decision) : null,
+      comment: evaluation?.comment ?? null,
+    }
+  })
+}
+
+export function toStageEvaluationDetail(
+  operators: OperatorEvaluation[],
+  stage: EvaluationStage,
+  myMemberId: string,
+  locked: boolean,
+): StageEvaluationDetail {
+  return {
+    stage,
+    myEvaluatorId: myMemberId,
+    locked,
+    operators,
+  }
+}

--- a/src/features/recruiting/ui/detail/ApplicationEvaluationDetailPage.tsx
+++ b/src/features/recruiting/ui/detail/ApplicationEvaluationDetailPage.tsx
@@ -1,10 +1,10 @@
 import { Link } from "@tanstack/react-router"
-import { useState } from "react"
 
 import LeftChevronIcon from "@/shared/assets/icon/chevron/LeftChevronIcon"
 import { Breadcrumb } from "@/shared/ui/breadcrumb/Breadcrumb"
 
-import { getApplicationDetailMock } from "../../model/applicationDetail.mock"
+import { useApplicationDetail } from "../../hooks/useApplicationDetail"
+import { useStageEvaluations } from "../../hooks/useStageEvaluations"
 import {
   EVALUATION_STAGE_LABEL,
   EVALUATION_STAGE_SHORT_LABEL,
@@ -13,11 +13,8 @@ import {
 import { ApplicationFormReadonly } from "./ApplicationFormReadonly"
 import { EvaluationResultToggle } from "./EvaluationResultToggle"
 import { EvaluationStepper } from "./EvaluationStepper"
-import { InterviewAnswerCards } from "./InterviewAnswerCards"
 import { MyStageEvaluationPanel } from "./MyStageEvaluationPanel"
 import { OperatorEvaluationList } from "./OperatorEvaluationList"
-
-import type { EvaluationResult } from "../../model/applicantListTypes"
 
 const STAGE_LIST_PATH: Record<EvaluationStage, string> = {
   document: "/recruiting/evaluations/document",
@@ -31,40 +28,46 @@ interface ApplicationEvaluationDetailPageProps {
   roundId: string | undefined
 }
 
+function DetailSkeleton() {
+  return (
+    <div className="flex animate-pulse gap-6">
+      <div className="flex min-w-0 flex-1 flex-col gap-6">
+        <div className="bg-teal-gray-100 h-12 rounded-[10px]" />
+        <div className="bg-teal-gray-100 h-40 rounded-[10px]" />
+        <div className="bg-teal-gray-100 h-40 rounded-[10px]" />
+      </div>
+      <div className="flex w-115 shrink-0 flex-col gap-5">
+        <div className="bg-teal-gray-100 h-12 rounded-[10px]" />
+        <div className="bg-teal-gray-100 h-64 rounded-[16px]" />
+      </div>
+    </div>
+  )
+}
+
+function DetailMessage({ children }: { children: string }) {
+  return (
+    <div className="flex min-h-60 items-center justify-center">
+      <p className="text-body-1-regular text-teal-gray-500">{children}</p>
+    </div>
+  )
+}
+
 export function ApplicationEvaluationDetailPage({
   stage,
   applicationId,
   roundId,
 }: ApplicationEvaluationDetailPageProps) {
-  const [detail, setDetail] = useState(() =>
-    getApplicationDetailMock(applicationId),
-  )
-  const evaluation = detail.evaluations[stage]
+  const { detail, isError } = useApplicationDetail(applicationId, roundId)
+  const {
+    evaluation,
+    rosterKnown,
+    isError: isEvaluationError,
+  } = useStageEvaluations(applicationId, roundId, stage)
+
   const listPath = STAGE_LIST_PATH[stage]
   const showFinalResult = stage !== "document"
   const finalResultLabel =
     stage === "final" ? "지원자 최종 평가" : "지원자 최종 결과"
-
-  const handleComplete = (result: EvaluationResult, comment: string) => {
-    setDetail((prev) => {
-      const current = prev.evaluations[stage]
-      if (!current) return prev
-      return {
-        ...prev,
-        evaluations: {
-          ...prev.evaluations,
-          [stage]: {
-            ...current,
-            operators: current.operators.map((operator) =>
-              operator.evaluatorId === current.myEvaluatorId
-                ? { ...operator, progress: "done", result, comment }
-                : operator,
-            ),
-          },
-        },
-      }
-    })
-  }
 
   return (
     <div className="flex w-full max-w-286.5 flex-col gap-8">
@@ -87,63 +90,80 @@ export function ApplicationEvaluationDetailPage({
           <LeftChevronIcon width={16} height={16} />
           지원자 목록으로
         </Link>
-        <div className="flex flex-col gap-1">
-          <span className="text-body-2-semibold text-teal-600">
-            {detail.chapter}
-          </span>
-          <h1 className="text-heading-4-semibold text-teal-gray-900">
-            {detail.applicantName} 지원서
-          </h1>
-          <span className="text-body-2-regular text-teal-gray-500">
-            {detail.recruitmentLabel}
-          </span>
-        </div>
+        {detail && (
+          <div className="flex flex-col gap-1">
+            <span className="text-body-2-semibold text-teal-600">
+              {detail.chapter}
+            </span>
+            <h1 className="text-heading-4-semibold text-teal-gray-900">
+              {detail.applicantName} 지원서
+            </h1>
+            <span className="text-body-2-regular text-teal-gray-500">
+              {detail.recruitmentLabel}
+            </span>
+          </div>
+        )}
       </div>
 
-      <div className="flex gap-6">
-        <div className="min-w-0 flex-1">
-          <ApplicationFormReadonly sections={detail.sections} />
-        </div>
-        <div className="flex w-115 shrink-0 flex-col gap-5">
-          <EvaluationStepper
-            applicationId={applicationId}
-            roundId={roundId}
-            stage={stage}
-            reachedStages={detail.reachedStages}
-          />
-          {stage === "interview" && detail.interview && (
-            <InterviewAnswerCards content={detail.interview} />
-          )}
-          {evaluation && (
-            <>
-              {stage !== "final" && (
-                <MyStageEvaluationPanel
-                  evaluation={evaluation}
-                  stage={stage}
-                  onComplete={handleComplete}
+      {isError ? (
+        <DetailMessage>
+          지원서를 불러오지 못했습니다. 목록에서 다시 진입해주세요.
+        </DetailMessage>
+      ) : !detail ? (
+        <DetailSkeleton />
+      ) : (
+        <div className="flex gap-6">
+          <div className="min-w-0 flex-1">
+            <ApplicationFormReadonly sections={detail.sections} />
+          </div>
+          <div className="flex w-115 shrink-0 flex-col gap-5">
+            <EvaluationStepper
+              applicationId={applicationId}
+              roundId={roundId}
+              stage={stage}
+              reachedStages={detail.reachedStages}
+            />
+            {isEvaluationError ? (
+              <div className="border-teal-gray-100 flex min-h-30 items-center justify-center rounded-[16px] border bg-white p-6">
+                <p className="text-body-2-regular text-teal-gray-500">
+                  평가 정보를 불러오지 못했습니다.
+                </p>
+              </div>
+            ) : (
+              evaluation && (
+                <>
+                  {stage !== "final" && (
+                    <MyStageEvaluationPanel
+                      evaluation={evaluation}
+                      stage={stage}
+                      onComplete={() => {}}
+                    />
+                  )}
+                  <OperatorEvaluationList
+                    evaluation={evaluation}
+                    viewerIsAdmin={rosterKnown}
+                  />
+                </>
+              )
+            )}
+            {showFinalResult && (
+              <div className="flex items-center justify-center gap-4 pt-2">
+                <span className="text-heading-7-semibold text-teal-gray-800">
+                  {finalResultLabel}
+                </span>
+                <EvaluationResultToggle
+                  value={detail.finalResult}
+                  onChange={() => {}}
+                  disabled
+                  variant="strong"
+                  failLabel="최종 불합격"
+                  passLabel="최종 합격"
                 />
-              )}
-              <OperatorEvaluationList evaluation={evaluation} />
-            </>
-          )}
-          {showFinalResult && (
-            <div className="flex items-center justify-center gap-4 pt-2">
-              <span className="text-heading-7-semibold text-teal-gray-800">
-                {finalResultLabel}
-              </span>
-              <EvaluationResultToggle
-                value={detail.finalResult}
-                onChange={(next) =>
-                  setDetail((prev) => ({ ...prev, finalResult: next }))
-                }
-                variant="strong"
-                failLabel="최종 불합격"
-                passLabel="최종 합격"
-              />
-            </div>
-          )}
+              </div>
+            )}
+          </div>
         </div>
-      </div>
+      )}
     </div>
   )
 }

--- a/src/features/recruiting/ui/detail/OperatorEvaluationList.test.tsx
+++ b/src/features/recruiting/ui/detail/OperatorEvaluationList.test.tsx
@@ -94,4 +94,77 @@ describe("OperatorEvaluationList", () => {
       screen.queryByText("현재 완료된 평가가 없습니다."),
     ).not.toBeInTheDocument()
   })
+
+  it("내가 평가자가 아니어도 전달받은 평가는 그대로 보여준다", () => {
+    render(
+      <OperatorEvaluationList
+        evaluation={buildEvaluation([
+          buildOperator({
+            evaluatorId: "other",
+            evaluatorName: "김운영",
+            progress: "done",
+            result: "pass",
+            comment: "적합합니다",
+          }),
+        ])}
+      />,
+    )
+
+    expect(screen.getByText("김운영")).toBeInTheDocument()
+    expect(screen.getByText("적합합니다")).toBeInTheDocument()
+    expect(
+      screen.queryByText("나의 평가를 등록 후에 확인할 수 있습니다."),
+    ).not.toBeInTheDocument()
+  })
+
+  it("관리 권한이 없으면 총원을 알 수 없어 분모를 감춘다", () => {
+    render(
+      <OperatorEvaluationList
+        evaluation={buildEvaluation([
+          buildOperator({
+            evaluatorId: "me",
+            evaluatorName: "나",
+            progress: "done",
+            result: "pass",
+          }),
+        ])}
+      />,
+    )
+
+    const heading = screen.getByRole("heading", { name: /운영진 평가/ })
+    expect(heading.textContent).toBe("운영진 평가 1")
+  })
+
+  it("관리 권한이 있으면 총원을 함께 보여준다", () => {
+    render(
+      <OperatorEvaluationList
+        viewerIsAdmin
+        evaluation={buildEvaluation([
+          buildOperator({
+            evaluatorId: "a",
+            progress: "done",
+            result: "pass",
+          }),
+          buildOperator({ evaluatorId: "b" }),
+        ])}
+      />,
+    )
+
+    const heading = screen.getByRole("heading", { name: /운영진 평가/ })
+    expect(heading.textContent).toBe("운영진 평가 1/2")
+  })
+
+  it("평가자가 아닌 운영진에게 평가 등록 안내를 보여주지 않는다", () => {
+    render(
+      <OperatorEvaluationList
+        viewerIsAdmin
+        evaluation={buildEvaluation([buildOperator({ evaluatorId: "other" })])}
+      />,
+    )
+
+    expect(screen.getByText("현재 완료된 평가가 없습니다.")).toBeInTheDocument()
+    expect(
+      screen.queryByText("나의 평가를 등록 후에 확인할 수 있습니다."),
+    ).not.toBeInTheDocument()
+  })
 })

--- a/src/features/recruiting/ui/detail/OperatorEvaluationList.tsx
+++ b/src/features/recruiting/ui/detail/OperatorEvaluationList.tsx
@@ -10,6 +10,11 @@ import { EVALUATION_STAGE_LABEL } from "../../model/evaluationStage"
 
 interface OperatorEvaluationListProps {
   evaluation: StageEvaluationDetail
+  /**
+   * 모집 관리 권한 보유 여부. 있으면 평가자 명단을 받아 총원을 셀 수 있고,
+   * 서버도 다른 평가를 제한 없이 내려준다. 없으면 총원을 알 수 없다.
+   */
+  viewerIsAdmin?: boolean
 }
 
 function OperatorStatusChip({ done }: { done: boolean }) {
@@ -58,22 +63,28 @@ function SortIcon() {
 
 export function OperatorEvaluationList({
   evaluation,
+  viewerIsAdmin = false,
 }: OperatorEvaluationListProps) {
   const { done, total } = countOperatorProgress(evaluation.operators)
   const myEvaluation = getMyEvaluation(evaluation)
-  const revealed = myEvaluation?.progress === "done"
   const othersDone = evaluation.operators.filter(
     (operator) =>
       operator.evaluatorId !== evaluation.myEvaluatorId &&
       operator.progress === "done",
   ).length
+  // 서버가 열람 가능한 평가만 내려준다. 운영진에게는 제한 없이 주고, 평가자에게는
+  // 본인이 제출한 뒤에만 준다. 받은 것이 있으면 그대로 보여준다.
+  const revealed =
+    viewerIsAdmin || myEvaluation?.progress === "done" || othersDone > 0
 
   return (
     <section className="border-teal-gray-100 flex flex-col gap-4 rounded-[16px] border bg-white p-6">
       <div className="flex items-center justify-between">
         <h3 className="text-heading-6-semibold text-teal-gray-800">
           운영진 평가 <span className="text-teal-500">{done}</span>
-          <span className="text-teal-gray-400">/{total}</span>
+          {viewerIsAdmin && (
+            <span className="text-teal-gray-400">/{total}</span>
+          )}
         </h3>
         {revealed && <SortIcon />}
       </div>

--- a/src/features/recruiting/ui/detail/ReadonlyAnswerField.tsx
+++ b/src/features/recruiting/ui/detail/ReadonlyAnswerField.tsx
@@ -80,18 +80,28 @@ function AnswerBody({ question }: { question: ApplicationQuestion }) {
             <span className="truncate">{link}</span>
           </a>
         )}
-        {question.files.map((file) => (
-          <a
-            key={file.fileId}
-            href={file.url}
-            target="_blank"
-            rel="noreferrer"
-            className="text-body-1-regular text-teal-gray-700 flex items-center gap-1.5 underline-offset-2 hover:underline"
-          >
-            <FileClip className="text-teal-gray-500 size-5 shrink-0" />
-            <span className="truncate">{file.name}</span>
-          </a>
-        ))}
+        {question.files.map((file) =>
+          file.url ? (
+            <a
+              key={file.fileId}
+              href={file.url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-body-1-regular text-teal-gray-700 flex items-center gap-1.5 underline-offset-2 hover:underline"
+            >
+              <FileClip className="text-teal-gray-500 size-5 shrink-0" />
+              <span className="truncate">{file.name}</span>
+            </a>
+          ) : (
+            <span
+              key={file.fileId}
+              className="text-body-1-regular text-teal-gray-700 flex items-center gap-1.5"
+            >
+              <FileClip className="text-teal-gray-500 size-5 shrink-0" />
+              <span className="truncate">{file.name}</span>
+            </span>
+          ),
+        )}
       </QuestionFieldBox>
     )
   }


### PR DESCRIPTION
## 📸 작업 내용

- 평가 상세 화면(서류·면접·최종)을 목업에서 실제 API 조회로 전환했습니다. **이번 PR은 조회까지이며, 평가 등록·합불 결정은 후속 PR에서 붙입니다.**
- 지원서 상세 응답이 답변을 `questionId` 로만 주고 문항 제목·선택지를 포함하지 않아, 문항 구조 응답과 합쳐 화면을 조립하는 매퍼를 추가했습니다.
- 차수 정보를 관리자용 목록에서 **공개 모집 목록**으로 옮겼습니다. 관리자용 목록은 모집 관리 권한이 있어야 조회할 수 있어 평가자 권한만 가진 운영진이 403 을 받습니다. 이미 머지된 **지원자 목록 화면도 같은 문제로 통째로 에러**여서 함께 고쳤습니다.
- 평가자 명단 조회 실패를 치명적으로 다루지 않아, 명단을 받지 못하는 운영진도 화면을 쓸 수 있습니다.
- 문항 타입에 일정(`SCHEDULE`)을 추가하고, 다운로드 주소가 없는 첨부 파일도 목록에 남도록 했습니다.
- 단위 테스트 33건을 추가했습니다 (총 464건 통과).

## 🎞️ 주요 코드 설명

### 문항·답변 조인

지원서 상세는 `{ application, formResponseId, answers[] }` 만 주고 답변은 `questionId` 로만 식별됩니다. 문항 구조 조회는 1지망을 필수 쿼리로 요구하므로 상세 → 구조 순서로 조회한 뒤 합칩니다. id 가 문자열로 직렬화되므로 양쪽을 문자열로 정규화해 비교합니다.

```TypeScript
const answerByQuestionId = new Map(
  answers.map((answer) => [toId(answer.questionId), answer]),
)
```

- 폼에서 지워진 선택지는 문항 구조에 없지만 답변에는 응답 시점 내용이 남습니다. 그대로 버리면 지원자가 무엇을 골랐는지 평가자에게 보이지 않아, 선택지 목록 끝에 되살려 표시합니다.
- 조인이 어긋나도 화면에는 "빈 답변"으로만 보여 조용히 넘어가므로 단위 테스트로 고정했습니다.

### 차수 조회 경로

공개 모집 목록의 `phase` 는 생략하면 지원 기간이 열린 차수만 반환합니다. 평가는 서류 마감 후에 하므로 그대로 두면 평가 대상 차수가 빠집니다. 값이 두 개뿐이라 한쪽으로 전 구간을 덮을 수 없어 둘 다 조회한 뒤 시즌별로 합치고 차수 id 로 중복을 제거합니다.

```TypeScript
export async function getAllPublicRounds(gisuId: string, roundIds?: string[]) {
  const phases: RecruitingRoundPhase[] = ["PAST", "OPEN"]
  const perPhase = await Promise.all(
    phases.map((phase) => getPublicRounds({ gisuId, roundIds, phase })),
  )
  return mergeRoundGroups(perPhase.flat())
}
```

- 상세 화면은 차수 id 필터를 걸어 한 건만, 목록 화면은 기수 전체를 가져옵니다.

### 평가자 명단과 평가 목록

평가 목록 응답은 제출된 평가만 주므로, 명단과 합쳐야 아직 평가하지 않은 운영진이 목록에 나옵니다. 명단 조회는 모집 관리 권한이 필요해 403 이 날 수 있습니다.

```TypeScript
retry: (failureCount, error) =>
  !(isAxiosError(error) && error.response?.status === 403) && failureCount < 2,
```

- 403 은 권한 없음의 확정 답이라 재시도하지 않고, 나머지 오류만 재시도해 일시적 실패가 권한 없음으로 굳지 않게 합니다.
- 명단 결과가 확정되기 전에는 패널을 조립하지 않아 화면이 뒤바뀌지 않습니다.
- 명단을 받지 못하면 미평가자를 알 수 없으므로 총원(분모)을 표시하지 않습니다.

## 🖥️ 구현화면

|          서류 평가 상세          |          면접 평가 상세          |
| :------------------------------: | :------------------------------: |
|   <img src = "" width ="250">    |   <img src = "" width ="250">    |

## 🔗 연결된 이슈

- Connected: #641

## 💬 기타 더 이야기해볼 점

- 이번 PR 범위는 조회까지입니다. 평가 등록·수정, 서류/최종 합불, 면접 질문 연결, 목업 제거가 남아 있어 #641 은 후속 PR에서 닫습니다.
- dev 로그인이 막혀 있어 **실제 응답으로는 검증하지 못했습니다.** 타입·테스트·빌드와 API 스펙 대조까지만 확인한 상태라, 로그인이 열리면 `answers[].questionId` 와 문항 구조의 `questionId` 집합이 실제로 겹치는지 확인이 필요합니다.
- 지원서 응답에 면접 생략 이력이 남지 않아, 최종 상태로 넘어간 뒤에는 면접을 건너뛴 지원자인지 판별할 수 없습니다. 현재는 차수의 면접 필요 여부로 단계를 노출하고 있어 이 경로에서만 어긋납니다.