### PR TITLE
🐛 fix: 리크루팅 조회 범위를 실제 권한 기준으로 전환

### DIFF
--- a/src/features/recruiting/hooks/useApplicationDetail.ts
+++ b/src/features/recruiting/hooks/useApplicationDetail.ts
@@ -116,6 +116,8 @@ export function useApplicationDetail(
     // 원본 요약을 그대로 넘긴다.
     application: application ?? null,
     round: location?.round ?? null,
+    // 모집 관리 권한은 시즌 단위로 판정한다.
+    seasonId: location ? String(location.group.seasonId) : null,
     isError:
       gisuQuery.isError ||
       roundQuery.isError ||

--- a/src/features/recruiting/hooks/useRecruitingPermissions.ts
+++ b/src/features/recruiting/hooks/useRecruitingPermissions.ts
@@ -50,6 +50,8 @@ export function useRecruitingPermissions(seasonIds: string[]) {
   return {
     permittedSeasonIds,
     isLoading: query.isLoading,
-    isError: query.isError,
+    // 재조회가 실패해도 앞서 받은 결과는 남는다. 실패를 곧 판정 불가로 접으면
+    // 창에 다시 들어올 때마다 권한이 사라져 버튼이 잠긴다.
+    isUnresolved: query.isError && query.data === undefined,
   }
 }

--- a/src/features/recruiting/hooks/useRecruitingPermissions.ts
+++ b/src/features/recruiting/hooks/useRecruitingPermissions.ts
@@ -1,0 +1,55 @@
+import { useMemo } from "react"
+
+import { useResourcePermissionsBatch } from "@/entities/member/hooks/useResourcePermissionsBatch"
+
+// 모집 관리 권한은 시즌(학교×기수) 단위로 판정된다. 역할 타입으로 흉내 내면
+// 서버가 허용하는 범위와 어긋나므로 권한 조회 결과를 그대로 쓴다.
+export function useRecruitingPermissions(seasonIds: string[]) {
+  const seasonKey = [...new Set(seasonIds)].sort().join(",")
+
+  const resourceIds = useMemo(
+    () =>
+      seasonKey
+        .split(",")
+        .filter(Boolean)
+        .map(Number)
+        .filter((id) => Number.isFinite(id)),
+    [seasonKey],
+  )
+
+  const query = useResourcePermissionsBatch(
+    [
+      {
+        resourceType: "RECRUITMENT",
+        resourceIds,
+        permissionTypes: ["EDIT"],
+      },
+    ],
+    { enabled: resourceIds.length > 0 },
+  )
+
+  const { hasPermission } = query
+  const permittedSeasonIds = useMemo(() => {
+    const permitted = new Set<string>()
+    resourceIds.forEach((resourceId) => {
+      if (
+        hasPermission({
+          resourceType: "RECRUITMENT",
+          resourceId,
+          permissionType: "EDIT",
+        })
+      ) {
+        permitted.add(String(resourceId))
+      }
+    })
+    return permitted
+    // hasPermission 은 매 렌더 새로 만들어지므로 응답 데이터를 의존성으로 쓴다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [query.data, resourceIds])
+
+  return {
+    permittedSeasonIds,
+    isLoading: query.isLoading,
+    isError: query.isError,
+  }
+}

--- a/src/features/recruiting/hooks/useSchoolApplicants.ts
+++ b/src/features/recruiting/hooks/useSchoolApplicants.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
+import { isAxiosError } from "axios"
 
 import { recruitingKeys } from "../api/queryKeys"
 import { getAllRoundApplications } from "../api/recruitingApi"
@@ -32,6 +33,10 @@ export function useSchoolApplicants(
       return perRound.flat()
     },
     enabled: roundIds.length > 0,
+    // 403 은 권한이 없다는 확정 답이라 다시 물어봐도 달라지지 않는다.
+    retry: (failureCount, error) =>
+      !(isAxiosError(error) && error.response?.status === 403) &&
+      failureCount < 2,
     staleTime: 60 * 1000,
   })
 }

--- a/src/features/recruiting/hooks/useStageEvaluations.ts
+++ b/src/features/recruiting/hooks/useStageEvaluations.ts
@@ -18,6 +18,7 @@ import type { RecruitingApplicationStatus } from "../api/types"
 import type {
   EvaluationBlockReason,
   EvaluatorState,
+  ManagePermission,
 } from "../model/evaluationRules"
 import type { EvaluationStage } from "../model/evaluationStage"
 
@@ -34,9 +35,10 @@ export function useStageEvaluations(
   roundId: string | undefined,
   stage: EvaluationStage,
   status: RecruitingApplicationStatus | undefined,
-  /** 모집 관리 권한. 아직 확정되지 않았으면 undefined. */
-  hasManagePermission: boolean | undefined,
+  managePermission: ManagePermission,
 ) {
+  const { isGranted: hasManagePermission, isResolved: isPermissionResolved } =
+    managePermission
   const { data: me } = useMe()
   const apiStage = toApiStage(stage)
   // 평가 목록은 단계별 API 라 최종 단계에는 없지만, 평가자 명단은 차수 단위라
@@ -60,11 +62,10 @@ export function useStageEvaluations(
     [evaluatorsQuery.data],
   )
   const rosterKnown = evaluatorsQuery.isSuccess
-  // 관리 권한자인데 명단을 못 받은 경우. 미평가자를 알 수 없어 총원을 못 센다.
-  const rosterUnavailable = evaluatorsQuery.isError
-  // 권한이 없다고 확정됐으면 명단을 기다릴 필요가 없다.
+  // 명단은 관리 권한자만 조회한다. 권한 판정이 끝났고 권한자가 아니라면 기다릴
+  // 것이 없다. 판정 자체가 아직 안 끝났으면 기다린다.
   const rosterSettled =
-    hasManagePermission === false ||
+    (isPermissionResolved && hasManagePermission !== true) ||
     evaluatorsQuery.isSuccess ||
     evaluatorsQuery.isError
 
@@ -172,9 +173,6 @@ export function useStageEvaluations(
 
   return {
     evaluation,
-    // 명단을 못 받으면 아직 평가하지 않은 운영진을 알 수 없어 총원을 셀 수 없다.
-    rosterKnown,
-    rosterUnavailable,
     hasManagePermission: hasManagePermission === true,
     canSubmit: eligibility.canSubmit,
     isLoading: evaluationsQuery.isLoading,

--- a/src/features/recruiting/hooks/useStageEvaluations.ts
+++ b/src/features/recruiting/hooks/useStageEvaluations.ts
@@ -112,24 +112,27 @@ export function useStageEvaluations(
 
   // 평가 등록은 평가자 명단에 있는 사람만 할 수 있다.
   //  · 관리 권한이 있으면 명단을 직접 받아 확인한다.
-  //  · 권한이 없다고 확정됐다면, 그런데도 평가 목록을 받았다는 사실이
-  //    서버가 평가자로 인정했다는 뜻이다(운영진 경로가 막혔으므로).
-  //  · 권한 자체를 아직 모르면 단정하지 않는다.
+  //  · 권한이 없거나 판정하지 못했다면, 그런데도 평가 목록을 받았다는 사실이
+  //    서버가 평가자로 인정했다는 뜻이다(운영진 경로가 막혔으므로). 권한 조회
+  //    장애로 평가자를 막지 않는다. 평가자가 이 화면의 주 사용자다.
+  //  · 조회가 아직 끝나지 않았으면 단정하지 않는다.
   const evaluatorState: EvaluatorState = useMemo(() => {
-    if (!me || hasManagePermission === undefined) return "unknown"
-    if (hasManagePermission) {
+    if (!me) return "unknown"
+    if (hasManagePermission === true) {
       if (!rosterKnown) return "unknown"
       const myId = String(me.id)
       return roster.some((evaluator) => String(evaluator.memberId) === myId)
         ? "yes"
         : "no"
     }
+    if (!isPermissionResolved) return "unknown"
     if (evaluationsQuery.isSuccess) return "yes"
     if (evaluationsQuery.isError) return "no"
     return "unknown"
   }, [
     me,
     hasManagePermission,
+    isPermissionResolved,
     rosterKnown,
     roster,
     evaluationsQuery.isSuccess,

--- a/src/features/recruiting/hooks/useStageEvaluations.ts
+++ b/src/features/recruiting/hooks/useStageEvaluations.ts
@@ -34,6 +34,8 @@ export function useStageEvaluations(
   roundId: string | undefined,
   stage: EvaluationStage,
   status: RecruitingApplicationStatus | undefined,
+  /** 모집 관리 권한. 아직 확정되지 않았으면 undefined. */
+  hasManagePermission: boolean | undefined,
 ) {
   const { data: me } = useMe()
   const apiStage = toApiStage(stage)
@@ -42,14 +44,12 @@ export function useStageEvaluations(
   // 관리 권한을 판정하지 못해 합불 처리가 잠긴다.
   const evaluationsEnabled = roundId != null && apiStage != null
 
-  // 평가자 명단은 모집 관리 권한이 있어야 조회할 수 있다. 평가자 whitelist 에만
-  // 올라간 운영진은 403 을 받으므로, 실패해도 평가 목록은 그대로 보여준다.
-  // 403 은 권한이 없다는 확정 답이라 재시도하지 않고, 나머지 오류만 재시도해
-  // 일시적 실패가 권한 없음으로 오인되지 않게 한다.
+  // 평가자 명단은 모집 관리 권한이 있어야 조회할 수 있다. 권한이 없다고 이미
+  // 알고 있으면 403 을 부르지 않는다. 명단은 총원(분모) 계산에만 쓴다.
   const evaluatorsQuery = useQuery({
     queryKey: recruitingKeys.evaluators(roundId ?? ""),
     queryFn: () => getRoundEvaluators(roundId!),
-    enabled: roundId != null,
+    enabled: roundId != null && hasManagePermission === true,
     retry: (failureCount, error) =>
       !(isAxiosError(error) && error.response?.status === 403) &&
       failureCount < 2,
@@ -60,16 +60,13 @@ export function useStageEvaluations(
     [evaluatorsQuery.data],
   )
   const rosterKnown = evaluatorsQuery.isSuccess
-  // 403 은 "관리 권한 없음"이라는 확정 답이고, 그 외 실패는 아무것도 알려주지
-  // 않는다. 둘을 한 값으로 접으면 장애를 권한 없음으로 오인한다.
-  const rosterDenied =
-    evaluatorsQuery.isError &&
-    isAxiosError(evaluatorsQuery.error) &&
-    evaluatorsQuery.error.response?.status === 403
-  const rosterUnavailable = evaluatorsQuery.isError && !rosterDenied
-  // 명단 조회가 끝나기 전에는 관리 권한 유무를 알 수 없다. 그 사이에 비운영진
-  // 화면을 보였다가 뒤바뀌지 않도록 결과가 확정된 뒤에 조립한다.
-  const rosterSettled = evaluatorsQuery.isSuccess || evaluatorsQuery.isError
+  // 관리 권한자인데 명단을 못 받은 경우. 미평가자를 알 수 없어 총원을 못 센다.
+  const rosterUnavailable = evaluatorsQuery.isError
+  // 권한이 없다고 확정됐으면 명단을 기다릴 필요가 없다.
+  const rosterSettled =
+    hasManagePermission === false ||
+    evaluatorsQuery.isSuccess ||
+    evaluatorsQuery.isError
 
   const evaluationsQuery = useQuery({
     queryKey: recruitingKeys.stageEvaluations(
@@ -113,22 +110,30 @@ export function useStageEvaluations(
   })
 
   // 평가 등록은 평가자 명단에 있는 사람만 할 수 있다.
-  //  · 명단을 받았으면 직접 확인한다.
-  //  · 403 이면 관리 권한이 없다는 뜻이고, 그런데도 평가 목록을 받았다면
-  //    서버가 평가자로 인정한 것이다(운영진 경로가 막혔으므로).
-  //  · 그 밖의 실패는 아무것도 증명하지 못한다. 운영진도 이 경로로 떨어질 수
-  //    있어 평가자로 단정하면 제출 단계에서 거부된다.
+  //  · 관리 권한이 있으면 명단을 직접 받아 확인한다.
+  //  · 권한이 없다고 확정됐다면, 그런데도 평가 목록을 받았다는 사실이
+  //    서버가 평가자로 인정했다는 뜻이다(운영진 경로가 막혔으므로).
+  //  · 권한 자체를 아직 모르면 단정하지 않는다.
   const evaluatorState: EvaluatorState = useMemo(() => {
-    if (!me) return "unknown"
-    if (rosterKnown) {
+    if (!me || hasManagePermission === undefined) return "unknown"
+    if (hasManagePermission) {
+      if (!rosterKnown) return "unknown"
       const myId = String(me.id)
       return roster.some((evaluator) => String(evaluator.memberId) === myId)
         ? "yes"
         : "no"
     }
-    if (rosterDenied) return evaluationsQuery.isSuccess ? "yes" : "no"
+    if (evaluationsQuery.isSuccess) return "yes"
+    if (evaluationsQuery.isError) return "no"
     return "unknown"
-  }, [me, rosterKnown, rosterDenied, roster, evaluationsQuery.isSuccess])
+  }, [
+    me,
+    hasManagePermission,
+    rosterKnown,
+    roster,
+    evaluationsQuery.isSuccess,
+    evaluationsQuery.isError,
+  ])
 
   const eligibility = resolveEvaluationEligibility(
     stage,
@@ -170,6 +175,7 @@ export function useStageEvaluations(
     // 명단을 못 받으면 아직 평가하지 않은 운영진을 알 수 없어 총원을 셀 수 없다.
     rosterKnown,
     rosterUnavailable,
+    hasManagePermission: hasManagePermission === true,
     canSubmit: eligibility.canSubmit,
     isLoading: evaluationsQuery.isLoading,
     isError: evaluationsQuery.isError,

--- a/src/features/recruiting/model/evaluationRules.test.ts
+++ b/src/features/recruiting/model/evaluationRules.test.ts
@@ -17,7 +17,7 @@ describe("resolveManagePermission", () => {
         seasonId: "7",
         permittedSeasonIds: permitted,
         isLoading: false,
-        isError: false,
+        isUnresolved: false,
       }),
     ).toEqual({ isGranted: true, isResolved: true })
   })
@@ -28,7 +28,7 @@ describe("resolveManagePermission", () => {
         seasonId: "9",
         permittedSeasonIds: permitted,
         isLoading: false,
-        isError: false,
+        isUnresolved: false,
       }),
     ).toEqual({ isGranted: false, isResolved: true })
   })
@@ -39,7 +39,7 @@ describe("resolveManagePermission", () => {
         seasonId: "7",
         permittedSeasonIds: new Set(),
         isLoading: false,
-        isError: true,
+        isUnresolved: true,
       }),
     ).toEqual({ isGranted: undefined, isResolved: true })
   })
@@ -50,7 +50,7 @@ describe("resolveManagePermission", () => {
         seasonId: "7",
         permittedSeasonIds: new Set(),
         isLoading: true,
-        isError: false,
+        isUnresolved: false,
       }),
     ).toEqual({ isGranted: undefined, isResolved: false })
   })
@@ -61,7 +61,7 @@ describe("resolveManagePermission", () => {
         seasonId: null,
         permittedSeasonIds: permitted,
         isLoading: false,
-        isError: false,
+        isUnresolved: false,
       }),
     ).toEqual({ isGranted: undefined, isResolved: false })
   })

--- a/src/features/recruiting/model/evaluationRules.test.ts
+++ b/src/features/recruiting/model/evaluationRules.test.ts
@@ -4,8 +4,68 @@ import {
   buildFinalDecisionBody,
   canDecideFinal,
   resolveEvaluationEligibility,
+  resolveManagePermission,
   toAcceptableTracks,
 } from "./evaluationRules"
+
+describe("resolveManagePermission", () => {
+  const permitted = new Set(["7"])
+
+  it("권한 목록에 있으면 허용한다", () => {
+    expect(
+      resolveManagePermission({
+        seasonId: "7",
+        permittedSeasonIds: permitted,
+        isLoading: false,
+        isError: false,
+      }),
+    ).toEqual({ isGranted: true, isResolved: true })
+  })
+
+  it("권한 목록에 없으면 없음으로 확정한다", () => {
+    expect(
+      resolveManagePermission({
+        seasonId: "9",
+        permittedSeasonIds: permitted,
+        isLoading: false,
+        isError: false,
+      }),
+    ).toEqual({ isGranted: false, isResolved: true })
+  })
+
+  it("조회가 실패하면 권한 없음이 아니라 판정 불가로 둔다", () => {
+    expect(
+      resolveManagePermission({
+        seasonId: "7",
+        permittedSeasonIds: new Set(),
+        isLoading: false,
+        isError: true,
+      }),
+    ).toEqual({ isGranted: undefined, isResolved: true })
+  })
+
+  it("조회 중에는 확정하지 않고 기다린다", () => {
+    expect(
+      resolveManagePermission({
+        seasonId: "7",
+        permittedSeasonIds: new Set(),
+        isLoading: true,
+        isError: false,
+      }),
+    ).toEqual({ isGranted: undefined, isResolved: false })
+  })
+
+  it("시즌을 모르면 판정하지 않는다", () => {
+    expect(
+      resolveManagePermission({
+        seasonId: null,
+        permittedSeasonIds: permitted,
+        isLoading: false,
+        isError: false,
+      }),
+    ).toEqual({ isGranted: undefined, isResolved: false })
+  })
+})
 
 describe("resolveEvaluationEligibility", () => {
   it("평가자가 판정 전 서류를 평가할 수 있다", () => {

--- a/src/features/recruiting/model/evaluationRules.ts
+++ b/src/features/recruiting/model/evaluationRules.ts
@@ -22,6 +22,34 @@ export interface EvaluationEligibility {
 // 접으면 권한 있는 사람에게 잘못된 안내가 나가므로 따로 둔다.
 export type EvaluatorState = "yes" | "no" | "unknown"
 
+export interface ManagePermission {
+  isGranted: boolean | undefined
+  isResolved: boolean
+}
+
+// 권한 조회 실패는 '권한 없음'이 아니다. 둘을 한 값으로 접으면 관리 권한자의
+// 합불 버튼이 사유 없이 잠긴다. 실패는 '판정 불가'로 두고, 아직 조회 중인
+// 구간과도 구분해 기다릴지 말지를 호출부가 가릴 수 있게 한다.
+export function resolveManagePermission({
+  seasonId,
+  permittedSeasonIds,
+  isLoading,
+  isError,
+}: {
+  seasonId: string | null
+  permittedSeasonIds: ReadonlySet<string>
+  isLoading: boolean
+  isError: boolean
+}): ManagePermission {
+  if (seasonId == null || isLoading) {
+    return { isGranted: undefined, isResolved: false }
+  }
+  if (isError) {
+    return { isGranted: undefined, isResolved: true }
+  }
+  return { isGranted: permittedSeasonIds.has(seasonId), isResolved: true }
+}
+
 // 서버는 전형이 열려 있는 동안에만 평가 등록을 받는다. 서류는 판정 전(SUBMITTED),
 // 면접은 면접 대상으로 확정된 뒤(INTERVIEW_ASSIGNED)만 열린다.
 const OPEN_STATUS: Partial<

--- a/src/features/recruiting/model/evaluationRules.ts
+++ b/src/features/recruiting/model/evaluationRules.ts
@@ -34,17 +34,17 @@ export function resolveManagePermission({
   seasonId,
   permittedSeasonIds,
   isLoading,
-  isError,
+  isUnresolved,
 }: {
   seasonId: string | null
   permittedSeasonIds: ReadonlySet<string>
   isLoading: boolean
-  isError: boolean
+  isUnresolved: boolean
 }): ManagePermission {
   if (seasonId == null || isLoading) {
     return { isGranted: undefined, isResolved: false }
   }
-  if (isError) {
+  if (isUnresolved) {
     return { isGranted: undefined, isResolved: true }
   }
   return { isGranted: permittedSeasonIds.has(seasonId), isResolved: true }

--- a/src/features/recruiting/model/recruitingRole.ts
+++ b/src/features/recruiting/model/recruitingRole.ts
@@ -1,22 +1,9 @@
-import {
-  getViewerBranch,
-  isCentralStaff,
-  isChapterPresident,
-  isSuperAdmin,
-} from "@/entities/member/model/identity"
+import { getViewerBranch } from "@/entities/member/model/identity"
 
 import type { MemberInfoResponse } from "@/entities/member/api/me"
 
-import type { RecruitingListRole } from "./recruitingListRole"
-
-export function resolveRecruitingListRole(
-  me: MemberInfoResponse | undefined,
-): RecruitingListRole {
-  if (isSuperAdmin(me) || isCentralStaff(me)) return "central"
-  if (isChapterPresident(me)) return "chapterAdmin"
-  return "schoolStaff"
-}
-
+// 조회 범위는 역할 타입이 아니라 모집 관리 권한으로 정한다(model/recruitingScope.ts).
+// 역할 타입으로 판정하면 서버가 허용하는 범위와 어긋난다.
 export function resolveViewerChapter(me: MemberInfoResponse | undefined) {
   return getViewerBranch(me)
 }

--- a/src/features/recruiting/model/recruitingScope.test.ts
+++ b/src/features/recruiting/model/recruitingScope.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  applyScopeFilters,
+  resolveRecruitingScope,
+  resolveScopeTabs,
+} from "./recruitingScope"
+
+import type { RecruitingRoundGroup } from "../api/types"
+
+function group(
+  seasonId: string,
+  chapterName: string,
+  schoolName: string,
+): RecruitingRoundGroup {
+  return {
+    seasonId,
+    gisuId: "5",
+    chapterId: "1",
+    chapterName,
+    schoolId: seasonId,
+    schoolName,
+    rounds: [],
+  }
+}
+
+const GROUPS = [
+  group("1", "서울", "중앙대학교"),
+  group("2", "서울", "한양대학교"),
+  group("3", "경기", "아주대학교"),
+]
+
+describe("resolveRecruitingScope", () => {
+  it("관리 권한이 있는 시즌만 범위에 넣는다", () => {
+    const scope = resolveRecruitingScope(
+      GROUPS,
+      new Set(["1", "3"]),
+      "중앙대학교",
+    )
+
+    expect(scope.groups.map((g) => g.seasonId)).toEqual(["1", "3"])
+    expect(scope.chapters).toEqual(["서울", "경기"])
+    expect(scope.isFallback).toBe(false)
+  })
+
+  it("권한이 하나도 없으면 내 학교로 좁힌다", () => {
+    const scope = resolveRecruitingScope(GROUPS, new Set(), "한양대학교")
+
+    expect(scope.groups.map((g) => g.seasonId)).toEqual(["2"])
+    expect(scope.isFallback).toBe(true)
+  })
+
+  it("권한도 없고 내 학교 모집도 없으면 비어 있다", () => {
+    const scope = resolveRecruitingScope(GROUPS, new Set(), "고려대학교")
+    expect(scope.groups).toEqual([])
+    expect(scope.isFallback).toBe(false)
+  })
+
+  it("학교 정보를 모르면 폴백하지 않는다", () => {
+    const scope = resolveRecruitingScope(GROUPS, new Set(), undefined)
+    expect(scope.groups).toEqual([])
+  })
+
+  it("권한이 있으면 내 학교가 아니어도 폴백으로 덮지 않는다", () => {
+    const scope = resolveRecruitingScope(GROUPS, new Set(["3"]), "중앙대학교")
+
+    expect(scope.groups.map((g) => g.schoolName)).toEqual(["아주대학교"])
+    expect(scope.isFallback).toBe(false)
+  })
+
+  it("시즌 id 가 숫자로 와도 매칭된다", () => {
+    const numeric = [
+      { ...group("1", "서울", "중앙대학교"), seasonId: 1 as unknown as string },
+    ]
+    const scope = resolveRecruitingScope(numeric, new Set(["1"]), undefined)
+    expect(scope.groups).toHaveLength(1)
+  })
+})
+
+describe("resolveScopeTabs", () => {
+  it("지부가 여럿이면 지부 탭을 쓴다", () => {
+    const scope = resolveRecruitingScope(GROUPS, new Set(["1", "3"]), undefined)
+    expect(resolveScopeTabs(scope)).toEqual({
+      showChapterTabs: true,
+      showSchoolTabs: false,
+    })
+  })
+
+  it("한 지부에 학교가 여럿이면 학교 탭을 쓴다", () => {
+    const scope = resolveRecruitingScope(GROUPS, new Set(["1", "2"]), undefined)
+    expect(resolveScopeTabs(scope)).toEqual({
+      showChapterTabs: false,
+      showSchoolTabs: true,
+    })
+  })
+
+  it("학교 하나면 탭을 두지 않는다", () => {
+    const scope = resolveRecruitingScope(GROUPS, new Set(["1"]), undefined)
+    expect(resolveScopeTabs(scope)).toEqual({
+      showChapterTabs: false,
+      showSchoolTabs: false,
+    })
+  })
+})
+
+describe("applyScopeFilters", () => {
+  const wide = resolveRecruitingScope(
+    GROUPS,
+    new Set(["1", "2", "3"]),
+    undefined,
+  )
+
+  it("지부 탭을 고르면 그 지부만 남긴다", () => {
+    expect(
+      applyScopeFilters(wide, "서울", "all", []).map((g) => g.schoolName),
+    ).toEqual(["중앙대학교", "한양대학교"])
+  })
+
+  it("전체 탭에서 지부를 고르지 않으면 아무것도 조회하지 않는다", () => {
+    expect(applyScopeFilters(wide, "all", "all", [])).toEqual([])
+  })
+
+  it("전체 탭에서 고른 지부만 조회한다", () => {
+    expect(
+      applyScopeFilters(wide, "all", "all", ["경기"]).map((g) => g.schoolName),
+    ).toEqual(["아주대학교"])
+  })
+
+  it("한 지부 안에서는 학교 탭으로 좁힌다", () => {
+    const chapterScope = resolveRecruitingScope(
+      GROUPS,
+      new Set(["1", "2"]),
+      undefined,
+    )
+    expect(
+      applyScopeFilters(chapterScope, "all", "한양대학교", []).map(
+        (g) => g.schoolName,
+      ),
+    ).toEqual(["한양대학교"])
+  })
+
+  it("탭이 없으면 범위를 그대로 쓴다", () => {
+    const single = resolveRecruitingScope(GROUPS, new Set(["1"]), undefined)
+    expect(applyScopeFilters(single, "all", "all", [])).toHaveLength(1)
+  })
+})

--- a/src/features/recruiting/model/recruitingScope.ts
+++ b/src/features/recruiting/model/recruitingScope.ts
@@ -1,0 +1,80 @@
+import type { RecruitingRoundGroup } from "../api/types"
+
+export interface RecruitingScope {
+  /** 화면에 올릴 후보 그룹. 권한이 있는 시즌이거나, 없으면 내 학교. */
+  groups: RecruitingRoundGroup[]
+  chapters: string[]
+  schools: string[]
+  /** 관리 권한 없이 내 학교로 좁힌 경우. 평가자가 여기에 해당한다. */
+  isFallback: boolean
+}
+
+const EMPTY: RecruitingScope = {
+  groups: [],
+  chapters: [],
+  schools: [],
+  isFallback: false,
+}
+
+function summarize(
+  groups: RecruitingRoundGroup[],
+  isFallback: boolean,
+): RecruitingScope {
+  if (groups.length === 0) return EMPTY
+  return {
+    groups,
+    chapters: [...new Set(groups.map((group) => group.chapterName))],
+    schools: [...new Set(groups.map((group) => group.schoolName))],
+    isFallback,
+  }
+}
+
+// 관리 권한이 있는 시즌이 곧 조회 범위다. 평가자는 시즌 권한이 없어 이 조회에
+// 잡히지 않으므로, 권한이 하나도 없으면 내 학교를 후보로 두고 조회를 시도한다.
+// 권한이 없는 학교는 카드 단계에서 걸러진다.
+export function resolveRecruitingScope(
+  groups: RecruitingRoundGroup[],
+  permittedSeasonIds: ReadonlySet<string>,
+  viewerSchool: string | undefined,
+): RecruitingScope {
+  const permitted = groups.filter((group) =>
+    permittedSeasonIds.has(String(group.seasonId)),
+  )
+  if (permitted.length > 0) return summarize(permitted, false)
+
+  if (!viewerSchool) return EMPTY
+  const mySchool = groups.filter((group) => group.schoolName === viewerSchool)
+  return summarize(mySchool, true)
+}
+
+/** 지부가 여럿이면 지부 탭으로, 한 지부 안에 학교가 여럿이면 학교 탭으로 가른다. */
+export function resolveScopeTabs(scope: RecruitingScope) {
+  return {
+    showChapterTabs: scope.chapters.length > 1,
+    showSchoolTabs: scope.chapters.length === 1 && scope.schools.length > 1,
+  }
+}
+
+export function applyScopeFilters(
+  scope: RecruitingScope,
+  chapterTab: string,
+  schoolTab: string,
+  chapters: string[],
+): RecruitingRoundGroup[] {
+  const { showChapterTabs, showSchoolTabs } = resolveScopeTabs(scope)
+
+  if (showChapterTabs) {
+    if (chapterTab !== "all") {
+      return scope.groups.filter((group) => group.chapterName === chapterTab)
+    }
+    // 전 지부를 한 번에 조회하면 차수 수만큼 요청이 나간다. 지부를 고르게 한다.
+    if (chapters.length === 0) return []
+    return scope.groups.filter((group) => chapters.includes(group.chapterName))
+  }
+
+  if (showSchoolTabs && schoolTab !== "all") {
+    return scope.groups.filter((group) => group.schoolName === schoolTab)
+  }
+
+  return scope.groups
+}

--- a/src/features/recruiting/ui/ApplicantListPage.tsx
+++ b/src/features/recruiting/ui/ApplicantListPage.tsx
@@ -4,6 +4,7 @@ import { useMe } from "@/entities/member/hooks/useMe"
 import { isChapter } from "@/entities/organization/model/chapters"
 import { PageLabel } from "@/shared/ui/page-label/PageLabel"
 
+import { useRecruitingPermissions } from "../hooks/useRecruitingPermissions"
 import { useRecruitingRounds } from "../hooks/useRecruitingRounds"
 import {
   type ApplicantListFilters,
@@ -18,17 +19,21 @@ import {
 } from "../model/evaluationStage"
 import {
   formatGisuLabel,
-  resolveRecruitingListRole,
   resolveViewerChapter,
   resolveViewerSchool,
 } from "../model/recruitingRole"
+import {
+  applyScopeFilters,
+  resolveRecruitingScope,
+  resolveScopeTabs,
+} from "../model/recruitingScope"
 import { ApplicantFilterBar } from "./ApplicantFilterBar"
 import { ChapterTabs } from "./ChapterTabs"
 import { SchoolApplicantSection } from "./SchoolApplicantSection"
 import { SchoolTabs } from "./SchoolTabs"
 
 import type { RecruitingRoundGroup } from "../api/types"
-import type { RecruitingListRole } from "../model/recruitingListRole"
+import type { RecruitingScope } from "../model/recruitingScope"
 import type { ApplicantColumnOptions } from "./applicantTableColumns"
 
 const RESULT_FILTER_LABEL: Record<EvaluationStage, string> = {
@@ -42,41 +47,15 @@ const SCHOOL_CARD_COLUMNS: ApplicantColumnOptions = {
   hideSchool: true,
 }
 
-function pageDescription(stage: EvaluationStage, role: RecruitingListRole) {
+function pageDescription(stage: EvaluationStage, scope: RecruitingScope) {
   const shortLabel = EVALUATION_STAGE_SHORT_LABEL[stage]
-  if (role === "chapterAdmin") {
+  if (scope.chapters.length === 1 && scope.schools.length > 1) {
     return `지부 ${shortLabel} 평가 현황을 확인하고, 내 학교 지원자를 평가합니다.`
   }
-  if (role === "schoolStaff") {
+  if (scope.schools.length <= 1) {
     return `내 학교 지원자의 ${shortLabel} 평가 현황을 확인하고 평가합니다.`
   }
   return EVALUATION_STAGE_DESCRIPTION[stage]
-}
-
-function scopeGroups(
-  groups: RecruitingRoundGroup[],
-  role: RecruitingListRole,
-  filters: ApplicantListFilters,
-  viewerChapter: string | undefined,
-  viewerSchool: string | undefined,
-) {
-  if (role === "schoolStaff") {
-    return groups.filter((group) => group.schoolName === viewerSchool)
-  }
-  if (role === "chapterAdmin") {
-    const inChapter = groups.filter(
-      (group) => group.chapterName === viewerChapter,
-    )
-    if (filters.schoolTab === "all") return inChapter
-    return inChapter.filter((group) => group.schoolName === filters.schoolTab)
-  }
-  if (filters.chapterTab === "all") {
-    if (filters.chapters.length === 0) return []
-    return groups.filter((group) =>
-      filters.chapters.includes(group.chapterName),
-    )
-  }
-  return groups.filter((group) => group.chapterName === filters.chapterTab)
 }
 
 interface ApplicantListPageProps {
@@ -91,13 +70,31 @@ export function ApplicantListPage({ stage }: ApplicantListPageProps) {
   const { data: me } = useMe()
   const { groups, generation, isLoading, isError } = useRecruitingRounds()
 
-  const role = resolveRecruitingListRole(me)
   const viewerChapter = resolveViewerChapter(me)
   const viewerSchool = resolveViewerSchool(me)
 
+  const seasonIds = useMemo(
+    () => groups.map((group) => String(group.seasonId)),
+    [groups],
+  )
+  const { permittedSeasonIds, isLoading: isPermissionLoading } =
+    useRecruitingPermissions(seasonIds)
+
+  const scope = useMemo(
+    () => resolveRecruitingScope(groups, permittedSeasonIds, viewerSchool),
+    [groups, permittedSeasonIds, viewerSchool],
+  )
+  const { showChapterTabs, showSchoolTabs } = resolveScopeTabs(scope)
+
   const scopedGroups = useMemo(
-    () => scopeGroups(groups, role, filters, viewerChapter, viewerSchool),
-    [groups, role, filters, viewerChapter, viewerSchool],
+    () =>
+      applyScopeFilters(
+        scope,
+        filters.chapterTab,
+        filters.schoolTab,
+        filters.chapters,
+      ),
+    [scope, filters.chapterTab, filters.schoolTab, filters.chapters],
   )
 
   const chapterGroups = useMemo(() => {
@@ -113,17 +110,6 @@ export function ApplicantListPage({ stage }: ApplicantListPageProps) {
     }))
   }, [scopedGroups])
 
-  const chapterSchools = useMemo(
-    () => [
-      ...new Set(
-        groups
-          .filter((group) => group.chapterName === viewerChapter)
-          .map((group) => group.schoolName),
-      ),
-    ],
-    [groups, viewerChapter],
-  )
-
   const handleFiltersChange = (partial: Partial<ApplicantListFilters>) => {
     setFilters((prev) => ({ ...prev, ...partial }))
   }
@@ -131,7 +117,7 @@ export function ApplicantListPage({ stage }: ApplicantListPageProps) {
   const baseTime = formatBaseTime(new Date())
   const gisuLabel = formatGisuLabel(generation)
   const needsChapterPick =
-    role === "central" &&
+    showChapterTabs &&
     filters.chapterTab === "all" &&
     filters.chapters.length === 0
 
@@ -144,10 +130,10 @@ export function ApplicantListPage({ stage }: ApplicantListPageProps) {
           { id: stage, label: EVALUATION_STAGE_LABEL[stage] },
         ]}
         title={EVALUATION_STAGE_LABEL[stage]}
-        description={pageDescription(stage, role)}
+        description={pageDescription(stage, scope)}
         className="pl-3"
       />
-      {role === "central" && (
+      {showChapterTabs && (
         <ChapterTabs
           value={filters.chapterTab}
           onValueChange={(chapterTab) =>
@@ -156,9 +142,9 @@ export function ApplicantListPage({ stage }: ApplicantListPageProps) {
           className="mt-8"
         />
       )}
-      {role === "chapterAdmin" && (
+      {showSchoolTabs && (
         <SchoolTabs
-          schools={chapterSchools}
+          schools={scope.schools}
           value={filters.schoolTab}
           onValueChange={(schoolTab) =>
             handleFiltersChange({ schoolTab, schools: [] })
@@ -171,11 +157,9 @@ export function ApplicantListPage({ stage }: ApplicantListPageProps) {
         onFiltersChange={handleFiltersChange}
         resultFilterLabel={RESULT_FILTER_LABEL[stage]}
         chapterScope={
-          role === "chapterAdmin" && isChapter(viewerChapter)
-            ? viewerChapter
-            : undefined
+          showSchoolTabs && isChapter(viewerChapter) ? viewerChapter : undefined
         }
-        hideSchoolControls={role === "schoolStaff"}
+        hideSchoolControls={!showChapterTabs && !showSchoolTabs}
         className="mt-6"
       />
       {gisuLabel && (
@@ -185,10 +169,12 @@ export function ApplicantListPage({ stage }: ApplicantListPageProps) {
       )}
       {needsChapterPick ? (
         <EmptyNotice message="지부를 선택하면 해당 지부의 지원자를 확인할 수 있습니다." />
-      ) : isLoading ? (
+      ) : isLoading || isPermissionLoading ? (
         <EmptyNotice message="모집 정보를 불러오는 중입니다." />
       ) : isError ? (
         <EmptyNotice message="모집 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요." />
+      ) : scope.groups.length === 0 ? (
+        <EmptyNotice message="조회할 수 있는 모집이 없습니다." />
       ) : chapterGroups.length === 0 ? (
         <EmptyNotice message="현재 등록된 모집 공고가 없습니다." />
       ) : (

--- a/src/features/recruiting/ui/ApplicantListPage.tsx
+++ b/src/features/recruiting/ui/ApplicantListPage.tsx
@@ -77,8 +77,11 @@ export function ApplicantListPage({ stage }: ApplicantListPageProps) {
     () => groups.map((group) => String(group.seasonId)),
     [groups],
   )
-  const { permittedSeasonIds, isLoading: isPermissionLoading } =
-    useRecruitingPermissions(seasonIds)
+  const {
+    permittedSeasonIds,
+    isLoading: isPermissionLoading,
+    isError: isPermissionError,
+  } = useRecruitingPermissions(seasonIds)
 
   const scope = useMemo(
     () => resolveRecruitingScope(groups, permittedSeasonIds, viewerSchool),
@@ -173,6 +176,8 @@ export function ApplicantListPage({ stage }: ApplicantListPageProps) {
         <EmptyNotice message="모집 정보를 불러오는 중입니다." />
       ) : isError ? (
         <EmptyNotice message="모집 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요." />
+      ) : isPermissionError ? (
+        <EmptyNotice message="권한 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요." />
       ) : scope.groups.length === 0 ? (
         <EmptyNotice message="조회할 수 있는 모집이 없습니다." />
       ) : chapterGroups.length === 0 ? (

--- a/src/features/recruiting/ui/ApplicantListPage.tsx
+++ b/src/features/recruiting/ui/ApplicantListPage.tsx
@@ -47,7 +47,14 @@ const SCHOOL_CARD_COLUMNS: ApplicantColumnOptions = {
   hideSchool: true,
 }
 
-function pageDescription(stage: EvaluationStage, scope: RecruitingScope) {
+function pageDescription(
+  stage: EvaluationStage,
+  scope: RecruitingScope,
+  isScopeReady: boolean,
+) {
+  // 조회가 끝나기 전 빈 스코프로 문구를 정하면 전 지부를 보는 사용자에게도
+  // '내 학교' 설명이 먼저 뜬 뒤 뒤바뀐다.
+  if (!isScopeReady) return EVALUATION_STAGE_DESCRIPTION[stage]
   const shortLabel = EVALUATION_STAGE_SHORT_LABEL[stage]
   if (scope.chapters.length === 1 && scope.schools.length > 1) {
     return `지부 ${shortLabel} 평가 현황을 확인하고, 내 학교 지원자를 평가합니다.`
@@ -80,7 +87,7 @@ export function ApplicantListPage({ stage }: ApplicantListPageProps) {
   const {
     permittedSeasonIds,
     isLoading: isPermissionLoading,
-    isError: isPermissionError,
+    isUnresolved: isPermissionUnresolved,
   } = useRecruitingPermissions(seasonIds)
 
   const scope = useMemo(
@@ -133,7 +140,11 @@ export function ApplicantListPage({ stage }: ApplicantListPageProps) {
           { id: stage, label: EVALUATION_STAGE_LABEL[stage] },
         ]}
         title={EVALUATION_STAGE_LABEL[stage]}
-        description={pageDescription(stage, scope)}
+        description={pageDescription(
+          stage,
+          scope,
+          !isLoading && !isPermissionLoading,
+        )}
         className="pl-3"
       />
       {showChapterTabs && (
@@ -176,10 +187,14 @@ export function ApplicantListPage({ stage }: ApplicantListPageProps) {
         <EmptyNotice message="모집 정보를 불러오는 중입니다." />
       ) : isError ? (
         <EmptyNotice message="모집 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요." />
-      ) : isPermissionError ? (
-        <EmptyNotice message="권한 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요." />
       ) : scope.groups.length === 0 ? (
-        <EmptyNotice message="조회할 수 있는 모집이 없습니다." />
+        <EmptyNotice
+          message={
+            isPermissionUnresolved
+              ? "권한 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요."
+              : "조회할 수 있는 모집이 없습니다."
+          }
+        />
       ) : chapterGroups.length === 0 ? (
         <EmptyNotice message="현재 등록된 모집 공고가 없습니다." />
       ) : (

--- a/src/features/recruiting/ui/SchoolApplicantSection.tsx
+++ b/src/features/recruiting/ui/SchoolApplicantSection.tsx
@@ -1,3 +1,4 @@
+import { isAxiosError } from "axios"
 import { useEffect } from "react"
 
 import { cn } from "@/shared/lib/utils"
@@ -30,10 +31,15 @@ export function SchoolApplicantSection({
   className,
 }: SchoolApplicantSectionProps) {
   const addToast = useToastStore((state) => state.addToast)
-  const { data, isLoading, isError } = useSchoolApplicants(group, stage)
+  const { data, isLoading, isError, error } = useSchoolApplicants(group, stage)
+
+  // 조회 권한이 없는 학교는 장애가 아니라 정상 상황이다. 카드도 토스트도 내지
+  // 않는다. 그러지 않으면 권한 밖 학교 수만큼 오류가 쏟아진다.
+  const isForbidden =
+    isError && isAxiosError(error) && error.response?.status === 403
 
   useEffect(() => {
-    if (!isError) return
+    if (!isError || isForbidden) return
     addToast({
       message: `${group.schoolName} 지원자를 불러오지 못했습니다.`,
       color: "red",
@@ -41,7 +47,11 @@ export function SchoolApplicantSection({
       type: "default",
       duration: 3000,
     })
-  }, [isError, group.schoolName, addToast])
+  }, [isError, isForbidden, group.schoolName, addToast])
+
+  if (isForbidden) {
+    return null
+  }
 
   if (isLoading) {
     return <ApplicantSectionSkeleton className={className} />

--- a/src/features/recruiting/ui/detail/ApplicationEvaluationDetailPage.tsx
+++ b/src/features/recruiting/ui/detail/ApplicationEvaluationDetailPage.tsx
@@ -8,7 +8,10 @@ import { useSubmitEvaluation } from "../../hooks/useEvaluationMutations"
 import { useInterviewQuestions } from "../../hooks/useInterviewQuestions"
 import { useRecruitingPermissions } from "../../hooks/useRecruitingPermissions"
 import { useStageEvaluations } from "../../hooks/useStageEvaluations"
-import { canDecideFinal } from "../../model/evaluationRules"
+import {
+  canDecideFinal,
+  resolveManagePermission,
+} from "../../model/evaluationRules"
 import {
   EVALUATION_STAGE_LABEL,
   EVALUATION_STAGE_SHORT_LABEL,
@@ -66,16 +69,19 @@ export function ApplicationEvaluationDetailPage({
     applicationId,
     roundId,
   )
-  const { permittedSeasonIds, isLoading: isPermissionLoading } =
-    useRecruitingPermissions(seasonId ? [seasonId] : [])
-  // 권한 조회가 끝나기 전에는 확정하지 않는다. 모른 채로 잠그면 사유가 잘못 나간다.
-  const hasManagePermission =
-    seasonId == null || isPermissionLoading
-      ? undefined
-      : permittedSeasonIds.has(seasonId)
+  const {
+    permittedSeasonIds,
+    isLoading: isPermissionLoading,
+    isError: isPermissionError,
+  } = useRecruitingPermissions(seasonId ? [seasonId] : [])
+  const managePermission = resolveManagePermission({
+    seasonId,
+    permittedSeasonIds,
+    isLoading: isPermissionLoading,
+    isError: isPermissionError,
+  })
   const {
     evaluation,
-    rosterUnavailable,
     hasManagePermission: viewerIsAdmin,
     isError: isEvaluationError,
   } = useStageEvaluations(
@@ -83,7 +89,7 @@ export function ApplicationEvaluationDetailPage({
     roundId,
     stage,
     application?.status,
-    hasManagePermission,
+    managePermission,
   )
   const submitEvaluation = useSubmitEvaluation(applicationId, roundId, stage)
   const { interview, isError: isInterviewError } = useInterviewQuestions(
@@ -197,7 +203,7 @@ export function ApplicationEvaluationDetailPage({
                   currentResult={detail.finalResult}
                   canDecide={canDecideFinal(application.status, viewerIsAdmin)}
                 />
-                {rosterUnavailable && (
+                {isPermissionError && (
                   <p className="text-body-2-regular text-teal-gray-500 text-center">
                     권한 정보를 불러오지 못해 합불 처리를 열지 못했습니다.
                     새로고침 후 다시 시도해주세요.

--- a/src/features/recruiting/ui/detail/ApplicationEvaluationDetailPage.tsx
+++ b/src/features/recruiting/ui/detail/ApplicationEvaluationDetailPage.tsx
@@ -72,13 +72,13 @@ export function ApplicationEvaluationDetailPage({
   const {
     permittedSeasonIds,
     isLoading: isPermissionLoading,
-    isError: isPermissionError,
+    isUnresolved: isPermissionUnresolved,
   } = useRecruitingPermissions(seasonId ? [seasonId] : [])
   const managePermission = resolveManagePermission({
     seasonId,
     permittedSeasonIds,
     isLoading: isPermissionLoading,
-    isError: isPermissionError,
+    isUnresolved: isPermissionUnresolved,
   })
   const {
     evaluation,
@@ -203,7 +203,7 @@ export function ApplicationEvaluationDetailPage({
                   currentResult={detail.finalResult}
                   canDecide={canDecideFinal(application.status, viewerIsAdmin)}
                 />
-                {isPermissionError && (
+                {isPermissionUnresolved && (
                   <p className="text-body-2-regular text-teal-gray-500 text-center">
                     권한 정보를 불러오지 못해 합불 처리를 열지 못했습니다.
                     새로고침 후 다시 시도해주세요.

--- a/src/features/recruiting/ui/detail/ApplicationEvaluationDetailPage.tsx
+++ b/src/features/recruiting/ui/detail/ApplicationEvaluationDetailPage.tsx
@@ -6,6 +6,7 @@ import { Breadcrumb } from "@/shared/ui/breadcrumb/Breadcrumb"
 import { useApplicationDetail } from "../../hooks/useApplicationDetail"
 import { useSubmitEvaluation } from "../../hooks/useEvaluationMutations"
 import { useInterviewQuestions } from "../../hooks/useInterviewQuestions"
+import { useRecruitingPermissions } from "../../hooks/useRecruitingPermissions"
 import { useStageEvaluations } from "../../hooks/useStageEvaluations"
 import { canDecideFinal } from "../../model/evaluationRules"
 import {
@@ -61,16 +62,29 @@ export function ApplicationEvaluationDetailPage({
   applicationId,
   roundId,
 }: ApplicationEvaluationDetailPageProps) {
-  const { detail, application, isError } = useApplicationDetail(
+  const { detail, application, seasonId, isError } = useApplicationDetail(
     applicationId,
     roundId,
   )
+  const { permittedSeasonIds, isLoading: isPermissionLoading } =
+    useRecruitingPermissions(seasonId ? [seasonId] : [])
+  // 권한 조회가 끝나기 전에는 확정하지 않는다. 모른 채로 잠그면 사유가 잘못 나간다.
+  const hasManagePermission =
+    seasonId == null || isPermissionLoading
+      ? undefined
+      : permittedSeasonIds.has(seasonId)
   const {
     evaluation,
-    rosterKnown,
     rosterUnavailable,
+    hasManagePermission: viewerIsAdmin,
     isError: isEvaluationError,
-  } = useStageEvaluations(applicationId, roundId, stage, application?.status)
+  } = useStageEvaluations(
+    applicationId,
+    roundId,
+    stage,
+    application?.status,
+    hasManagePermission,
+  )
   const submitEvaluation = useSubmitEvaluation(applicationId, roundId, stage)
   const { interview, isError: isInterviewError } = useInterviewQuestions(
     applicationId,
@@ -170,7 +184,7 @@ export function ApplicationEvaluationDetailPage({
                   )}
                   <OperatorEvaluationList
                     evaluation={evaluation}
-                    viewerIsAdmin={rosterKnown}
+                    viewerIsAdmin={viewerIsAdmin}
                   />
                 </>
               )
@@ -181,7 +195,7 @@ export function ApplicationEvaluationDetailPage({
                   label={finalResultLabel}
                   application={application}
                   currentResult={detail.finalResult}
-                  canDecide={canDecideFinal(application.status, rosterKnown)}
+                  canDecide={canDecideFinal(application.status, viewerIsAdmin)}
                 />
                 {rosterUnavailable && (
                   <p className="text-body-2-regular text-teal-gray-500 text-center">


### PR DESCRIPTION
## 📸 작업 내용

- 리크루팅 화면의 권한 판정을 **역할 타입 추론에서 권한 조회 API 직접 질의로 교체**했습니다. 지원자 목록의 조회 범위와 평가 상세의 합불 처리 권한이 모두 이 결과를 따릅니다.
- 역할 타입으로 범위를 정하던 `resolveRecruitingListRole` 을 제거했습니다. 이 판정이 API 가 허용하는 범위보다 넓어서, 중앙운영팀원·교육팀원·지부장 계정은 전 지부 화면을 본 뒤 **모든 학교 카드가 403 으로 실패**했습니다.
- 평가 상세가 **평가자 명단 조회의 성공·실패를 관리 권한 대용으로 쓰던 추론을 걷어냈습니다.** 권한이 없다고 확정되면 명단을 아예 호출하지 않습니다.
- 조회 권한이 없는 학교 카드는 렌더하지 않고 토스트도 내지 않습니다. 권한 없음은 장애가 아니라 정상 상황인데, 이전에는 권한 밖 학교 수만큼 오류 토스트가 쏟아졌습니다.
- **권한 조회 실패를 '권한 없음'과 구분했습니다.** 실패를 없음으로 접으면 권한자의 합불 버튼이 사유 없이 잠기고 조회 범위가 안내 없이 좁혀집니다.

## 🎞️ 주요 코드 설명

### 조회 범위를 권한 조회 결과에서 파생

차수 그룹 응답에 이미 들어 있는 시즌 식별자로 권한을 batch 조회하고, 권한이 있는 시즌이 곧 조회 범위가 됩니다.

```TypeScript
export function resolveRecruitingScope(
  groups: RecruitingRoundGroup[],
  permittedSeasonIds: ReadonlySet<string>,
  viewerSchool: string | undefined,
): RecruitingScope {
  const permitted = groups.filter((group) =>
    permittedSeasonIds.has(String(group.seasonId)),
  )
  if (permitted.length > 0) return summarize(permitted, false)

  if (!viewerSchool) return EMPTY
  const mySchool = groups.filter((group) => group.schoolName === viewerSchool)
  return summarize(mySchool, true)
}
```

- 평가자는 시즌 단위 관리 권한이 없어 이 조회에 잡히지 않습니다. 권한이 하나도 없으면 **내 학교를 후보로 두고 조회를 시도**합니다. 평가자는 통상 자기 학교 차수의 평가자라 실제와 맞고, 권한이 없는 학교는 카드 단계에서 걸러집니다.
- 지부/학교 탭도 하드코딩 상수 대신 이 결과에서 만듭니다.

### 권한 조회 실패와 권한 없음의 구분

이 PR 에서 가장 조심한 부분입니다. 세 상태를 한 불리언에 접으면 **일시 장애가 영구 권한 없음으로 굳습니다.**

```TypeScript
export function resolveManagePermission({
  seasonId,
  permittedSeasonIds,
  isLoading,
  isError,
}: {
  seasonId: string | null
  permittedSeasonIds: ReadonlySet<string>
  isLoading: boolean
  isError: boolean
}): ManagePermission {
  if (seasonId == null || isLoading) {
    return { isGranted: undefined, isResolved: false }
  }
  if (isError) {
    return { isGranted: undefined, isResolved: true }
  }
  return { isGranted: permittedSeasonIds.has(seasonId), isResolved: true }
}
```

- `isGranted: undefined` = **판정 불가**입니다. 권한 없음(`false`)과 다르게 다뤄, 입력을 잠그되 "권한이 없습니다"가 아니라 "권한 정보를 불러오지 못했습니다"로 안내합니다.
- `isResolved` 는 **더 기다릴지**를 가릅니다. 조회 중이면 평가 패널을 조립하지 않고, 실패로 끝났으면 확정으로 보고 사유와 함께 렌더합니다. 이 구분이 없으면 로딩 한 프레임 동안 권한자에게 비권한 화면이 스칩니다.
- 지원자 목록도 같은 실패를 "조회할 수 있는 모집이 없습니다"로 오인하지 않도록 별도 안내를 붙였습니다.

## 🔗 연결된 이슈

- Connected: #655, #656
- Closes #655
- Closes #656

## 💬 기타 더 이야기해볼 점

**평가자 여부 판정은 이 PR 로 해결되지 않습니다.** 권한 조회는 운영진 권한을 다루고, 특정 차수의 평가자로 지정됐는지는 다른 종류의 정보입니다. 지원서·평가 응답에 해당 필드가 없어 여전히 평가 목록 조회 성공 여부로 추론합니다. 필드가 추가되면 남은 추론도 걷어낼 예정입니다.

`RecruitingListRole` 타입은 **남겨 뒀습니다.** 모집 목록·생성 화면이 prop 타입으로 쓰고 있어 제거하면 그쪽이 깨집니다. 제거한 것은 역할 타입으로 조회 범위를 정하던 판정 함수뿐입니다.

### 검증

dev 로그인이 열리지 않아 런타임 확인을 못 했습니다. 대신 권한·상태 판정을 순수 함수로 빼 단위 테스트로 고정했고, 5개 관점(권한 정확성 / 로딩·에러 3상태 / 쿼리 배선 / 렌더 정확성 / 기존 기능 회귀)으로 정적 교차 검증했습니다.

- `pnpm lint` — 0 errors (기존 13 warnings 유지)
- `pnpm build` — 통과
- `pnpm test:run` — 70 files / 509 tests 통과 (신규 19건)

로그인이 열리면 **역할이 다른 계정 세 개**로 확인이 필요합니다. 총괄은 전 지부 탭, 학교 회장은 자기 학교, 권한 없는 운영팀원은 오류가 아니라 안내가 나와야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 모집 목록이 사용자에게 부여된 시즌 권한과 소속 범위에 따라 표시됩니다.
  * 지부·학교별 필터와 탭이 조회 가능한 범위에 맞게 제공됩니다.
  * 평가 및 최종 결정 화면에서 관리 권한을 기준으로 기능 접근이 제어됩니다.

* **버그 수정**
  * 권한이 없는 모집 정보 조회 시 불필요한 오류 알림이 표시되지 않습니다.
  * 권한 오류가 발생한 요청은 불필요하게 재시도되지 않습니다.

* **테스트**
  * 모집 범위, 필터, 권한 판정에 대한 검증을 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->