### PR TITLE
✨ feat: 지원자 평가 등록·최종 합불 API 연동

### DIFF
--- a/src/features/recruiting/api/queryKeys.ts
+++ b/src/features/recruiting/api/queryKeys.ts
@@ -52,4 +52,17 @@ export const recruitingKeys = {
 
   evaluatorProfiles: (memberIds: string[]) =>
     [...recruitingKeys.all, "evaluator-profiles", memberIds] as const,
+
+  interviewQuestions: () =>
+    [...recruitingKeys.all, "interview-questions"] as const,
+
+  roundInterviewQuestions: (roundId: string) =>
+    [...recruitingKeys.interviewQuestions(), "round", roundId] as const,
+
+  applicationInterviewQuestions: (applicationId: string) =>
+    [
+      ...recruitingKeys.interviewQuestions(),
+      "application",
+      applicationId,
+    ] as const,
 }

--- a/src/features/recruiting/api/recruitingApi.ts
+++ b/src/features/recruiting/api/recruitingApi.ts
@@ -4,6 +4,7 @@ import type { ApiResponse } from "@/shared/lib/apiResponse"
 
 import type {
   ApiEvaluationStage,
+  FinalDecisionBody,
   FormStructureQuery,
   PublicRoundsQuery,
   RecruitingApplicationDetail,
@@ -11,10 +12,12 @@ import type {
   RecruitingApplicationSummary,
   RecruitingEvaluation,
   RecruitingFormStructure,
+  RecruitingInterviewQuestion,
   RecruitingRoundEvaluator,
   RecruitingRoundGroup,
   RecruitingRoundPhase,
   RoundApplicationsQuery,
+  SubmitEvaluationBody,
 } from "./types"
 
 const APPLICATIONS_PAGE_SIZE = 100
@@ -132,6 +135,46 @@ export async function getRoundEvaluators(
 ): Promise<RecruitingRoundEvaluator[]> {
   const { data } = await api.get<ApiResponse<RecruitingRoundEvaluator[]>>(
     `/v1/recruiting/admin/rounds/${roundId}/evaluators`,
+  )
+  return data.result
+}
+
+export async function submitEvaluation(
+  roundId: string,
+  applicationId: string,
+  stage: ApiEvaluationStage,
+  body: SubmitEvaluationBody,
+): Promise<void> {
+  await api.put(
+    `/v1/recruiting/rounds/${roundId}/applications/${applicationId}/evaluations/${stage}`,
+    body,
+  )
+}
+
+export async function decideFinal(
+  applicationId: string,
+  body: FinalDecisionBody,
+): Promise<void> {
+  await api.patch(
+    `/v1/recruiting/admin/applications/${applicationId}/final-decision`,
+    body,
+  )
+}
+
+export async function getRoundInterviewQuestions(
+  roundId: string,
+): Promise<RecruitingInterviewQuestion[]> {
+  const { data } = await api.get<ApiResponse<RecruitingInterviewQuestion[]>>(
+    `/v1/recruiting/admin/rounds/${roundId}/questions`,
+  )
+  return data.result
+}
+
+export async function getApplicationInterviewQuestions(
+  applicationId: string,
+): Promise<RecruitingInterviewQuestion[]> {
+  const { data } = await api.get<ApiResponse<RecruitingInterviewQuestion[]>>(
+    `/v1/recruiting/admin/applications/${applicationId}/questions`,
   )
   return data.result
 }

--- a/src/features/recruiting/api/types.ts
+++ b/src/features/recruiting/api/types.ts
@@ -176,8 +176,30 @@ export interface RecruitingEvaluation {
   submittedAt: string | null
 }
 
+export interface SubmitEvaluationBody {
+  decision: RecruitingEvaluationDecision
+  comment?: string
+}
+
 export interface RecruitingRoundEvaluator {
   id: string
   roundId: string
   memberId: string
 }
+
+export interface RecruitingInterviewQuestion {
+  id: string
+  roundId: string
+  applicationId: string | null
+  content: string
+  orderNo: number
+  active: boolean
+}
+
+export type RecruitingDecision = "PASS" | "FAIL"
+
+// 합격에는 확정 트랙이 필수이고 지원자의 1·2지망 중 하나여야 한다. 불합격에는
+// 담으면 거부되므로 두 형태를 타입으로 갈라 둔다.
+export type FinalDecisionBody =
+  | { decision: "PASS"; acceptedTrack: RecruitingTrack; reason?: string }
+  | { decision: "FAIL"; reason?: string }

--- a/src/features/recruiting/hooks/useApplicationDetail.ts
+++ b/src/features/recruiting/hooks/useApplicationDetail.ts
@@ -112,6 +112,9 @@ export function useApplicationDetail(
 
   return {
     detail,
+    // 평가 등록 가능 여부는 지원서 상태로 갈린다. 조립된 detail 에는 남지 않아
+    // 원본 요약을 그대로 넘긴다.
+    application: application ?? null,
     round: location?.round ?? null,
     isError:
       gisuQuery.isError ||

--- a/src/features/recruiting/hooks/useEvaluationMutations.ts
+++ b/src/features/recruiting/hooks/useEvaluationMutations.ts
@@ -1,0 +1,66 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { useToastStore } from "@/shared/ui/toast/useToastStore"
+
+import { recruitingKeys } from "../api/queryKeys"
+import { decideFinal, submitEvaluation } from "../api/recruitingApi"
+import { toApiStage } from "../model/evaluatorMapper"
+
+import type { FinalDecisionBody, SubmitEvaluationBody } from "../api/types"
+import type { EvaluationStage } from "../model/evaluationStage"
+
+function useErrorToast() {
+  const addToast = useToastStore((state) => state.addToast)
+  return (message: string) =>
+    addToast({
+      message,
+      color: "red",
+      variant: "deep",
+      type: "default",
+      duration: 3000,
+    })
+}
+
+// 실패 안내는 호출부(MyStageEvaluationPanel)가 이미 띄운다. 여기서 또 띄우면
+// 토스트가 두 번 뜬다.
+export function useSubmitEvaluation(
+  applicationId: string,
+  roundId: string | undefined,
+  stage: EvaluationStage,
+) {
+  const queryClient = useQueryClient()
+  const apiStage = toApiStage(stage)
+
+  return useMutation({
+    mutationFn: (body: SubmitEvaluationBody) =>
+      submitEvaluation(roundId!, applicationId, apiStage!, body),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: recruitingKeys.evaluations(),
+      })
+      // 목록의 '내 평가 완료' 표시가 바뀐다. applications() 는 상세 키의
+      // 접두사라 상세도 함께 무효화된다.
+      void queryClient.invalidateQueries({
+        queryKey: recruitingKeys.applications(),
+      })
+    },
+  })
+}
+
+export function useFinalDecision(applicationId: string) {
+  const queryClient = useQueryClient()
+  const showError = useErrorToast()
+
+  return useMutation({
+    mutationFn: (body: FinalDecisionBody) => decideFinal(applicationId, body),
+    onSuccess: () => {
+      // 합불은 지원서 상태를 바꾼다. 상세와 목록이 모두 이 접두사 아래에 있다.
+      void queryClient.invalidateQueries({
+        queryKey: recruitingKeys.applications(),
+      })
+    },
+    onError: () => {
+      showError("최종 결과 저장에 실패했습니다. 잠시 후 다시 시도해주세요.")
+    },
+  })
+}

--- a/src/features/recruiting/hooks/useInterviewQuestions.ts
+++ b/src/features/recruiting/hooks/useInterviewQuestions.ts
@@ -1,0 +1,39 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { recruitingKeys } from "../api/queryKeys"
+import {
+  getApplicationInterviewQuestions,
+  getRoundInterviewQuestions,
+} from "../api/recruitingApi"
+import { toInterviewContent } from "../model/interviewMapper"
+
+// 공통 질문은 차수에만, 개별 질문은 지원서에만 의존한다. 하나로 묶으면 같은
+// 차수의 다른 지원자를 볼 때마다 공통 질문을 다시 받게 되므로 캐시를 나눈다.
+export function useInterviewQuestions(
+  applicationId: string,
+  roundId: string | undefined,
+  enabled: boolean,
+) {
+  const roundQuestions = useQuery({
+    queryKey: recruitingKeys.roundInterviewQuestions(roundId ?? ""),
+    queryFn: () => getRoundInterviewQuestions(roundId!),
+    enabled: enabled && roundId != null,
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  const applicationQuestions = useQuery({
+    queryKey: recruitingKeys.applicationInterviewQuestions(applicationId),
+    queryFn: () => getApplicationInterviewQuestions(applicationId),
+    enabled,
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  return {
+    interview: toInterviewContent(
+      roundQuestions.data ?? [],
+      applicationQuestions.data ?? [],
+    ),
+  }
+}

--- a/src/features/recruiting/hooks/useInterviewQuestions.ts
+++ b/src/features/recruiting/hooks/useInterviewQuestions.ts
@@ -30,10 +30,17 @@ export function useInterviewQuestions(
     staleTime: 5 * 60 * 1000,
   })
 
+  // 한쪽만 실패하면 남은 블록만 그려져 질문이 원래 없는 것처럼 보인다.
+  // 둘 다 확보된 뒤에 조립하고, 그 전까지는 상태를 그대로 넘긴다.
+  const isLoading = roundQuestions.isLoading || applicationQuestions.isLoading
+  const isError = roundQuestions.isError || applicationQuestions.isError
+  const ready = roundQuestions.isSuccess && applicationQuestions.isSuccess
+
   return {
-    interview: toInterviewContent(
-      roundQuestions.data ?? [],
-      applicationQuestions.data ?? [],
-    ),
+    interview: ready
+      ? toInterviewContent(roundQuestions.data, applicationQuestions.data)
+      : null,
+    isLoading,
+    isError,
   }
 }

--- a/src/features/recruiting/hooks/useStageEvaluations.ts
+++ b/src/features/recruiting/hooks/useStageEvaluations.ts
@@ -7,18 +7,33 @@ import { useMe } from "@/entities/member/hooks/useMe"
 
 import { recruitingKeys } from "../api/queryKeys"
 import { getRoundEvaluators, getStageEvaluations } from "../api/recruitingApi"
+import { resolveEvaluationEligibility } from "../model/evaluationRules"
 import {
   toApiStage,
   toOperatorEvaluations,
   toStageEvaluationDetail,
 } from "../model/evaluatorMapper"
 
+import type { RecruitingApplicationStatus } from "../api/types"
+import type {
+  EvaluationBlockReason,
+  EvaluatorState,
+} from "../model/evaluationRules"
 import type { EvaluationStage } from "../model/evaluationStage"
+
+const LOCK_REASON: Record<EvaluationBlockReason, string | undefined> = {
+  stageHasNoEvaluation: undefined,
+  permissionUnknown:
+    "권한 정보를 불러오지 못했습니다. 새로고침 후 다시 시도해주세요.",
+  notEvaluator: "평가자로 지정된 운영진만 평가를 등록할 수 있습니다.",
+  stageClosed: "판정이 끝난 전형이라 평가를 수정할 수 없습니다.",
+}
 
 export function useStageEvaluations(
   applicationId: string,
   roundId: string | undefined,
   stage: EvaluationStage,
+  status: RecruitingApplicationStatus | undefined,
 ) {
   const { data: me } = useMe()
   const apiStage = toApiStage(stage)
@@ -42,6 +57,13 @@ export function useStageEvaluations(
     [evaluatorsQuery.data],
   )
   const rosterKnown = evaluatorsQuery.isSuccess
+  // 403 은 "관리 권한 없음"이라는 확정 답이고, 그 외 실패는 아무것도 알려주지
+  // 않는다. 둘을 한 값으로 접으면 장애를 권한 없음으로 오인한다.
+  const rosterDenied =
+    evaluatorsQuery.isError &&
+    isAxiosError(evaluatorsQuery.error) &&
+    evaluatorsQuery.error.response?.status === 403
+  const rosterUnavailable = evaluatorsQuery.isError && !rosterDenied
   // 명단 조회가 끝나기 전에는 관리 권한 유무를 알 수 없다. 그 사이에 비운영진
   // 화면을 보였다가 뒤바뀌지 않도록 결과가 확정된 뒤에 조립한다.
   const rosterSettled = evaluatorsQuery.isSuccess || evaluatorsQuery.isError
@@ -87,6 +109,30 @@ export function useStageEvaluations(
     staleTime: 10 * 60 * 1000,
   })
 
+  // 평가 등록은 평가자 명단에 있는 사람만 할 수 있다.
+  //  · 명단을 받았으면 직접 확인한다.
+  //  · 403 이면 관리 권한이 없다는 뜻이고, 그런데도 평가 목록을 받았다면
+  //    서버가 평가자로 인정한 것이다(운영진 경로가 막혔으므로).
+  //  · 그 밖의 실패는 아무것도 증명하지 못한다. 운영진도 이 경로로 떨어질 수
+  //    있어 평가자로 단정하면 제출 단계에서 거부된다.
+  const evaluatorState: EvaluatorState = useMemo(() => {
+    if (!me) return "unknown"
+    if (rosterKnown) {
+      const myId = String(me.id)
+      return roster.some((evaluator) => String(evaluator.memberId) === myId)
+        ? "yes"
+        : "no"
+    }
+    if (rosterDenied) return evaluationsQuery.isSuccess ? "yes" : "no"
+    return "unknown"
+  }, [me, rosterKnown, rosterDenied, roster, evaluationsQuery.isSuccess])
+
+  const eligibility = resolveEvaluationEligibility(
+    stage,
+    status,
+    evaluatorState,
+  )
+
   const evaluation = useMemo(() => {
     if (!enabled || !me || !rosterSettled) return null
     const evaluations = evaluationsQuery.data
@@ -101,8 +147,8 @@ export function useStageEvaluations(
       ),
       stage,
       String(me.id),
-      // 평가 등록 mutation 은 후속 작업이라 이번에는 읽기 전용으로 둔다.
-      true,
+      !eligibility.canSubmit,
+      LOCK_REASON[eligibility.reason ?? "stageHasNoEvaluation"],
     )
   }, [
     enabled,
@@ -112,12 +158,16 @@ export function useStageEvaluations(
     evaluationsQuery.data,
     profilesQuery.data,
     stage,
+    eligibility.canSubmit,
+    eligibility.reason,
   ])
 
   return {
     evaluation,
     // 명단을 못 받으면 아직 평가하지 않은 운영진을 알 수 없어 총원을 셀 수 없다.
     rosterKnown,
+    rosterUnavailable,
+    canSubmit: eligibility.canSubmit,
     isLoading: evaluationsQuery.isLoading,
     isError: evaluationsQuery.isError,
   }

--- a/src/features/recruiting/hooks/useStageEvaluations.ts
+++ b/src/features/recruiting/hooks/useStageEvaluations.ts
@@ -37,7 +37,10 @@ export function useStageEvaluations(
 ) {
   const { data: me } = useMe()
   const apiStage = toApiStage(stage)
-  const enabled = roundId != null && apiStage != null
+  // 평가 목록은 단계별 API 라 최종 단계에는 없지만, 평가자 명단은 차수 단위라
+  // 최종 화면에서도 조회해야 한다. 하나로 묶으면 최종 화면에서 명단이 비어
+  // 관리 권한을 판정하지 못해 합불 처리가 잠긴다.
+  const evaluationsEnabled = roundId != null && apiStage != null
 
   // 평가자 명단은 모집 관리 권한이 있어야 조회할 수 있다. 평가자 whitelist 에만
   // 올라간 운영진은 403 을 받으므로, 실패해도 평가 목록은 그대로 보여준다.
@@ -46,7 +49,7 @@ export function useStageEvaluations(
   const evaluatorsQuery = useQuery({
     queryKey: recruitingKeys.evaluators(roundId ?? ""),
     queryFn: () => getRoundEvaluators(roundId!),
-    enabled,
+    enabled: roundId != null,
     retry: (failureCount, error) =>
       !(isAxiosError(error) && error.response?.status === 403) &&
       failureCount < 2,
@@ -75,7 +78,7 @@ export function useStageEvaluations(
       apiStage ?? "DOCUMENT",
     ),
     queryFn: () => getStageEvaluations(roundId!, applicationId, apiStage!),
-    enabled,
+    enabled: evaluationsEnabled,
     staleTime: 60 * 1000,
   })
 
@@ -134,7 +137,7 @@ export function useStageEvaluations(
   )
 
   const evaluation = useMemo(() => {
-    if (!enabled || !me || !rosterSettled) return null
+    if (!evaluationsEnabled || !me || !rosterSettled) return null
     const evaluations = evaluationsQuery.data
     if (!evaluations) return null
 
@@ -151,7 +154,7 @@ export function useStageEvaluations(
       LOCK_REASON[eligibility.reason ?? "stageHasNoEvaluation"],
     )
   }, [
-    enabled,
+    evaluationsEnabled,
     me,
     rosterSettled,
     roster,

--- a/src/features/recruiting/model/applicationDetail.mock.ts
+++ b/src/features/recruiting/model/applicationDetail.mock.ts
@@ -242,10 +242,10 @@ function buildInterviewContent(row: ApplicantRow): InterviewContent {
         totalCountLabel,
         timestampLabel: "26-07-04 02:48 기준",
         questions: [
-          { text: "UMC는 어떻게 알게 되셨나요?" },
-          { text: "재학 중이신가요, 휴학 중이신가요?" },
-          { text: "무슨 노래 좋아하세요?" },
-          { text: "MBTI가 어떻게 되세요?" },
+          { id: "q-mock-1", text: "UMC는 어떻게 알게 되셨나요?" },
+          { id: "q-mock-2", text: "재학 중이신가요, 휴학 중이신가요?" },
+          { id: "q-mock-3", text: "무슨 노래 좋아하세요?" },
+          { id: "q-mock-4", text: "MBTI가 어떻게 되세요?" },
         ],
         answers: [
           {
@@ -264,13 +264,14 @@ function buildInterviewContent(row: ApplicantRow): InterviewContent {
         group: "individual",
         title: "개별 질문",
         questions: [
-          { text: "전공이 어떻게 되시나요?" },
-          { text: "오프라인 참여도 가능하신가요?" },
+          { id: "q-mock-5", text: "전공이 어떻게 되시나요?" },
+          { id: "q-mock-6", text: "오프라인 참여도 가능하신가요?" },
           {
+            id: "q-mock-9",
             text: "포트폴리오에서 OOO 프로젝트는 무엇인가요? 참여 비율은 어떻게 되나요?",
           },
-          { text: "개발자와 협업해 보신 경험이 있으신가요?" },
-          { text: "서비스 배포 경험이 있으신가요?" },
+          { id: "q-mock-7", text: "개발자와 협업해 보신 경험이 있으신가요?" },
+          { id: "q-mock-8", text: "서비스 배포 경험이 있으신가요?" },
         ],
         answers: [
           {

--- a/src/features/recruiting/model/applicationDetail.ts
+++ b/src/features/recruiting/model/applicationDetail.ts
@@ -71,7 +71,7 @@ export interface InterviewQuestionBlock {
   title: string
   totalCountLabel?: string
   timestampLabel?: string
-  questions: { text: string }[]
+  questions: { id: string; text: string }[]
   answers: InterviewAnswerSession[]
 }
 

--- a/src/features/recruiting/model/evaluationRules.test.ts
+++ b/src/features/recruiting/model/evaluationRules.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildFinalDecisionBody,
+  canDecideFinal,
+  resolveEvaluationEligibility,
+  toAcceptableTracks,
+} from "./evaluationRules"
+
+describe("resolveEvaluationEligibility", () => {
+  it("평가자가 판정 전 서류를 평가할 수 있다", () => {
+    expect(
+      resolveEvaluationEligibility("document", "SUBMITTED", "yes"),
+    ).toEqual({
+      canSubmit: true,
+      reason: null,
+    })
+  })
+
+  it("서류 판정이 끝나면 서류 평가를 막는다", () => {
+    expect(
+      resolveEvaluationEligibility("document", "INTERVIEW_ASSIGNED", "yes")
+        .reason,
+    ).toBe("stageClosed")
+    expect(
+      resolveEvaluationEligibility("document", "DOCUMENT_FAILED", "yes").reason,
+    ).toBe("stageClosed")
+  })
+
+  it("면접 대상으로 확정된 뒤에만 면접을 평가할 수 있다", () => {
+    expect(
+      resolveEvaluationEligibility("interview", "INTERVIEW_ASSIGNED", "yes")
+        .canSubmit,
+    ).toBe(true)
+    expect(
+      resolveEvaluationEligibility("interview", "SUBMITTED", "yes").reason,
+    ).toBe("stageClosed")
+    expect(
+      resolveEvaluationEligibility("interview", "FINAL_PASSED", "yes").reason,
+    ).toBe("stageClosed")
+  })
+
+  it("평가자가 아니면 등록할 수 없다", () => {
+    expect(
+      resolveEvaluationEligibility("document", "SUBMITTED", "no").reason,
+    ).toBe("notEvaluator")
+  })
+
+  it("최종 전형에는 평가 등록이 없다", () => {
+    expect(
+      resolveEvaluationEligibility("final", "FINAL_PASSED", "yes").reason,
+    ).toBe("stageHasNoEvaluation")
+  })
+
+  it("상태를 아직 모르면 등록을 열지 않는다", () => {
+    expect(
+      resolveEvaluationEligibility("document", undefined, "yes").canSubmit,
+    ).toBe(false)
+  })
+
+  it("평가자인지 확정하지 못하면 권한 없음과 다르게 안내한다", () => {
+    expect(
+      resolveEvaluationEligibility("document", "SUBMITTED", "unknown"),
+    ).toEqual({ canSubmit: false, reason: "permissionUnknown" })
+  })
+})
+
+describe("canDecideFinal", () => {
+  it("면접 대상자와 면접 생략자를 판정할 수 있다", () => {
+    expect(canDecideFinal("INTERVIEW_ASSIGNED", true)).toBe(true)
+    expect(canDecideFinal("INTERVIEW_SKIPPED", true)).toBe(true)
+  })
+
+  it("이미 최종 결과가 나온 지원서는 다시 판정하지 않는다", () => {
+    expect(canDecideFinal("FINAL_PASSED", true)).toBe(false)
+    expect(canDecideFinal("FINAL_FAILED", true)).toBe(false)
+  })
+
+  it("서류 단계에 머문 지원서는 판정 대상이 아니다", () => {
+    expect(canDecideFinal("SUBMITTED", true)).toBe(false)
+    expect(canDecideFinal("DOCUMENT_FAILED", true)).toBe(false)
+  })
+
+  it("관리 권한이 없으면 판정할 수 없다", () => {
+    expect(canDecideFinal("INTERVIEW_ASSIGNED", false)).toBe(false)
+  })
+
+  it("상태를 아직 모르면 열지 않는다", () => {
+    expect(canDecideFinal(undefined, true)).toBe(false)
+  })
+})
+
+describe("toAcceptableTracks", () => {
+  it("1지망만 있으면 하나만 고를 수 있다", () => {
+    expect(
+      toAcceptableTracks({ firstChoice: "PLAN", secondChoice: null }),
+    ).toEqual(["PLAN"])
+  })
+
+  it("2지망이 있으면 둘 다 후보가 된다", () => {
+    expect(
+      toAcceptableTracks({ firstChoice: "PLAN", secondChoice: "DESIGN" }),
+    ).toEqual(["PLAN", "DESIGN"])
+  })
+
+  it("1·2지망이 같으면 하나로 접는다", () => {
+    expect(
+      toAcceptableTracks({ firstChoice: "PLAN", secondChoice: "PLAN" }),
+    ).toEqual(["PLAN"])
+  })
+})
+
+describe("buildFinalDecisionBody", () => {
+  it("불합격에는 확정 트랙을 담지 않는다", () => {
+    expect(buildFinalDecisionBody("FAIL", "PLAN")).toEqual({ decision: "FAIL" })
+    expect(buildFinalDecisionBody("FAIL", null)).toEqual({ decision: "FAIL" })
+  })
+
+  it("합격에는 확정 트랙을 담는다", () => {
+    expect(buildFinalDecisionBody("PASS", "DESIGN")).toEqual({
+      decision: "PASS",
+      acceptedTrack: "DESIGN",
+    })
+  })
+
+  it("확정 트랙 없이 합격 요청을 만들지 않는다", () => {
+    expect(buildFinalDecisionBody("PASS", null)).toBeNull()
+  })
+})

--- a/src/features/recruiting/model/evaluationRules.ts
+++ b/src/features/recruiting/model/evaluationRules.ts
@@ -1,0 +1,92 @@
+import type {
+  FinalDecisionBody,
+  RecruitingApplicationStatus,
+  RecruitingApplicationSummary,
+  RecruitingTrack,
+} from "../api/types"
+import type { EvaluationStage } from "./evaluationStage"
+
+export type EvaluationBlockReason =
+  | "stageHasNoEvaluation"
+  | "permissionUnknown"
+  | "notEvaluator"
+  | "stageClosed"
+
+export interface EvaluationEligibility {
+  canSubmit: boolean
+  reason: EvaluationBlockReason | null
+}
+
+// 평가자인지 확정하지 못하는 구간이 있다. 평가자 명단 조회가 일시적으로 실패하면
+// 권한이 없는 것인지 서버가 잠깐 죽은 것인지 구분할 수 없다. 그 상태를 '아님'으로
+// 접으면 권한 있는 사람에게 잘못된 안내가 나가므로 따로 둔다.
+export type EvaluatorState = "yes" | "no" | "unknown"
+
+// 서버는 전형이 열려 있는 동안에만 평가 등록을 받는다. 서류는 판정 전(SUBMITTED),
+// 면접은 면접 대상으로 확정된 뒤(INTERVIEW_ASSIGNED)만 열린다.
+const OPEN_STATUS: Partial<
+  Record<EvaluationStage, RecruitingApplicationStatus>
+> = {
+  document: "SUBMITTED",
+  interview: "INTERVIEW_ASSIGNED",
+}
+
+export function resolveEvaluationEligibility(
+  stage: EvaluationStage,
+  status: RecruitingApplicationStatus | undefined,
+  evaluator: EvaluatorState,
+): EvaluationEligibility {
+  const openStatus = OPEN_STATUS[stage]
+  if (!openStatus) {
+    return { canSubmit: false, reason: "stageHasNoEvaluation" }
+  }
+  if (evaluator === "unknown") {
+    return { canSubmit: false, reason: "permissionUnknown" }
+  }
+  if (evaluator === "no") {
+    return { canSubmit: false, reason: "notEvaluator" }
+  }
+  if (status !== openStatus) {
+    return { canSubmit: false, reason: "stageClosed" }
+  }
+  return { canSubmit: true, reason: null }
+}
+
+// 최종 판정은 면접 대상이거나 면접을 건너뛴 지원서에서만 가능하다. 이미 최종
+// 결과가 나온 지원서를 다시 판정하면 서버가 전이를 거부하므로 화면에서 막는다.
+const FINAL_DECIDABLE_STATUS: RecruitingApplicationStatus[] = [
+  "INTERVIEW_ASSIGNED",
+  "INTERVIEW_SKIPPED",
+]
+
+export function canDecideFinal(
+  status: RecruitingApplicationStatus | undefined,
+  hasManagePermission: boolean,
+): boolean {
+  if (!hasManagePermission || !status) return false
+  return FINAL_DECIDABLE_STATUS.includes(status)
+}
+
+export function toAcceptableTracks(
+  application: Pick<
+    RecruitingApplicationSummary,
+    "firstChoice" | "secondChoice"
+  >,
+): RecruitingTrack[] {
+  const tracks = [application.firstChoice, application.secondChoice].filter(
+    (track): track is RecruitingTrack => track != null,
+  )
+  return [...new Set(tracks)]
+}
+
+// 합격에는 확정 트랙이 필수이고, 불합격에 트랙을 담으면 서버가 거부한다.
+export function buildFinalDecisionBody(
+  decision: "PASS" | "FAIL",
+  acceptedTrack: RecruitingTrack | null,
+): FinalDecisionBody | null {
+  if (decision === "FAIL") {
+    return { decision: "FAIL" }
+  }
+  if (!acceptedTrack) return null
+  return { decision: "PASS", acceptedTrack }
+}

--- a/src/features/recruiting/model/evaluatorMapper.ts
+++ b/src/features/recruiting/model/evaluatorMapper.ts
@@ -66,11 +66,13 @@ export function toStageEvaluationDetail(
   stage: EvaluationStage,
   myMemberId: string,
   locked: boolean,
+  lockReason?: string,
 ): StageEvaluationDetail {
   return {
     stage,
     myEvaluatorId: myMemberId,
     locked,
+    lockReason,
     operators,
   }
 }

--- a/src/features/recruiting/model/interviewMapper.test.ts
+++ b/src/features/recruiting/model/interviewMapper.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+
+import { toInterviewContent } from "./interviewMapper"
+
+import type { RecruitingInterviewQuestion } from "../api/types"
+
+function question(
+  id: string,
+  content: string,
+  orderNo: number,
+): RecruitingInterviewQuestion {
+  return {
+    id,
+    roundId: "3",
+    applicationId: null,
+    content,
+    orderNo,
+    active: true,
+  }
+}
+
+describe("toInterviewContent", () => {
+  it("공통 질문과 개별 질문을 각각 블록으로 만든다", () => {
+    const content = toInterviewContent(
+      [question("1", "자기소개를 해주세요", 1)],
+      [question("2", "포트폴리오를 설명해주세요", 1)],
+    )
+
+    expect(content?.blocks.map((block) => block.title)).toEqual([
+      "공통 질문",
+      "개별 질문",
+    ])
+    expect(content?.blocks[0]?.group).toBe("common")
+    expect(content?.blocks[1]?.group).toBe("individual")
+  })
+
+  it("질문을 orderNo 순으로 정렬한다", () => {
+    const content = toInterviewContent(
+      [question("2", "두 번째", 2), question("1", "첫 번째", 1)],
+      [],
+    )
+
+    expect(content?.blocks[0]?.questions.map((q) => q.text)).toEqual([
+      "첫 번째",
+      "두 번째",
+    ])
+  })
+
+  it("비어 있는 쪽은 블록을 만들지 않는다", () => {
+    const content = toInterviewContent([question("1", "공통", 1)], [])
+    expect(content?.blocks).toHaveLength(1)
+  })
+
+  it("질문이 하나도 없으면 렌더할 것이 없다", () => {
+    expect(toInterviewContent([], [])).toBeNull()
+  })
+
+  it("답변 저장 경로가 없어 답변은 비워 둔다", () => {
+    const content = toInterviewContent([question("1", "공통", 1)], [])
+    expect(content?.blocks[0]?.answers).toEqual([])
+  })
+})

--- a/src/features/recruiting/model/interviewMapper.test.ts
+++ b/src/features/recruiting/model/interviewMapper.test.ts
@@ -55,6 +55,40 @@ describe("toInterviewContent", () => {
     expect(toInterviewContent([], [])).toBeNull()
   })
 
+  it("비활성 질문은 렌더 대상에서 뺀다", () => {
+    const content = toInterviewContent(
+      [
+        { ...question("1", "지워진 질문", 1), active: false },
+        question("2", "살아 있는 질문", 2),
+      ],
+      [],
+    )
+
+    expect(content?.blocks[0]?.questions.map((q) => q.text)).toEqual([
+      "살아 있는 질문",
+    ])
+  })
+
+  it("전부 비활성이면 블록을 만들지 않는다", () => {
+    const content = toInterviewContent(
+      [{ ...question("1", "지워진 질문", 1), active: false }],
+      [],
+    )
+
+    expect(content).toBeNull()
+  })
+
+  it("내용이 같은 질문도 서로 다른 식별자를 갖는다", () => {
+    const content = toInterviewContent(
+      [question("1", "같은 질문", 1), question("2", "같은 질문", 2)],
+      [],
+    )
+
+    const ids = content?.blocks[0]?.questions.map((q) => q.id)
+    expect(ids).toEqual(["1", "2"])
+    expect(new Set(ids).size).toBe(2)
+  })
+
   it("답변 저장 경로가 없어 답변은 비워 둔다", () => {
     const content = toInterviewContent([question("1", "공통", 1)], [])
     expect(content?.blocks[0]?.answers).toEqual([])

--- a/src/features/recruiting/model/interviewMapper.ts
+++ b/src/features/recruiting/model/interviewMapper.ts
@@ -9,14 +9,17 @@ function toBlock(
   title: string,
   questions: RecruitingInterviewQuestion[],
 ): InterviewQuestionBlock | null {
-  if (questions.length === 0) return null
+  // 조회 API 가 활성 질문만 준다고 알려져 있지만, 응답에 active 가 실려 오므로
+  // 여기서도 거른다. 이 함수만 놓고 봐도 결과가 맞아야 한다.
+  const active = questions.filter((question) => question.active)
+  if (active.length === 0) return null
   return {
     group,
     title,
-    questions: questions
+    questions: active
       .slice()
       .sort((a, b) => a.orderNo - b.orderNo)
-      .map((question) => ({ text: question.content })),
+      .map((question) => ({ id: String(question.id), text: question.content })),
     // 답변을 저장·조회하는 경로가 아직 없다. 질문만 채운다.
     answers: [],
   }

--- a/src/features/recruiting/model/interviewMapper.ts
+++ b/src/features/recruiting/model/interviewMapper.ts
@@ -1,0 +1,36 @@
+import type { RecruitingInterviewQuestion } from "../api/types"
+import type {
+  InterviewContent,
+  InterviewQuestionBlock,
+} from "./applicationDetail"
+
+function toBlock(
+  group: InterviewQuestionBlock["group"],
+  title: string,
+  questions: RecruitingInterviewQuestion[],
+): InterviewQuestionBlock | null {
+  if (questions.length === 0) return null
+  return {
+    group,
+    title,
+    questions: questions
+      .slice()
+      .sort((a, b) => a.orderNo - b.orderNo)
+      .map((question) => ({ text: question.content })),
+    // 답변을 저장·조회하는 경로가 아직 없다. 질문만 채운다.
+    answers: [],
+  }
+}
+
+export function toInterviewContent(
+  roundQuestions: RecruitingInterviewQuestion[],
+  applicationQuestions: RecruitingInterviewQuestion[],
+): InterviewContent | null {
+  const blocks = [
+    toBlock("common", "공통 질문", roundQuestions),
+    toBlock("individual", "개별 질문", applicationQuestions),
+  ].filter((block): block is InterviewQuestionBlock => block != null)
+
+  if (blocks.length === 0) return null
+  return { blocks }
+}

--- a/src/features/recruiting/ui/detail/ApplicationEvaluationDetailPage.tsx
+++ b/src/features/recruiting/ui/detail/ApplicationEvaluationDetailPage.tsx
@@ -4,15 +4,19 @@ import LeftChevronIcon from "@/shared/assets/icon/chevron/LeftChevronIcon"
 import { Breadcrumb } from "@/shared/ui/breadcrumb/Breadcrumb"
 
 import { useApplicationDetail } from "../../hooks/useApplicationDetail"
+import { useSubmitEvaluation } from "../../hooks/useEvaluationMutations"
+import { useInterviewQuestions } from "../../hooks/useInterviewQuestions"
 import { useStageEvaluations } from "../../hooks/useStageEvaluations"
+import { canDecideFinal } from "../../model/evaluationRules"
 import {
   EVALUATION_STAGE_LABEL,
   EVALUATION_STAGE_SHORT_LABEL,
   type EvaluationStage,
 } from "../../model/evaluationStage"
 import { ApplicationFormReadonly } from "./ApplicationFormReadonly"
-import { EvaluationResultToggle } from "./EvaluationResultToggle"
 import { EvaluationStepper } from "./EvaluationStepper"
+import { FinalDecisionSection } from "./FinalDecisionSection"
+import { InterviewAnswerCards } from "./InterviewAnswerCards"
 import { MyStageEvaluationPanel } from "./MyStageEvaluationPanel"
 import { OperatorEvaluationList } from "./OperatorEvaluationList"
 
@@ -57,12 +61,22 @@ export function ApplicationEvaluationDetailPage({
   applicationId,
   roundId,
 }: ApplicationEvaluationDetailPageProps) {
-  const { detail, isError } = useApplicationDetail(applicationId, roundId)
+  const { detail, application, isError } = useApplicationDetail(
+    applicationId,
+    roundId,
+  )
   const {
     evaluation,
     rosterKnown,
+    rosterUnavailable,
     isError: isEvaluationError,
-  } = useStageEvaluations(applicationId, roundId, stage)
+  } = useStageEvaluations(applicationId, roundId, stage, application?.status)
+  const submitEvaluation = useSubmitEvaluation(applicationId, roundId, stage)
+  const { interview } = useInterviewQuestions(
+    applicationId,
+    roundId,
+    stage === "interview",
+  )
 
   const listPath = STAGE_LIST_PATH[stage]
   const showFinalResult = stage !== "document"
@@ -123,6 +137,9 @@ export function ApplicationEvaluationDetailPage({
               stage={stage}
               reachedStages={detail.reachedStages}
             />
+            {stage === "interview" && interview && (
+              <InterviewAnswerCards content={interview} />
+            )}
             {isEvaluationError ? (
               <div className="border-teal-gray-100 flex min-h-30 items-center justify-center rounded-[16px] border bg-white p-6">
                 <p className="text-body-2-regular text-teal-gray-500">
@@ -136,7 +153,12 @@ export function ApplicationEvaluationDetailPage({
                     <MyStageEvaluationPanel
                       evaluation={evaluation}
                       stage={stage}
-                      onComplete={() => {}}
+                      onComplete={(result, comment) =>
+                        submitEvaluation.mutateAsync({
+                          decision: result === "pass" ? "APPROVED" : "REJECTED",
+                          comment: comment || undefined,
+                        })
+                      }
                     />
                   )}
                   <OperatorEvaluationList
@@ -146,20 +168,21 @@ export function ApplicationEvaluationDetailPage({
                 </>
               )
             )}
-            {showFinalResult && (
-              <div className="flex items-center justify-center gap-4 pt-2">
-                <span className="text-heading-7-semibold text-teal-gray-800">
-                  {finalResultLabel}
-                </span>
-                <EvaluationResultToggle
-                  value={detail.finalResult}
-                  onChange={() => {}}
-                  disabled
-                  variant="strong"
-                  failLabel="최종 불합격"
-                  passLabel="최종 합격"
+            {showFinalResult && application && (
+              <>
+                <FinalDecisionSection
+                  label={finalResultLabel}
+                  application={application}
+                  currentResult={detail.finalResult}
+                  canDecide={canDecideFinal(application.status, rosterKnown)}
                 />
-              </div>
+                {rosterUnavailable && (
+                  <p className="text-body-2-regular text-teal-gray-500 text-center">
+                    권한 정보를 불러오지 못해 합불 처리를 열지 못했습니다.
+                    새로고침 후 다시 시도해주세요.
+                  </p>
+                )}
+              </>
             )}
           </div>
         </div>

--- a/src/features/recruiting/ui/detail/ApplicationEvaluationDetailPage.tsx
+++ b/src/features/recruiting/ui/detail/ApplicationEvaluationDetailPage.tsx
@@ -72,7 +72,7 @@ export function ApplicationEvaluationDetailPage({
     isError: isEvaluationError,
   } = useStageEvaluations(applicationId, roundId, stage, application?.status)
   const submitEvaluation = useSubmitEvaluation(applicationId, roundId, stage)
-  const { interview } = useInterviewQuestions(
+  const { interview, isError: isInterviewError } = useInterviewQuestions(
     applicationId,
     roundId,
     stage === "interview",
@@ -137,9 +137,16 @@ export function ApplicationEvaluationDetailPage({
               stage={stage}
               reachedStages={detail.reachedStages}
             />
-            {stage === "interview" && interview && (
-              <InterviewAnswerCards content={interview} />
-            )}
+            {stage === "interview" &&
+              (isInterviewError ? (
+                <div className="border-teal-gray-100 flex min-h-20 items-center justify-center rounded-[16px] border bg-white p-6">
+                  <p className="text-body-2-regular text-teal-gray-500">
+                    면접 질문을 불러오지 못했습니다.
+                  </p>
+                </div>
+              ) : (
+                interview && <InterviewAnswerCards content={interview} />
+              ))}
             {isEvaluationError ? (
               <div className="border-teal-gray-100 flex min-h-30 items-center justify-center rounded-[16px] border bg-white p-6">
                 <p className="text-body-2-regular text-teal-gray-500">

--- a/src/features/recruiting/ui/detail/FinalDecisionSection.tsx
+++ b/src/features/recruiting/ui/detail/FinalDecisionSection.tsx
@@ -1,0 +1,132 @@
+import { useState } from "react"
+
+import { cn } from "@/shared/lib/utils"
+import { PART_TAG_LABEL } from "@/shared/model/domain"
+import { CtaModal } from "@/shared/ui/modal/CtaModal"
+
+import { useFinalDecision } from "../../hooks/useEvaluationMutations"
+import { toPartTags } from "../../model/applicantMapper"
+import {
+  buildFinalDecisionBody,
+  toAcceptableTracks,
+} from "../../model/evaluationRules"
+import { EvaluationResultToggle } from "./EvaluationResultToggle"
+
+import type {
+  RecruitingApplicationSummary,
+  RecruitingTrack,
+} from "../../api/types"
+import type { EvaluationResult } from "../../model/applicantListTypes"
+
+interface FinalDecisionSectionProps {
+  label: string
+  application: RecruitingApplicationSummary
+  currentResult: EvaluationResult | null
+  canDecide: boolean
+}
+
+function trackLabel(track: RecruitingTrack): string {
+  const [tag] = toPartTags(track, null)
+  return tag ? PART_TAG_LABEL[tag] : track
+}
+
+export function FinalDecisionSection({
+  label,
+  application,
+  currentResult,
+  canDecide,
+}: FinalDecisionSectionProps) {
+  const decideFinal = useFinalDecision(String(application.applicationId))
+  const tracks = toAcceptableTracks(application)
+  const [pending, setPending] = useState<EvaluationResult | null>(null)
+  const [selectedTrack, setSelectedTrack] = useState<RecruitingTrack | null>(
+    null,
+  )
+
+  const openConfirm = (next: EvaluationResult) => {
+    setPending(next)
+    setSelectedTrack(next === "pass" ? (tracks[0] ?? null) : null)
+  }
+
+  const closeConfirm = () => {
+    setPending(null)
+    setSelectedTrack(null)
+  }
+
+  const confirm = async () => {
+    if (!pending) return
+    const body = buildFinalDecisionBody(
+      pending === "pass" ? "PASS" : "FAIL",
+      selectedTrack,
+    )
+    if (!body) return
+    await decideFinal.mutateAsync(body)
+    closeConfirm()
+  }
+
+  const needsTrackChoice = pending === "pass" && tracks.length > 1
+
+  return (
+    <>
+      <div className="flex items-center justify-center gap-4 pt-2">
+        <span className="text-heading-7-semibold text-teal-gray-800">
+          {label}
+        </span>
+        <EvaluationResultToggle
+          value={currentResult}
+          onChange={openConfirm}
+          disabled={!canDecide}
+          variant="strong"
+          failLabel="최종 불합격"
+          passLabel="최종 합격"
+        />
+      </div>
+
+      <CtaModal
+        open={pending != null}
+        variant={pending === "pass" ? "success" : "warning"}
+        title={pending === "pass" ? "최종 합격 처리" : "최종 불합격 처리"}
+        confirmText="확인"
+        cancelText="취소"
+        confirmLoading={decideFinal.isPending}
+        onOpenChange={(open) => {
+          if (!open) closeConfirm()
+        }}
+        onCancel={closeConfirm}
+        onConfirm={confirm}
+        content={
+          <div className="flex flex-col gap-4">
+            <p>
+              {application.applicantName} 지원자를{" "}
+              {pending === "pass" ? "최종 합격" : "최종 불합격"} 처리합니다.
+            </p>
+            {needsTrackChoice && (
+              <div className="flex flex-col gap-2">
+                <span className="text-body-2-medium text-teal-gray-700">
+                  합격 파트를 선택해주세요.
+                </span>
+                <div className="flex gap-2">
+                  {tracks.map((track) => (
+                    <button
+                      key={track}
+                      type="button"
+                      onClick={() => setSelectedTrack(track)}
+                      className={cn(
+                        "text-body-2-medium rounded-[8px] border px-3 py-2",
+                        selectedTrack === track
+                          ? "border-teal-500 bg-teal-50 text-teal-700"
+                          : "border-teal-gray-200 text-teal-gray-600",
+                      )}
+                    >
+                      {trackLabel(track)}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        }
+      />
+    </>
+  )
+}

--- a/src/features/recruiting/ui/detail/InterviewAnswerCards.tsx
+++ b/src/features/recruiting/ui/detail/InterviewAnswerCards.tsx
@@ -83,7 +83,12 @@ function InterviewBlockCard({ block }: { block: InterviewQuestionBlock }) {
             ))}
           </ol>
 
-          <div className="flex flex-col gap-4">
+          <div
+            className={cn(
+              "flex flex-col gap-4",
+              block.answers.length === 0 && "hidden",
+            )}
+          >
             <h4 className="text-heading-7-semibold text-teal-gray-800">
               지원자 답변
             </h4>

--- a/src/features/recruiting/ui/detail/InterviewAnswerCards.tsx
+++ b/src/features/recruiting/ui/detail/InterviewAnswerCards.tsx
@@ -72,7 +72,7 @@ function InterviewBlockCard({ block }: { block: InterviewQuestionBlock }) {
           <ol className="flex flex-col gap-3">
             {block.questions.map((question, index) => (
               <li
-                key={question.text}
+                key={question.id}
                 className="text-body-1-regular text-teal-gray-800 flex gap-2"
               >
                 <span className="text-teal-gray-500 shrink-0">


### PR DESCRIPTION
## 📸 작업 내용

- 평가 상세 화면의 **쓰기**를 연결했습니다. 조회는 #648 에서 마쳤고 이번 PR로 #641 이 완료됩니다.
- 내 평가 등록·수정을 실제 API 로 전환했습니다. 서버가 거부할 조건(평가자가 아니거나 이미 판정이 끝난 전형)은 화면에서 먼저 막고 사유를 보여줍니다.
- 최종 합불 처리를 붙였습니다. 합격 시 확정 파트를 함께 보내야 해서, **2지망이 있는 지원자만** 확인 시점에 파트를 고르게 했습니다.
- 면접 질문(공통·개별)을 연결했습니다. 답변은 저장·조회 경로가 없어 질문만 렌더합니다.
- 권한·상태 판정을 순수 함수로 분리하고 단위 테스트 21건을 추가했습니다 (총 487건 통과).

## 🎞️ 주요 코드 설명

### 합불 요청 조립

합격과 불합격의 필수 필드가 다릅니다. 합격에는 확정 파트가 반드시 있어야 하고, 불합격에 담으면 거부됩니다. 타입을 유니온으로 갈라 잘못된 조합이 컴파일 단계에서 막히게 했습니다.

```TypeScript
export type FinalDecisionBody =
  | { decision: "PASS"; acceptedTrack: RecruitingTrack; reason?: string }
  | { decision: "FAIL"; reason?: string }
```

- 확정 파트는 지원자의 1·2지망 중 하나여야 합니다. 문서에는 선택 값으로 표기돼 있으나 실제 검증은 더 엄격해, 관찰된 검증 기준을 따랐습니다.

### 평가 등록 가능 여부

```TypeScript
export function resolveEvaluationEligibility(
  stage: EvaluationStage,
  status: RecruitingApplicationStatus | undefined,
  evaluator: EvaluatorState,
): EvaluationEligibility
```

- 서류는 판정 전, 면접은 면접 대상으로 확정된 뒤에만 등록이 열립니다. 판정이 끝나면 수정할 수 없습니다.
- 최종 전형은 평가자별 평가가 없어 등록 대상이 아닙니다.
- 최종 판정은 이미 결과가 나온 지원서에 다시 내릴 수 없어 `canDecideFinal` 로 함께 막았습니다.

### 권한을 확정하지 못하는 구간

평가자 여부를 알려주는 조회 경로가 없어 평가자 명단 조회 결과로 판정합니다. 여기서 **403 과 그 외 실패를 구분**해야 합니다.

```TypeScript
export type EvaluatorState = "yes" | "no" | "unknown"
```

- 403 은 권한이 없다는 확정 답이라 재시도하지 않습니다.
- 그 외 실패는 재시도 후에도 실패하면 `unknown` 으로 남깁니다. 이 상태를 `no` 로 접으면 일시적 장애가 권한 없음으로 굳어, 권한 있는 사용자에게 "평가자만 등록할 수 있습니다" 라는 잘못된 안내가 나갑니다.
- `unknown` 일 때는 잠그되 "권한 정보를 불러오지 못했습니다" 로 안내하고, 합불 영역에도 같은 안내를 붙여 버튼이 왜 막혔는지 보이게 했습니다.

## 🖥️ 구현화면

|        평가 등록         |        최종 합불 확인         |
| :----------------------: | :---------------------------: |
| <img src = "" width ="250"> | <img src = "" width ="250"> |

## 🔗 연결된 이슈

- Connected: #641
- Closes #641

## 💬 기타 더 이야기해볼 점

- **서류 합불은 이번 범위에서 제외했습니다.** API 는 있으나 시안과 화면 어디에도 컨트롤이 없어 임의로 만들지 않았습니다. 어디서 처리하는지 확인이 필요합니다.
- **지원 폼이 참조 중이라 목업 파일을 아직 지우지 못했습니다.** 지원 폼 연동 때 함께 정리합니다.
- dev 로그인이 막혀 있어 **실제 요청을 보내 확인하지는 못했습니다.** 권한·상태 분기는 단위 테스트로 고정했고 타입·빌드·테스트는 통과한 상태입니다.
- 권한 판정을 추론이 아닌 권한 조회 API 기반으로 옮기는 작업을 #656 으로, 역할 판정 불일치를 #655 로 분리해 두었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 단계별 평가 결과를 제출하고 지원자의 최종 합격·불합격 결과를 확정할 수 있습니다.
  * 공통 및 지원서별 면접 질문을 조회하고 면접 평가 화면에서 확인할 수 있습니다.
  * 복수의 합격 트랙이 있는 경우 선택할 트랙을 지정할 수 있습니다.
  * 평가 제출 가능 여부와 제한 사유를 화면에 안내합니다.

* **개선 사항**
  * 평가 및 최종 결과 저장 후 관련 지원자 정보가 자동으로 갱신됩니다.
  * 최종 결과 처리에 필요한 권한이나 정보가 unavailable한 경우 안내 메시지를 표시합니다.
  * 답변이 없는 면접 질문 영역은 화면에 표시되지 않습니다.

* **테스트**
  * 평가 가능 여부, 최종 판정, 트랙 선택 및 면접 질문 표시 규칙을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->