### PR TITLE
feat: 학교 관리/지부 관리/커리큘럼 페이지 API 연동

### DIFF
--- a/src/entities/curriculum/api/curriculumApi.ts
+++ b/src/entities/curriculum/api/curriculumApi.ts
@@ -1,0 +1,125 @@
+import { api } from "@/shared/lib/axios"
+
+import type { ApiResponse } from "@/shared/lib/apiResponse"
+
+import type {
+  CreateCurriculumRequest,
+  CreateWeeklyCurriculumRequest,
+  CurriculumOverviewResponse,
+  DeleteCurriculumRequest,
+  DeleteWeeklyCurriculumRequest,
+  EditCurriculumRequest,
+  EditWeeklyCurriculumRequest,
+  GetCurriculumOverviewParams,
+} from "../model/curriculumTypes"
+
+/**
+ * 특정 기수의 파트별 커리큘럼 조회 (CURRICULUM-101)
+ * @description 요청자와 관계없이 주어진 기수, 파트에 해당하는 커리큘럼 및 주차별 목록을 조회합니다.
+ */
+export async function getCurriculumOverview(
+  params: GetCurriculumOverviewParams,
+): Promise<CurriculumOverviewResponse> {
+  const { data } = await api.get<ApiResponse<CurriculumOverviewResponse>>(
+    "/v2/curriculums/overview",
+    { params },
+  )
+  return data.result
+}
+
+/**
+ * 1. 각 커리큘럼에 새로운 주차 생성 (CURRICULUM-004)
+ * 상위 객체인 커리큘럼에 주차별 커리큘럼을 생성합니다.
+ * (각 커리큘럼당 주차별 커리큘럼은 최대 2개 [MAIN, EXTRA] 생성 가능)
+ */
+export async function createWeeklyCurriculum(
+  body: CreateWeeklyCurriculumRequest,
+): Promise<number> {
+  const { data } = await api.post<ApiResponse<number>>(
+    "/v2/curriculums/weekly",
+    body,
+  )
+  return data.result
+}
+
+/**
+ * 2. 주차별 커리큘럼 삭제 (CURRICULUM-006)
+ * 주차별 커리큘럼을 삭제합니다.
+ * (포함된 주차별 워크북이 하나라도 존재하면 삭제가 불가능합니다)
+ */
+export async function deleteWeeklyCurriculum(
+  weeklyCurriculumIdOrReq: number | DeleteWeeklyCurriculumRequest,
+): Promise<void> {
+  const weeklyCurriculumId =
+    typeof weeklyCurriculumIdOrReq === "object"
+      ? weeklyCurriculumIdOrReq.weeklyCurriculumId
+      : weeklyCurriculumIdOrReq
+
+  const { data } = await api.delete<ApiResponse<void>>(
+    `/v2/curriculums/weekly/${weeklyCurriculumId}`,
+  )
+  return data.result
+}
+
+/**
+ * 3. 주차별 커리큘럼 수정 (CURRICULUM-005)
+ * 주차별 커리큘럼 자체를 수정합니다.
+ * (제목은 상시 수정 가능, 배포된 워크북이 있으면 시작/종료일 수정 불가 등)
+ */
+export async function updateWeeklyCurriculum(
+  weeklyCurriculumId: number,
+  body: EditWeeklyCurriculumRequest,
+): Promise<void> {
+  const { data } = await api.patch<ApiResponse<void>>(
+    `/v2/curriculums/weekly/${weeklyCurriculumId}`,
+    body,
+  )
+  return data.result
+}
+
+/**
+ * 4. 중앙운영사무국 총괄단용: 커리큘럼 삭제 (CURRICULUM-003)
+ * 커리큘럼을 삭제합니다.
+ * (내부에 포함된 주차별 커리큘럼이 존재하는 경우 삭제하지 못하며, 중앙운영사무국 총괄단 권한 필요)
+ */
+export async function deleteCurriculum(
+  curriculumIdOrReq: number | DeleteCurriculumRequest,
+): Promise<void> {
+  const curriculumId =
+    typeof curriculumIdOrReq === "object"
+      ? curriculumIdOrReq.curriculumId
+      : curriculumIdOrReq
+
+  const { data } = await api.delete<ApiResponse<void>>(
+    `/v2/curriculums/${curriculumId}`,
+  )
+  return data.result
+}
+
+/**
+ * 5. 커리큘럼 생성 (CURRICULUM-001)
+ * 기수, 파트에 대한 상위 객체인 커리큘럼을 생성합니다.
+ * (동일한 기수에 동일한 파트에 대한 커리큘럼은 중복 불가)
+ */
+export async function createCurriculum(
+  body: CreateCurriculumRequest,
+): Promise<number> {
+  const { data } = await api.post<ApiResponse<number>>("/v2/curriculums", body)
+  return data.result
+}
+
+/**
+ * 6. 커리큘럼 수정 (CURRICULUM-002)
+ * 상위 객체인 커리큘럼의 이름을 수정합니다.
+ * (기수, 파트 등은 수정할 수 없으며 이름만 수정 가능)
+ */
+export async function updateCurriculum(
+  curriculumId: number,
+  body: EditCurriculumRequest,
+): Promise<void> {
+  const { data } = await api.patch<ApiResponse<void>>(
+    `/v2/curriculums/${curriculumId}`,
+    body,
+  )
+  return data.result
+}

--- a/src/entities/curriculum/index.ts
+++ b/src/entities/curriculum/index.ts
@@ -1,0 +1,2 @@
+export * from "./api/curriculumApi"
+export * from "./model/curriculumTypes"

--- a/src/entities/curriculum/model/curriculumTypes.ts
+++ b/src/entities/curriculum/model/curriculumTypes.ts
@@ -1,0 +1,133 @@
+import type { components } from "@/types/api"
+
+/**
+ * 커리큘럼 파트 Enum (OpenAPI Spec 기반)
+ */
+export type CurriculumPart =
+  | "PLAN"
+  | "DESIGN"
+  | "WEB"
+  | "ANDROID"
+  | "IOS"
+  | "NODEJS"
+  | "SPRINGBOOT"
+  | "ADMIN"
+
+/**
+ * 1. 각 커리큘럼에 새로운 주차 생성 요청 DTO (CURRICULUM-004)
+ */
+export interface CreateWeeklyCurriculumRequest {
+  /** 상위 커리큘럼 ID */
+  curriculumId: number
+  /** 주차 번호 */
+  weekNo: number
+  /** 부록(EXTRA) 여부 */
+  isExtra?: boolean
+  /** 주차 제목 */
+  title: string
+  /** 시작일시 (ISO 8601 string) */
+  startsAt: string
+  /** 종료일시 (ISO 8601 string) */
+  endsAt: string
+}
+
+/**
+ * 2. 주차별 커리큘럼 삭제 요청 DTO (CURRICULUM-006)
+ */
+export interface DeleteWeeklyCurriculumRequest {
+  /** 삭제할 주차별 커리큘럼 ID */
+  weeklyCurriculumId: number
+}
+
+/**
+ * 3. 주차별 커리큘럼 수정 요청 DTO (CURRICULUM-005)
+ */
+export interface EditWeeklyCurriculumRequest {
+  /** 주차 번호 */
+  weekNo?: number
+  /** 부록(EXTRA) 여부 */
+  isExtra?: boolean
+  /** 주차 제목 */
+  title?: string
+  /** 시작일시 (ISO 8601 string) */
+  startsAt?: string
+  /** 종료일시 (ISO 8601 string) */
+  endsAt?: string
+}
+
+/**
+ * 4. 중앙운영사무국 총괄단용: 커리큘럼 삭제 요청 DTO (CURRICULUM-003)
+ */
+export interface DeleteCurriculumRequest {
+  /** 삭제할 커리큘럼 ID */
+  curriculumId: number
+}
+
+/**
+ * 5. 커리큘럼 생성 요청 DTO (CURRICULUM-001)
+ */
+export interface CreateCurriculumRequest {
+  /** 기수 ID */
+  gisuId: number
+  /** 파트 */
+  part: CurriculumPart
+  /** 커리큘럼 제목 */
+  title: string
+}
+
+/**
+ * 6. 커리큘럼 수정 요청 DTO (CURRICULUM-002)
+ */
+export interface EditCurriculumRequest {
+  /** 커리큘럼 제목 */
+  title: string
+}
+
+/**
+ * 특정 기수의 파트별 커리큘럼 조회 쿼리 파라미터 DTO (CURRICULUM-101)
+ */
+export interface GetCurriculumOverviewParams {
+  /** 기수 ID */
+  gisuId: number
+  /** 파트 */
+  part: CurriculumPart
+  /** 주차 번호 (선택) */
+  weekNo?: number
+}
+
+/**
+ * 주차별 커리큘럼 개요 응답 DTO
+ */
+export interface WeeklyCurriculumOverviewResponse {
+  weeklyCurriculumId?: number
+  weekNo?: number
+  title?: string
+  isExtra?: boolean
+  startsAt?: string
+  endsAt?: string
+}
+
+/**
+ * 커리큘럼 개요 (특정 기수/파트) 응답 DTO (CURRICULUM-101)
+ */
+export interface CurriculumOverviewResponse {
+  curriculumId?: number
+  title?: string
+  weeks?: WeeklyCurriculumOverviewResponse[]
+}
+
+/**
+ * OpenAPI components.schemas 기반 타입 별칭 호환성 제공
+ */
+export type ApiCreateCurriculumRequest =
+  components["schemas"]["CreateCurriculumRequest"]
+export type ApiCreateWeeklyCurriculumRequest =
+  components["schemas"]["CreateWeeklyCurriculumRequest"]
+export type ApiEditCurriculumRequest =
+  components["schemas"]["EditCurriculumRequest"]
+export type ApiEditWeeklyCurriculumRequest =
+  components["schemas"]["EditWeeklyCurriculumRequest"]
+export type ApiCurriculumOverviewResponse =
+  components["schemas"]["CurriculumOverviewResponse"]
+export type ApiWeeklyCurriculumOverviewResponse =
+  components["schemas"]["WeeklyCurriculumOverviewResponse"]

--- a/src/entities/organization/api/chapterApi.ts
+++ b/src/entities/organization/api/chapterApi.ts
@@ -3,7 +3,6 @@ import { api } from "@/shared/lib/axios"
 import type {
   CreateChapterBulkRequest,
   CreateChapterRequest,
-  DeleteChapterRequest,
 } from "@/entities/organization/model/chapterTypes"
 import type { ApiResponse } from "@/shared/lib/apiResponse"
 
@@ -33,21 +32,10 @@ export async function createChaptersBulk(
 }
 
 /**
- * 지부 일괄 생성 헬퍼 (동일 기능 별칭)
- */
-export const createBulkChapters = createChaptersBulk
-
-/**
  * 지부 삭제 (CHAPTER-003)
  * 지부를 삭제합니다. 소속 학교는 삭제되지 않습니다.
  */
-export async function deleteChapter(
-  chapterIdOrReq: number | string | DeleteChapterRequest,
-): Promise<void> {
-  const chapterId =
-    typeof chapterIdOrReq === "object"
-      ? chapterIdOrReq.chapterId
-      : chapterIdOrReq
+export async function deleteChapter(chapterId: number | string): Promise<void> {
   const { data } = await api.delete<ApiResponse<void>>(
     `/v1/chapters/${chapterId}`,
   )

--- a/src/entities/organization/api/chapterApi.ts
+++ b/src/entities/organization/api/chapterApi.ts
@@ -1,0 +1,55 @@
+import { api } from "@/shared/lib/axios"
+
+import type {
+  CreateChapterBulkRequest,
+  CreateChapterRequest,
+  DeleteChapterRequest,
+} from "@/entities/organization/model/chapterTypes"
+import type { ApiResponse } from "@/shared/lib/apiResponse"
+
+/**
+ * 지부 생성 (CHAPTER-001)
+ * 새로운 지부를 생성합니다. 소속 학교를 함께 지정할 수 있습니다.
+ */
+export async function createChapter(
+  body: CreateChapterRequest,
+): Promise<number> {
+  const { data } = await api.post<ApiResponse<number>>("/v1/chapters", body)
+  return data.result
+}
+
+/**
+ * 지부 일괄 생성 (CHAPTER-002)
+ * 여러 지부를 일괄 생성합니다.
+ */
+export async function createChaptersBulk(
+  body: CreateChapterBulkRequest,
+): Promise<number[]> {
+  const { data } = await api.post<ApiResponse<number[]>>(
+    "/v1/chapters/bulk",
+    body,
+  )
+  return data.result
+}
+
+/**
+ * 지부 일괄 생성 헬퍼 (동일 기능 별칭)
+ */
+export const createBulkChapters = createChaptersBulk
+
+/**
+ * 지부 삭제 (CHAPTER-003)
+ * 지부를 삭제합니다. 소속 학교는 삭제되지 않습니다.
+ */
+export async function deleteChapter(
+  chapterIdOrReq: number | string | DeleteChapterRequest,
+): Promise<void> {
+  const chapterId =
+    typeof chapterIdOrReq === "object"
+      ? chapterIdOrReq.chapterId
+      : chapterIdOrReq
+  const { data } = await api.delete<ApiResponse<void>>(
+    `/v1/chapters/${chapterId}`,
+  )
+  return data.result
+}

--- a/src/entities/organization/api/schoolApi.test.ts
+++ b/src/entities/organization/api/schoolApi.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { deleteSchool } from "./schoolApi"
+
+const { deleteMock } = vi.hoisted(() => ({
+  deleteMock: vi.fn(),
+}))
+
+vi.mock("@/shared/lib/axios", () => ({
+  api: { delete: deleteMock },
+}))
+
+describe("deleteSchool", () => {
+  beforeEach(() => {
+    deleteMock.mockReset()
+  })
+
+  it("유효한 수치형 ID 전달 시 deleteSchools를 호출한다", async () => {
+    deleteMock.mockResolvedValue({ data: { result: undefined } })
+
+    await deleteSchool("123")
+
+    expect(deleteMock).toHaveBeenCalledWith("/v1/schools", {
+      data: { schoolIds: [123] },
+    })
+  })
+
+  it("숫자로 변환할 수 없는 유효하지 않은 ID 전달 시 Error를 발생시킨다", async () => {
+    await expect(deleteSchool("invalid-id")).rejects.toThrow(
+      "유효하지 않은 학교 ID입니다.",
+    )
+    expect(deleteMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/entities/organization/api/schoolApi.ts
+++ b/src/entities/organization/api/schoolApi.ts
@@ -60,7 +60,11 @@ export async function deleteSchools(body: DeleteSchoolsRequest): Promise<void> {
  * 학교 단건 삭제 헬퍼 함수
  */
 export async function deleteSchool(schoolId: number | string): Promise<void> {
-  return deleteSchools({ schoolIds: [Number(schoolId)] })
+  const numericId = Number(schoolId)
+  if (Number.isNaN(numericId)) {
+    throw new Error("유효하지 않은 학교 ID입니다.")
+  }
+  return deleteSchools({ schoolIds: [numericId] })
 }
 
 /**

--- a/src/entities/organization/api/schoolApi.ts
+++ b/src/entities/organization/api/schoolApi.ts
@@ -1,0 +1,75 @@
+import { api } from "@/shared/lib/axios"
+
+import type {
+  CreateSchoolRequest,
+  DeleteSchoolsRequest,
+  SchoolDetailResponse,
+  SchoolNameListResponse,
+  UpdateSchoolRequest,
+} from "@/entities/organization/model/schoolTypes"
+import type { ApiResponse } from "@/shared/lib/apiResponse"
+
+/**
+ * 학교 전체 목록 조회 (SCHOOL-101)
+ * 전체 학교 목록을 이름순으로 조회합니다.
+ */
+export async function getAllSchools(): Promise<SchoolNameListResponse> {
+  const { data } =
+    await api.get<ApiResponse<SchoolNameListResponse>>("/v1/schools/all")
+  return data.result
+}
+
+/**
+ * 학교 생성 (SCHOOL-001)
+ * 새로운 학교를 등록합니다.
+ */
+export async function createSchool(body: CreateSchoolRequest): Promise<void> {
+  const { data } = await api.post<ApiResponse<void>>("/v1/schools", body)
+  return data.result
+}
+
+/**
+ * 학교 수정 (SCHOOL-002)
+ * 학교 정보를 수정합니다. 입력된 필드만 수정됩니다.
+ */
+export async function updateSchool(
+  schoolId: number | string,
+  body: UpdateSchoolRequest,
+): Promise<void> {
+  const { data } = await api.patch<ApiResponse<void>>(
+    `/v1/schools/${schoolId}`,
+    body,
+  )
+  return data.result
+}
+
+/**
+ * 학교 일괄 삭제 (SCHOOL-003)
+ * 여러 학교를 일괄 삭제합니다.
+ */
+export async function deleteSchools(body: DeleteSchoolsRequest): Promise<void> {
+  const { data } = await api.delete<ApiResponse<void>>("/v1/schools", {
+    data: body,
+  })
+  return data.result
+}
+
+/**
+ * 학교 단건 삭제 헬퍼 함수
+ */
+export async function deleteSchool(schoolId: number | string): Promise<void> {
+  return deleteSchools({ schoolIds: [Number(schoolId)] })
+}
+
+/**
+ * 학교 상세 조회 (SCHOOL-102)
+ * 학교 상세 정보를 조회합니다.
+ */
+export async function getSchoolDetail(
+  schoolId: number | string,
+): Promise<SchoolDetailResponse> {
+  const { data } = await api.get<ApiResponse<SchoolDetailResponse>>(
+    `/v1/schools/${schoolId}`,
+  )
+  return data.result
+}

--- a/src/entities/organization/api/schoolApi.ts
+++ b/src/entities/organization/api/schoolApi.ts
@@ -3,6 +3,7 @@ import { api } from "@/shared/lib/axios"
 import type {
   CreateSchoolRequest,
   DeleteSchoolsRequest,
+  PageResponseAdminSchoolSummaryResponse,
   SchoolDetailResponse,
   SchoolNameListResponse,
   UpdateSchoolRequest,
@@ -71,5 +72,22 @@ export async function getSchoolDetail(
   const { data } = await api.get<ApiResponse<SchoolDetailResponse>>(
     `/v1/schools/${schoolId}`,
   )
+  return data.result
+}
+
+/**
+ * 학교 현황 및 지부/인원 통계 요약 조회 (DASHBOARD-100)
+ * 지부명, 학교명, 소속 인원 수 등을 함께 반환합니다.
+ */
+export async function getAdminSchoolsSummary(params?: {
+  gisuId?: number
+  chapterId?: number
+  search?: string
+  page?: number
+  size?: number
+}): Promise<PageResponseAdminSchoolSummaryResponse> {
+  const { data } = await api.get<
+    ApiResponse<PageResponseAdminSchoolSummaryResponse>
+  >("/v1/analytics/admin/schools/summary", { params })
   return data.result
 }

--- a/src/entities/organization/api/schoolApi.ts
+++ b/src/entities/organization/api/schoolApi.ts
@@ -1,6 +1,7 @@
 import { api } from "@/shared/lib/axios"
 
 import type {
+  AdminSchoolsSummaryParams,
   CreateSchoolRequest,
   DeleteSchoolsRequest,
   PageResponseAdminSchoolSummaryResponse,
@@ -79,14 +80,9 @@ export async function getSchoolDetail(
  * 학교 현황 및 지부/인원 통계 요약 조회 (DASHBOARD-100)
  * 지부명, 학교명, 소속 인원 수 등을 함께 반환합니다.
  */
-export async function getAdminSchoolsSummary(params?: {
-  gisuId?: number
-  chapterId?: number
-  search?: string
-  page?: number
-  size?: number
-  sort?: string | string[]
-}): Promise<PageResponseAdminSchoolSummaryResponse> {
+export async function getAdminSchoolsSummary(
+  params?: AdminSchoolsSummaryParams,
+): Promise<PageResponseAdminSchoolSummaryResponse> {
   const { data } = await api.get<
     ApiResponse<PageResponseAdminSchoolSummaryResponse>
   >("/v1/analytics/admin/schools/summary", { params })

--- a/src/entities/organization/api/schoolApi.ts
+++ b/src/entities/organization/api/schoolApi.ts
@@ -85,6 +85,7 @@ export async function getAdminSchoolsSummary(params?: {
   search?: string
   page?: number
   size?: number
+  sort?: string | string[]
 }): Promise<PageResponseAdminSchoolSummaryResponse> {
   const { data } = await api.get<
     ApiResponse<PageResponseAdminSchoolSummaryResponse>

--- a/src/entities/organization/hooks/useChapter.ts
+++ b/src/entities/organization/hooks/useChapter.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import {
+  createChapter,
+  createChaptersBulk,
+  deleteChapter,
+} from "@/entities/organization/api/chapterApi"
+
+import type {
+  CreateChapterBulkRequest,
+  CreateChapterRequest,
+} from "@/entities/organization/model/chapterTypes"
+
+/** 지부 생성 뮤테이션 훅 */
+export function useCreateChapter() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (body: CreateChapterRequest) => createChapter(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["chapters"] })
+      queryClient.invalidateQueries({ queryKey: ["chaptersWithSchools"] })
+    },
+  })
+}
+
+/** 지부 일괄 생성 뮤테이션 훅 */
+export function useCreateChaptersBulk() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (body: CreateChapterBulkRequest) => createChaptersBulk(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["chapters"] })
+      queryClient.invalidateQueries({ queryKey: ["chaptersWithSchools"] })
+    },
+  })
+}
+
+/** 지부 삭제 뮤테이션 훅 */
+export function useDeleteChapter() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (chapterId: string | number) => deleteChapter(chapterId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["chapters"] })
+      queryClient.invalidateQueries({ queryKey: ["chaptersWithSchools"] })
+    },
+  })
+}

--- a/src/entities/organization/hooks/useSchool.ts
+++ b/src/entities/organization/hooks/useSchool.ts
@@ -11,6 +11,7 @@ import {
 } from "@/entities/organization/api/schoolApi"
 
 import type {
+  AdminSchoolsSummaryParams,
   CreateSchoolRequest,
   DeleteSchoolsRequest,
   UpdateSchoolRequest,
@@ -36,15 +37,9 @@ export function useSchoolList() {
 }
 
 /** 관리자용 학교 현황 요약 목록 조회 훅 (지부명/인원수 포함) */
-export function useAdminSchoolsSummary(params?: {
-  gisuId?: number
-  chapterId?: number
-  search?: string
-  page?: number
-  size?: number
-  sort?: string | string[]
-  enabled?: boolean
-}) {
+export function useAdminSchoolsSummary(
+  params?: AdminSchoolsSummaryParams & { enabled?: boolean },
+) {
   return useQuery({
     queryKey: ["schools", "admin-summary", params],
     queryFn: () => getAdminSchoolsSummary(params),

--- a/src/entities/organization/hooks/useSchool.ts
+++ b/src/entities/organization/hooks/useSchool.ts
@@ -42,6 +42,7 @@ export function useAdminSchoolsSummary(params?: {
   search?: string
   page?: number
   size?: number
+  sort?: string | string[]
 }) {
   return useQuery({
     queryKey: ["schools", "admin-summary", params],

--- a/src/entities/organization/hooks/useSchool.ts
+++ b/src/entities/organization/hooks/useSchool.ts
@@ -43,10 +43,12 @@ export function useAdminSchoolsSummary(params?: {
   page?: number
   size?: number
   sort?: string | string[]
+  enabled?: boolean
 }) {
   return useQuery({
     queryKey: ["schools", "admin-summary", params],
     queryFn: () => getAdminSchoolsSummary(params),
+    enabled: params?.enabled ?? params?.gisuId != null,
     staleTime: 5 * 60 * 1000,
   })
 }

--- a/src/entities/organization/hooks/useSchool.ts
+++ b/src/entities/organization/hooks/useSchool.ts
@@ -40,10 +40,12 @@ export function useSchoolList() {
 export function useAdminSchoolsSummary(
   params?: AdminSchoolsSummaryParams & { enabled?: boolean },
 ) {
+  const { enabled, ...queryParams } = params ?? {}
+
   return useQuery({
-    queryKey: ["schools", "admin-summary", params],
-    queryFn: () => getAdminSchoolsSummary(params),
-    enabled: params?.enabled ?? params?.gisuId != null,
+    queryKey: ["schools", "admin-summary", queryParams],
+    queryFn: () => getAdminSchoolsSummary(queryParams),
+    enabled: enabled ?? queryParams.gisuId != null,
     staleTime: 5 * 60 * 1000,
   })
 }

--- a/src/entities/organization/hooks/useSchool.ts
+++ b/src/entities/organization/hooks/useSchool.ts
@@ -1,0 +1,112 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import {
+  createSchool,
+  deleteSchool,
+  deleteSchools,
+  getAdminSchoolsSummary,
+  getAllSchools,
+  getSchoolDetail,
+  updateSchool,
+} from "@/entities/organization/api/schoolApi"
+
+import type {
+  CreateSchoolRequest,
+  DeleteSchoolsRequest,
+  UpdateSchoolRequest,
+} from "@/entities/organization/model/schoolTypes"
+
+/** 학교 상세 정보 조회 훅 */
+export function useSchoolDetail(schoolId?: string | number) {
+  return useQuery({
+    queryKey: ["school", "detail", String(schoolId)],
+    queryFn: () => getSchoolDetail(schoolId!),
+    enabled: Boolean(schoolId),
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/** 전체 학교 목록 조회 훅 */
+export function useSchoolList() {
+  return useQuery({
+    queryKey: ["schools", "all"],
+    queryFn: getAllSchools,
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/** 관리자용 학교 현황 요약 목록 조회 훅 (지부명/인원수 포함) */
+export function useAdminSchoolsSummary(params?: {
+  gisuId?: number
+  chapterId?: number
+  search?: string
+  page?: number
+  size?: number
+}) {
+  return useQuery({
+    queryKey: ["schools", "admin-summary", params],
+    queryFn: () => getAdminSchoolsSummary(params),
+    staleTime: 5 * 60 * 1000,
+  })
+}
+
+/** 학교 생성 뮤테이션 훅 */
+export function useCreateSchool() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (body: CreateSchoolRequest) => createSchool(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["schools"] })
+      queryClient.invalidateQueries({ queryKey: ["chaptersWithSchools"] })
+    },
+  })
+}
+
+/** 학교 정보 수정 뮤테이션 훅 */
+export function useUpdateSchool() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: ({
+      schoolId,
+      body,
+    }: {
+      schoolId: string | number
+      body: UpdateSchoolRequest
+    }) => updateSchool(schoolId, body),
+    onSuccess: (_, { schoolId }) => {
+      queryClient.invalidateQueries({
+        queryKey: ["school", "detail", String(schoolId)],
+      })
+      queryClient.invalidateQueries({ queryKey: ["schools"] })
+      queryClient.invalidateQueries({ queryKey: ["chaptersWithSchools"] })
+    },
+  })
+}
+
+/** 학교 삭제 뮤테이션 훅 (단건) */
+export function useDeleteSchool() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (schoolId: string | number) => deleteSchool(schoolId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["schools"] })
+      queryClient.invalidateQueries({ queryKey: ["chaptersWithSchools"] })
+    },
+  })
+}
+
+/** 학교 일괄 삭제 뮤테이션 훅 */
+export function useDeleteSchools() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (body: DeleteSchoolsRequest) => deleteSchools(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["schools"] })
+      queryClient.invalidateQueries({ queryKey: ["chaptersWithSchools"] })
+    },
+  })
+}

--- a/src/entities/organization/hooks/useSchoolChapterMap.ts
+++ b/src/entities/organization/hooks/useSchoolChapterMap.ts
@@ -16,6 +16,8 @@ export function useSchoolChapterMap() {
     staleTime: 5 * 60 * 1000,
   })
 
+  const chapters = useMemo(() => chaptersData?.chapters ?? [], [chaptersData])
+
   const schoolToChapterId = useMemo(() => {
     const map = new Map<string, number>()
     for (const chapter of chaptersData?.chapters ?? []) {
@@ -45,6 +47,7 @@ export function useSchoolChapterMap() {
   )
 
   return {
+    chapters,
     getChapterIdBySchool,
     getChapterIdByName,
   }

--- a/src/entities/organization/hooks/useSchoolChapterMap.ts
+++ b/src/entities/organization/hooks/useSchoolChapterMap.ts
@@ -1,7 +1,5 @@
-// 사용자의 지부 정보 조회 가능 훅입니다. (CHAPTER-102 연결)
-
 import { useQuery } from "@tanstack/react-query"
-import { useMemo } from "react"
+import { useCallback, useMemo } from "react"
 
 import { getChaptersWithSchools } from "@/entities/organization/api/organization"
 import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
@@ -36,10 +34,18 @@ export function useSchoolChapterMap() {
     return map
   }, [chaptersData])
 
+  const getChapterIdBySchool = useCallback(
+    (schoolName: string) => schoolToChapterId.get(schoolName),
+    [schoolToChapterId],
+  )
+
+  const getChapterIdByName = useCallback(
+    (chapterName: string) => chapterNameToId.get(chapterName),
+    [chapterNameToId],
+  )
+
   return {
-    getChapterIdBySchool: (schoolName: string) =>
-      schoolToChapterId.get(schoolName),
-    getChapterIdByName: (chapterName: string) =>
-      chapterNameToId.get(chapterName),
+    getChapterIdBySchool,
+    getChapterIdByName,
   }
 }

--- a/src/entities/organization/hooks/useSchoolChapterMap.ts
+++ b/src/entities/organization/hooks/useSchoolChapterMap.ts
@@ -28,8 +28,18 @@ export function useSchoolChapterMap() {
     return map
   }, [chaptersData])
 
+  const chapterNameToId = useMemo(() => {
+    const map = new Map<string, number>()
+    for (const chapter of chaptersData?.chapters ?? []) {
+      map.set(chapter.chapterName, Number(chapter.chapterId))
+    }
+    return map
+  }, [chaptersData])
+
   return {
     getChapterIdBySchool: (schoolName: string) =>
       schoolToChapterId.get(schoolName),
+    getChapterIdByName: (chapterName: string) =>
+      chapterNameToId.get(chapterName),
   }
 }

--- a/src/entities/organization/model/chapterTypes.ts
+++ b/src/entities/organization/model/chapterTypes.ts
@@ -1,6 +1,6 @@
 /**
- * 지부 생성, 일괄 생성 및 삭제를 위한 DTO 정의
- * OpenAPI 스펙 (CHAPTER-001, CHAPTER-002, CHAPTER-003) 기반
+ * 지부 생성 및 일괄 생성을 위한 DTO 정의
+ * OpenAPI 스펙 (CHAPTER-001, CHAPTER-002) 기반
  */
 
 /** 지부 생성 요청 DTO (CHAPTER-001) */
@@ -15,9 +15,3 @@ export interface CreateChapterRequest {
 
 /** 지부 일괄 생성 요청 DTO (CHAPTER-002) */
 export type CreateChapterBulkRequest = CreateChapterRequest[]
-
-/** 지부 삭제 요청 DTO (CHAPTER-003) */
-export interface DeleteChapterRequest {
-  /** 삭제할 지부 ID */
-  chapterId: number | string
-}

--- a/src/entities/organization/model/chapterTypes.ts
+++ b/src/entities/organization/model/chapterTypes.ts
@@ -1,0 +1,23 @@
+/**
+ * 지부 생성, 일괄 생성 및 삭제를 위한 DTO 정의
+ * OpenAPI 스펙 (CHAPTER-001, CHAPTER-002, CHAPTER-003) 기반
+ */
+
+/** 지부 생성 요청 DTO (CHAPTER-001) */
+export interface CreateChapterRequest {
+  /** 기수 ID */
+  gisuId: number
+  /** 지부명 (예: 서울) */
+  name: string
+  /** 소속 학교 ID 목록 */
+  schoolIds?: number[]
+}
+
+/** 지부 일괄 생성 요청 DTO (CHAPTER-002) */
+export type CreateChapterBulkRequest = CreateChapterRequest[]
+
+/** 지부 삭제 요청 DTO (CHAPTER-003) */
+export interface DeleteChapterRequest {
+  /** 삭제할 지부 ID */
+  chapterId: number | string
+}

--- a/src/entities/organization/model/schoolTypes.ts
+++ b/src/entities/organization/model/schoolTypes.ts
@@ -105,6 +105,16 @@ export interface AdminSchoolSummaryResponse {
   activeChallengerCount?: number
 }
 
+/** 학교 현황 및 지부/인원 통계 요약 조회 쿼리 파라미터 DTO (DASHBOARD-100) */
+export interface AdminSchoolsSummaryParams {
+  gisuId?: number
+  chapterId?: number
+  search?: string
+  page?: number
+  size?: number
+  sort?: string | string[]
+}
+
 /** 학교 현황 페이징 응답 DTO (DASHBOARD-100) */
 export interface PageResponseAdminSchoolSummaryResponse {
   content?: AdminSchoolSummaryResponse[]

--- a/src/entities/organization/model/schoolTypes.ts
+++ b/src/entities/organization/model/schoolTypes.ts
@@ -64,7 +64,7 @@ export interface DeleteSchoolsRequest {
 /** 학교 기본 정보 아이템 (SCHOOL-101) */
 export interface SchoolItem {
   /** 학교 ID */
-  schoolId: string
+  schoolId: number
   /** 학교명 */
   schoolName: string
   /** 약칭 */

--- a/src/entities/organization/model/schoolTypes.ts
+++ b/src/entities/organization/model/schoolTypes.ts
@@ -87,3 +87,23 @@ export interface SchoolDetailResponse {
   /** 학교 링크 목록 */
   links?: SchoolLinkResponse[]
 }
+
+/** 학교 현황 및 지부/인원 수 요약 정보 (DASHBOARD-100) */
+export interface AdminSchoolSummaryResponse {
+  schoolId?: number
+  schoolName?: string
+  chapterId?: number
+  chapterName?: string
+  activeChallengerCount?: number
+}
+
+/** 학교 현황 페이징 응답 DTO (DASHBOARD-100) */
+export interface PageResponseAdminSchoolSummaryResponse {
+  content?: AdminSchoolSummaryResponse[]
+  page?: number
+  size?: number
+  totalElements?: number
+  totalPages?: number
+  hasNext?: boolean
+  hasPrevious?: boolean
+}

--- a/src/entities/organization/model/schoolTypes.ts
+++ b/src/entities/organization/model/schoolTypes.ts
@@ -29,6 +29,8 @@ export interface SchoolLinkResponse {
 export interface CreateSchoolRequest {
   /** 학교명 (예: 서울대학교) */
   schoolName: string
+  /** 약칭 (예: 서울대) */
+  shortName?: string
   /** 비고 (예: 관악캠퍼스) */
   remark?: string
   /** 로고 이미지 파일 ID (presigned URL 업로드 후 전달) */
@@ -41,6 +43,8 @@ export interface CreateSchoolRequest {
 export interface UpdateSchoolRequest {
   /** 학교명 (수정할 경우만 입력) */
   schoolName?: string
+  /** 약칭 (수정할 경우만 입력) */
+  shortName?: string
   /** 지부 ID (수정할 경우만 입력) */
   chapterId?: number
   /** 비고 (수정할 경우만 입력) */
@@ -63,6 +67,8 @@ export interface SchoolItem {
   schoolId: string
   /** 학교명 */
   schoolName: string
+  /** 약칭 */
+  shortName?: string
 }
 
 /** 학교 전체 목록 응답 DTO (SCHOOL-101) */
@@ -78,6 +84,8 @@ export interface SchoolDetailResponse {
   chapterName?: string
   /** 학교명 */
   schoolName?: string
+  /** 약칭 */
+  shortName?: string
   /** 학교 ID */
   schoolId?: number
   /** 비고 */

--- a/src/entities/organization/model/schoolTypes.ts
+++ b/src/entities/organization/model/schoolTypes.ts
@@ -1,0 +1,89 @@
+/**
+ * 학교 생성, 수정, 삭제 및 상세 조회를 위한 DTO 정의
+ * OpenAPI 스펙 (SCHOOL-001, SCHOOL-002, SCHOOL-003, SCHOOL-102) 기반
+ */
+
+export type SchoolLinkType = "KAKAO" | "YOUTUBE" | "INSTAGRAM"
+
+export interface SchoolLinkRequest {
+  /** 링크 제목 (예: UMC 카카오톡 오픈채팅) */
+  title: string
+  /** 링크 타입 (KAKAO | YOUTUBE | INSTAGRAM) */
+  type: SchoolLinkType
+  /** 링크 URL (예: https://open.kakao.com/o/example) */
+  url: string
+}
+
+export interface SchoolLinkResponse {
+  /** 링크 ID */
+  id?: number
+  /** 링크 제목 */
+  title?: string
+  /** 링크 타입 */
+  type?: SchoolLinkType
+  /** 링크 URL */
+  url?: string
+}
+
+/** 학교 생성 요청 DTO (SCHOOL-001) */
+export interface CreateSchoolRequest {
+  /** 학교명 (예: 서울대학교) */
+  schoolName: string
+  /** 비고 (예: 관악캠퍼스) */
+  remark?: string
+  /** 로고 이미지 파일 ID (presigned URL 업로드 후 전달) */
+  logoImageId?: string
+  /** 학교 링크 목록 */
+  links?: SchoolLinkRequest[]
+}
+
+/** 학교 수정 요청 DTO (SCHOOL-002) */
+export interface UpdateSchoolRequest {
+  /** 학교명 (수정할 경우만 입력) */
+  schoolName?: string
+  /** 지부 ID (수정할 경우만 입력) */
+  chapterId?: number
+  /** 비고 (수정할 경우만 입력) */
+  remark?: string
+  /** 로고 이미지 파일 ID (수정할 경우만 입력) */
+  logoImageId?: string
+  /** 학교 링크 목록 (전달 시 전체 교체) */
+  links?: SchoolLinkRequest[]
+}
+
+/** 학교 삭제 요청 DTO (SCHOOL-003) */
+export interface DeleteSchoolsRequest {
+  /** 삭제할 학교 ID 목록 */
+  schoolIds: number[]
+}
+
+/** 학교 기본 정보 아이템 (SCHOOL-101) */
+export interface SchoolItem {
+  /** 학교 ID */
+  schoolId: string
+  /** 학교명 */
+  schoolName: string
+}
+
+/** 학교 전체 목록 응답 DTO (SCHOOL-101) */
+export interface SchoolNameListResponse {
+  schools: SchoolItem[]
+}
+
+/** 학교 상세 응답 DTO (SCHOOL-102) */
+export interface SchoolDetailResponse {
+  /** 지부 ID */
+  chapterId?: number
+  /** 지부명 */
+  chapterName?: string
+  /** 학교명 */
+  schoolName?: string
+  /** 학교 ID */
+  schoolId?: number
+  /** 비고 */
+  remark?: string
+  /** 로고 이미지 URL */
+  logoImageUrl?: string
+  /** 학교 링크 목록 */
+  links?: SchoolLinkResponse[]
+}

--- a/src/features/chapter/ui/ChapterManagePage.tsx
+++ b/src/features/chapter/ui/ChapterManagePage.tsx
@@ -4,6 +4,7 @@ import {
   DragOverlay,
   type DragStartEvent,
 } from "@dnd-kit/core"
+import { useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
 
 import {
@@ -39,6 +40,7 @@ import { SchoolChip } from "./SchoolChip"
 import { SchoolListPanel } from "./SchoolListPanel"
 
 export function ChapterManagePage() {
+  const queryClient = useQueryClient()
   const addToast = useToastStore((state) => state.addToast)
   const [unassignedSchools, setUnassignedSchools] = useState<School[]>(
     INITIAL_UNASSIGNED_SCHOOLS,
@@ -318,15 +320,27 @@ export function ChapterManagePage() {
             return serverId ? { ...ch, id: serverId } : ch
           }),
         )
+        addToast({
+          message: "지부 정보가 저장되었습니다.",
+          color: "primary",
+          variant: "deep",
+          type: "default",
+          duration: 3000,
+        })
+      } else {
+        queryClient.invalidateQueries({ queryKey: ["chapters"] })
+        queryClient.invalidateQueries({ queryKey: ["chaptersWithSchools"] })
+        addToast({
+          message: "지부 정보 저장에 실패했습니다.",
+          color: "red",
+          variant: "deep",
+          type: "default",
+          duration: 3000,
+        })
       }
-      addToast({
-        message: "지부 정보가 저장되었습니다.",
-        color: "primary",
-        variant: "deep",
-        type: "default",
-        duration: 3000,
-      })
     } catch {
+      queryClient.invalidateQueries({ queryKey: ["chapters"] })
+      queryClient.invalidateQueries({ queryKey: ["chaptersWithSchools"] })
       addToast({
         message: "지부 정보 저장에 실패했습니다.",
         color: "red",

--- a/src/features/chapter/ui/ChapterManagePage.tsx
+++ b/src/features/chapter/ui/ChapterManagePage.tsx
@@ -209,13 +209,40 @@ export function ChapterManagePage() {
               return
             }
 
-            await createChapterMutation.mutateAsync({
-              gisuId: activeGisuId,
-              name: chapterToDelete.name,
-              schoolIds: chapterToDelete.assignedSchools
-                .map((s) => Number(s.id))
-                .filter((id) => !Number.isNaN(id)),
-            })
+            try {
+              const createdId = await createChapterMutation.mutateAsync({
+                gisuId: activeGisuId,
+                name: chapterToDelete.name,
+                schoolIds: chapterToDelete.assignedSchools
+                  .map((s) => Number(s.id))
+                  .filter((id) => !Number.isNaN(id)),
+              })
+              if (createdId != null) {
+                setChapters((prev) =>
+                  prev.map((ch) =>
+                    ch.id === chapterToDelete.id
+                      ? { ...ch, id: String(createdId) }
+                      : ch,
+                  ),
+                )
+              }
+            } catch {
+              setChapters((prev) =>
+                prev.filter((ch) => ch.id !== chapterToDelete.id),
+              )
+              if (chapterToDelete.assignedSchools.length > 0) {
+                setUnassignedSchools((prev) =>
+                  withSchoolsAppended(prev, chapterToDelete.assignedSchools),
+                )
+              }
+              addToast({
+                message: "지부 복원에 실패했습니다.",
+                color: "red",
+                variant: "deep",
+                type: "default",
+                duration: 3000,
+              })
+            }
           }
         },
       },

--- a/src/features/chapter/ui/ChapterManagePage.tsx
+++ b/src/features/chapter/ui/ChapterManagePage.tsx
@@ -142,7 +142,31 @@ export function ChapterManagePage() {
       try {
         await deleteChapterMutation.mutateAsync(chapterId)
       } catch {
-        // API 삭제 시도 중 실패 시 로깅 또는 무시
+        setChapters((prev) => {
+          if (prev.some((ch) => ch.id === chapterToDelete.id)) return prev
+          const next = [...prev]
+          const insertIndex = Math.min(targetIndex, next.length)
+          next.splice(insertIndex, 0, chapterToDelete)
+          return next
+        })
+
+        if (chapterToDelete.assignedSchools.length > 0) {
+          const restoredSchoolIds = new Set(
+            chapterToDelete.assignedSchools.map((s) => s.id),
+          )
+          setUnassignedSchools((prev) =>
+            prev.filter((s) => !restoredSchoolIds.has(s.id)),
+          )
+        }
+
+        addToast({
+          message: "지부 삭제에 실패했습니다.",
+          color: "red",
+          variant: "deep",
+          type: "default",
+          duration: 3000,
+        })
+        return
       }
     }
 

--- a/src/features/chapter/ui/ChapterManagePage.tsx
+++ b/src/features/chapter/ui/ChapterManagePage.tsx
@@ -51,7 +51,7 @@ export function ChapterManagePage() {
   const deleteChapterMutation = useDeleteChapter()
   const createChapterMutation = useCreateChapter()
   const createChaptersBulkMutation = useCreateChaptersBulk()
-  const { data: activeGisuId } = useActiveGisuId()
+  const { data: activeGisuId, isLoading: isGisuLoading } = useActiveGisuId()
 
   const assignedSchools = chapters.flatMap((ch) => ch.assignedSchools)
 
@@ -197,8 +197,20 @@ export function ChapterManagePage() {
           }
 
           if (isExistingChapter) {
+            if (isGisuLoading || activeGisuId == null) {
+              addToast({
+                message:
+                  "기수 정보를 불러오는 중이거나 선택된 기수가 없습니다.",
+                color: "red",
+                variant: "deep",
+                type: "default",
+                duration: 3000,
+              })
+              return
+            }
+
             await createChapterMutation.mutateAsync({
-              gisuId: activeGisuId ?? 1,
+              gisuId: activeGisuId,
               name: chapterToDelete.name,
               schoolIds: chapterToDelete.assignedSchools
                 .map((s) => Number(s.id))
@@ -240,8 +252,19 @@ export function ChapterManagePage() {
   async function handleSave() {
     if (chapters.length === 0) return
 
+    if (isGisuLoading || activeGisuId == null) {
+      addToast({
+        message: "기수 정보를 불러오는 중이거나 선택된 기수가 없습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return
+    }
+
     const bulkPayload = chapters.map((ch) => ({
-      gisuId: activeGisuId ?? 1,
+      gisuId: activeGisuId,
       name: ch.name,
       schoolIds: ch.assignedSchools
         .map((s) => Number(s.id))

--- a/src/features/chapter/ui/ChapterManagePage.tsx
+++ b/src/features/chapter/ui/ChapterManagePage.tsx
@@ -250,7 +250,8 @@ export function ChapterManagePage() {
   }
 
   async function handleSave() {
-    if (chapters.length === 0) return
+    const newChapters = chapters.filter((ch) => ch.id.startsWith("chapter-"))
+    if (newChapters.length === 0) return
 
     if (isGisuLoading || activeGisuId == null) {
       addToast({
@@ -263,7 +264,7 @@ export function ChapterManagePage() {
       return
     }
 
-    const bulkPayload = chapters.map((ch) => ({
+    const bulkPayload = newChapters.map((ch) => ({
       gisuId: activeGisuId,
       name: ch.name,
       schoolIds: ch.assignedSchools

--- a/src/features/chapter/ui/ChapterManagePage.tsx
+++ b/src/features/chapter/ui/ChapterManagePage.tsx
@@ -6,8 +6,14 @@ import {
 } from "@dnd-kit/core"
 import { useState } from "react"
 
+import {
+  useCreateChapter,
+  useCreateChaptersBulk,
+  useDeleteChapter,
+} from "@/entities/organization/hooks/useChapter"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import ResetIcon from "@/shared/assets/icon/reset/ResetIcon"
+import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
 import { useChipAssignment } from "@/shared/lib/useChipAssignment"
 import { Button } from "@/shared/ui/Button"
 import { PageLabel } from "@/shared/ui/page-label/PageLabel"
@@ -41,6 +47,11 @@ export function ChapterManagePage() {
   const [activeSchoolVariant, setActiveSchoolVariant] = useState<
     "waiting" | "assigned"
   >("waiting")
+
+  const deleteChapterMutation = useDeleteChapter()
+  const createChapterMutation = useCreateChapter()
+  const createChaptersBulkMutation = useCreateChaptersBulk()
+  const { data: activeGisuId } = useActiveGisuId()
 
   const assignedSchools = chapters.flatMap((ch) => ch.assignedSchools)
 
@@ -114,7 +125,7 @@ export function ChapterManagePage() {
     setSelectedChipId(null)
   }
 
-  function handleDeleteChapter(chapterId: string) {
+  async function handleDeleteChapter(chapterId: string) {
     const chapterToDelete = chapters.find((ch) => ch.id === chapterId)
     if (!chapterToDelete) return
     const targetIndex = chapters.indexOf(chapterToDelete)
@@ -126,6 +137,15 @@ export function ChapterManagePage() {
     setChapters((prev) => prev.filter((ch) => ch.id !== chapterId))
     setSelectedChipId(null)
 
+    const isExistingChapter = !chapterId.startsWith("chapter-")
+    if (isExistingChapter) {
+      try {
+        await deleteChapterMutation.mutateAsync(chapterId)
+      } catch {
+        // API 삭제 시도 중 실패 시 로깅 또는 무시
+      }
+    }
+
     addToast({
       message: "지부가 삭제되었습니다.",
       color: "red",
@@ -134,7 +154,7 @@ export function ChapterManagePage() {
       duration: 5000,
       action: {
         label: "되돌리기",
-        onClick: () => {
+        onClick: async () => {
           setChapters((prev) => {
             if (prev.some((ch) => ch.id === chapterToDelete.id)) return prev
             const next = [...prev]
@@ -150,6 +170,16 @@ export function ChapterManagePage() {
             setUnassignedSchools((prev) =>
               prev.filter((s) => !restoredSchoolIds.has(s.id)),
             )
+          }
+
+          if (isExistingChapter) {
+            await createChapterMutation.mutateAsync({
+              gisuId: activeGisuId ?? 1,
+              name: chapterToDelete.name,
+              schoolIds: chapterToDelete.assignedSchools
+                .map((s) => Number(s.id))
+                .filter((id) => !Number.isNaN(id)),
+            })
           }
         },
       },
@@ -181,6 +211,37 @@ export function ChapterManagePage() {
       prev.map((ch) => (ch.id === id ? { ...ch, name: name.trim() } : ch)),
     )
     return true
+  }
+
+  async function handleSave() {
+    if (chapters.length === 0) return
+
+    const bulkPayload = chapters.map((ch) => ({
+      gisuId: activeGisuId ?? 1,
+      name: ch.name,
+      schoolIds: ch.assignedSchools
+        .map((s) => Number(s.id))
+        .filter((id) => !Number.isNaN(id)),
+    }))
+
+    try {
+      await createChaptersBulkMutation.mutateAsync(bulkPayload)
+      addToast({
+        message: "지부 정보가 저장되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } catch {
+      addToast({
+        message: "지부 정보 저장에 실패했습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    }
   }
 
   return (
@@ -239,6 +300,7 @@ export function ChapterManagePage() {
               color="primary"
               variant="fill"
               className="w-fit rounded-[8px] px-3 py-1.5"
+              onClick={handleSave}
             >
               저장하기
             </Button>

--- a/src/features/chapter/ui/ChapterManagePage.tsx
+++ b/src/features/chapter/ui/ChapterManagePage.tsx
@@ -273,7 +273,25 @@ export function ChapterManagePage() {
     }))
 
     try {
-      await createChaptersBulkMutation.mutateAsync(bulkPayload)
+      const createdIds =
+        await createChaptersBulkMutation.mutateAsync(bulkPayload)
+      if (
+        Array.isArray(createdIds) &&
+        createdIds.length === newChapters.length
+      ) {
+        const idMap = new Map<string, string>()
+        newChapters.forEach((ch, idx) => {
+          if (createdIds[idx] != null) {
+            idMap.set(ch.id, String(createdIds[idx]))
+          }
+        })
+        setChapters((prev) =>
+          prev.map((ch) => {
+            const serverId = idMap.get(ch.id)
+            return serverId ? { ...ch, id: serverId } : ch
+          }),
+        )
+      }
       addToast({
         message: "지부 정보가 저장되었습니다.",
         color: "primary",

--- a/src/features/curriculum/hooks/useCurriculumEditor.test.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.test.ts
@@ -115,3 +115,38 @@ describe("useCurriculumEditor - temporary ID handleBlur", () => {
     })
   })
 })
+
+describe("useCurriculumEditor - handleRestoreCurriculum", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("커리큘럼 복원 중 createCurriculum 실패 시 에러 처리하고 추가한 커리큘럼을 제거한다", async () => {
+    vi.mocked(createCurriculum).mockRejectedValue(new Error("Creation failed"))
+
+    const initialCurriculums = [
+      {
+        id: "1",
+        number: "01",
+        title: "기존 커리큘럼",
+        workbookCount: 1,
+        missionCount: 1,
+        workbooks: [{ id: "10", number: 1, title: "Wb 1", missions: [""] }],
+      },
+    ]
+
+    const { result } = renderHook(() =>
+      useCurriculumEditor({ initialCurriculums, part: "PM" }),
+    )
+
+    await act(async () => {
+      await result.current.handleDeleteCurriculum("999") // dummy call
+    })
+
+    // 직접 restore 호출 테스트
+    await act(async () => {
+      const curriculums = result.current.curriculums
+      expect(curriculums).toBeDefined()
+    })
+  })
+})

--- a/src/features/curriculum/hooks/useCurriculumEditor.test.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.test.ts
@@ -4,6 +4,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
   createCurriculum,
   createWeeklyCurriculum,
+  deleteCurriculum,
+  deleteWeeklyCurriculum,
   updateCurriculum,
   updateWeeklyCurriculum,
 } from "@/entities/curriculum"
@@ -11,7 +13,7 @@ import {
 import { useCurriculumEditor } from "./useCurriculumEditor"
 
 vi.mock("@/entities/curriculum", () => ({
-  getCurriculumOverview: vi.fn().mockResolvedValue(null),
+  getCurriculumOverview: vi.fn().mockRejectedValue(new Error("No overview")),
   createCurriculum: vi.fn(),
   createWeeklyCurriculum: vi.fn(),
   updateCurriculum: vi.fn(),
@@ -116,19 +118,19 @@ describe("useCurriculumEditor - temporary ID handleBlur", () => {
   })
 })
 
-describe("useCurriculumEditor - handleRestoreCurriculum", () => {
+describe("useCurriculumEditor - deletion failure restoration", () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it("커리큘럼 복원 중 createCurriculum 실패 시 에러 처리하고 추가한 커리큘럼을 제거한다", async () => {
-    vi.mocked(createCurriculum).mockRejectedValue(new Error("Creation failed"))
+  it("deleteCurriculum 실패 시 targetCurriculum을 복구하고 번호를 재계산한다", async () => {
+    vi.mocked(deleteCurriculum).mockRejectedValue(new Error("Delete failed"))
 
     const initialCurriculums = [
       {
-        id: "1",
+        id: "100",
         number: "01",
-        title: "기존 커리큘럼",
+        title: "커리큘럼 1",
         workbookCount: 1,
         missionCount: 1,
         workbooks: [{ id: "10", number: 1, title: "Wb 1", missions: [""] }],
@@ -140,13 +142,45 @@ describe("useCurriculumEditor - handleRestoreCurriculum", () => {
     )
 
     await act(async () => {
-      await result.current.handleDeleteCurriculum("999") // dummy call
+      await result.current.handleDeleteCurriculum("100")
     })
 
-    // 직접 restore 호출 테스트
+    expect(result.current.curriculums).toHaveLength(1)
+    expect(result.current.curriculums[0]?.id).toBe("100")
+    expect(result.current.curriculums[0]?.number).toBe("01")
+  })
+
+  it("deleteWeeklyCurriculum 실패 시 targetWb를 복구하고 워크북 번호 및 개수를 재계산한다", async () => {
+    vi.mocked(deleteWeeklyCurriculum).mockRejectedValue(
+      new Error("Delete wb failed"),
+    )
+
+    const initialCurriculums = [
+      {
+        id: "100",
+        number: "01",
+        title: "커리큘럼 1",
+        workbookCount: 2,
+        missionCount: 2,
+        workbooks: [
+          { id: "10", number: 1, title: "Wb 1", missions: [""] },
+          { id: "20", number: 2, title: "Wb 2", missions: [""] },
+        ],
+      },
+    ]
+
+    const { result } = renderHook(() =>
+      useCurriculumEditor({ initialCurriculums, part: "PM" }),
+    )
+
     await act(async () => {
-      const curriculums = result.current.curriculums
-      expect(curriculums).toBeDefined()
+      await result.current.handleDeleteWorkbook("100", 0)
     })
+
+    const restoredWorkbooks = result.current.curriculums[0]?.workbooks
+    expect(restoredWorkbooks).toHaveLength(2)
+    expect(restoredWorkbooks?.[0]?.id).toBe("10")
+    expect(restoredWorkbooks?.[0]?.number).toBe(1)
+    expect(result.current.curriculums[0]?.workbookCount).toBe(2)
   })
 })

--- a/src/features/curriculum/hooks/useCurriculumEditor.test.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.test.ts
@@ -1,0 +1,117 @@
+import { act, renderHook } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  createCurriculum,
+  createWeeklyCurriculum,
+  updateCurriculum,
+  updateWeeklyCurriculum,
+} from "@/entities/curriculum"
+
+import { useCurriculumEditor } from "./useCurriculumEditor"
+
+vi.mock("@/entities/curriculum", () => ({
+  getCurriculumOverview: vi.fn().mockResolvedValue(null),
+  createCurriculum: vi.fn(),
+  createWeeklyCurriculum: vi.fn(),
+  updateCurriculum: vi.fn(),
+  updateWeeklyCurriculum: vi.fn(),
+  deleteCurriculum: vi.fn(),
+  deleteWeeklyCurriculum: vi.fn(),
+}))
+
+vi.mock("@/shared/hooks/useActiveGisu", () => ({
+  useActiveGisuId: () => ({ data: 1, isLoading: false }),
+}))
+
+describe("useCurriculumEditor - temporary ID handleBlur", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("생성 중인 임시 커리큘럼 ID에 대해 blur 발생 시 생성 완료 후 updateCurriculum을 호출한다", async () => {
+    let resolveCreate: (id: number) => void = () => {}
+    const createPromise = new Promise<number>((resolve) => {
+      resolveCreate = resolve
+    })
+    vi.mocked(createCurriculum).mockReturnValue(createPromise)
+    vi.mocked(createWeeklyCurriculum).mockResolvedValue(101)
+    vi.mocked(updateCurriculum).mockResolvedValue(undefined)
+
+    const { result } = renderHook(() =>
+      useCurriculumEditor({ initialCurriculums: [], part: "PM" }),
+    )
+
+    // 1. 커리큘럼 생성 클릭 (서버 응답 대기 상태)
+    act(() => {
+      result.current.handleCreateCurriculum()
+    })
+
+    const tempCurriculumId = result.current.curriculums[0]?.id
+    expect(tempCurriculumId).toMatch(/^curriculum-/)
+
+    // 2. 임시 ID 상태에서 제목 입력 후 blur 처리
+    let blurPromise: Promise<void> | undefined
+    act(() => {
+      blurPromise = result.current.handleBlurCurriculumTitle(
+        tempCurriculumId!,
+        "수정된 커리큘럼 제목",
+      )
+    })
+
+    // 서버 생성 완료 처리
+    await act(async () => {
+      resolveCreate(99)
+      await blurPromise
+    })
+
+    // 3. updateCurriculum이 생성 완료된 ID(99)로 호출되었는지 검증
+    expect(updateCurriculum).toHaveBeenCalledWith(99, {
+      title: "수정된 커리큘럼 제목",
+    })
+  })
+
+  it("생성 중인 임시 워크북 ID에 대해 blur 발생 시 생성 완료 후 updateWeeklyCurriculum을 호출한다", async () => {
+    vi.mocked(createCurriculum).mockResolvedValue(99)
+    let resolveWeeklyCreate: (id: number) => void = () => {}
+    const weeklyCreatePromise = new Promise<number>((resolve) => {
+      resolveWeeklyCreate = resolve
+    })
+    vi.mocked(createWeeklyCurriculum).mockReturnValue(weeklyCreatePromise)
+    vi.mocked(updateWeeklyCurriculum).mockResolvedValue(undefined)
+
+    const { result } = renderHook(() =>
+      useCurriculumEditor({ initialCurriculums: [], part: "PM" }),
+    )
+
+    // 1. 커리큘럼 생성
+    act(() => {
+      result.current.handleCreateCurriculum()
+    })
+
+    const tempWbId = result.current.curriculums[0]?.workbooks[0]?.id
+    expect(tempWbId).toMatch(/^wb-/)
+
+    // 2. 임시 워크북 ID 상태에서 blur 처리
+    let blurPromise: Promise<void> | undefined
+    act(() => {
+      blurPromise = result.current.handleBlurWorkbookTitle(
+        result.current.curriculums[0]!.id,
+        0,
+        "수정된 워크북 제목",
+      )
+    })
+
+    // 워크북 서버 생성 완료 처리
+    await act(async () => {
+      resolveWeeklyCreate(202)
+      await blurPromise
+    })
+
+    // 3. updateWeeklyCurriculum이 생성 완료된 워크북 ID(202)로 호출되었는지 검증
+    expect(updateWeeklyCurriculum).toHaveBeenCalledWith(202, {
+      title: "수정된 워크북 제목",
+      weekNo: 1,
+    })
+  })
+})

--- a/src/features/curriculum/hooks/useCurriculumEditor.test.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.test.ts
@@ -212,11 +212,10 @@ describe("useCurriculumEditor - handleDragEnd workbook sequential update", () =>
     )
 
     await act(async () => {
-      // @ts-expect-error test event call
       result.current.handleDragEnd({
         active: { id: "10", data: { current: { type: "workbook" } } },
         over: { id: "20" },
-      })
+      } as unknown as Parameters<typeof result.current.handleDragEnd>[0])
     })
 
     expect(updateWeeklyCurriculum).toHaveBeenCalledTimes(2)
@@ -254,11 +253,10 @@ describe("useCurriculumEditor - handleDragEnd workbook sequential update", () =>
     )
 
     await act(async () => {
-      // @ts-expect-error test event call
       result.current.handleDragEnd({
         active: { id: "10", data: { current: { type: "workbook" } } },
         over: { id: "20" },
-      })
+      } as unknown as Parameters<typeof result.current.handleDragEnd>[0])
     })
 
     expect(updateWeeklyCurriculum).toHaveBeenCalledTimes(1)

--- a/src/features/curriculum/hooks/useCurriculumEditor.test.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.test.ts
@@ -184,3 +184,83 @@ describe("useCurriculumEditor - deletion failure restoration", () => {
     expect(result.current.curriculums[0]?.workbookCount).toBe(2)
   })
 })
+
+describe("useCurriculumEditor - handleDragEnd workbook sequential update", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("워크북 드래그앤드롭 후 순차적으로 updateWeeklyCurriculum을 호출한다", async () => {
+    vi.mocked(updateWeeklyCurriculum).mockResolvedValue(undefined)
+
+    const initialCurriculums = [
+      {
+        id: "100",
+        number: "01",
+        title: "커리큘럼 1",
+        workbookCount: 2,
+        missionCount: 2,
+        workbooks: [
+          { id: "10", number: 1, title: "Wb 1", missions: [""] },
+          { id: "20", number: 2, title: "Wb 2", missions: [""] },
+        ],
+      },
+    ]
+
+    const { result } = renderHook(() =>
+      useCurriculumEditor({ initialCurriculums, part: "PM" }),
+    )
+
+    await act(async () => {
+      // @ts-expect-error test event call
+      result.current.handleDragEnd({
+        active: { id: "10", data: { current: { type: "workbook" } } },
+        over: { id: "20" },
+      })
+    })
+
+    expect(updateWeeklyCurriculum).toHaveBeenCalledTimes(2)
+    expect(updateWeeklyCurriculum).toHaveBeenNthCalledWith(1, 10, {
+      weekNo: 1,
+      title: "Wb 1",
+    })
+    expect(updateWeeklyCurriculum).toHaveBeenNthCalledWith(2, 20, {
+      weekNo: 2,
+      title: "Wb 2",
+    })
+  })
+
+  it("updateWeeklyCurriculum 실패 시 순차 업데이트를 중단한다", async () => {
+    vi.mocked(updateWeeklyCurriculum).mockRejectedValueOnce(
+      new Error("Failed update"),
+    )
+
+    const initialCurriculums = [
+      {
+        id: "100",
+        number: "01",
+        title: "커리큘럼 1",
+        workbookCount: 2,
+        missionCount: 2,
+        workbooks: [
+          { id: "10", number: 1, title: "Wb 1", missions: [""] },
+          { id: "20", number: 2, title: "Wb 2", missions: [""] },
+        ],
+      },
+    ]
+
+    const { result } = renderHook(() =>
+      useCurriculumEditor({ initialCurriculums, part: "PM" }),
+    )
+
+    await act(async () => {
+      // @ts-expect-error test event call
+      result.current.handleDragEnd({
+        active: { id: "10", data: { current: { type: "workbook" } } },
+        over: { id: "20" },
+      })
+    })
+
+    expect(updateWeeklyCurriculum).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/features/curriculum/hooks/useCurriculumEditor.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.ts
@@ -754,48 +754,93 @@ export function useCurriculumEditor({
     })
 
     // 백엔드 재등록 API 연동
+    let newCurriculumId: number | null = null
     try {
       const apiPart = mapPartToApiEnum(part)
-      const newCurriculumId = await createCurriculum({
+      newCurriculumId = await createCurriculum({
         gisuId: activeGisuId,
         part: apiPart,
         title: restoredItem.title || "복원된 커리큘럼",
       })
-
-      if (newCurriculumId) {
-        setCurriculums((prev) =>
-          prev.map((c) =>
-            c.id === restoredItem.id
-              ? { ...c, id: String(newCurriculumId) }
-              : c,
-          ),
-        )
-
-        for (const wb of restoredItem.workbooks) {
-          const now = new Date()
-          const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
-          const createdWbId = await createWeeklyCurriculum({
-            curriculumId: newCurriculumId,
-            weekNo: wb.number,
-            title: wb.title,
-            startsAt: now.toISOString(),
-            endsAt: nextWeek.toISOString(),
-          })
-          if (createdWbId) {
-            setCurriculums((prev) =>
-              prev.map((c) => {
-                if (c.id !== String(newCurriculumId)) return c
-                const updatedWbs = c.workbooks.map((w) =>
-                  w.id === wb.id ? { ...w, id: String(createdWbId) } : w,
-                )
-                return { ...c, workbooks: updatedWbs }
-              }),
-            )
-          }
-        }
-      }
     } catch {
-      // Ignore background restore sync fallback
+      setCurriculums((prev) => {
+        const filtered = prev.filter((c) => c.id !== restoredItem.id)
+        return recalculateCurriculumNumbers(filtered, baseCount)
+      })
+      addToast({
+        message: "커리큘럼 복원에 실패했습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return
+    }
+
+    if (!newCurriculumId) {
+      setCurriculums((prev) => {
+        const filtered = prev.filter((c) => c.id !== restoredItem.id)
+        return recalculateCurriculumNumbers(filtered, baseCount)
+      })
+      addToast({
+        message: "커리큘럼 복원에 실패했습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return
+    }
+
+    setCurriculums((prev) =>
+      prev.map((c) =>
+        c.id === restoredItem.id ? { ...c, id: String(newCurriculumId) } : c,
+      ),
+    )
+
+    let completedWbCount = 0
+    let wbFailed = false
+
+    for (const wb of restoredItem.workbooks) {
+      try {
+        const now = new Date()
+        const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+        const createdWbId = await createWeeklyCurriculum({
+          curriculumId: newCurriculumId,
+          weekNo: wb.number,
+          title: wb.title,
+          startsAt: now.toISOString(),
+          endsAt: nextWeek.toISOString(),
+        })
+        if (createdWbId) {
+          setCurriculums((prev) =>
+            prev.map((c) => {
+              if (c.id !== String(newCurriculumId)) return c
+              const updatedWbs = c.workbooks.map((w) =>
+                w.id === wb.id ? { ...w, id: String(createdWbId) } : w,
+              )
+              return { ...c, workbooks: updatedWbs }
+            }),
+          )
+          completedWbCount += 1
+        } else {
+          wbFailed = true
+          break
+        }
+      } catch {
+        wbFailed = true
+        break
+      }
+    }
+
+    if (wbFailed) {
+      addToast({
+        message: `커리큘럼은 복원되었으나 워크북 복원에 실패했습니다. (성공: ${completedWbCount}/${restoredItem.workbooks.length}개). 남은 워크북 복원이 필요합니다.`,
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 4000,
+      })
     }
   }
 

--- a/src/features/curriculum/hooks/useCurriculumEditor.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.ts
@@ -8,11 +8,24 @@ import {
   useSensors,
 } from "@dnd-kit/core"
 import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
+import {
+  createCurriculum,
+  createWeeklyCurriculum,
+  deleteCurriculum,
+  deleteWeeklyCurriculum,
+  getCurriculumOverview,
+  updateCurriculum,
+  updateWeeklyCurriculum,
+} from "@/entities/curriculum"
+import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
 import { useToastStore } from "@/shared/ui/toast/useToastStore"
 
-import { INITIAL_CURRICULUM_DATA } from "../model/curriculumData"
+import {
+  mapOverviewToCurriculumItem,
+  mapPartToApiEnum,
+} from "../model/curriculumMapper"
 
 import type { CurriculumItem, Workbook } from "../model/curriculumData"
 
@@ -149,7 +162,35 @@ export function useCurriculumEditor({
 }: UseCurriculumEditorOptions) {
   const [curriculums, setCurriculums] =
     useState<CurriculumItem[]>(initialCurriculums)
+  const [isLoading, setIsLoading] = useState<boolean>(false)
   const addToast = useToastStore((state) => state.addToast)
+  const { data: activeGisuId } = useActiveGisuId()
+  const gisuId = activeGisuId ?? 10
+
+  // 서버에서 기수 및 파트별 커리큘럼 데이터 동기화
+  useEffect(() => {
+    let isSubscribed = true
+    async function fetchOverview() {
+      if (!gisuId) return
+      setIsLoading(true)
+      try {
+        const apiPart = mapPartToApiEnum(part)
+        const overview = await getCurriculumOverview({ gisuId, part: apiPart })
+        if (isSubscribed && overview && overview.curriculumId) {
+          const fetchedItem = mapOverviewToCurriculumItem(overview, 0)
+          setCurriculums([fetchedItem])
+        }
+      } catch {
+        // 서버에 데이터가 없을 시 기존 초기값 유지
+      } finally {
+        if (isSubscribed) setIsLoading(false)
+      }
+    }
+    fetchOverview()
+    return () => {
+      isSubscribed = false
+    }
+  }, [gisuId, part])
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
@@ -158,18 +199,21 @@ export function useCurriculumEditor({
     }),
   )
 
-  const handleCreateCurriculum = () => {
-    const baseCount = INITIAL_CURRICULUM_DATA[part]?.length || 0
+  const handleCreateCurriculum = async () => {
+    const baseCount = 0
+
+    const newCurriculumTempId = `curriculum-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
+    const newWorkbookTempId = `wb-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
 
     const newWorkbook: Workbook = {
-      id: `wb-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+      id: newWorkbookTempId,
       number: 1,
       title: "",
       missions: ["", ""],
     }
 
     const newCurriculum: CurriculumItem = {
-      id: `curriculum-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
+      id: newCurriculumTempId,
       number: "00",
       title: "",
       workbookCount: 1,
@@ -180,11 +224,57 @@ export function useCurriculumEditor({
     setCurriculums((prev) =>
       recalculateCurriculumNumbers([...prev, newCurriculum], baseCount),
     )
+
+    // API 연동: 서버에 커리큘럼 생성 요청
+    try {
+      const apiPart = mapPartToApiEnum(part)
+      const createdId = await createCurriculum({
+        gisuId,
+        part: apiPart,
+        title: "새 커리큘럼",
+      })
+
+      if (createdId) {
+        setCurriculums((prev) =>
+          prev.map((c) =>
+            c.id === newCurriculumTempId ? { ...c, id: String(createdId) } : c,
+          ),
+        )
+        try {
+          const now = new Date()
+          const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+          const createdWbId = await createWeeklyCurriculum({
+            curriculumId: createdId,
+            weekNo: 1,
+            title: "",
+            startsAt: now.toISOString(),
+            endsAt: nextWeek.toISOString(),
+          })
+          if (createdWbId) {
+            setCurriculums((prev) =>
+              prev.map((c) => {
+                if (c.id !== String(createdId)) return c
+                const updatedWorkbooks = c.workbooks.map((wb) =>
+                  wb.id === newWorkbookTempId
+                    ? { ...wb, id: String(createdWbId) }
+                    : wb,
+                )
+                return { ...c, workbooks: updatedWorkbooks }
+              }),
+            )
+          }
+        } catch {
+          // Ignore secondary creation error
+        }
+      }
+    } catch {
+      // Ignore initial creation error fallback to local state
+    }
   }
 
   const handleUpdateCurriculumTitle = (id: string, title: string) => {
     const trimmed = title.trim()
-    const baseCount = INITIAL_CURRICULUM_DATA[part]?.length || 0
+    const baseCount = 0
 
     if (trimmed !== "") {
       const isDuplicate = curriculums.some(
@@ -210,6 +300,25 @@ export function useCurriculumEditor({
       const updated = prev.map((c) => (c.id === id ? { ...c, title } : c))
       return recalculateCurriculumNumbers(updated, baseCount)
     })
+  }
+
+  const handleBlurCurriculumTitle = async (id: string, title: string) => {
+    const trimmed = title.trim()
+    if (!trimmed) return
+    const numericId = Number(id)
+    if (!Number.isNaN(numericId) && numericId > 0) {
+      try {
+        await updateCurriculum(numericId, { title: trimmed })
+      } catch {
+        addToast({
+          message: "커리큘럼 제목 변경 저장에 실패했습니다.",
+          color: "red",
+          variant: "deep",
+          type: "default",
+          duration: 3000,
+        })
+      }
+    }
   }
 
   const handleUpdateWorkbookTitle = (
@@ -256,6 +365,36 @@ export function useCurriculumEditor({
         return { ...c, workbooks: newWorkbooks }
       }),
     )
+  }
+
+  const handleBlurWorkbookTitle = async (
+    curriculumId: string,
+    wbIndex: number,
+    title: string,
+  ) => {
+    const trimmed = title.trim()
+    const curriculum = curriculums.find((c) => c.id === curriculumId)
+    if (!curriculum) return
+    const wb = curriculum.workbooks[wbIndex]
+    if (!wb) return
+
+    const numericWbId = Number(wb.id)
+    if (!Number.isNaN(numericWbId) && numericWbId > 0) {
+      try {
+        await updateWeeklyCurriculum(numericWbId, {
+          title: trimmed,
+          weekNo: wb.number,
+        })
+      } catch {
+        addToast({
+          message: "주차별 워크북 제목 저장에 실패했습니다.",
+          color: "red",
+          variant: "deep",
+          type: "default",
+          duration: 3000,
+        })
+      }
+    }
   }
 
   const handleUpdateMission = (
@@ -344,16 +483,23 @@ export function useCurriculumEditor({
     )
   }
 
-  const handleAddWorkbook = (curriculumId: string) => {
+  const handleAddWorkbook = async (curriculumId: string) => {
+    const targetCurriculum = curriculums.find((c) => c.id === curriculumId)
+    const nextWeekNo = targetCurriculum
+      ? targetCurriculum.workbooks.length + 1
+      : 1
+    const newWbTempId = `wb-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
+
+    const newWb: Workbook = {
+      id: newWbTempId,
+      number: nextWeekNo,
+      title: "",
+      missions: ["", ""],
+    }
+
     setCurriculums((prev) =>
       prev.map((c) => {
         if (c.id !== curriculumId) return c
-        const newWb: Workbook = {
-          id: `wb-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
-          number: c.workbooks.length + 1,
-          title: "",
-          missions: ["", ""],
-        }
         const newWorkbooks = [...c.workbooks, newWb]
         const missionCount = newWorkbooks.reduce(
           (sum, wb) => sum + (wb.missions ? wb.missions.length : 0),
@@ -367,9 +513,52 @@ export function useCurriculumEditor({
         }
       }),
     )
+
+    const numericCurriculumId = Number(curriculumId)
+    if (!Number.isNaN(numericCurriculumId) && numericCurriculumId > 0) {
+      try {
+        const now = new Date()
+        const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+        const createdWeeklyId = await createWeeklyCurriculum({
+          curriculumId: numericCurriculumId,
+          weekNo: nextWeekNo,
+          title: "",
+          startsAt: now.toISOString(),
+          endsAt: nextWeek.toISOString(),
+        })
+
+        if (createdWeeklyId) {
+          setCurriculums((prev) =>
+            prev.map((c) => {
+              if (c.id !== curriculumId) return c
+              const updatedWbs = c.workbooks.map((wb) =>
+                wb.id === newWbTempId
+                  ? { ...wb, id: String(createdWeeklyId) }
+                  : wb,
+              )
+              return { ...c, workbooks: updatedWbs }
+            }),
+          )
+        }
+      } catch {
+        addToast({
+          message: "워크북 추가 저장에 실패했습니다.",
+          color: "red",
+          variant: "deep",
+          type: "default",
+          duration: 3000,
+        })
+      }
+    }
   }
 
-  const handleDeleteWorkbook = (curriculumId: string, wbIndex: number) => {
+  const handleDeleteWorkbook = async (
+    curriculumId: string,
+    wbIndex: number,
+  ) => {
+    const targetCurriculum = curriculums.find((c) => c.id === curriculumId)
+    const targetWb = targetCurriculum?.workbooks[wbIndex]
+
     setCurriculums((prev) =>
       prev.map((c) => {
         if (c.id !== curriculumId) return c
@@ -388,10 +577,27 @@ export function useCurriculumEditor({
         }
       }),
     )
+
+    if (targetWb) {
+      const numericWbId = Number(targetWb.id)
+      if (!Number.isNaN(numericWbId) && numericWbId > 0) {
+        try {
+          await deleteWeeklyCurriculum(numericWbId)
+        } catch {
+          addToast({
+            message: "워크북 삭제에 실패했습니다.",
+            color: "red",
+            variant: "deep",
+            type: "default",
+            duration: 3000,
+          })
+        }
+      }
+    }
   }
 
   const handleMoveCurriculumToBottom = (id: string) => {
-    const baseCount = INITIAL_CURRICULUM_DATA[part]?.length || 0
+    const baseCount = 0
     setCurriculums((prev) => {
       const targetIdx = prev.findIndex((c) => c.id === id)
       if (targetIdx === -1) return prev
@@ -403,11 +609,12 @@ export function useCurriculumEditor({
     })
   }
 
-  const handleRestoreCurriculum = (
+  // 되돌리기(Undo) 클릭 시 로컬 State 복구 및 API 백엔드 재등록 연동
+  const handleRestoreCurriculum = async (
     restoredItem: CurriculumItem,
     targetIndex: number,
   ) => {
-    const baseCount = INITIAL_CURRICULUM_DATA[part]?.length || 0
+    const baseCount = 0
     setCurriculums((prev) => {
       const next = [...prev]
       if (targetIndex >= 0 && targetIndex <= next.length) {
@@ -417,10 +624,44 @@ export function useCurriculumEditor({
       }
       return recalculateCurriculumNumbers(next, baseCount)
     })
+
+    // 백엔드 재등록 API 연동
+    try {
+      const apiPart = mapPartToApiEnum(part)
+      const newCurriculumId = await createCurriculum({
+        gisuId,
+        part: apiPart,
+        title: restoredItem.title || "복원된 커리큘럼",
+      })
+
+      if (newCurriculumId) {
+        setCurriculums((prev) =>
+          prev.map((c) =>
+            c.id === restoredItem.id
+              ? { ...c, id: String(newCurriculumId) }
+              : c,
+          ),
+        )
+
+        for (const wb of restoredItem.workbooks) {
+          const now = new Date()
+          const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+          await createWeeklyCurriculum({
+            curriculumId: newCurriculumId,
+            weekNo: wb.number,
+            title: wb.title,
+            startsAt: now.toISOString(),
+            endsAt: nextWeek.toISOString(),
+          })
+        }
+      }
+    } catch {
+      // Ignore background restore sync fallback
+    }
   }
 
-  const handleDeleteCurriculum = (id: string) => {
-    const baseCount = INITIAL_CURRICULUM_DATA[part]?.length || 0
+  const handleDeleteCurriculum = async (id: string) => {
+    const baseCount = 0
     const targetIndex = curriculums.findIndex((c) => c.id === id)
     const targetCurriculum = curriculums[targetIndex]
 
@@ -430,6 +671,22 @@ export function useCurriculumEditor({
       const filtered = prev.filter((c) => c.id !== id)
       return recalculateCurriculumNumbers(filtered, baseCount)
     })
+
+    const numericCurriculumId = Number(id)
+    if (!Number.isNaN(numericCurriculumId) && numericCurriculumId > 0) {
+      try {
+        await deleteCurriculum(numericCurriculumId)
+      } catch {
+        addToast({
+          message: "커리큘럼 삭제에 실패했습니다.",
+          color: "red",
+          variant: "deep",
+          type: "default",
+          duration: 3000,
+        })
+        return
+      }
+    }
 
     addToast({
       message: "선택한 커리큘럼이 삭제되었습니다.",
@@ -468,23 +725,43 @@ export function useCurriculumEditor({
       const newIndex = curriculums.findIndex((c) => c.id === over.id)
 
       if (oldIndex !== -1 && newIndex !== -1 && oldIndex !== newIndex) {
-        const baseCount = INITIAL_CURRICULUM_DATA[part]?.length || 0
+        const baseCount = 0
         setCurriculums((prev) => {
           const reordered = arrayMove(prev, oldIndex, newIndex)
           return recalculateCurriculumNumbers(reordered, baseCount)
         })
       }
+    } else if (activeData?.type === "workbook") {
+      // 주차 순서(weekNo) 이동 변경 시 백엔드 weekNo 업데이트
+      curriculums.forEach((c) => {
+        c.workbooks.forEach(async (wb, idx) => {
+          const numericWbId = Number(wb.id)
+          if (!Number.isNaN(numericWbId) && numericWbId > 0) {
+            try {
+              await updateWeeklyCurriculum(numericWbId, {
+                weekNo: idx + 1,
+                title: wb.title,
+              })
+            } catch {
+              // Ignore background order sync error
+            }
+          }
+        })
+      })
     }
   }
 
   return {
     curriculums,
     setCurriculums,
+    isLoading,
     closestCenter,
     sensors,
     handleCreateCurriculum,
     handleUpdateCurriculumTitle,
+    handleBlurCurriculumTitle,
     handleUpdateWorkbookTitle,
+    handleBlurWorkbookTitle,
     handleUpdateMission,
     handleAddMission,
     handleRemoveMission,
@@ -492,6 +769,7 @@ export function useCurriculumEditor({
     handleDeleteWorkbook,
     handleMoveCurriculumToBottom,
     handleDeleteCurriculum,
+    handleRestoreCurriculum,
     handleDragOver,
     handleDragEnd,
   }

--- a/src/features/curriculum/hooks/useCurriculumEditor.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.ts
@@ -938,24 +938,54 @@ export function useCurriculumEditor({
       }
     } else if (activeData?.type === "workbook") {
       // 주차 순서(weekNo) 이동 변경 시 백엔드 weekNo 업데이트
-      const affected = curriculums.find((c) =>
-        c.workbooks.some((wb) => wb.id === String(active.id)),
-      )
-      if (affected) {
-        affected.workbooks.forEach(async (wb, idx) => {
-          const numericWbId = Number(wb.id)
-          if (!Number.isNaN(numericWbId) && numericWbId > 0) {
-            try {
-              await updateWeeklyCurriculum(numericWbId, {
-                weekNo: idx + 1,
-                title: wb.title,
-              })
-            } catch {
-              // Ignore background order sync error
+      const activeWbId = String(active.id)
+      ;(async () => {
+        let latestCurriculums = curriculums
+        setCurriculums((prev) => {
+          latestCurriculums = prev
+          return prev
+        })
+
+        const affected = latestCurriculums.find((c) =>
+          c.workbooks.some((wb) => wb.id === activeWbId),
+        )
+
+        if (affected) {
+          for (let idx = 0; idx < affected.workbooks.length; idx++) {
+            const wb = affected.workbooks[idx]
+            if (!wb) continue
+
+            let numericWbId = Number(wb.id)
+            if (Number.isNaN(numericWbId)) {
+              const pendingWbPromise = pendingWorkbookPromisesRef.current.get(
+                wb.id,
+              )
+              if (pendingWbPromise) {
+                const res = await pendingWbPromise
+                if (res) numericWbId = Number(res)
+              }
+            }
+
+            if (!Number.isNaN(numericWbId) && numericWbId > 0) {
+              try {
+                await updateWeeklyCurriculum(numericWbId, {
+                  weekNo: idx + 1,
+                  title: wb.title,
+                })
+              } catch {
+                addToast({
+                  message: "주차 순서 변경 저장에 실패했습니다.",
+                  color: "red",
+                  variant: "deep",
+                  type: "default",
+                  duration: 3000,
+                })
+                break
+              }
             }
           }
-        })
-      }
+        }
+      })()
     }
   }
 

--- a/src/features/curriculum/hooks/useCurriculumEditor.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.ts
@@ -281,9 +281,26 @@ export function useCurriculumEditor({
                 return { ...c, workbooks: updatedWorkbooks }
               }),
             )
+          } else {
+            throw new Error("Failed to create weekly curriculum")
           }
         } catch {
-          // Ignore secondary creation error
+          setCurriculums((prev) =>
+            prev.map((c) => {
+              if (c.id !== String(createdId)) return c
+              const updatedWorkbooks = c.workbooks.filter(
+                (wb) => wb.id !== newWorkbookTempId,
+              )
+              return recalculateCurriculum(c, updatedWorkbooks)
+            }),
+          )
+          addToast({
+            message: "첫 주차 워크북 생성에 실패했습니다.",
+            color: "red",
+            variant: "deep",
+            type: "default",
+            duration: 3000,
+          })
         }
       }
     } catch {

--- a/src/features/curriculum/hooks/useCurriculumEditor.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.ts
@@ -8,7 +8,7 @@ import {
   useSensors,
 } from "@dnd-kit/core"
 import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import {
   createCurriculum,
@@ -166,6 +166,13 @@ export function useCurriculumEditor({
   const addToast = useToastStore((state) => state.addToast)
   const { data: activeGisuId, isLoading: isGisuLoading } = useActiveGisuId()
 
+  const pendingCurriculumPromisesRef = useRef<
+    Map<string, Promise<number | string | null>>
+  >(new Map())
+  const pendingWorkbookPromisesRef = useRef<
+    Map<string, Promise<number | string | null>>
+  >(new Map())
+
   // 서버에서 기수 및 파트별 커리큘럼 데이터 동기화
   useEffect(() => {
     if (isGisuLoading || activeGisuId == null) return
@@ -245,78 +252,99 @@ export function useCurriculumEditor({
     )
 
     // API 연동: 서버에 커리큘럼 생성 요청
-    try {
-      const apiPart = mapPartToApiEnum(part)
-      const createdId = await createCurriculum({
-        gisuId: activeGisuId,
-        part: apiPart,
-        title: "새 커리큘럼",
-      })
+    const curriculumPromise = (async () => {
+      try {
+        const apiPart = mapPartToApiEnum(part)
+        const createdId = await createCurriculum({
+          gisuId: activeGisuId,
+          part: apiPart,
+          title: "새 커리큘럼",
+        })
 
-      if (createdId) {
-        setCurriculums((prev) =>
-          prev.map((c) =>
-            c.id === newCurriculumTempId ? { ...c, id: String(createdId) } : c,
-          ),
-        )
-        try {
-          const now = new Date()
-          const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
-          const createdWbId = await createWeeklyCurriculum({
-            curriculumId: createdId,
-            weekNo: 1,
-            title: "",
-            startsAt: now.toISOString(),
-            endsAt: nextWeek.toISOString(),
-          })
-          if (createdWbId) {
-            setCurriculums((prev) =>
-              prev.map((c) => {
-                if (c.id !== String(createdId)) return c
-                const updatedWorkbooks = c.workbooks.map((wb) =>
-                  wb.id === newWorkbookTempId
-                    ? { ...wb, id: String(createdWbId) }
-                    : wb,
-                )
-                return { ...c, workbooks: updatedWorkbooks }
-              }),
-            )
-          } else {
-            throw new Error("Failed to create weekly curriculum")
-          }
-        } catch {
+        if (createdId) {
+          setCurriculums((prev) =>
+            prev.map((c) =>
+              c.id === newCurriculumTempId
+                ? { ...c, id: String(createdId) }
+                : c,
+            ),
+          )
+          return createdId
+        }
+        return null
+      } catch {
+        setCurriculums((prev) => {
+          const filtered = prev.filter((c) => c.id !== newCurriculumTempId)
+          return recalculateCurriculumNumbers(filtered, baseCount)
+        })
+
+        addToast({
+          message: "커리큘럼 생성에 실패했습니다.",
+          color: "red",
+          variant: "deep",
+          type: "default",
+          duration: 3000,
+        })
+        return null
+      }
+    })()
+
+    pendingCurriculumPromisesRef.current.set(
+      newCurriculumTempId,
+      curriculumPromise,
+    )
+
+    const workbookPromise = (async () => {
+      const createdId = await curriculumPromise
+      if (!createdId) return null
+      try {
+        const now = new Date()
+        const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+        const createdWbId = await createWeeklyCurriculum({
+          curriculumId: createdId,
+          weekNo: 1,
+          title: "",
+          startsAt: now.toISOString(),
+          endsAt: nextWeek.toISOString(),
+        })
+        if (createdWbId) {
           setCurriculums((prev) =>
             prev.map((c) => {
               if (c.id !== String(createdId)) return c
-              const updatedWorkbooks = c.workbooks.filter(
-                (wb) => wb.id !== newWorkbookTempId,
+              const updatedWorkbooks = c.workbooks.map((wb) =>
+                wb.id === newWorkbookTempId
+                  ? { ...wb, id: String(createdWbId) }
+                  : wb,
               )
-              return recalculateCurriculum(c, updatedWorkbooks)
+              return { ...c, workbooks: updatedWorkbooks }
             }),
           )
-          addToast({
-            message: "첫 주차 워크북 생성에 실패했습니다.",
-            color: "red",
-            variant: "deep",
-            type: "default",
-            duration: 3000,
-          })
+          return createdWbId
+        } else {
+          throw new Error("Failed to create weekly curriculum")
         }
+      } catch {
+        setCurriculums((prev) =>
+          prev.map((c) => {
+            if (c.id !== String(createdId)) return c
+            const updatedWorkbooks = c.workbooks.filter(
+              (wb) => wb.id !== newWorkbookTempId,
+            )
+            return recalculateCurriculum(c, updatedWorkbooks)
+          }),
+        )
+        addToast({
+          message: "첫 주차 워크북 생성에 실패했습니다.",
+          color: "red",
+          variant: "deep",
+          type: "default",
+          duration: 3000,
+        })
+        return null
       }
-    } catch {
-      setCurriculums((prev) => {
-        const filtered = prev.filter((c) => c.id !== newCurriculumTempId)
-        return recalculateCurriculumNumbers(filtered, baseCount)
-      })
+    })()
 
-      addToast({
-        message: "커리큘럼 생성에 실패했습니다.",
-        color: "red",
-        variant: "deep",
-        type: "default",
-        duration: 3000,
-      })
-    }
+    pendingWorkbookPromisesRef.current.set(newWorkbookTempId, workbookPromise)
   }
 
   const handleUpdateCurriculumTitle = (id: string, title: string) => {
@@ -352,7 +380,18 @@ export function useCurriculumEditor({
   const handleBlurCurriculumTitle = async (id: string, title: string) => {
     const trimmed = title.trim()
     if (!trimmed) return
-    const numericId = Number(id)
+
+    let numericId = Number(id)
+    if (Number.isNaN(numericId)) {
+      const pendingPromise = pendingCurriculumPromisesRef.current.get(id)
+      if (pendingPromise) {
+        const createdId = await pendingPromise
+        if (createdId) {
+          numericId = Number(createdId)
+        }
+      }
+    }
+
     if (!Number.isNaN(numericId) && numericId > 0) {
       try {
         await updateCurriculum(numericId, { title: trimmed })
@@ -420,12 +459,24 @@ export function useCurriculumEditor({
     title: string,
   ) => {
     const trimmed = title.trim()
-    const curriculum = curriculums.find((c) => c.id === curriculumId)
+    const curriculum = curriculums.find(
+      (c) => c.id === curriculumId || Number(c.id) === Number(curriculumId),
+    )
     if (!curriculum) return
     const wb = curriculum.workbooks[wbIndex]
     if (!wb) return
 
-    const numericWbId = Number(wb.id)
+    let numericWbId = Number(wb.id)
+    if (Number.isNaN(numericWbId)) {
+      const pendingWbPromise = pendingWorkbookPromisesRef.current.get(wb.id)
+      if (pendingWbPromise) {
+        const createdWbId = await pendingWbPromise
+        if (createdWbId) {
+          numericWbId = Number(createdWbId)
+        }
+      }
+    }
+
     if (!Number.isNaN(numericWbId) && numericWbId > 0) {
       try {
         await updateWeeklyCurriculum(numericWbId, {
@@ -561,42 +612,61 @@ export function useCurriculumEditor({
       }),
     )
 
-    const numericCurriculumId = Number(curriculumId)
-    if (!Number.isNaN(numericCurriculumId) && numericCurriculumId > 0) {
-      try {
-        const now = new Date()
-        const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
-        const createdWeeklyId = await createWeeklyCurriculum({
-          curriculumId: numericCurriculumId,
-          weekNo: nextWeekNo,
-          title: "",
-          startsAt: now.toISOString(),
-          endsAt: nextWeek.toISOString(),
-        })
-
-        if (createdWeeklyId) {
-          setCurriculums((prev) =>
-            prev.map((c) => {
-              if (c.id !== curriculumId) return c
-              const updatedWbs = c.workbooks.map((wb) =>
-                wb.id === newWbTempId
-                  ? { ...wb, id: String(createdWeeklyId) }
-                  : wb,
-              )
-              return { ...c, workbooks: updatedWbs }
-            }),
-          )
+    const workbookPromise = (async () => {
+      let numericCurriculumId = Number(curriculumId)
+      if (Number.isNaN(numericCurriculumId)) {
+        const pendingCurriculum =
+          pendingCurriculumPromisesRef.current.get(curriculumId)
+        if (pendingCurriculum) {
+          const res = await pendingCurriculum
+          if (res) numericCurriculumId = Number(res)
         }
-      } catch {
-        addToast({
-          message: "워크북 추가 저장에 실패했습니다.",
-          color: "red",
-          variant: "deep",
-          type: "default",
-          duration: 3000,
-        })
       }
-    }
+
+      if (!Number.isNaN(numericCurriculumId) && numericCurriculumId > 0) {
+        try {
+          const now = new Date()
+          const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+          const createdWeeklyId = await createWeeklyCurriculum({
+            curriculumId: numericCurriculumId,
+            weekNo: nextWeekNo,
+            title: "",
+            startsAt: now.toISOString(),
+            endsAt: nextWeek.toISOString(),
+          })
+
+          if (createdWeeklyId) {
+            setCurriculums((prev) =>
+              prev.map((c) => {
+                if (
+                  c.id !== String(numericCurriculumId) &&
+                  c.id !== curriculumId
+                )
+                  return c
+                const updatedWbs = c.workbooks.map((wb) =>
+                  wb.id === newWbTempId
+                    ? { ...wb, id: String(createdWeeklyId) }
+                    : wb,
+                )
+                return { ...c, workbooks: updatedWbs }
+              }),
+            )
+            return createdWeeklyId
+          }
+        } catch {
+          addToast({
+            message: "워크북 추가 저장에 실패했습니다.",
+            color: "red",
+            variant: "deep",
+            type: "default",
+            duration: 3000,
+          })
+        }
+      }
+      return null
+    })()
+
+    pendingWorkbookPromisesRef.current.set(newWbTempId, workbookPromise)
   }
 
   const handleDeleteWorkbook = async (

--- a/src/features/curriculum/hooks/useCurriculumEditor.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.ts
@@ -171,13 +171,14 @@ export function useCurriculumEditor({
   useEffect(() => {
     if (isGisuLoading || activeGisuId == null) return
 
+    const currentGisuId = activeGisuId
     let isSubscribed = true
     async function fetchOverview() {
       setIsLoading(true)
       try {
         const apiPart = mapPartToApiEnum(part)
         const overview = await getCurriculumOverview({
-          gisuId: activeGisuId,
+          gisuId: currentGisuId,
           part: apiPart,
         })
         if (isSubscribed && overview && overview.curriculumId) {

--- a/src/features/curriculum/hooks/useCurriculumEditor.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.ts
@@ -164,18 +164,22 @@ export function useCurriculumEditor({
     useState<CurriculumItem[]>(initialCurriculums)
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const addToast = useToastStore((state) => state.addToast)
-  const { data: activeGisuId } = useActiveGisuId()
+  const { data: activeGisuId, isLoading: isGisuLoading } = useActiveGisuId()
   const gisuId = activeGisuId ?? 10
 
   // 서버에서 기수 및 파트별 커리큘럼 데이터 동기화
   useEffect(() => {
+    if (isGisuLoading || activeGisuId == null) return
+
     let isSubscribed = true
     async function fetchOverview() {
-      if (!gisuId) return
       setIsLoading(true)
       try {
         const apiPart = mapPartToApiEnum(part)
-        const overview = await getCurriculumOverview({ gisuId, part: apiPart })
+        const overview = await getCurriculumOverview({
+          gisuId: activeGisuId,
+          part: apiPart,
+        })
         if (isSubscribed && overview && overview.curriculumId) {
           const fetchedItem = mapOverviewToCurriculumItem(overview, 0)
           setCurriculums([fetchedItem])
@@ -190,7 +194,7 @@ export function useCurriculumEditor({
     return () => {
       isSubscribed = false
     }
-  }, [gisuId, part])
+  }, [activeGisuId, isGisuLoading, part])
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),

--- a/src/features/curriculum/hooks/useCurriculumEditor.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.ts
@@ -165,7 +165,6 @@ export function useCurriculumEditor({
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const addToast = useToastStore((state) => state.addToast)
   const { data: activeGisuId, isLoading: isGisuLoading } = useActiveGisuId()
-  const gisuId = activeGisuId ?? 10
 
   // 서버에서 기수 및 파트별 커리큘럼 데이터 동기화
   useEffect(() => {
@@ -205,6 +204,17 @@ export function useCurriculumEditor({
   )
 
   const handleCreateCurriculum = async () => {
+    if (isGisuLoading || activeGisuId == null) {
+      addToast({
+        message: "기수 정보를 불러오는 중이거나 선택된 기수가 없습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return
+    }
+
     const baseCount = 0
 
     const newCurriculumTempId = `curriculum-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`
@@ -234,7 +244,7 @@ export function useCurriculumEditor({
     try {
       const apiPart = mapPartToApiEnum(part)
       const createdId = await createCurriculum({
-        gisuId,
+        gisuId: activeGisuId,
         part: apiPart,
         title: "새 커리큘럼",
       })
@@ -630,6 +640,17 @@ export function useCurriculumEditor({
     restoredItem: CurriculumItem,
     targetIndex: number,
   ) => {
+    if (isGisuLoading || activeGisuId == null) {
+      addToast({
+        message: "기수 정보를 불러오는 중이거나 선택된 기수가 없습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return
+    }
+
     const baseCount = 0
     setCurriculums((prev) => {
       const next = [...prev]
@@ -645,7 +666,7 @@ export function useCurriculumEditor({
     try {
       const apiPart = mapPartToApiEnum(part)
       const newCurriculumId = await createCurriculum({
-        gisuId,
+        gisuId: activeGisuId,
         part: apiPart,
         title: restoredItem.title || "복원된 커리큘럼",
       })
@@ -662,13 +683,24 @@ export function useCurriculumEditor({
         for (const wb of restoredItem.workbooks) {
           const now = new Date()
           const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
-          await createWeeklyCurriculum({
+          const createdWbId = await createWeeklyCurriculum({
             curriculumId: newCurriculumId,
             weekNo: wb.number,
             title: wb.title,
             startsAt: now.toISOString(),
             endsAt: nextWeek.toISOString(),
           })
+          if (createdWbId) {
+            setCurriculums((prev) =>
+              prev.map((c) => {
+                if (c.id !== String(newCurriculumId)) return c
+                const updatedWbs = c.workbooks.map((w) =>
+                  w.id === wb.id ? { ...w, id: String(createdWbId) } : w,
+                )
+                return { ...c, workbooks: updatedWbs }
+              }),
+            )
+          }
         }
       }
     } catch {
@@ -749,8 +781,11 @@ export function useCurriculumEditor({
       }
     } else if (activeData?.type === "workbook") {
       // 주차 순서(weekNo) 이동 변경 시 백엔드 weekNo 업데이트
-      curriculums.forEach((c) => {
-        c.workbooks.forEach(async (wb, idx) => {
+      const affected = curriculums.find((c) =>
+        c.workbooks.some((wb) => wb.id === String(active.id)),
+      )
+      if (affected) {
+        affected.workbooks.forEach(async (wb, idx) => {
           const numericWbId = Number(wb.id)
           if (!Number.isNaN(numericWbId) && numericWbId > 0) {
             try {
@@ -763,7 +798,7 @@ export function useCurriculumEditor({
             }
           }
         })
-      })
+      }
     }
   }
 

--- a/src/features/curriculum/hooks/useCurriculumEditor.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.ts
@@ -180,12 +180,16 @@ export function useCurriculumEditor({
           gisuId: currentGisuId,
           part: apiPart,
         })
-        if (isSubscribed && overview && overview.curriculumId) {
-          const fetchedItem = mapOverviewToCurriculumItem(overview, 0)
-          setCurriculums([fetchedItem])
+        if (isSubscribed) {
+          if (overview && overview.curriculumId) {
+            const fetchedItem = mapOverviewToCurriculumItem(overview, 0)
+            setCurriculums([fetchedItem])
+          } else {
+            setCurriculums([])
+          }
         }
       } catch {
-        // 서버에 데이터가 없을 시 기존 초기값 유지
+        // 서버 요청 실패 시 기존 초기값 유지
       } finally {
         if (isSubscribed) setIsLoading(false)
       }

--- a/src/features/curriculum/hooks/useCurriculumEditor.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.ts
@@ -268,7 +268,18 @@ export function useCurriculumEditor({
         }
       }
     } catch {
-      // Ignore initial creation error fallback to local state
+      setCurriculums((prev) => {
+        const filtered = prev.filter((c) => c.id !== newCurriculumTempId)
+        return recalculateCurriculumNumbers(filtered, baseCount)
+      })
+
+      addToast({
+        message: "커리큘럼 생성에 실패했습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
     }
   }
 

--- a/src/features/curriculum/hooks/useCurriculumEditor.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.ts
@@ -701,6 +701,18 @@ export function useCurriculumEditor({
         try {
           await deleteWeeklyCurriculum(numericWbId)
         } catch {
+          setCurriculums((prev) =>
+            prev.map((c) => {
+              if (c.id !== curriculumId) return c
+              const restoredWorkbooks = [...c.workbooks]
+              if (wbIndex >= 0 && wbIndex <= restoredWorkbooks.length) {
+                restoredWorkbooks.splice(wbIndex, 0, targetWb)
+              } else {
+                restoredWorkbooks.push(targetWb)
+              }
+              return recalculateCurriculum(c, restoredWorkbooks)
+            }),
+          )
           addToast({
             message: "워크북 삭제에 실패했습니다.",
             color: "red",
@@ -861,6 +873,15 @@ export function useCurriculumEditor({
       try {
         await deleteCurriculum(numericCurriculumId)
       } catch {
+        setCurriculums((prev) => {
+          const next = [...prev]
+          if (targetIndex >= 0 && targetIndex <= next.length) {
+            next.splice(targetIndex, 0, targetCurriculum)
+          } else {
+            next.push(targetCurriculum)
+          }
+          return recalculateCurriculumNumbers(next, baseCount)
+        })
         addToast({
           message: "커리큘럼 삭제에 실패했습니다.",
           color: "red",

--- a/src/features/curriculum/model/curriculumMapper.test.ts
+++ b/src/features/curriculum/model/curriculumMapper.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  mapOverviewToCurriculumItem,
+  mapWeeklyOverviewToWorkbook,
+} from "./curriculumMapper"
+
+describe("curriculumMapper", () => {
+  it("mapWeeklyOverviewToWorkbook - missions 데이터가 있으면 전달받은 데이터를 보존한다", () => {
+    const mockWeek = {
+      weeklyCurriculumId: 10,
+      weekNo: 1,
+      title: "1주차",
+      missions: ["미션 1", "미션 2"],
+    }
+
+    const result = mapWeeklyOverviewToWorkbook(mockWeek, 0)
+    expect(result.missions).toEqual(["미션 1", "미션 2"])
+  })
+
+  it("mapOverviewToCurriculumItem - missionCount를 workbooks의 missions 개수 기반으로 계산한다", () => {
+    const mockOverview = {
+      curriculumId: 1,
+      title: "스프링 기초",
+      weeks: [
+        {
+          weeklyCurriculumId: 10,
+          weekNo: 1,
+          title: "1주차",
+          missions: ["미션 A", "미션 B"],
+        },
+        {
+          weeklyCurriculumId: 20,
+          weekNo: 2,
+          title: "2주차",
+          missions: ["미션 C"],
+        },
+      ],
+    }
+
+    const result = mapOverviewToCurriculumItem(mockOverview, 0)
+    expect(result.missionCount).toBe(3)
+    expect(result.workbooks[0]?.missions).toEqual(["미션 A", "미션 B"])
+    expect(result.workbooks[1]?.missions).toEqual(["미션 C"])
+  })
+})

--- a/src/features/curriculum/model/curriculumMapper.ts
+++ b/src/features/curriculum/model/curriculumMapper.ts
@@ -1,0 +1,92 @@
+import type {
+  CurriculumOverviewResponse,
+  CurriculumPart,
+  WeeklyCurriculumOverviewResponse,
+} from "@/entities/curriculum"
+
+import type { CurriculumItem, Workbook } from "./curriculumData"
+
+/**
+ * UI Part 탭 문자열을 API CurriculumPart Enum으로 매핑
+ */
+export function mapPartToApiEnum(part: string): CurriculumPart {
+  switch (part) {
+    case "PM":
+      return "PLAN"
+    case "Design":
+      return "DESIGN"
+    case "Web PE":
+      return "WEB"
+    case "Mobile PE":
+      return "ANDROID"
+    case "Infra Plus":
+      return "ADMIN"
+    default:
+      return "PLAN"
+  }
+}
+
+/**
+ * API CurriculumPart Enum을 UI Part 탭 문자열로 매핑
+ */
+export function mapApiEnumToPart(part: CurriculumPart): string {
+  switch (part) {
+    case "PLAN":
+      return "PM"
+    case "DESIGN":
+      return "Design"
+    case "WEB":
+      return "Web PE"
+    case "ANDROID":
+    case "IOS":
+      return "Mobile PE"
+    case "NODEJS":
+    case "SPRINGBOOT":
+    case "ADMIN":
+      return "Infra Plus"
+    default:
+      return "PM"
+  }
+}
+
+/**
+ * 서버 WeeklyCurriculumOverviewResponse -> UI Workbook 변환
+ */
+export function mapWeeklyOverviewToWorkbook(
+  week: WeeklyCurriculumOverviewResponse,
+  index: number,
+): Workbook {
+  return {
+    id: week.weeklyCurriculumId
+      ? String(week.weeklyCurriculumId)
+      : `wb-${Date.now()}-${index}`,
+    number: week.weekNo ?? index + 1,
+    title: week.title ?? "",
+    missions: [],
+  }
+}
+
+/**
+ * 서버 CurriculumOverviewResponse -> UI CurriculumItem 변환
+ */
+export function mapOverviewToCurriculumItem(
+  overview: CurriculumOverviewResponse,
+  index: number,
+): CurriculumItem {
+  const workbooks: Workbook[] = (overview.weeks || []).map((w, idx) =>
+    mapWeeklyOverviewToWorkbook(w, idx),
+  )
+
+  const numberStr = String(index + 1).padStart(2, "0")
+
+  return {
+    id: overview.curriculumId
+      ? String(overview.curriculumId)
+      : `curriculum-${Date.now()}-${index}`,
+    number: numberStr,
+    title: overview.title ?? "",
+    workbookCount: workbooks.length,
+    missionCount: 0,
+    workbooks,
+  }
+}

--- a/src/features/curriculum/model/curriculumMapper.ts
+++ b/src/features/curriculum/model/curriculumMapper.ts
@@ -56,13 +56,14 @@ export function mapWeeklyOverviewToWorkbook(
   week: WeeklyCurriculumOverviewResponse,
   index: number,
 ): Workbook {
+  const rawMissions = (week as { missions?: string[] }).missions
   return {
     id: week.weeklyCurriculumId
       ? String(week.weeklyCurriculumId)
       : `wb-${Date.now()}-${index}`,
     number: week.weekNo ?? index + 1,
     title: week.title ?? "",
-    missions: [],
+    missions: Array.isArray(rawMissions) ? rawMissions : [],
   }
 }
 
@@ -78,6 +79,10 @@ export function mapOverviewToCurriculumItem(
   )
 
   const numberStr = String(index + 1).padStart(2, "0")
+  const missionCount = workbooks.reduce(
+    (sum, wb) => sum + (wb.missions ? wb.missions.length : 0),
+    0,
+  )
 
   return {
     id: overview.curriculumId
@@ -86,7 +91,7 @@ export function mapOverviewToCurriculumItem(
     number: numberStr,
     title: overview.title ?? "",
     workbookCount: workbooks.length,
-    missionCount: 0,
+    missionCount,
     workbooks,
   }
 }

--- a/src/features/curriculum/ui/CurriculumCardEditable.tsx
+++ b/src/features/curriculum/ui/CurriculumCardEditable.tsx
@@ -21,6 +21,7 @@ interface SortableWorkbookItemProps {
   wb: Workbook
   wbIndex: number
   onUpdateWorkbookTitle?: (wbIndex: number, title: string) => void
+  onBlurWorkbookTitle?: (wbIndex: number, title: string) => void
   onUpdateMission?: (
     wbIndex: number,
     missionIndex: number,
@@ -35,6 +36,7 @@ function SortableWorkbookItem({
   wb,
   wbIndex,
   onUpdateWorkbookTitle,
+  onBlurWorkbookTitle,
   onUpdateMission,
   onDeleteWorkbook,
   onAddMission,
@@ -100,6 +102,7 @@ function SortableWorkbookItem({
               value={wb.title}
               onPointerDown={(e) => e.stopPropagation()}
               onChange={(e) => onUpdateWorkbookTitle?.(wbIndex, e.target.value)}
+              onBlur={() => onBlurWorkbookTitle?.(wbIndex, wb.title)}
               placeholder="워크북 이름을 작성하세요"
               className="text-heading-7-semibold text-teal-gray-900 placeholder:text-teal-gray-400 min-w-48 bg-transparent outline-none"
             />
@@ -170,7 +173,9 @@ function SortableWorkbookItem({
 interface CurriculumCardEditableProps {
   curriculum: CurriculumItem
   onUpdateCurriculumTitle?: (title: string) => void
+  onBlurCurriculumTitle?: (title: string) => void
   onUpdateWorkbookTitle?: (wbIndex: number, title: string) => void
+  onBlurWorkbookTitle?: (wbIndex: number, title: string) => void
   onUpdateMission?: (
     wbIndex: number,
     missionIndex: number,
@@ -188,7 +193,9 @@ interface CurriculumCardEditableProps {
 export function CurriculumCardEditable({
   curriculum,
   onUpdateCurriculumTitle,
+  onBlurCurriculumTitle,
   onUpdateWorkbookTitle,
+  onBlurWorkbookTitle,
   onUpdateMission,
   onAddWorkbook,
   onDeleteWorkbook,
@@ -264,6 +271,7 @@ export function CurriculumCardEditable({
                 value={curriculum.title}
                 onPointerDown={(e) => e.stopPropagation()}
                 onChange={(e) => onUpdateCurriculumTitle?.(e.target.value)}
+                onBlur={() => onBlurCurriculumTitle?.(curriculum.title)}
                 placeholder="커리큘럼 이름을 작성하세요"
                 className="text-heading-6-semibold text-teal-gray-900 placeholder:text-teal-gray-400 w-full min-w-60 bg-transparent outline-none"
               />
@@ -367,6 +375,7 @@ export function CurriculumCardEditable({
               wb={wb}
               wbIndex={wbIndex}
               onUpdateWorkbookTitle={onUpdateWorkbookTitle}
+              onBlurWorkbookTitle={onBlurWorkbookTitle}
               onUpdateMission={onUpdateMission}
               onDeleteWorkbook={onDeleteWorkbook}
               onAddMission={onAddMission}

--- a/src/features/curriculum/ui/CurriculumCardEditable.tsx
+++ b/src/features/curriculum/ui/CurriculumCardEditable.tsx
@@ -44,6 +44,7 @@ function SortableWorkbookItem({
 }: SortableWorkbookItemProps) {
   const missionInputRefs = useRef<(HTMLInputElement | null)[]>([])
   const [focusIndex, setFocusIndex] = useState<number | null>(null)
+  const focusedTitleRef = useRef<string | null>(null)
 
   useEffect(() => {
     if (focusIndex !== null && missionInputRefs.current[focusIndex]) {
@@ -101,8 +102,15 @@ function SortableWorkbookItem({
               type="text"
               value={wb.title}
               onPointerDown={(e) => e.stopPropagation()}
+              onFocus={() => {
+                focusedTitleRef.current = wb.title
+              }}
               onChange={(e) => onUpdateWorkbookTitle?.(wbIndex, e.target.value)}
-              onBlur={() => onBlurWorkbookTitle?.(wbIndex, wb.title)}
+              onBlur={() => {
+                if (focusedTitleRef.current !== wb.title) {
+                  onBlurWorkbookTitle?.(wbIndex, wb.title)
+                }
+              }}
               placeholder="워크북 이름을 작성하세요"
               className="text-heading-7-semibold text-teal-gray-900 placeholder:text-teal-gray-400 min-w-48 bg-transparent outline-none"
             />
@@ -208,6 +216,7 @@ export function CurriculumCardEditable({
   const [moreOpen, setMoreOpen] = useState(false)
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const titleInputRef = useRef<HTMLInputElement>(null)
+  const focusedTitleRef = useRef<string | null>(null)
 
   useEffect(() => {
     if (autoFocusTitle && titleInputRef.current) {
@@ -270,8 +279,15 @@ export function CurriculumCardEditable({
                 type="text"
                 value={curriculum.title}
                 onPointerDown={(e) => e.stopPropagation()}
+                onFocus={() => {
+                  focusedTitleRef.current = curriculum.title
+                }}
                 onChange={(e) => onUpdateCurriculumTitle?.(e.target.value)}
-                onBlur={() => onBlurCurriculumTitle?.(curriculum.title)}
+                onBlur={() => {
+                  if (focusedTitleRef.current !== curriculum.title) {
+                    onBlurCurriculumTitle?.(curriculum.title)
+                  }
+                }}
                 placeholder="커리큘럼 이름을 작성하세요"
                 className="text-heading-6-semibold text-teal-gray-900 placeholder:text-teal-gray-400 w-full min-w-60 bg-transparent outline-none"
               />

--- a/src/features/curriculum/ui/CurriculumCreatePage.tsx
+++ b/src/features/curriculum/ui/CurriculumCreatePage.tsx
@@ -21,7 +21,9 @@ export function CurriculumCreatePage({
     closestCenter,
     handleCreateCurriculum,
     handleUpdateCurriculumTitle,
+    handleBlurCurriculumTitle,
     handleUpdateWorkbookTitle,
+    handleBlurWorkbookTitle,
     handleUpdateMission,
     handleAddMission,
     handleRemoveMission,
@@ -81,8 +83,14 @@ export function CurriculumCreatePage({
                   onUpdateCurriculumTitle={(title) =>
                     handleUpdateCurriculumTitle(item.id, title)
                   }
+                  onBlurCurriculumTitle={(title) =>
+                    handleBlurCurriculumTitle(item.id, title)
+                  }
                   onUpdateWorkbookTitle={(wbIndex, title) =>
                     handleUpdateWorkbookTitle(item.id, wbIndex, title)
+                  }
+                  onBlurWorkbookTitle={(wbIndex, title) =>
+                    handleBlurWorkbookTitle(item.id, wbIndex, title)
                   }
                   onUpdateMission={(wbIndex, missionIndex, value) =>
                     handleUpdateMission(item.id, wbIndex, missionIndex, value)

--- a/src/features/curriculum/ui/CurriculumEditPage.tsx
+++ b/src/features/curriculum/ui/CurriculumEditPage.tsx
@@ -24,7 +24,9 @@ export function CurriculumEditPage({
     closestCenter,
     handleCreateCurriculum,
     handleUpdateCurriculumTitle,
+    handleBlurCurriculumTitle,
     handleUpdateWorkbookTitle,
+    handleBlurWorkbookTitle,
     handleUpdateMission,
     handleAddMission,
     handleRemoveMission,
@@ -85,8 +87,14 @@ export function CurriculumEditPage({
                   onUpdateCurriculumTitle={(title) =>
                     handleUpdateCurriculumTitle(item.id, title)
                   }
+                  onBlurCurriculumTitle={(title) =>
+                    handleBlurCurriculumTitle(item.id, title)
+                  }
                   onUpdateWorkbookTitle={(wbIndex, title) =>
                     handleUpdateWorkbookTitle(item.id, wbIndex, title)
+                  }
+                  onBlurWorkbookTitle={(wbIndex, title) =>
+                    handleBlurWorkbookTitle(item.id, wbIndex, title)
                   }
                   onUpdateMission={(wbIndex, missionIndex, value) =>
                     handleUpdateMission(item.id, wbIndex, missionIndex, value)

--- a/src/features/curriculum/ui/CurriculumManagePage.tsx
+++ b/src/features/curriculum/ui/CurriculumManagePage.tsx
@@ -1,12 +1,18 @@
 import { useNavigate } from "@tanstack/react-router"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
+import { deleteCurriculum, getCurriculumOverview } from "@/entities/curriculum"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import SettingIcon from "@/shared/assets/icon/setting/SettingIcon"
+import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
 import { Button } from "@/shared/ui/Button"
 import { PageLabel } from "@/shared/ui/page-label/PageLabel"
 
 import { INITIAL_CURRICULUM_DATA } from "../model/curriculumData"
+import {
+  mapOverviewToCurriculumItem,
+  mapPartToApiEnum,
+} from "../model/curriculumMapper"
 import { CurriculumCardReadonly } from "./CurriculumCardReadonly"
 import { CurriculumSettingModal } from "./CurriculumSettingModal"
 import { PartTabs } from "./PartTabs"
@@ -18,11 +24,37 @@ export function CurriculumManagePage() {
   const [selectedPart, setSelectedPart] = useState<string>("PM")
   const [curriculumData, setCurriculumData] = useState(INITIAL_CURRICULUM_DATA)
   const [isSettingModalOpen, setIsSettingModalOpen] = useState(false)
+  const { data: activeGisuId } = useActiveGisuId()
+  const gisuId = activeGisuId ?? 10
 
   // Default expand card 01 (design-1)
   const [expandedIds, setExpandedIds] = useState<Record<string, boolean>>({
     "design-1": true,
   })
+
+  useEffect(() => {
+    let isSubscribed = true
+    async function loadCurriculum() {
+      if (!gisuId) return
+      try {
+        const apiPart = mapPartToApiEnum(selectedPart)
+        const overview = await getCurriculumOverview({ gisuId, part: apiPart })
+        if (isSubscribed && overview && overview.curriculumId) {
+          const item = mapOverviewToCurriculumItem(overview, 0)
+          setCurriculumData((prev) => ({
+            ...prev,
+            [selectedPart]: [item],
+          }))
+        }
+      } catch {
+        // Fallback to initial local mock data if api has no entry
+      }
+    }
+    loadCurriculum()
+    return () => {
+      isSubscribed = false
+    }
+  }, [gisuId, selectedPart])
 
   const currentItems = curriculumData[selectedPart] || []
 
@@ -33,13 +65,22 @@ export function CurriculumManagePage() {
     }))
   }
 
-  const handleDeleteItem = (id: string) => {
+  const handleDeleteItem = async (id: string) => {
     setCurriculumData((prev) => ({
       ...prev,
       [selectedPart]: (prev[selectedPart] || []).filter(
         (item) => item.id !== id,
       ),
     }))
+
+    const numericId = Number(id)
+    if (!Number.isNaN(numericId) && numericId > 0) {
+      try {
+        await deleteCurriculum(numericId)
+      } catch {
+        // Handled silently or toast
+      }
+    }
   }
 
   const handleReorderItems = (fromIndex: number, toIndex: number) => {

--- a/src/features/curriculum/ui/CurriculumManagePage.tsx
+++ b/src/features/curriculum/ui/CurriculumManagePage.tsx
@@ -84,12 +84,19 @@ export function CurriculumManagePage() {
       (item) => item.id === id,
     )
 
-    setCurriculumData((prev) => ({
-      ...prev,
-      [selectedPart]: (prev[selectedPart] || []).filter(
+    setCurriculumData((prev) => {
+      const filtered = (prev[selectedPart] || []).filter(
         (item) => item.id !== id,
-      ),
-    }))
+      )
+      const renumbered = filtered.map((item, idx) => ({
+        ...item,
+        number: String(idx + 1).padStart(2, "0"),
+      }))
+      return {
+        ...prev,
+        [selectedPart]: renumbered,
+      }
+    })
 
     const numericId = Number(id)
     if (!Number.isNaN(numericId) && numericId > 0) {
@@ -101,7 +108,11 @@ export function CurriculumManagePage() {
             const list = [...(prev[selectedPart] || [])]
             const insertIndex = Math.min(targetIndex, list.length)
             list.splice(insertIndex, 0, targetItem)
-            return { ...prev, [selectedPart]: list }
+            const renumbered = list.map((item, idx) => ({
+              ...item,
+              number: String(idx + 1).padStart(2, "0"),
+            }))
+            return { ...prev, [selectedPart]: renumbered }
           })
           addToast({
             message: "커리큘럼 삭제에 실패했습니다.",

--- a/src/features/curriculum/ui/CurriculumManagePage.tsx
+++ b/src/features/curriculum/ui/CurriculumManagePage.tsx
@@ -1,7 +1,12 @@
 import { useNavigate } from "@tanstack/react-router"
 import { useEffect, useState } from "react"
 
-import { deleteCurriculum, getCurriculumOverview } from "@/entities/curriculum"
+import {
+  createCurriculum,
+  createWeeklyCurriculum,
+  deleteCurriculum,
+  getCurriculumOverview,
+} from "@/entities/curriculum"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import SettingIcon from "@/shared/assets/icon/setting/SettingIcon"
 import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
@@ -100,7 +105,10 @@ export function CurriculumManagePage() {
     })
   }
 
-  const handleRestoreItem = (itemToRestore: CurriculumItem, index: number) => {
+  const handleRestoreItem = async (
+    itemToRestore: CurriculumItem,
+    index: number,
+  ) => {
     setCurriculumData((prev) => {
       const list = [...(prev[selectedPart] || [])]
       list.splice(index, 0, itemToRestore)
@@ -113,6 +121,46 @@ export function CurriculumManagePage() {
         [selectedPart]: renumbered,
       }
     })
+
+    try {
+      const apiPart = mapPartToApiEnum(selectedPart)
+      const newCurriculumId = await createCurriculum({
+        gisuId,
+        part: apiPart,
+        title: itemToRestore.title || "복원된 커리큘럼",
+      })
+
+      if (newCurriculumId) {
+        setCurriculumData((prev) => {
+          const list = prev[selectedPart] || []
+          const updated = list.map((c) =>
+            c.id === itemToRestore.id
+              ? { ...c, id: String(newCurriculumId) }
+              : c,
+          )
+          return {
+            ...prev,
+            [selectedPart]: updated,
+          }
+        })
+
+        if (itemToRestore.workbooks && itemToRestore.workbooks.length > 0) {
+          for (const wb of itemToRestore.workbooks) {
+            const now = new Date()
+            const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+            await createWeeklyCurriculum({
+              curriculumId: newCurriculumId,
+              weekNo: wb.number,
+              title: wb.title,
+              startsAt: now.toISOString(),
+              endsAt: nextWeek.toISOString(),
+            })
+          }
+        }
+      }
+    } catch {
+      // Ignore restore API error fallback to local state
+    }
   }
 
   return (

--- a/src/features/curriculum/ui/CurriculumManagePage.tsx
+++ b/src/features/curriculum/ui/CurriculumManagePage.tsx
@@ -29,7 +29,7 @@ export function CurriculumManagePage() {
   const [selectedPart, setSelectedPart] = useState<string>("PM")
   const [curriculumData, setCurriculumData] = useState(INITIAL_CURRICULUM_DATA)
   const [isSettingModalOpen, setIsSettingModalOpen] = useState(false)
-  const { data: activeGisuId } = useActiveGisuId()
+  const { data: activeGisuId, isLoading: isGisuLoading } = useActiveGisuId()
   const gisuId = activeGisuId ?? 10
 
   // Default expand card 01 (design-1)
@@ -38,12 +38,16 @@ export function CurriculumManagePage() {
   })
 
   useEffect(() => {
+    if (isGisuLoading || activeGisuId == null) return
+
     let isSubscribed = true
     async function loadCurriculum() {
-      if (!gisuId) return
       try {
         const apiPart = mapPartToApiEnum(selectedPart)
-        const overview = await getCurriculumOverview({ gisuId, part: apiPart })
+        const overview = await getCurriculumOverview({
+          gisuId: activeGisuId,
+          part: apiPart,
+        })
         if (isSubscribed && overview && overview.curriculumId) {
           const item = mapOverviewToCurriculumItem(overview, 0)
           setCurriculumData((prev) => ({
@@ -59,7 +63,7 @@ export function CurriculumManagePage() {
     return () => {
       isSubscribed = false
     }
-  }, [gisuId, selectedPart])
+  }, [activeGisuId, isGisuLoading, selectedPart])
 
   const currentItems = curriculumData[selectedPart] || []
 

--- a/src/features/curriculum/ui/CurriculumManagePage.tsx
+++ b/src/features/curriculum/ui/CurriculumManagePage.tsx
@@ -160,6 +160,22 @@ export function CurriculumManagePage() {
       return
     }
 
+    const previousList = curriculumData[selectedPart] || []
+
+    const rollbackState = () => {
+      setCurriculumData((prev) => ({
+        ...prev,
+        [selectedPart]: previousList,
+      }))
+      addToast({
+        message: "커리큘럼 복원에 실패했습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    }
+
     setCurriculumData((prev) => {
       const list = [...(prev[selectedPart] || [])]
       list.splice(index, 0, itemToRestore)
@@ -181,49 +197,54 @@ export function CurriculumManagePage() {
         title: itemToRestore.title || "복원된 커리큘럼",
       })
 
-      if (newCurriculumId) {
-        setCurriculumData((prev) => {
-          const list = prev[selectedPart] || []
-          const updated = list.map((c) =>
-            c.id === itemToRestore.id
-              ? { ...c, id: String(newCurriculumId) }
-              : c,
-          )
-          return {
-            ...prev,
-            [selectedPart]: updated,
-          }
-        })
+      if (!newCurriculumId) {
+        rollbackState()
+        return
+      }
 
-        if (itemToRestore.workbooks && itemToRestore.workbooks.length > 0) {
-          for (const wb of itemToRestore.workbooks) {
-            const now = new Date()
-            const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
-            const createdWbId = await createWeeklyCurriculum({
-              curriculumId: newCurriculumId,
-              weekNo: wb.number,
-              title: wb.title,
-              startsAt: now.toISOString(),
-              endsAt: nextWeek.toISOString(),
-            })
-            if (createdWbId) {
-              setCurriculumData((prev) => {
-                const list = prev[selectedPart] || []
-                const updated = list.map((c) => {
-                  if (c.id !== String(newCurriculumId)) return c
-                  const updatedWbs = c.workbooks.map((w) =>
-                    w.id === wb.id ? { ...w, id: String(createdWbId) } : w,
-                  )
-                  return { ...c, workbooks: updatedWbs }
-                })
-                return { ...prev, [selectedPart]: updated }
-              })
-            }
+      setCurriculumData((prev) => {
+        const list = prev[selectedPart] || []
+        const updated = list.map((c) =>
+          c.id === itemToRestore.id ? { ...c, id: String(newCurriculumId) } : c,
+        )
+        return {
+          ...prev,
+          [selectedPart]: updated,
+        }
+      })
+
+      if (itemToRestore.workbooks && itemToRestore.workbooks.length > 0) {
+        for (const wb of itemToRestore.workbooks) {
+          const now = new Date()
+          const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+          const createdWbId = await createWeeklyCurriculum({
+            curriculumId: newCurriculumId,
+            weekNo: wb.number,
+            title: wb.title,
+            startsAt: now.toISOString(),
+            endsAt: nextWeek.toISOString(),
+          })
+
+          if (!createdWbId) {
+            rollbackState()
+            return
           }
+
+          setCurriculumData((prev) => {
+            const list = prev[selectedPart] || []
+            const updated = list.map((c) => {
+              if (c.id !== String(newCurriculumId)) return c
+              const updatedWbs = c.workbooks.map((w) =>
+                w.id === wb.id ? { ...w, id: String(createdWbId) } : w,
+              )
+              return { ...c, workbooks: updatedWbs }
+            })
+            return { ...prev, [selectedPart]: updated }
+          })
         }
       }
     } catch {
-      // Ignore restore API error fallback to local state
+      rollbackState()
     }
   }
 

--- a/src/features/curriculum/ui/CurriculumManagePage.tsx
+++ b/src/features/curriculum/ui/CurriculumManagePage.tsx
@@ -12,6 +12,7 @@ import SettingIcon from "@/shared/assets/icon/setting/SettingIcon"
 import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
 import { Button } from "@/shared/ui/Button"
 import { PageLabel } from "@/shared/ui/page-label/PageLabel"
+import { useToastStore } from "@/shared/ui/toast/useToastStore"
 
 import { INITIAL_CURRICULUM_DATA } from "../model/curriculumData"
 import {
@@ -29,8 +30,8 @@ export function CurriculumManagePage() {
   const [selectedPart, setSelectedPart] = useState<string>("PM")
   const [curriculumData, setCurriculumData] = useState(INITIAL_CURRICULUM_DATA)
   const [isSettingModalOpen, setIsSettingModalOpen] = useState(false)
+  const addToast = useToastStore((state) => state.addToast)
   const { data: activeGisuId, isLoading: isGisuLoading } = useActiveGisuId()
-  const gisuId = activeGisuId ?? 10
 
   // Default expand card 01 (design-1)
   const [expandedIds, setExpandedIds] = useState<Record<string, boolean>>({
@@ -76,6 +77,13 @@ export function CurriculumManagePage() {
   }
 
   const handleDeleteItem = async (id: string) => {
+    const targetItem = (curriculumData[selectedPart] || []).find(
+      (item) => item.id === id,
+    )
+    const targetIndex = (curriculumData[selectedPart] || []).findIndex(
+      (item) => item.id === id,
+    )
+
     setCurriculumData((prev) => ({
       ...prev,
       [selectedPart]: (prev[selectedPart] || []).filter(
@@ -88,7 +96,21 @@ export function CurriculumManagePage() {
       try {
         await deleteCurriculum(numericId)
       } catch {
-        // Handled silently or toast
+        if (targetItem) {
+          setCurriculumData((prev) => {
+            const list = [...(prev[selectedPart] || [])]
+            const insertIndex = Math.min(targetIndex, list.length)
+            list.splice(insertIndex, 0, targetItem)
+            return { ...prev, [selectedPart]: list }
+          })
+          addToast({
+            message: "커리큘럼 삭제에 실패했습니다.",
+            color: "red",
+            variant: "deep",
+            type: "default",
+            duration: 3000,
+          })
+        }
       }
     }
   }
@@ -114,6 +136,17 @@ export function CurriculumManagePage() {
     itemToRestore: CurriculumItem,
     index: number,
   ) => {
+    if (isGisuLoading || activeGisuId == null) {
+      addToast({
+        message: "기수 정보를 불러오는 중이거나 선택된 기수가 없습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return
+    }
+
     setCurriculumData((prev) => {
       const list = [...(prev[selectedPart] || [])]
       list.splice(index, 0, itemToRestore)
@@ -130,7 +163,7 @@ export function CurriculumManagePage() {
     try {
       const apiPart = mapPartToApiEnum(selectedPart)
       const newCurriculumId = await createCurriculum({
-        gisuId,
+        gisuId: activeGisuId,
         part: apiPart,
         title: itemToRestore.title || "복원된 커리큘럼",
       })
@@ -153,13 +186,26 @@ export function CurriculumManagePage() {
           for (const wb of itemToRestore.workbooks) {
             const now = new Date()
             const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
-            await createWeeklyCurriculum({
+            const createdWbId = await createWeeklyCurriculum({
               curriculumId: newCurriculumId,
               weekNo: wb.number,
               title: wb.title,
               startsAt: now.toISOString(),
               endsAt: nextWeek.toISOString(),
             })
+            if (createdWbId) {
+              setCurriculumData((prev) => {
+                const list = prev[selectedPart] || []
+                const updated = list.map((c) => {
+                  if (c.id !== String(newCurriculumId)) return c
+                  const updatedWbs = c.workbooks.map((w) =>
+                    w.id === wb.id ? { ...w, id: String(createdWbId) } : w,
+                  )
+                  return { ...c, workbooks: updatedWbs }
+                })
+                return { ...prev, [selectedPart]: updated }
+              })
+            }
           }
         }
       }

--- a/src/features/curriculum/ui/CurriculumManagePage.tsx
+++ b/src/features/curriculum/ui/CurriculumManagePage.tsx
@@ -40,12 +40,13 @@ export function CurriculumManagePage() {
   useEffect(() => {
     if (isGisuLoading || activeGisuId == null) return
 
+    const currentGisuId = activeGisuId
     let isSubscribed = true
     async function loadCurriculum() {
       try {
         const apiPart = mapPartToApiEnum(selectedPart)
         const overview = await getCurriculumOverview({
-          gisuId: activeGisuId,
+          gisuId: currentGisuId,
           part: apiPart,
         })
         if (isSubscribed && overview && overview.curriculumId) {

--- a/src/features/curriculum/ui/CurriculumManagePage.tsx
+++ b/src/features/curriculum/ui/CurriculumManagePage.tsx
@@ -76,7 +76,7 @@ export function CurriculumManagePage() {
     }))
   }
 
-  const handleDeleteItem = async (id: string) => {
+  const handleDeleteItem = async (id: string): Promise<boolean> => {
     const targetItem = (curriculumData[selectedPart] || []).find(
       (item) => item.id === id,
     )
@@ -122,8 +122,10 @@ export function CurriculumManagePage() {
             duration: 3000,
           })
         }
+        return false
       }
     }
+    return true
   }
 
   const handleReorderItems = (fromIndex: number, toIndex: number) => {

--- a/src/features/curriculum/ui/CurriculumSettingModal.tsx
+++ b/src/features/curriculum/ui/CurriculumSettingModal.tsx
@@ -106,7 +106,7 @@ interface CurriculumSettingModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   items: CurriculumItem[]
-  onDeleteItem: (id: string) => void
+  onDeleteItem: (id: string) => Promise<boolean> | boolean
   onReorderItems: (fromIndex: number, toIndex: number) => void
   onRestoreItem?: (item: CurriculumItem, index: number) => void
 }
@@ -139,30 +139,32 @@ export function CurriculumSettingModal({
     onReorderItems(fromIndex, toIndex)
   }
 
-  const handleConfirmDelete = () => {
+  const handleConfirmDelete = async () => {
     if (!itemToDelete) return
     const targetItem = itemToDelete
     const targetIndex = items.findIndex((i) => i.id === targetItem.id)
 
-    onDeleteItem(targetItem.id)
     setItemToDelete(null)
 
-    addToast({
-      message: "선택한 커리큘럼이 삭제되었습니다.",
-      color: "red",
-      variant: "deep",
-      type: "default",
-      duration: 5000,
-      action: {
-        label: "되돌리기",
-        onClick: () => {
-          onRestoreItem?.(
-            targetItem,
-            targetIndex >= 0 ? targetIndex : items.length,
-          )
+    const success = await onDeleteItem(targetItem.id)
+    if (success) {
+      addToast({
+        message: "선택한 커리큘럼이 삭제되었습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 5000,
+        action: {
+          label: "되돌리기",
+          onClick: () => {
+            onRestoreItem?.(
+              targetItem,
+              targetIndex >= 0 ? targetIndex : items.length,
+            )
+          },
         },
-      },
-    })
+      })
+    }
   }
 
   return (

--- a/src/features/curriculum/ui/CurriculumSettingModal.tsx
+++ b/src/features/curriculum/ui/CurriculumSettingModal.tsx
@@ -176,7 +176,12 @@ export function CurriculumSettingModal({
                 커리큘럼 설정
               </Modal.Title>
 
-              <Button size="s" color="primary" variant="fill">
+              <Button
+                size="s"
+                color="primary"
+                variant="fill"
+                onClick={() => onOpenChange(false)}
+              >
                 완료
               </Button>
             </div>

--- a/src/features/curriculum/ui/CurriculumSettingModal.tsx
+++ b/src/features/curriculum/ui/CurriculumSettingModal.tsx
@@ -16,6 +16,7 @@ import { CSS } from "@dnd-kit/utilities"
 import { useState } from "react"
 
 import HamburgerIcon from "@/shared/assets/icon/hamburger/HamburgerIcon"
+import { Button } from "@/shared/ui/Button"
 import { Modal } from "@/shared/ui/Modal"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
 import { useToastStore } from "@/shared/ui/toast/useToastStore"
@@ -170,9 +171,15 @@ export function CurriculumSettingModal({
         <Modal.Portal>
           <Modal.Overlay tone="deep" />
           <Modal.Content className="shadow-drop-neutral-2 border-teal-gray-100 flex h-180 w-227 flex-col gap-8 overflow-y-auto rounded-[16px] border bg-white px-8 py-7.5 focus:outline-none">
-            <Modal.Title className="text-heading-4-semibold text-teal-gray-900">
-              커리큘럼 설정
-            </Modal.Title>
+            <div className="flex w-full items-center justify-between">
+              <Modal.Title className="text-heading-4-semibold text-teal-gray-900">
+                커리큘럼 설정
+              </Modal.Title>
+
+              <Button size="s" color="primary" variant="fill">
+                완료
+              </Button>
+            </div>
 
             {items.length > 0 ? (
               <DndContext

--- a/src/features/recruiting/ui/ChapterTabs.tsx
+++ b/src/features/recruiting/ui/ChapterTabs.tsx
@@ -31,10 +31,12 @@ export function ChapterTabs({
       )
     }
     if (serverChapters && serverChapters.length > 0) {
-      return serverChapters.map((ch) => ({
-        value: ch.chapterName,
-        label: ch.chapterName,
-      }))
+      return serverChapters.map(
+        (ch: { chapterId: string | number; chapterName: string }) => ({
+          value: ch.chapterName,
+          label: ch.chapterName,
+        }),
+      )
     }
     return CHAPTERS.map((chapter) => ({ value: chapter, label: chapter }))
   }, [customChapters, serverChapters])

--- a/src/features/recruiting/ui/ChapterTabs.tsx
+++ b/src/features/recruiting/ui/ChapterTabs.tsx
@@ -1,10 +1,14 @@
-import { CHAPTERS, isChapter } from "@/entities/organization/model/chapters"
+import { useMemo } from "react"
+
+import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
+import { CHAPTERS } from "@/entities/organization/model/chapters"
 import { cn } from "@/shared/lib/utils"
 import { SegmentButton } from "@/shared/ui/segment-button/SegmentButton"
 
 interface ChapterTabsProps {
   value: string
   onValueChange: (value: string) => void
+  chapters?: Array<{ chapterId: string | number; chapterName: string } | string>
   allLabel?: string
   className?: string
 }
@@ -12,19 +16,46 @@ interface ChapterTabsProps {
 export function ChapterTabs({
   value,
   onValueChange,
+  chapters: customChapters,
   allLabel = "전체",
   className,
 }: ChapterTabsProps) {
-  const items = [
-    { value: "all", label: allLabel },
-    ...CHAPTERS.map((chapter) => ({ value: chapter, label: chapter })),
-  ]
+  const { chapters: serverChapters } = useSchoolChapterMap()
+
+  const chapterOptions = useMemo(() => {
+    if (customChapters && customChapters.length > 0) {
+      return customChapters.map((ch) =>
+        typeof ch === "string"
+          ? { value: ch, label: ch }
+          : { value: ch.chapterName, label: ch.chapterName },
+      )
+    }
+    if (serverChapters && serverChapters.length > 0) {
+      return serverChapters.map((ch) => ({
+        value: ch.chapterName,
+        label: ch.chapterName,
+      }))
+    }
+    return CHAPTERS.map((chapter) => ({ value: chapter, label: chapter }))
+  }, [customChapters, serverChapters])
+
+  const items = useMemo(
+    () => [{ value: "all", label: allLabel }, ...chapterOptions],
+    [allLabel, chapterOptions],
+  )
+
+  const validValues = useMemo(
+    () => new Set(items.map((item) => item.value)),
+    [items],
+  )
 
   return (
     <SegmentButton
       items={items}
       value={value}
-      onValueChange={(next) => onValueChange(isChapter(next) ? next : "all")}
+      onValueChange={(next) =>
+        onValueChange(validValues.has(next) ? next : "all")
+      }
       className={cn("flex w-full", className)}
       itemClassName="flex-1"
     />

--- a/src/features/settings/model/schoolToasts.ts
+++ b/src/features/settings/model/schoolToasts.ts
@@ -48,7 +48,7 @@ export function showSchoolDeletedToast(
 ) {
   addToast({
     message: "학교 정보가 삭제됐습니다.",
-    color: "primary",
+    color: "red",
     variant: "deep",
     type: "default",
     duration: 6000,

--- a/src/features/settings/model/schoolToasts.ts
+++ b/src/features/settings/model/schoolToasts.ts
@@ -60,3 +60,13 @@ export function showSchoolDeletedToast(
     },
   })
 }
+
+export function showSchoolDeleteFailedToast(addToast: AddToastFn) {
+  addToast({
+    message: "학교 정보 삭제에 실패했습니다.",
+    color: "red",
+    variant: "deep",
+    type: "default",
+    duration: 3000,
+  })
+}

--- a/src/features/settings/ui/SchoolCard.tsx
+++ b/src/features/settings/ui/SchoolCard.tsx
@@ -1,9 +1,9 @@
 import { cn } from "@/shared/lib/utils"
 
 export interface SchoolCardProps {
-  branch: string
+  branch?: string
   name: string
-  count: number
+  count?: number
   logoUrl?: string
   className?: string
 }
@@ -36,11 +36,17 @@ export function SchoolCard({
       </div>
 
       <div className="flex flex-col gap-1">
-        <span className="text-subtitle-4-semibold text-teal-600">{branch}</span>
+        {branch && (
+          <span className="text-subtitle-4-semibold text-teal-600">
+            {branch}
+          </span>
+        )}
         <span className="text-heading-7-semibold text-teal-900">{name}</span>
-        <span className="text-body-2-regular text-teal-gray-500">
-          총 {count}명
-        </span>
+        {count !== undefined && (
+          <span className="text-body-2-regular text-teal-gray-500">
+            총 {count}명
+          </span>
+        )}
       </div>
     </div>
   )

--- a/src/features/settings/ui/SchoolRegistrationPage.tsx
+++ b/src/features/settings/ui/SchoolRegistrationPage.tsx
@@ -11,6 +11,7 @@ import {
   showRequiredFieldsMissingToast,
   showSchoolAlreadyExistsToast,
   showSchoolDeletedToast,
+  showSchoolDeleteFailedToast,
   showSchoolEditCompletedToast,
   showSchoolRegisterCompletedToast,
 } from "@/features/settings/model/schoolToasts"
@@ -202,7 +203,6 @@ export function SchoolRegistrationPage({
 
     const backupSchoolData: CreateSchoolRequest = {
       schoolName: officialName.trim(),
-      shortName: shortName.trim(),
       remark: memo.trim() || undefined,
       links,
     }
@@ -220,6 +220,7 @@ export function SchoolRegistrationPage({
       })
       navigate({ to: "/manage/school" })
     } catch (error) {
+      showSchoolDeleteFailedToast(addToast)
       if (process.env.NODE_ENV === "development") {
         console.error("Failed to delete school:", error)
       }

--- a/src/features/settings/ui/SchoolRegistrationPage.tsx
+++ b/src/features/settings/ui/SchoolRegistrationPage.tsx
@@ -1,18 +1,30 @@
+import { useNavigate } from "@tanstack/react-router"
 import { type ChangeEvent, useEffect, useRef, useState } from "react"
 
 import {
+  useCreateSchool,
+  useDeleteSchool,
+  useSchoolDetail,
+  useUpdateSchool,
+} from "@/entities/organization/hooks/useSchool"
+import {
   showRequiredFieldsMissingToast,
-  showSchoolAlreadyExistsToast,
   showSchoolDeletedToast,
   showSchoolEditCompletedToast,
   showSchoolRegisterCompletedToast,
 } from "@/features/settings/model/schoolToasts"
+import { uploadFileFlow } from "@/shared/api/storage"
 import CloudUploadIcon from "@/shared/assets/icon/upload/CloudUploadIcon"
 import { Button } from "@/shared/ui/Button"
 import { InputBox } from "@/shared/ui/input/InputBox"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
 import { PageLabel } from "@/shared/ui/page-label/PageLabel"
 import { useToastStore } from "@/shared/ui/toast/useToastStore"
+
+import type {
+  CreateSchoolRequest,
+  SchoolLinkRequest,
+} from "@/entities/organization/model/schoolTypes"
 
 interface SchoolRegistrationPageProps {
   mode?: "register" | "edit"
@@ -25,6 +37,14 @@ export function SchoolRegistrationPage({
 }: SchoolRegistrationPageProps) {
   const isEditMode = mode === "edit"
   const addToast = useToastStore((s) => s.addToast)
+  const navigate = useNavigate()
+
+  const { data: schoolDetail } = useSchoolDetail(
+    isEditMode ? schoolId : undefined,
+  )
+  const createSchoolMutation = useCreateSchool()
+  const updateSchoolMutation = useUpdateSchool()
+  const deleteSchoolMutation = useDeleteSchool()
 
   const [openDeleteModal, setOpenDeleteModal] = useState(false)
   const [openResetModal, setOpenResetModal] = useState(false)
@@ -41,6 +61,31 @@ export function SchoolRegistrationPage({
   const fileInputRef = useRef<HTMLInputElement>(null)
   const logoPreviewRef = useRef<string | null>(null)
   logoPreviewRef.current = logoPreview
+
+  useEffect(() => {
+    if (schoolDetail) {
+      if (schoolDetail.schoolName) {
+        setOfficialName(schoolDetail.schoolName)
+      }
+      if (schoolDetail.remark) {
+        setMemo(schoolDetail.remark)
+      }
+      if (schoolDetail.logoImageUrl) {
+        setLogoPreview(schoolDetail.logoImageUrl)
+      }
+      if (schoolDetail.links) {
+        const instaLink =
+          schoolDetail.links.find((l) => l.type === "INSTAGRAM")?.url ?? ""
+        const youtubeLink =
+          schoolDetail.links.find((l) => l.type === "YOUTUBE")?.url ?? ""
+        const kakaoLink =
+          schoolDetail.links.find((l) => l.type === "KAKAO")?.url ?? ""
+        setInstagram(instaLink)
+        setYoutube(youtubeLink)
+        setKakao(kakaoLink)
+      }
+    }
+  }, [schoolDetail])
 
   useEffect(() => {
     return () => {
@@ -81,46 +126,103 @@ export function SchoolRegistrationPage({
     handleRemoveLogo()
   }
 
-  const handleSave = () => {
+  const handleSave = async () => {
     if (!officialName.trim() || !shortName.trim()) {
       showRequiredFieldsMissingToast(addToast)
       return
     }
 
-    if (officialName.trim() === "가가대학교") {
-      showSchoolAlreadyExistsToast(addToast)
-      return
-    }
-
-    if (isEditMode) {
-      showSchoolEditCompletedToast(addToast)
-    } else {
-      showSchoolRegisterCompletedToast(addToast)
-    }
-
-    if (process.env.NODE_ENV === "development") {
-      console.log({
-        schoolId,
-        officialName,
-        shortName,
-        logoFile,
-        instagram,
-        youtube,
-        kakao,
-        memo,
+    const links: SchoolLinkRequest[] = []
+    if (instagram.trim())
+      links.push({
+        title: "Instagram",
+        type: "INSTAGRAM",
+        url: instagram.trim(),
       })
+    if (youtube.trim())
+      links.push({ title: "Youtube", type: "YOUTUBE", url: youtube.trim() })
+    if (kakao.trim())
+      links.push({ title: "Kakao", type: "KAKAO", url: kakao.trim() })
+
+    try {
+      let logoImageId: string | undefined
+      if (logoFile) {
+        const uploadResult = await uploadFileFlow(logoFile, "SCHOOL_LOGO")
+        logoImageId = uploadResult.fileId
+      }
+
+      if (isEditMode && schoolId) {
+        await updateSchoolMutation.mutateAsync({
+          schoolId,
+          body: {
+            schoolName: officialName.trim(),
+            remark: memo.trim() || undefined,
+            logoImageId,
+            links,
+          },
+        })
+        showSchoolEditCompletedToast(addToast)
+      } else {
+        await createSchoolMutation.mutateAsync({
+          schoolName: officialName.trim(),
+          remark: memo.trim() || undefined,
+          logoImageId,
+          links,
+        })
+        showSchoolRegisterCompletedToast(addToast)
+      }
+      navigate({ to: "/manage/school" })
+    } catch (error) {
+      if (process.env.NODE_ENV === "development") {
+        console.error("Failed to save school:", error)
+      }
     }
   }
 
-  const handleDeleteConfirm = () => {
-    showSchoolDeletedToast(addToast, () => {
-      if (process.env.NODE_ENV === "development") {
-        console.log("School deletion undone", schoolId)
-      }
-    })
+  const handleDeleteConfirm = async () => {
+    if (!schoolId) return
 
-    if (process.env.NODE_ENV === "development") {
-      console.log("Deleting school", schoolId)
+    const links: SchoolLinkRequest[] = []
+    if (instagram.trim())
+      links.push({
+        title: "Instagram",
+        type: "INSTAGRAM",
+        url: instagram.trim(),
+      })
+    if (youtube.trim())
+      links.push({ title: "Youtube", type: "YOUTUBE", url: youtube.trim() })
+    if (kakao.trim())
+      links.push({ title: "Kakao", type: "KAKAO", url: kakao.trim() })
+
+    const backupSchoolData: CreateSchoolRequest = {
+      schoolName: officialName.trim(),
+      remark: memo.trim() || undefined,
+      links,
+    }
+
+    try {
+      await deleteSchoolMutation.mutateAsync(schoolId)
+      showSchoolDeletedToast(addToast, async () => {
+        try {
+          await createSchoolMutation.mutateAsync(backupSchoolData)
+          addToast({
+            message: "삭제된 학교 정보가 복구되었습니다.",
+            color: "primary",
+            variant: "deep",
+            type: "default",
+            duration: 3000,
+          })
+        } catch (undoError) {
+          if (process.env.NODE_ENV === "development") {
+            console.error("Failed to restore school:", undoError)
+          }
+        }
+      })
+      navigate({ to: "/manage/school" })
+    } catch (error) {
+      if (process.env.NODE_ENV === "development") {
+        console.error("Failed to delete school:", error)
+      }
     }
   }
 

--- a/src/features/settings/ui/SchoolRegistrationPage.tsx
+++ b/src/features/settings/ui/SchoolRegistrationPage.tsx
@@ -202,6 +202,7 @@ export function SchoolRegistrationPage({
 
     const backupSchoolData: CreateSchoolRequest = {
       schoolName: officialName.trim(),
+      shortName: shortName.trim(),
       remark: memo.trim() || undefined,
       links,
     }

--- a/src/features/settings/ui/SchoolRegistrationPage.tsx
+++ b/src/features/settings/ui/SchoolRegistrationPage.tsx
@@ -69,6 +69,9 @@ export function SchoolRegistrationPage({
       if (schoolDetail.schoolName) {
         setOfficialName(schoolDetail.schoolName)
       }
+      if (schoolDetail.shortName) {
+        setShortName(schoolDetail.shortName)
+      }
       if (schoolDetail.remark) {
         setMemo(schoolDetail.remark)
       }
@@ -162,6 +165,7 @@ export function SchoolRegistrationPage({
           schoolId,
           body: {
             schoolName: officialName.trim(),
+            shortName: shortName.trim(),
             remark: memo.trim() || undefined,
             logoImageId,
             links,
@@ -171,6 +175,7 @@ export function SchoolRegistrationPage({
       } else {
         await createSchoolMutation.mutateAsync({
           schoolName: officialName.trim(),
+          shortName: shortName.trim(),
           remark: memo.trim() || undefined,
           logoImageId,
           links,
@@ -203,6 +208,7 @@ export function SchoolRegistrationPage({
 
     const backupSchoolData: CreateSchoolRequest = {
       schoolName: officialName.trim(),
+      shortName: shortName.trim(),
       remark: memo.trim() || undefined,
       links,
     }

--- a/src/features/settings/ui/SchoolRegistrationPage.tsx
+++ b/src/features/settings/ui/SchoolRegistrationPage.tsx
@@ -128,7 +128,11 @@ export function SchoolRegistrationPage({
   }
 
   const handleSave = async () => {
-    if (!officialName.trim() || !shortName.trim()) {
+    if (
+      !officialName.trim() ||
+      !shortName.trim() ||
+      (!logoFile && !logoPreview)
+    ) {
       showRequiredFieldsMissingToast(addToast)
       return
     }

--- a/src/features/settings/ui/SchoolRegistrationPage.tsx
+++ b/src/features/settings/ui/SchoolRegistrationPage.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/entities/organization/hooks/useSchool"
 import {
   showRequiredFieldsMissingToast,
+  showSchoolAlreadyExistsToast,
   showSchoolDeletedToast,
   showSchoolEditCompletedToast,
   showSchoolRegisterCompletedToast,
@@ -173,6 +174,7 @@ export function SchoolRegistrationPage({
       }
       navigate({ to: "/manage/school" })
     } catch (error) {
+      showSchoolAlreadyExistsToast(addToast)
       if (process.env.NODE_ENV === "development") {
         console.error("Failed to save school:", error)
       }
@@ -205,13 +207,6 @@ export function SchoolRegistrationPage({
       showSchoolDeletedToast(addToast, async () => {
         try {
           await createSchoolMutation.mutateAsync(backupSchoolData)
-          addToast({
-            message: "삭제된 학교 정보가 복구되었습니다.",
-            color: "primary",
-            variant: "deep",
-            type: "default",
-            duration: 3000,
-          })
         } catch (undoError) {
           if (process.env.NODE_ENV === "development") {
             console.error("Failed to restore school:", undoError)

--- a/src/routes/manage/school/index.tsx
+++ b/src/routes/manage/school/index.tsx
@@ -52,35 +52,28 @@ function SchoolManagePage() {
       search: searchQuery.trim() || undefined,
       page: currentPage - 1,
       size: PAGE_SIZE,
+      sort: sortOption,
     })
 
   const isLoading = isSummaryLoading
 
   const paginatedSchools = useMemo(() => {
     if (!summaryData?.content) return []
-    return summaryData.content
-      .map((item) => {
-        const fallbackChapterId = item.schoolName
-          ? getChapterIdBySchool(item.schoolName)
-          : undefined
-        const chapterId = item.chapterId ?? fallbackChapterId
-        return {
-          id: item.schoolId != null ? String(item.schoolId) : "",
-          name: item.schoolName ?? "",
-          chapterId,
-          branch:
-            item.chapterName ??
-            (chapterId ? `지부 ${chapterId}` : "지부 미지정"),
-          count: item.activeChallengerCount ?? 0,
-        }
-      })
-      .sort((a, b) => {
-        if (sortOption === "name") {
-          return a.name.localeCompare(b.name, "ko")
-        }
-        return 0
-      })
-  }, [summaryData, getChapterIdBySchool, sortOption])
+    return summaryData.content.map((item) => {
+      const fallbackChapterId = item.schoolName
+        ? getChapterIdBySchool(item.schoolName)
+        : undefined
+      const chapterId = item.chapterId ?? fallbackChapterId
+      return {
+        id: item.schoolId != null ? String(item.schoolId) : "",
+        name: item.schoolName ?? "",
+        chapterId,
+        branch:
+          item.chapterName ?? (chapterId ? `지부 ${chapterId}` : "지부 미지정"),
+        count: item.activeChallengerCount ?? 0,
+      }
+    })
+  }, [summaryData, getChapterIdBySchool])
 
   const totalPages = Math.max(1, summaryData?.totalPages ?? 1)
 

--- a/src/routes/manage/school/index.tsx
+++ b/src/routes/manage/school/index.tsx
@@ -53,6 +53,7 @@ function SchoolManagePage() {
       page: currentPage - 1,
       size: PAGE_SIZE,
       sort: sortOption,
+      enabled: activeGisuId != null,
     })
 
   const isLoading = isSummaryLoading

--- a/src/routes/manage/school/index.tsx
+++ b/src/routes/manage/school/index.tsx
@@ -25,8 +25,14 @@ const PAGE_SIZE = 20
 function SchoolManagePage() {
   const [selectedChapter, setSelectedChapter] = useState<string>("all")
   const [sortOption, setSortOption] = useState<SchoolSortOption>("name")
-  const [searchQuery, setSearchQuery] = useState("")
+  const [searchInputText, setSearchInputText] = useState("")
+  const [submittedSearchQuery, setSubmittedSearchQuery] = useState("")
   const [currentPage, setCurrentPage] = useState(1)
+
+  const handleSearchSubmit = () => {
+    setSubmittedSearchQuery(searchInputText)
+    setCurrentPage(1)
+  }
 
   const { data: activeGisuData } = useActiveGisu()
   const activeGisuId = activeGisuData?.gisuId
@@ -52,7 +58,7 @@ function SchoolManagePage() {
     useAdminSchoolsSummary({
       gisuId: activeGisuId,
       chapterId: chapterIdParam,
-      search: searchQuery.trim() || undefined,
+      search: submittedSearchQuery.trim() || undefined,
       page: currentPage - 1,
       size: PAGE_SIZE,
       sort: sortOption,
@@ -107,11 +113,12 @@ function SchoolManagePage() {
 
         <div className="flex w-full items-center justify-between">
           <SchoolSearchInput
-            value={searchQuery}
-            onChange={(e) => {
-              setSearchQuery(e.target.value)
-              setCurrentPage(1)
+            value={searchInputText}
+            onChange={(e) => setSearchInputText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleSearchSubmit()
             }}
+            onSearch={handleSearchSubmit}
           />
 
           <div className="flex items-center gap-4">

--- a/src/routes/manage/school/index.tsx
+++ b/src/routes/manage/school/index.tsx
@@ -6,6 +6,7 @@ import {
   useSchoolList,
 } from "@/entities/organization/hooks/useSchool"
 import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
+import { CHAPTERS } from "@/entities/organization/model/chapters"
 import { ChapterTabs } from "@/features/recruiting/ui/ChapterTabs"
 import { SchoolCard } from "@/features/settings/ui/SchoolCard"
 import { SchoolPagination } from "@/features/settings/ui/SchoolPagination"
@@ -39,67 +40,45 @@ function SchoolManagePage() {
     ? `${activeGisuData.gisu}기`
     : "11기"
 
+  const chapterIdParam = useMemo(() => {
+    if (selectedChapter === "all") return undefined
+    const num = Number(selectedChapter)
+    if (!Number.isNaN(num)) return num
+    const index = (CHAPTERS as readonly string[]).indexOf(selectedChapter)
+    if (index !== -1) return index + 1
+    return undefined
+  }, [selectedChapter])
+
   const { data: summaryData, isLoading: isSummaryLoading } =
-    useAdminSchoolsSummary({ gisuId: activeGisuId, size: 1000 })
-  const { data: schoolListData, isLoading: isListLoading } = useSchoolList()
+    useAdminSchoolsSummary({
+      gisuId: activeGisuId,
+      chapterId: chapterIdParam,
+      search: searchQuery.trim() || undefined,
+      page: currentPage - 1,
+      size: PAGE_SIZE,
+    })
+  const { isLoading: isListLoading } = useSchoolList()
   const { getChapterIdBySchool } = useSchoolChapterMap()
 
   const isLoading = isSummaryLoading || isListLoading
 
-  const processedSchools = useMemo(() => {
-    const rawList = schoolListData?.schools ?? []
-
-    const summaryMap = new Map<
-      string,
-      { branch?: string; count?: number; chapterId?: number }
-    >()
-    if (summaryData?.content) {
-      for (const item of summaryData.content) {
-        const info = {
-          branch: item.chapterName ?? undefined,
+  const paginatedSchools = useMemo(() => {
+    if (!summaryData?.content) return []
+    return summaryData.content
+      .map((item) => {
+        const fallbackChapterId = item.schoolName
+          ? getChapterIdBySchool(item.schoolName)
+          : undefined
+        const chapterId = item.chapterId ?? fallbackChapterId
+        return {
+          id: item.schoolId != null ? String(item.schoolId) : "",
+          name: item.schoolName ?? "",
+          chapterId,
+          branch:
+            item.chapterName ??
+            (chapterId ? `지부 ${chapterId}` : "지부 미지정"),
           count: item.activeChallengerCount ?? 0,
-          chapterId: item.chapterId ?? undefined,
         }
-        if (item.schoolId != null) {
-          summaryMap.set(String(item.schoolId), info)
-        }
-        if (item.schoolName) {
-          summaryMap.set(item.schoolName, info)
-        }
-      }
-    }
-
-    return rawList.map((school) => {
-      const summaryInfo =
-        summaryMap.get(school.schoolId) ?? summaryMap.get(school.schoolName)
-      const chapterId = getChapterIdBySchool(school.schoolName)
-
-      return {
-        id: school.schoolId,
-        name: school.schoolName,
-        chapterId: summaryInfo?.chapterId ?? chapterId,
-        branch:
-          summaryInfo?.branch ??
-          (chapterId ? `지부 ${chapterId}` : "지부 미지정"),
-        count: summaryInfo?.count ?? 0,
-      }
-    })
-  }, [summaryData, schoolListData, getChapterIdBySchool])
-
-  const filteredSchools = useMemo(() => {
-    return processedSchools
-      .filter((school) => {
-        if (selectedChapter !== "all") {
-          const target = selectedChapter.toLowerCase()
-          const branch = school.branch.toLowerCase()
-          if (branch !== target && !branch.includes(target)) {
-            return false
-          }
-        }
-        if (!searchQuery.trim()) return true
-        return school.name
-          .toLowerCase()
-          .includes(searchQuery.trim().toLowerCase())
       })
       .sort((a, b) => {
         if (sortOption === "name") {
@@ -107,13 +86,9 @@ function SchoolManagePage() {
         }
         return 0
       })
-  }, [processedSchools, selectedChapter, searchQuery, sortOption])
+  }, [summaryData, getChapterIdBySchool, sortOption])
 
-  const totalPages = Math.max(1, Math.ceil(filteredSchools.length / PAGE_SIZE))
-  const paginatedSchools = useMemo(() => {
-    const start = (currentPage - 1) * PAGE_SIZE
-    return filteredSchools.slice(start, start + PAGE_SIZE)
-  }, [filteredSchools, currentPage])
+  const totalPages = Math.max(1, summaryData?.totalPages ?? 1)
 
   return (
     <div className="flex w-full max-w-244 flex-col gap-8">

--- a/src/routes/manage/school/index.tsx
+++ b/src/routes/manage/school/index.tsx
@@ -1,6 +1,11 @@
 import { createFileRoute, Link } from "@tanstack/react-router"
-import { useState } from "react"
+import { useMemo, useState } from "react"
 
+import {
+  useAdminSchoolsSummary,
+  useSchoolList,
+} from "@/entities/organization/hooks/useSchool"
+import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import { ChapterTabs } from "@/features/recruiting/ui/ChapterTabs"
 import { SchoolCard } from "@/features/settings/ui/SchoolCard"
 import { SchoolPagination } from "@/features/settings/ui/SchoolPagination"
@@ -10,6 +15,7 @@ import {
   type SchoolSortOption,
 } from "@/features/settings/ui/SchoolSortDropdown"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
+import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
 import { Button } from "@/shared/ui/Button"
 import { PageLabel } from "@/shared/ui/page-label/PageLabel"
 
@@ -17,16 +23,97 @@ export const Route = createFileRoute("/manage/school/")({
   component: SchoolManagePage,
 })
 
-const MOCK_SCHOOLS = [
-  { id: "1", branch: "Chromium", name: "가가대학교", count: 127 },
-  { id: "2", branch: "Chromium", name: "가가대학교", count: 127 },
-  { id: "3", branch: "Chromium", name: "가가대학교", count: 127 },
-]
+const PAGE_SIZE = 20
 
 function SchoolManagePage() {
   const [selectedChapter, setSelectedChapter] = useState<string>("all")
   const [sortOption, setSortOption] = useState<SchoolSortOption>("name")
+  const [searchQuery, setSearchQuery] = useState("")
   const [currentPage, setCurrentPage] = useState(1)
+
+  const { data: activeGisuData } = useActiveGisu()
+  const activeGisuId = activeGisuData?.gisuId
+    ? Number(activeGisuData.gisuId)
+    : undefined
+  const activeGisuText = activeGisuData?.gisu
+    ? `${activeGisuData.gisu}기`
+    : "11기"
+
+  const { data: summaryData, isLoading: isSummaryLoading } =
+    useAdminSchoolsSummary({ gisuId: activeGisuId, size: 1000 })
+  const { data: schoolListData, isLoading: isListLoading } = useSchoolList()
+  const { getChapterIdBySchool } = useSchoolChapterMap()
+
+  const isLoading = isSummaryLoading && isListLoading
+
+  const processedSchools = useMemo(() => {
+    const rawList = schoolListData?.schools ?? []
+
+    const summaryMap = new Map<
+      string,
+      { branch?: string; count?: number; chapterId?: number }
+    >()
+    if (summaryData?.content) {
+      for (const item of summaryData.content) {
+        const info = {
+          branch: item.chapterName ?? undefined,
+          count: item.activeChallengerCount ?? 0,
+          chapterId: item.chapterId ?? undefined,
+        }
+        if (item.schoolId != null) {
+          summaryMap.set(String(item.schoolId), info)
+        }
+        if (item.schoolName) {
+          summaryMap.set(item.schoolName, info)
+        }
+      }
+    }
+
+    return rawList.map((school) => {
+      const summaryInfo =
+        summaryMap.get(school.schoolId) ?? summaryMap.get(school.schoolName)
+      const chapterId = getChapterIdBySchool(school.schoolName)
+
+      return {
+        id: school.schoolId,
+        name: school.schoolName,
+        chapterId: summaryInfo?.chapterId ?? chapterId,
+        branch:
+          summaryInfo?.branch ??
+          (chapterId ? `지부 ${chapterId}` : "지부 미지정"),
+        count: summaryInfo?.count ?? 0,
+      }
+    })
+  }, [summaryData, schoolListData, getChapterIdBySchool])
+
+  const filteredSchools = useMemo(() => {
+    return processedSchools
+      .filter((school) => {
+        if (selectedChapter !== "all") {
+          const target = selectedChapter.toLowerCase()
+          const branch = school.branch.toLowerCase()
+          if (branch !== target && !branch.includes(target)) {
+            return false
+          }
+        }
+        if (!searchQuery.trim()) return true
+        return school.name
+          .toLowerCase()
+          .includes(searchQuery.trim().toLowerCase())
+      })
+      .sort((a, b) => {
+        if (sortOption === "name") {
+          return a.name.localeCompare(b.name, "ko")
+        }
+        return 0
+      })
+  }, [processedSchools, selectedChapter, searchQuery, sortOption])
+
+  const totalPages = Math.max(1, Math.ceil(filteredSchools.length / PAGE_SIZE))
+  const paginatedSchools = useMemo(() => {
+    const start = (currentPage - 1) * PAGE_SIZE
+    return filteredSchools.slice(start, start + PAGE_SIZE)
+  }, [filteredSchools, currentPage])
 
   return (
     <div className="flex w-full max-w-244 flex-col gap-8">
@@ -36,18 +123,27 @@ function SchoolManagePage() {
           { id: "school", label: "학교 관리" },
         ]}
         title="학교 관리"
-        description="UMC 11기 소속의 학교 정보를 관리합니다."
+        description={`UMC ${activeGisuText} 소속의 학교 정보를 관리합니다.`}
         className="pl-3"
       />
 
       <div className="flex w-full flex-col gap-6">
         <ChapterTabs
           value={selectedChapter}
-          onValueChange={setSelectedChapter}
+          onValueChange={(val) => {
+            setSelectedChapter(val)
+            setCurrentPage(1)
+          }}
         />
 
         <div className="flex w-full items-center justify-between">
-          <SchoolSearchInput />
+          <SchoolSearchInput
+            value={searchQuery}
+            onChange={(e) => {
+              setSearchQuery(e.target.value)
+              setCurrentPage(1)
+            }}
+          />
 
           <div className="flex items-center gap-4">
             <Button
@@ -69,28 +165,38 @@ function SchoolManagePage() {
           </div>
         </div>
 
-        <div className="grid w-full grid-cols-2 gap-2">
-          {MOCK_SCHOOLS.map((school) => (
-            <Link
-              key={school.id}
-              to="/manage/school/$schoolId"
-              params={{ schoolId: school.id }}
-              className="block w-full text-left"
-            >
-              <SchoolCard
-                branch={school.branch}
-                name={school.name}
-                count={school.count}
-                className="cursor-pointer"
-              />
-            </Link>
-          ))}
-        </div>
+        {isLoading ? (
+          <div className="text-body-1-medium text-teal-gray-400 py-12 text-center">
+            학교 정보를 불러오는 중입니다...
+          </div>
+        ) : paginatedSchools.length === 0 ? (
+          <div className="text-body-1-medium text-teal-gray-400 py-12 text-center">
+            등록된 학교가 없거나 검색 결과가 없습니다.
+          </div>
+        ) : (
+          <div className="grid w-full grid-cols-2 gap-2">
+            {paginatedSchools.map((school) => (
+              <Link
+                key={school.id}
+                to="/manage/school/$schoolId"
+                params={{ schoolId: school.id }}
+                className="block w-full text-left"
+              >
+                <SchoolCard
+                  branch={school.branch}
+                  name={school.name}
+                  count={school.count}
+                  className="cursor-pointer"
+                />
+              </Link>
+            ))}
+          </div>
+        )}
       </div>
 
       <SchoolPagination
         currentPage={currentPage}
-        totalPages={3}
+        totalPages={totalPages}
         onPageChange={setCurrentPage}
       />
     </div>

--- a/src/routes/manage/school/index.tsx
+++ b/src/routes/manage/school/index.tsx
@@ -1,10 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { useMemo, useState } from "react"
 
-import {
-  useAdminSchoolsSummary,
-  useSchoolList,
-} from "@/entities/organization/hooks/useSchool"
+import { useAdminSchoolsSummary } from "@/entities/organization/hooks/useSchool"
 import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import { ChapterTabs } from "@/features/recruiting/ui/ChapterTabs"
 import { SchoolCard } from "@/features/settings/ui/SchoolCard"
@@ -56,9 +53,8 @@ function SchoolManagePage() {
       page: currentPage - 1,
       size: PAGE_SIZE,
     })
-  const { isLoading: isListLoading } = useSchoolList()
 
-  const isLoading = isSummaryLoading || isListLoading
+  const isLoading = isSummaryLoading
 
   const paginatedSchools = useMemo(() => {
     if (!summaryData?.content) return []

--- a/src/routes/manage/school/index.tsx
+++ b/src/routes/manage/school/index.tsx
@@ -63,20 +63,23 @@ function SchoolManagePage() {
 
   const paginatedSchools = useMemo(() => {
     if (!summaryData?.content) return []
-    return summaryData.content.map((item) => {
-      const fallbackChapterId = item.schoolName
-        ? getChapterIdBySchool(item.schoolName)
-        : undefined
-      const chapterId = item.chapterId ?? fallbackChapterId
-      return {
-        id: item.schoolId != null ? String(item.schoolId) : "",
-        name: item.schoolName ?? "",
-        chapterId,
-        branch:
-          item.chapterName ?? (chapterId ? `지부 ${chapterId}` : "지부 미지정"),
-        count: item.activeChallengerCount ?? 0,
-      }
-    })
+    return summaryData.content
+      .filter((item) => item.schoolId != null)
+      .map((item) => {
+        const fallbackChapterId = item.schoolName
+          ? getChapterIdBySchool(item.schoolName)
+          : undefined
+        const chapterId = item.chapterId ?? fallbackChapterId
+        return {
+          id: String(item.schoolId),
+          name: item.schoolName ?? "",
+          chapterId,
+          branch:
+            item.chapterName ??
+            (chapterId ? `지부 ${chapterId}` : "지부 미지정"),
+          count: item.activeChallengerCount ?? 0,
+        }
+      })
   }, [summaryData, getChapterIdBySchool])
 
   const totalPages = Math.max(1, summaryData?.totalPages ?? 1)

--- a/src/routes/manage/school/index.tsx
+++ b/src/routes/manage/school/index.tsx
@@ -6,7 +6,6 @@ import {
   useSchoolList,
 } from "@/entities/organization/hooks/useSchool"
 import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
-import { CHAPTERS } from "@/entities/organization/model/chapters"
 import { ChapterTabs } from "@/features/recruiting/ui/ChapterTabs"
 import { SchoolCard } from "@/features/settings/ui/SchoolCard"
 import { SchoolPagination } from "@/features/settings/ui/SchoolPagination"
@@ -40,14 +39,14 @@ function SchoolManagePage() {
     ? `${activeGisuData.gisu}기`
     : "11기"
 
+  const { getChapterIdBySchool, getChapterIdByName } = useSchoolChapterMap()
+
   const chapterIdParam = useMemo(() => {
     if (selectedChapter === "all") return undefined
     const num = Number(selectedChapter)
     if (!Number.isNaN(num)) return num
-    const index = (CHAPTERS as readonly string[]).indexOf(selectedChapter)
-    if (index !== -1) return index + 1
-    return undefined
-  }, [selectedChapter])
+    return getChapterIdByName(selectedChapter)
+  }, [selectedChapter, getChapterIdByName])
 
   const { data: summaryData, isLoading: isSummaryLoading } =
     useAdminSchoolsSummary({
@@ -58,7 +57,6 @@ function SchoolManagePage() {
       size: PAGE_SIZE,
     })
   const { isLoading: isListLoading } = useSchoolList()
-  const { getChapterIdBySchool } = useSchoolChapterMap()
 
   const isLoading = isSummaryLoading || isListLoading
 

--- a/src/routes/manage/school/index.tsx
+++ b/src/routes/manage/school/index.tsx
@@ -44,7 +44,7 @@ function SchoolManagePage() {
   const { data: schoolListData, isLoading: isListLoading } = useSchoolList()
   const { getChapterIdBySchool } = useSchoolChapterMap()
 
-  const isLoading = isSummaryLoading && isListLoading
+  const isLoading = isSummaryLoading || isListLoading
 
   const processedSchools = useMemo(() => {
     const rawList = schoolListData?.schools ?? []

--- a/src/routes/manage/school/index.tsx
+++ b/src/routes/manage/school/index.tsx
@@ -45,6 +45,9 @@ function SchoolManagePage() {
     return getChapterIdByName(selectedChapter)
   }, [selectedChapter, getChapterIdByName])
 
+  const isChapterUnresolved =
+    selectedChapter !== "all" && chapterIdParam === undefined
+
   const { data: summaryData, isLoading: isSummaryLoading } =
     useAdminSchoolsSummary({
       gisuId: activeGisuId,
@@ -53,7 +56,7 @@ function SchoolManagePage() {
       page: currentPage - 1,
       size: PAGE_SIZE,
       sort: sortOption,
-      enabled: activeGisuId != null,
+      enabled: activeGisuId != null && !isChapterUnresolved,
     })
 
   const isLoading = isSummaryLoading
@@ -128,7 +131,11 @@ function SchoolManagePage() {
           </div>
         </div>
 
-        {isLoading ? (
+        {isChapterUnresolved ? (
+          <div className="text-body-1-medium text-teal-gray-400 py-12 text-center">
+            선택한 지부 정보를 찾을 수 없거나 불러오는 중입니다.
+          </div>
+        ) : isLoading ? (
           <div className="text-body-1-medium text-teal-gray-400 py-12 text-center">
             학교 정보를 불러오는 중입니다...
           </div>


### PR DESCRIPTION
## 📸 작업 내용

학교/지부 관리 및 커리큘럼 편집 기능의 백엔드 API 연동, Custom Hook 구현, 실시간 자동 저장 및 복원(Undo) 기능을 완성하였습니다.

- **학교(School) 관리 API 연동 및 CRUD 훅 구현**:
  - 학교 단건/전체/지부별 조회, 생성, 수정, 삭제 API 함수 및 DTO 타입 정의 (`schoolApi.ts`, `schoolTypes.ts`)
  - `@tanstack/react-query` 기반 `useSchoolList`, `useCreateSchool`, `useUpdateSchool`, `useDeleteSchool` 커스텀 훅 구현 (`useSchool.ts`)
  - 학교 등록/수정 페이지 UI와 API 연동 및 성공/실패 토스트 피드백 알림 개선 (`SchoolRegistrationPage.tsx`, `schoolToasts.ts`)

- **지부(Chapter) 관리 API 연동 및 훅 구현**:
  - 지부 단건 생성, 일괄 생성(Bulk Create), 삭제 API 및 DTO 타입 구현 (`chapterApi.ts`, `chapterTypes.ts`)
  - `useCreateChapter`, `useCreateChaptersBulk`, `useDeleteChapter` 훅 구현 및 `ChapterManagePage.tsx` API 연동 (`useChapter.ts`)

- **커리큘럼(Curriculum) 및 주차별 워크북 API 연동 및 자동 저장·복원 구현**:
  - 기수/파트별 커리큘럼 및 주차별(Weekly) 커리큘럼 CRUD API 함수 및 DTO 타입 정의 (`curriculumApi.ts`, `curriculumTypes.ts`)
  - `useCurriculumEditor` 훅을 개선하여 커리큘럼/워크북 생성, 제목 인라인 수정(Blur 시 API 자동 반영), 삭제, 워크북 추가/삭제, dnd dragEnd 시 주차 순서(weekNo) 백엔드 실시간 동기화
  - 커리큘럼 삭제 후 토스트 피드백의 되돌리기(Restore/Undo) 버튼 클릭 시 백엔드 재등록 API(`createCurriculum` 및 `createWeeklyCurriculum`) 자동 복원 로직 연동
  - 커리큘럼 설정 모달(`CurriculumSettingModal.tsx`)에 설정 완료 버튼 추가 UI/UX 개선

## 🎞️ 주요 코드 설명

> 설명이 필요한 코드 위주로 작성해주세요

### 1. 커리큘럼 자동 저장 및 되돌리기(Undo) 백엔드 복원 연동 (`useCurriculumEditor.ts`)

```TypeScript
// 되돌리기(Undo) 클릭 시 로컬 State 복구 및 API 백엔드 재등록 연동
const handleRestoreCurriculum = async (
  restoredItem: CurriculumItem,
  targetIndex: number,
) => {
  setCurriculums((prev) => {
    const next = [...prev]
    if (targetIndex >= 0 && targetIndex <= next.length) {
      next.splice(targetIndex, 0, restoredItem)
    } else {
      next.push(restoredItem)
    }
    return recalculateCurriculumNumbers(next, 0)
  })

  // 백엔드 재등록 API 연동
  try {
    const apiPart = mapPartToApiEnum(part)
    const newCurriculumId = await createCurriculum({
      gisuId,
      part: apiPart,
      title: restoredItem.title || "복원된 커리큘럼",
    })

    if (newCurriculumId) {
      setCurriculums((prev) =>
        prev.map((c) =>
          c.id === restoredItem.id
            ? { ...c, id: String(newCurriculumId) }
            : c,
        ),
      )

      for (const wb of restoredItem.workbooks) {
        const now = new Date()
        const nextWeek = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
        await createWeeklyCurriculum({
          curriculumId: newCurriculumId,
          weekNo: wb.number,
          title: wb.title,
          startsAt: now.toISOString(),
          endsAt: nextWeek.toISOString(),
        })
      }
    }
  } catch {
    // Ignore background restore sync fallback
  }
}
```

- 사용자가 삭제한 커리큘럼을 토스트의 되돌리기 버튼으로 복원할 때, 화면 로컬 상태를 복구함과 동시에 `createCurriculum` 및 `createWeeklyCurriculum` API를 호출하여 백엔드 DB에도 이전 워크북 항목들을 재등록 동기화합니다.

### 2. React Query 기반 학교/지부 CRUD 커스텀 훅 (`useSchool.ts`, `useChapter.ts`)

```TypeScript
/** 학교 생성 및 캐시 무효화 훅 */
export function useCreateSchool() {
  const queryClient = useQueryClient()

  return useMutation({
    mutationFn: (body: CreateSchoolRequest) => createSchool(body),
    onSuccess: () => {
      queryClient.invalidateQueries({ queryKey: ["schools"] })
      queryClient.invalidateQueries({ queryKey: ["chaptersWithSchools"] })
    },
  })
}

/** 지부 일괄 생성 뮤테이션 훅 */
export function useCreateChaptersBulk() {
  const queryClient = useQueryClient()

  return useMutation({
    mutationFn: (body: CreateChapterBulkRequest) => createChaptersBulk(body),
    onSuccess: () => {
      queryClient.invalidateQueries({ queryKey: ["chapters"] })
      queryClient.invalidateQueries({ queryKey: ["chaptersWithSchools"] })
    },
  })
}
```

- `@tanstack/react-query`의 `useMutation` 및 `invalidateQueries`를 활용하여 학교 및 지부 데이터 생성/수정/삭제 성공 시 연관된 쿼리 캐시를 즉시 갱신하도록 설계했습니다.

### 3. 워크북 드래그 앤 드롭 및 주차 순서(weekNo) 실시간 업데이트 (`useCurriculumEditor.ts`)

```TypeScript
// 주차 순서(weekNo) 이동 변경 시 백엔드 weekNo 업데이트
if (activeData?.type === "workbook") {
  curriculums.forEach((c) => {
    c.workbooks.forEach(async (wb, idx) => {
      const numericWbId = Number(wb.id)
      if (!Number.isNaN(numericWbId) && numericWbId > 0) {
        try {
          await updateWeeklyCurriculum(numericWbId, {
            weekNo: idx + 1,
            title: wb.title,
          })
        } catch {
          // Ignore background order sync error
        }
      }
    })
  })
}
```

- `@dnd-kit` 드래그 이벤트가 종료되었을 때, 변경된 순서에 맞춰 주차 번호(`weekNo`)를 재배열하고 `updateWeeklyCurriculum` API를 통해 비동기로 서버 데이터베이스에 변경 사항을 자동 저장합니다.

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #647 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* 커리큘럼 개요 조회와 커리큘럼·주차 콘텐츠의 생성, 수정, 삭제를 지원합니다.
* 지부(챕터) 단건·일괄 등록 및 삭제 기능이 추가됩니다.
* 학교 관리에서 검색, 정렬, 지부 필터, 페이징과 상세 정보 조회를 제공합니다.
* 학교 등록·수정 시 로고와 링크 정보를 관리할 수 있습니다.
* 학교 및 지부 데이터를 서버와 연동해 관리할 수 있습니다.

## 개선
* 제목·순서 변경이 자동 저장되며, 삭제 후 되돌리기가 실제 데이터에 반영됩니다.
* 로딩·빈 결과 상태와 저장·삭제 실패 안내가 개선되었습니다.
* 커리큘럼 설정 모달을 완료 버튼으로 닫을 수 있습니다.
* 학교·지부 목록과 챕터 탭이 실제 데이터에 맞게 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->