### PR TITLE
✨ feat: 면접 스케줄링 화면 추가

### DIFF
--- a/src/features/recruiting/index.ts
+++ b/src/features/recruiting/index.ts
@@ -45,3 +45,5 @@ export { RecruitmentSchoolSectionLabel } from "./ui/RecruitmentSchoolSectionLabe
 export { RecruitmentSectionHeader } from "./ui/RecruitmentSectionHeader"
 export { RecruitmentStatusChip } from "./ui/RecruitmentStatusChip"
 export { RecruitmentStepper } from "./ui/RecruitmentStepper"
+export { InterviewScheduleBoardPage } from "./ui/schedule/InterviewScheduleBoardPage"
+export { InterviewSchedulePage } from "./ui/schedule/InterviewSchedulePage"

--- a/src/features/recruiting/model/interviewSchedule.mock.ts
+++ b/src/features/recruiting/model/interviewSchedule.mock.ts
@@ -1,0 +1,65 @@
+import type { InterviewApplicant, InterviewSession } from "./interviewSchedule"
+
+export interface InterviewScheduleRound {
+  roundId: string
+  schoolName: string
+  roundTitle: string
+  documentClosedLabel: string
+  interviewStartAt: string
+  interviewEndAt: string
+  assignedCount: number
+  totalCount: number
+}
+
+export const INTERVIEW_SCHEDULE_ROUNDS_MOCK: InterviewScheduleRound[] = [
+  {
+    roundId: "round-1",
+    schoolName: "한양대학교 ERICA",
+    roundTitle: "한양대학교 ERICA UMC 11기 정규 모집",
+    documentClosedLabel: "서류 지원 마감",
+    interviewStartAt: "2026-07-18T10:00:00",
+    interviewEndAt: "2026-07-26T23:59:00",
+    assignedCount: 26,
+    totalCount: 42,
+  },
+]
+
+export const INTERVIEW_SESSIONS_MOCK: InterviewSession[] = [
+  {
+    id: "session-1",
+    name: "디자인 파트 면접 (담당자: 이예원)",
+    startTime: "10:00",
+    endTime: "15:00",
+    mode: "online",
+    place: "https://meet.example.com/umc-design",
+  },
+  {
+    id: "session-2",
+    name: "면접 B",
+    startTime: "10:00",
+    endTime: "15:00",
+    mode: "offline",
+    place: "한국대학교 유엠관 107호",
+  },
+]
+
+export const INTERVIEW_APPLICANTS_MOCK: InterviewApplicant[] = [
+  {
+    id: "applicant-1",
+    name: "이예원",
+    availabilities: ["10:00~12:00", "13:00~15:00"],
+  },
+  {
+    id: "applicant-2",
+    name: "이예원원",
+    availabilities: ["10:30~11:30", "14:00~15:00"],
+  },
+  { id: "applicant-3", name: "황지원", availabilities: ["11:00~13:00"] },
+  { id: "applicant-4", name: "강지훈", availabilities: ["10:00~11:00"] },
+  { id: "applicant-5", name: "한현서", availabilities: ["12:00~14:00"] },
+  { id: "applicant-6", name: "양혜원", availabilities: ["13:30~15:00"] },
+  { id: "applicant-7", name: "오창준", availabilities: ["10:00~10:30"] },
+  { id: "applicant-8", name: "박세은", availabilities: ["11:30~13:30"] },
+  { id: "applicant-9", name: "권도희", availabilities: ["14:30~15:00"] },
+  { id: "applicant-10", name: "박승범", availabilities: ["10:00~15:00"] },
+]

--- a/src/features/recruiting/model/interviewSchedule.test.ts
+++ b/src/features/recruiting/model/interviewSchedule.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  assignApplicant,
+  buildTimeSlots,
+  calcAllocationRate,
+  formatDateTabLabel,
+  isSessionComplete,
+  parseSlotKey,
+  resolveScheduleDates,
+  splitApplicantsByAssignment,
+  toSlotKey,
+  unassignApplicant,
+} from "./interviewSchedule"
+
+import type { InterviewSession, SlotAssignment } from "./interviewSchedule"
+
+describe("buildTimeSlots", () => {
+  it("30분 단위로 시간대를 쪼갠다", () => {
+    expect(buildTimeSlots("10:00", "11:30")).toEqual([
+      { start: "10:00", end: "10:30" },
+      { start: "10:30", end: "11:00" },
+      { start: "11:00", end: "11:30" },
+    ])
+  })
+
+  it("30분을 채우지 못하는 끝자락은 버린다", () => {
+    expect(buildTimeSlots("10:00", "11:10")).toEqual([
+      { start: "10:00", end: "10:30" },
+      { start: "10:30", end: "11:00" },
+    ])
+  })
+
+  it("끝시각이 시작시각보다 빠르면 만들지 않는다", () => {
+    expect(buildTimeSlots("14:00", "13:00")).toEqual([])
+    expect(buildTimeSlots("14:00", "14:00")).toEqual([])
+  })
+
+  it("형식이 어긋난 시각은 만들지 않는다", () => {
+    expect(buildTimeSlots("9시", "11:00")).toEqual([])
+    expect(buildTimeSlots("25:00", "26:00")).toEqual([])
+  })
+})
+
+describe("resolveScheduleDates", () => {
+  it("면접 기간을 하루 단위로 펼친다", () => {
+    expect(
+      resolveScheduleDates("2026-07-18T10:00:00", "2026-07-21T18:00:00"),
+    ).toEqual(["2026-07-18", "2026-07-19", "2026-07-20", "2026-07-21"])
+  })
+
+  it("같은 날이면 하루만 만든다", () => {
+    expect(
+      resolveScheduleDates("2026-07-18T10:00:00", "2026-07-18T23:00:00"),
+    ).toEqual(["2026-07-18"])
+  })
+
+  it("기간이 없거나 뒤집혀 있으면 비운다", () => {
+    expect(resolveScheduleDates(undefined, undefined)).toEqual([])
+    expect(
+      resolveScheduleDates("2026-07-20T00:00:00", "2026-07-18T00:00:00"),
+    ).toEqual([])
+  })
+})
+
+describe("formatDateTabLabel", () => {
+  it("앞의 0을 떼고 표기한다", () => {
+    expect(formatDateTabLabel("2026-07-08")).toBe("7월 8일")
+    expect(formatDateTabLabel("2026-11-26")).toBe("11월 26일")
+  })
+})
+
+describe("slotKey", () => {
+  it("세션 id 에 구분자가 들어 있어도 되돌린다", () => {
+    const key = toSlotKey("session__a", "10:30")
+    expect(parseSlotKey(key)).toEqual({
+      sessionId: "session__a",
+      slotStart: "10:30",
+    })
+  })
+
+  it("슬롯 키가 아니면 null 이다", () => {
+    expect(parseSlotKey("applicant-1")).toBeNull()
+  })
+})
+
+describe("assignApplicant", () => {
+  const base: SlotAssignment[] = [
+    { sessionId: "a", slotStart: "10:00", applicantId: "u1" },
+  ]
+
+  it("빈 슬롯에 배정한다", () => {
+    expect(assignApplicant(base, "a", "10:30", "u2")).toEqual([
+      { sessionId: "a", slotStart: "10:00", applicantId: "u1" },
+      { sessionId: "a", slotStart: "10:30", applicantId: "u2" },
+    ])
+  })
+
+  it("한 지원자가 두 슬롯을 차지하지 않는다", () => {
+    const moved = assignApplicant(base, "a", "11:00", "u1")
+    expect(moved).toEqual([
+      { sessionId: "a", slotStart: "11:00", applicantId: "u1" },
+    ])
+  })
+
+  it("이미 찬 슬롯에 넣으면 앞사람을 밀어낸다", () => {
+    const replaced = assignApplicant(base, "a", "10:00", "u2")
+    expect(replaced).toEqual([
+      { sessionId: "a", slotStart: "10:00", applicantId: "u2" },
+    ])
+  })
+
+  it("다른 면접방의 같은 시각은 별개다", () => {
+    const assigned = assignApplicant(base, "b", "10:00", "u2")
+    expect(assigned).toHaveLength(2)
+  })
+})
+
+describe("unassignApplicant", () => {
+  it("배정을 걷어낸다", () => {
+    const assignments: SlotAssignment[] = [
+      { sessionId: "a", slotStart: "10:00", applicantId: "u1" },
+      { sessionId: "a", slotStart: "10:30", applicantId: "u2" },
+    ]
+    expect(unassignApplicant(assignments, "u1")).toEqual([
+      { sessionId: "a", slotStart: "10:30", applicantId: "u2" },
+    ])
+  })
+})
+
+describe("splitApplicantsByAssignment", () => {
+  it("배정 대기와 배정 완료로 가른다", () => {
+    const applicants = [
+      { id: "u1", name: "이예원", availabilities: [] },
+      { id: "u2", name: "황지원", availabilities: [] },
+    ]
+    const result = splitApplicantsByAssignment(applicants, [
+      { sessionId: "a", slotStart: "10:00", applicantId: "u2" },
+    ])
+    expect(result.waiting.map((a) => a.id)).toEqual(["u1"])
+    expect(result.assigned.map((a) => a.id)).toEqual(["u2"])
+  })
+})
+
+describe("calcAllocationRate", () => {
+  it("배정률을 반올림해 낸다", () => {
+    expect(calcAllocationRate(26, 42)).toBe(62)
+  })
+
+  it("대상이 없으면 0 이다", () => {
+    expect(calcAllocationRate(0, 0)).toBe(0)
+  })
+})
+
+describe("isSessionComplete", () => {
+  const complete: InterviewSession = {
+    id: "s1",
+    name: "디자인 파트 면접",
+    startTime: "15:00",
+    endTime: "20:00",
+    mode: "online",
+    place: "https://meet.example.com/abc",
+  }
+
+  it("모두 채우면 완성이다", () => {
+    expect(isSessionComplete(complete)).toBe(true)
+  })
+
+  it("끝시각이 시작시각보다 빠르면 완성이 아니다", () => {
+    expect(isSessionComplete({ ...complete, endTime: "14:00" })).toBe(false)
+  })
+
+  it("이름이나 장소가 비면 완성이 아니다", () => {
+    expect(isSessionComplete({ ...complete, name: "  " })).toBe(false)
+    expect(isSessionComplete({ ...complete, place: "" })).toBe(false)
+  })
+})

--- a/src/features/recruiting/model/interviewSchedule.test.ts
+++ b/src/features/recruiting/model/interviewSchedule.test.ts
@@ -4,16 +4,47 @@ import {
   assignApplicant,
   buildTimeSlots,
   calcAllocationRate,
+  canExtendEndTime,
   formatDateTabLabel,
   isSessionComplete,
   parseSlotKey,
   resolveScheduleDates,
   splitApplicantsByAssignment,
+  toMinutes,
   toSlotKey,
+  toTimeLabel,
   unassignApplicant,
 } from "./interviewSchedule"
 
 import type { InterviewSession, SlotAssignment } from "./interviewSchedule"
+
+describe("toTimeLabel", () => {
+  it("하루를 넘는 값은 마지막 시각으로 자른다", () => {
+    // 24:00 을 만들면 toMinutes 가 되읽지 못해 슬롯 계산이 통째로 무너진다.
+    expect(toTimeLabel(24 * 60)).toBe("23:59")
+    expect(toMinutes(toTimeLabel(24 * 60))).not.toBeNull()
+  })
+
+  it("음수는 자정으로 자른다", () => {
+    expect(toTimeLabel(-30)).toBe("00:00")
+  })
+})
+
+describe("canExtendEndTime", () => {
+  it("자정을 넘기지 않으면 늘릴 수 있다", () => {
+    expect(canExtendEndTime("15:00")).toBe(true)
+    expect(canExtendEndTime("23:00")).toBe(true)
+  })
+
+  it("한 칸 더 넣으면 자정을 넘기는 경우 막는다", () => {
+    expect(canExtendEndTime("23:30")).toBe(false)
+    expect(canExtendEndTime("23:59")).toBe(false)
+  })
+
+  it("읽을 수 없는 시각은 늘리지 않는다", () => {
+    expect(canExtendEndTime("")).toBe(false)
+  })
+})
 
 describe("buildTimeSlots", () => {
   it("30분 단위로 시간대를 쪼갠다", () => {

--- a/src/features/recruiting/model/interviewSchedule.ts
+++ b/src/features/recruiting/model/interviewSchedule.ts
@@ -1,0 +1,216 @@
+export type InterviewMode = "online" | "offline"
+
+export interface InterviewSession {
+  id: string
+  name: string
+  startTime: string
+  endTime: string
+  mode: InterviewMode
+  place: string
+}
+
+export interface InterviewTimeSlot {
+  start: string
+  end: string
+}
+
+export interface InterviewApplicant {
+  id: string
+  name: string
+  availabilities: string[]
+}
+
+export interface SlotAssignment {
+  sessionId: string
+  slotStart: string
+  applicantId: string
+}
+
+export function isInterviewApplicant(
+  value: unknown,
+): value is InterviewApplicant {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "id" in value &&
+    typeof value.id === "string" &&
+    "name" in value &&
+    typeof value.name === "string" &&
+    "availabilities" in value &&
+    Array.isArray(value.availabilities)
+  )
+}
+
+export const SLOT_STEP_MINUTES = 30
+
+export function toMinutes(time: string): number | null {
+  const matched = /^(\d{1,2}):(\d{2})$/.exec(time.trim())
+  if (!matched) return null
+  const hours = Number(matched[1])
+  const minutes = Number(matched[2])
+  if (hours > 23 || minutes > 59) return null
+  return hours * 60 + minutes
+}
+
+export function toTimeLabel(minutes: number): string {
+  const hours = Math.floor(minutes / 60)
+  const rest = minutes % 60
+  return `${String(hours).padStart(2, "0")}:${String(rest).padStart(2, "0")}`
+}
+
+// 시안의 슬롯은 항상 30분 단위다. 끝시각에 걸쳐 30분을 채우지 못하는 구간은
+// 면접을 배정할 수 없으므로 만들지 않는다.
+export function buildTimeSlots(
+  startTime: string,
+  endTime: string,
+  stepMinutes: number = SLOT_STEP_MINUTES,
+): InterviewTimeSlot[] {
+  const start = toMinutes(startTime)
+  const end = toMinutes(endTime)
+  if (start == null || end == null || stepMinutes <= 0) return []
+
+  const slots: InterviewTimeSlot[] = []
+  for (let cursor = start; cursor + stepMinutes <= end; cursor += stepMinutes) {
+    slots.push({
+      start: toTimeLabel(cursor),
+      end: toTimeLabel(cursor + stepMinutes),
+    })
+  }
+  return slots
+}
+
+function toDateKey(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+
+// 면접 기간의 날짜를 하루 단위로 펼쳐 날짜 탭을 만든다. 시각 부분은 버린다.
+export function resolveScheduleDates(
+  interviewStartAt: string | undefined,
+  interviewEndAt: string | undefined,
+): string[] {
+  if (!interviewStartAt || !interviewEndAt) return []
+  const start = new Date(interviewStartAt)
+  const end = new Date(interviewEndAt)
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return []
+
+  const cursor = new Date(
+    start.getFullYear(),
+    start.getMonth(),
+    start.getDate(),
+  )
+  const last = new Date(end.getFullYear(), end.getMonth(), end.getDate())
+  if (cursor > last) return []
+
+  const dates: string[] = []
+  while (cursor <= last) {
+    dates.push(toDateKey(cursor))
+    cursor.setDate(cursor.getDate() + 1)
+  }
+  return dates
+}
+
+export function formatDateTabLabel(dateKey: string): string {
+  const matched = /^\d{4}-(\d{2})-(\d{2})$/.exec(dateKey)
+  if (!matched) return dateKey
+  return `${Number(matched[1])}월 ${Number(matched[2])}일`
+}
+
+export function toSlotKey(sessionId: string, slotStart: string): string {
+  return `${sessionId}__${slotStart}`
+}
+
+export function parseSlotKey(
+  slotKey: string,
+): { sessionId: string; slotStart: string } | null {
+  const index = slotKey.lastIndexOf("__")
+  if (index <= 0) return null
+  return {
+    sessionId: slotKey.slice(0, index),
+    slotStart: slotKey.slice(index + 2),
+  }
+}
+
+export function findAssignment(
+  assignments: SlotAssignment[],
+  sessionId: string,
+  slotStart: string,
+): SlotAssignment | undefined {
+  return assignments.find(
+    (assignment) =>
+      assignment.sessionId === sessionId && assignment.slotStart === slotStart,
+  )
+}
+
+// 한 지원자는 한 슬롯에만, 한 슬롯에는 한 명만 들어간다. 옮겨 놓는 동작이므로
+// 지원자의 기존 배정과 대상 슬롯의 기존 배정을 모두 걷어낸 뒤 넣는다.
+export function assignApplicant(
+  assignments: SlotAssignment[],
+  sessionId: string,
+  slotStart: string,
+  applicantId: string,
+): SlotAssignment[] {
+  const kept = assignments.filter(
+    (assignment) =>
+      assignment.applicantId !== applicantId &&
+      !(
+        assignment.sessionId === sessionId && assignment.slotStart === slotStart
+      ),
+  )
+  return [...kept, { sessionId, slotStart, applicantId }]
+}
+
+export function unassignApplicant(
+  assignments: SlotAssignment[],
+  applicantId: string,
+): SlotAssignment[] {
+  return assignments.filter(
+    (assignment) => assignment.applicantId !== applicantId,
+  )
+}
+
+export function splitApplicantsByAssignment(
+  applicants: InterviewApplicant[],
+  assignments: SlotAssignment[],
+) {
+  const assignedIds = new Set(
+    assignments.map((assignment) => assignment.applicantId),
+  )
+  return {
+    waiting: applicants.filter((applicant) => !assignedIds.has(applicant.id)),
+    assigned: applicants.filter((applicant) => assignedIds.has(applicant.id)),
+  }
+}
+
+export function calcAllocationRate(
+  assignedCount: number,
+  totalCount: number,
+): number {
+  if (totalCount <= 0) return 0
+  return Math.round((assignedCount / totalCount) * 100)
+}
+
+export function createEmptySession(index: number): InterviewSession {
+  return {
+    id: `session-${index}`,
+    name: "",
+    startTime: "",
+    endTime: "",
+    mode: "online",
+    place: "",
+  }
+}
+
+export function isSessionComplete(session: InterviewSession): boolean {
+  const start = toMinutes(session.startTime)
+  const end = toMinutes(session.endTime)
+  return (
+    session.name.trim().length > 0 &&
+    start != null &&
+    end != null &&
+    start < end &&
+    session.place.trim().length > 0
+  )
+}

--- a/src/features/recruiting/model/interviewSchedule.ts
+++ b/src/features/recruiting/model/interviewSchedule.ts
@@ -52,10 +52,24 @@ export function toMinutes(time: string): number | null {
   return hours * 60 + minutes
 }
 
+// 하루의 마지막 시각. 이 값을 넘기면 toMinutes 가 되읽지 못해 슬롯 계산이
+// 통째로 무너진다.
+export const MAX_MINUTES_OF_DAY = 23 * 60 + 59
+
 export function toTimeLabel(minutes: number): string {
-  const hours = Math.floor(minutes / 60)
-  const rest = minutes % 60
+  const clamped = Math.min(Math.max(minutes, 0), MAX_MINUTES_OF_DAY)
+  const hours = Math.floor(clamped / 60)
+  const rest = clamped % 60
   return `${String(hours).padStart(2, "0")}:${String(rest).padStart(2, "0")}`
+}
+
+// 슬롯을 하나 더 붙일 수 있는지. 마지막 슬롯이 자정을 넘기면 안 된다.
+export function canExtendEndTime(
+  endTime: string,
+  stepMinutes: number = SLOT_STEP_MINUTES,
+): boolean {
+  const end = toMinutes(endTime)
+  return end != null && end + stepMinutes <= MAX_MINUTES_OF_DAY
 }
 
 // 시안의 슬롯은 항상 30분 단위다. 끝시각에 걸쳐 30분을 채우지 못하는 구간은

--- a/src/features/recruiting/ui/schedule/ApplicantPoolPanel.tsx
+++ b/src/features/recruiting/ui/schedule/ApplicantPoolPanel.tsx
@@ -1,0 +1,68 @@
+import { useDroppable } from "@dnd-kit/core"
+
+import { cn } from "@/shared/lib/utils"
+
+import { DraggableApplicantChip } from "./DraggableApplicantChip"
+
+import type { InterviewApplicant } from "../../model/interviewSchedule"
+
+export const APPLICANT_POOL_ID = "applicant-pool"
+
+interface ApplicantPoolPanelProps {
+  totalCount: number
+  waiting: InterviewApplicant[]
+  assignedCount: number
+}
+
+export function ApplicantPoolPanel({
+  totalCount,
+  waiting,
+  assignedCount,
+}: ApplicantPoolPanelProps) {
+  const { setNodeRef, isOver } = useDroppable({ id: APPLICANT_POOL_ID })
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={cn(
+        "shadow-drop-neutral-3 border-teal-gray-100 flex w-70 shrink-0 flex-col gap-5 rounded-[12px] border bg-white px-6 py-7 transition-colors",
+        isOver && "border-teal-400 bg-teal-50/40",
+      )}
+    >
+      <div className="flex flex-col gap-1">
+        <span className="text-heading-6-semibold text-teal-gray-800">
+          지원자 목록
+        </span>
+        <span className="text-body-2-regular text-teal-gray-400">
+          총 {totalCount}명
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-2.5">
+        <span className="text-body-2-medium text-teal-gray-600">
+          배정 대기 중 {waiting.length}
+        </span>
+        {waiting.length === 0 ? (
+          <p className="text-label-1-medium text-teal-gray-400 py-4 text-center">
+            모든 지원자를 배정했습니다.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {waiting.map((applicant) => (
+              <DraggableApplicantChip
+                key={applicant.id}
+                applicant={applicant}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="border-teal-gray-100 border-t pt-4">
+        <span className="text-body-2-medium text-teal-gray-600">
+          배정 완료 {assignedCount}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/features/recruiting/ui/schedule/DraggableApplicantChip.tsx
+++ b/src/features/recruiting/ui/schedule/DraggableApplicantChip.tsx
@@ -1,0 +1,43 @@
+import { useDraggable } from "@dnd-kit/core"
+
+import HamburgerIcon from "@/shared/assets/icon/hamburger/HamburgerIcon"
+import { cn } from "@/shared/lib/utils"
+
+import type { InterviewApplicant } from "../../model/interviewSchedule"
+
+interface DraggableApplicantChipProps {
+  applicant: InterviewApplicant
+  compact?: boolean
+}
+
+export function DraggableApplicantChip({
+  applicant,
+  compact = false,
+}: DraggableApplicantChipProps) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: applicant.id,
+    data: applicant,
+  })
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...listeners}
+      {...attributes}
+      className={cn(
+        "flex w-full cursor-grab items-center gap-2 rounded-[8px] bg-teal-50 px-2.5 py-1.5 select-none active:cursor-grabbing",
+        isDragging && "opacity-40",
+      )}
+    >
+      <HamburgerIcon className="size-4 shrink-0 text-teal-600" />
+      <span className="text-subtitle-2-medium shrink-0 text-teal-700">
+        {applicant.name}
+      </span>
+      {!compact && applicant.availabilities.length > 0 && (
+        <span className="text-label-1-medium text-teal-gray-400 truncate">
+          {applicant.availabilities.join(" | ")}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/features/recruiting/ui/schedule/DraggableApplicantChip.tsx
+++ b/src/features/recruiting/ui/schedule/DraggableApplicantChip.tsx
@@ -1,43 +1,68 @@
 import { useDraggable } from "@dnd-kit/core"
+import { forwardRef } from "react"
 
 import HamburgerIcon from "@/shared/assets/icon/hamburger/HamburgerIcon"
 import { cn } from "@/shared/lib/utils"
 
 import type { InterviewApplicant } from "../../model/interviewSchedule"
 
-interface DraggableApplicantChipProps {
+interface ApplicantChipProps extends React.HTMLAttributes<HTMLDivElement> {
   applicant: InterviewApplicant
   compact?: boolean
+  dragging?: boolean
 }
+
+// 표시 전용. DragOverlay 는 이것을 쓴다 — 오버레이에서 useDraggable 을 다시
+// 부르면 같은 DndContext 안에 같은 id 가 두 번 등록된다.
+export const ApplicantChip = forwardRef<HTMLDivElement, ApplicantChipProps>(
+  function ApplicantChip(
+    { applicant, compact = false, dragging = false, className, ...rest },
+    ref,
+  ) {
+    return (
+      <div
+        ref={ref}
+        {...rest}
+        className={cn(
+          "flex w-full cursor-grab items-center gap-2 rounded-[8px] bg-teal-50 px-2.5 py-1.5 select-none active:cursor-grabbing",
+          dragging && "opacity-40",
+          className,
+        )}
+      >
+        <HamburgerIcon className="size-4 shrink-0 text-teal-600" />
+        <span className="text-subtitle-2-medium shrink-0 text-teal-700">
+          {applicant.name}
+        </span>
+        {!compact && applicant.availabilities.length > 0 && (
+          <span className="text-label-1-medium text-teal-gray-400 truncate">
+            {applicant.availabilities.join(" | ")}
+          </span>
+        )}
+      </div>
+    )
+  },
+)
 
 export function DraggableApplicantChip({
   applicant,
   compact = false,
-}: DraggableApplicantChipProps) {
+}: {
+  applicant: InterviewApplicant
+  compact?: boolean
+}) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: applicant.id,
     data: applicant,
   })
 
   return (
-    <div
+    <ApplicantChip
       ref={setNodeRef}
+      applicant={applicant}
+      compact={compact}
+      dragging={isDragging}
       {...listeners}
       {...attributes}
-      className={cn(
-        "flex w-full cursor-grab items-center gap-2 rounded-[8px] bg-teal-50 px-2.5 py-1.5 select-none active:cursor-grabbing",
-        isDragging && "opacity-40",
-      )}
-    >
-      <HamburgerIcon className="size-4 shrink-0 text-teal-600" />
-      <span className="text-subtitle-2-medium shrink-0 text-teal-700">
-        {applicant.name}
-      </span>
-      {!compact && applicant.availabilities.length > 0 && (
-        <span className="text-label-1-medium text-teal-gray-400 truncate">
-          {applicant.availabilities.join(" | ")}
-        </span>
-      )}
-    </div>
+    />
   )
 }

--- a/src/features/recruiting/ui/schedule/DroppableSlotRow.tsx
+++ b/src/features/recruiting/ui/schedule/DroppableSlotRow.tsx
@@ -1,0 +1,53 @@
+import { useDroppable } from "@dnd-kit/core"
+
+import { cn } from "@/shared/lib/utils"
+
+import { toSlotKey } from "../../model/interviewSchedule"
+import { DraggableApplicantChip } from "./DraggableApplicantChip"
+
+import type {
+  InterviewApplicant,
+  InterviewTimeSlot,
+} from "../../model/interviewSchedule"
+
+interface DroppableSlotRowProps {
+  sessionId: string
+  slot: InterviewTimeSlot
+  applicant: InterviewApplicant | undefined
+}
+
+export function DroppableSlotRow({
+  sessionId,
+  slot,
+  applicant,
+}: DroppableSlotRowProps) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: toSlotKey(sessionId, slot.start),
+  })
+
+  return (
+    <div className="flex items-center gap-5">
+      <span className="text-body-2-regular text-teal-gray-600 w-27 shrink-0">
+        {slot.start} ~ {slot.end}
+      </span>
+      <div
+        ref={setNodeRef}
+        className={cn(
+          "flex h-10 flex-1 items-center rounded-[10px] border px-2 transition-colors",
+          applicant
+            ? "border-teal-gray-200 bg-white"
+            : "border-teal-gray-200 border-dashed bg-white",
+          isOver && "border-teal-400 bg-teal-50",
+        )}
+      >
+        {applicant ? (
+          <DraggableApplicantChip applicant={applicant} compact />
+        ) : (
+          <span className="text-body-2-regular text-teal-gray-300 pl-2">
+            드래그하세요
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/features/recruiting/ui/schedule/InterviewScheduleBoardPage.tsx
+++ b/src/features/recruiting/ui/schedule/InterviewScheduleBoardPage.tsx
@@ -3,6 +3,7 @@ import {
   type DragEndEvent,
   DragOverlay,
   type DragStartEvent,
+  KeyboardSensor,
   PointerSensor,
   useSensor,
   useSensors,
@@ -18,6 +19,7 @@ import { useToastStore } from "@/shared/ui/toast/useToastStore"
 
 import {
   assignApplicant,
+  canExtendEndTime,
   formatDateTabLabel,
   isInterviewApplicant,
   parseSlotKey,
@@ -34,7 +36,7 @@ import {
   INTERVIEW_SESSIONS_MOCK,
 } from "../../model/interviewSchedule.mock"
 import { APPLICANT_POOL_ID, ApplicantPoolPanel } from "./ApplicantPoolPanel"
-import { DraggableApplicantChip } from "./DraggableApplicantChip"
+import { ApplicantChip } from "./DraggableApplicantChip"
 import { type ScheduleStep, ScheduleStepTabs } from "./ScheduleStepTabs"
 import { SessionEditorList } from "./SessionEditorList"
 import { SessionSlotBoard } from "./SessionSlotBoard"
@@ -75,8 +77,11 @@ export function InterviewScheduleBoardPage({
   const [draggingApplicant, setDraggingApplicant] =
     useState<InterviewApplicant | null>(null)
 
+  // 키보드만으로도 배정할 수 있어야 한다. PointerSensor 만 두면 마우스
+  // 없이는 이 화면을 쓸 수 없다.
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor),
   )
 
   const currentDate = activeDate || dates[0] || ""
@@ -90,17 +95,34 @@ export function InterviewScheduleBoardPage({
     () => new Map(INTERVIEW_APPLICANTS_MOCK.map((item) => [item.id, item])),
     [],
   )
+  // 배정 여부는 차수 전체로 판정한다. 지금 날짜의 배정만 보면, 다른 날짜에
+  // 이미 배정된 지원자가 대기 목록에 다시 나타나 두 슬롯을 차지하게 된다.
+  const allAssignments = useMemo(
+    () => Object.values(assignmentsByDate).flat(),
+    [assignmentsByDate],
+  )
   const { waiting, assigned } = useMemo(
-    () => splitApplicantsByAssignment(INTERVIEW_APPLICANTS_MOCK, assignments),
-    [assignments],
+    () =>
+      splitApplicantsByAssignment(INTERVIEW_APPLICANTS_MOCK, allAssignments),
+    [allAssignments],
   )
 
   const setSessions = (next: InterviewSession[]) => {
     setSessionsByDate((prev) => ({ ...prev, [currentDate]: next }))
   }
 
-  const setAssignments = (next: SlotAssignment[]) => {
-    setAssignmentsByDate((prev) => ({ ...prev, [currentDate]: next }))
+  // 한 지원자는 차수 전체에서 한 슬롯만 차지한다. 다른 날짜에 배정돼 있으면
+  // 그 배정을 먼저 걷어낸다.
+  const clearOtherDates = (
+    prev: Record<string, SlotAssignment[]>,
+    applicantId: string,
+  ) => {
+    const next: Record<string, SlotAssignment[]> = {}
+    Object.entries(prev).forEach(([date, list]) => {
+      next[date] =
+        date === currentDate ? list : unassignApplicant(list, applicantId)
+    })
+    return next
   }
 
   const handleAddSlotTime = (sessionId: string) => {
@@ -108,7 +130,8 @@ export function InterviewScheduleBoardPage({
       sessions.map((session) => {
         if (session.id !== sessionId) return session
         const end = toMinutes(session.endTime)
-        if (end == null) return session
+        // 자정을 넘기면 시각을 되읽지 못해 이 세션의 슬롯이 전부 사라진다.
+        if (end == null || !canExtendEndTime(session.endTime)) return session
         return { ...session, endTime: toTimeLabel(end + SLOT_STEP_MINUTES) }
       }),
     )
@@ -129,20 +152,34 @@ export function InterviewScheduleBoardPage({
     if (!isInterviewApplicant(applicant)) return
 
     if (over.id === APPLICANT_POOL_ID) {
-      setAssignments(unassignApplicant(assignments, applicant.id))
+      // 대기 목록으로 되돌리면 어느 날짜에 배정돼 있든 전부 푼다.
+      setAssignmentsByDate((prev) => {
+        const cleared = clearOtherDates(prev, applicant.id)
+        return {
+          ...cleared,
+          [currentDate]: unassignApplicant(
+            cleared[currentDate] ?? [],
+            applicant.id,
+          ),
+        }
+      })
       return
     }
 
     const slot = parseSlotKey(String(over.id))
     if (!slot) return
-    setAssignments(
-      assignApplicant(
-        assignments,
-        slot.sessionId,
-        slot.slotStart,
-        applicant.id,
-      ),
-    )
+    setAssignmentsByDate((prev) => {
+      const cleared = clearOtherDates(prev, applicant.id)
+      return {
+        ...cleared,
+        [currentDate]: assignApplicant(
+          cleared[currentDate] ?? [],
+          slot.sessionId,
+          slot.slotStart,
+          applicant.id,
+        ),
+      }
+    })
   }
 
   const handleSave = () => {
@@ -243,7 +280,7 @@ export function InterviewScheduleBoardPage({
           </div>
           <DragOverlay>
             {draggingApplicant && (
-              <DraggableApplicantChip applicant={draggingApplicant} compact />
+              <ApplicantChip applicant={draggingApplicant} compact />
             )}
           </DragOverlay>
         </DndContext>

--- a/src/features/recruiting/ui/schedule/InterviewScheduleBoardPage.tsx
+++ b/src/features/recruiting/ui/schedule/InterviewScheduleBoardPage.tsx
@@ -1,0 +1,253 @@
+import {
+  DndContext,
+  type DragEndEvent,
+  DragOverlay,
+  type DragStartEvent,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core"
+import { Link } from "@tanstack/react-router"
+import { useMemo, useState } from "react"
+
+import LeftChevronIcon from "@/shared/assets/icon/chevron/LeftChevronIcon"
+import { Breadcrumb } from "@/shared/ui/breadcrumb/Breadcrumb"
+import { Button } from "@/shared/ui/Button"
+import { Segment } from "@/shared/ui/segment/Segment"
+import { useToastStore } from "@/shared/ui/toast/useToastStore"
+
+import {
+  assignApplicant,
+  formatDateTabLabel,
+  isInterviewApplicant,
+  parseSlotKey,
+  resolveScheduleDates,
+  SLOT_STEP_MINUTES,
+  splitApplicantsByAssignment,
+  toMinutes,
+  toTimeLabel,
+  unassignApplicant,
+} from "../../model/interviewSchedule"
+import {
+  INTERVIEW_APPLICANTS_MOCK,
+  INTERVIEW_SCHEDULE_ROUNDS_MOCK,
+  INTERVIEW_SESSIONS_MOCK,
+} from "../../model/interviewSchedule.mock"
+import { APPLICANT_POOL_ID, ApplicantPoolPanel } from "./ApplicantPoolPanel"
+import { DraggableApplicantChip } from "./DraggableApplicantChip"
+import { type ScheduleStep, ScheduleStepTabs } from "./ScheduleStepTabs"
+import { SessionEditorList } from "./SessionEditorList"
+import { SessionSlotBoard } from "./SessionSlotBoard"
+
+import type {
+  InterviewApplicant,
+  InterviewSession,
+  SlotAssignment,
+} from "../../model/interviewSchedule"
+
+const LIST_PATH = "/recruiting/evaluations/interview-schedule"
+
+interface InterviewScheduleBoardPageProps {
+  roundId: string
+}
+
+export function InterviewScheduleBoardPage({
+  roundId,
+}: InterviewScheduleBoardPageProps) {
+  const addToast = useToastStore((state) => state.addToast)
+  const round = INTERVIEW_SCHEDULE_ROUNDS_MOCK.find(
+    (item) => item.roundId === roundId,
+  )
+
+  const dates = useMemo(
+    () => resolveScheduleDates(round?.interviewStartAt, round?.interviewEndAt),
+    [round?.interviewStartAt, round?.interviewEndAt],
+  )
+
+  const [activeDate, setActiveDate] = useState(dates[0] ?? "")
+  const [step, setStep] = useState<ScheduleStep>("sessions")
+  const [sessionsByDate, setSessionsByDate] = useState<
+    Record<string, InterviewSession[]>
+  >({})
+  const [assignmentsByDate, setAssignmentsByDate] = useState<
+    Record<string, SlotAssignment[]>
+  >({})
+  const [draggingApplicant, setDraggingApplicant] =
+    useState<InterviewApplicant | null>(null)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+  )
+
+  const currentDate = activeDate || dates[0] || ""
+  const sessions = sessionsByDate[currentDate] ?? INTERVIEW_SESSIONS_MOCK
+  const assignments = useMemo(
+    () => assignmentsByDate[currentDate] ?? [],
+    [assignmentsByDate, currentDate],
+  )
+
+  const applicantsById = useMemo(
+    () => new Map(INTERVIEW_APPLICANTS_MOCK.map((item) => [item.id, item])),
+    [],
+  )
+  const { waiting, assigned } = useMemo(
+    () => splitApplicantsByAssignment(INTERVIEW_APPLICANTS_MOCK, assignments),
+    [assignments],
+  )
+
+  const setSessions = (next: InterviewSession[]) => {
+    setSessionsByDate((prev) => ({ ...prev, [currentDate]: next }))
+  }
+
+  const setAssignments = (next: SlotAssignment[]) => {
+    setAssignmentsByDate((prev) => ({ ...prev, [currentDate]: next }))
+  }
+
+  const handleAddSlotTime = (sessionId: string) => {
+    setSessions(
+      sessions.map((session) => {
+        if (session.id !== sessionId) return session
+        const end = toMinutes(session.endTime)
+        if (end == null) return session
+        return { ...session, endTime: toTimeLabel(end + SLOT_STEP_MINUTES) }
+      }),
+    )
+  }
+
+  const handleDragStart = (event: DragStartEvent) => {
+    const applicant = event.active.data.current
+    if (!isInterviewApplicant(applicant)) return
+    setDraggingApplicant(applicant)
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setDraggingApplicant(null)
+    const { active, over } = event
+    if (!over) return
+
+    const applicant = active.data.current
+    if (!isInterviewApplicant(applicant)) return
+
+    if (over.id === APPLICANT_POOL_ID) {
+      setAssignments(unassignApplicant(assignments, applicant.id))
+      return
+    }
+
+    const slot = parseSlotKey(String(over.id))
+    if (!slot) return
+    setAssignments(
+      assignApplicant(
+        assignments,
+        slot.sessionId,
+        slot.slotStart,
+        applicant.id,
+      ),
+    )
+  }
+
+  const handleSave = () => {
+    addToast({
+      message: "면접 일정을 저장했습니다.",
+      color: "primary",
+      variant: "deep",
+      type: "default",
+      duration: 3000,
+    })
+  }
+
+  if (!round) {
+    return (
+      <div className="flex w-full max-w-286.5 flex-col">
+        <div className="border-teal-gray-100 text-body-2-regular text-teal-gray-500 mt-8 flex min-h-50 items-center justify-center rounded-[12px] border bg-white">
+          모집을 찾지 못했습니다. 목록에서 다시 진입해주세요.
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex w-full max-w-286.5 flex-col gap-6">
+      <div className="flex flex-col gap-5 pl-3">
+        <Breadcrumb
+          items={[
+            { id: "recruiting", label: "리크루팅" },
+            { id: "evaluation-management", label: "평가 관리" },
+            { id: "interview-schedule", label: "면접 스케줄링", to: LIST_PATH },
+          ]}
+        />
+        <Link
+          to={LIST_PATH}
+          className="text-body-2-medium text-teal-gray-500 hover:text-teal-gray-700 flex w-fit items-center gap-1"
+        >
+          <LeftChevronIcon width={16} height={16} />
+          면접 스케줄링 목록으로
+        </Link>
+        <div className="flex flex-col gap-1">
+          <h1 className="text-heading-4-semibold text-teal-gray-900">
+            {round.schoolName}
+          </h1>
+          <span className="text-body-2-regular text-teal-gray-500">
+            {round.roundTitle}
+          </span>
+        </div>
+      </div>
+
+      {dates.length > 0 && (
+        <Segment
+          items={dates.map((date) => ({
+            id: date,
+            label: formatDateTabLabel(date),
+          }))}
+          value={currentDate}
+          onValueChange={setActiveDate}
+        />
+      )}
+
+      <ScheduleStepTabs value={step} onValueChange={setStep} />
+
+      {step === "sessions" ? (
+        <SessionEditorList
+          sessions={sessions}
+          onChange={setSessions}
+          onSave={handleSave}
+        />
+      ) : (
+        <DndContext
+          sensors={sensors}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onDragCancel={() => setDraggingApplicant(null)}
+        >
+          <div className="flex items-start gap-6">
+            <ApplicantPoolPanel
+              totalCount={INTERVIEW_APPLICANTS_MOCK.length}
+              waiting={waiting}
+              assignedCount={assigned.length}
+            />
+            <SessionSlotBoard
+              sessions={sessions}
+              assignments={assignments}
+              applicantsById={applicantsById}
+              onAddSlotTime={handleAddSlotTime}
+            />
+          </div>
+          <div className="flex justify-end">
+            <Button
+              variant="fill"
+              color="primary"
+              size="m"
+              onClick={handleSave}
+            >
+              저장하기
+            </Button>
+          </div>
+          <DragOverlay>
+            {draggingApplicant && (
+              <DraggableApplicantChip applicant={draggingApplicant} compact />
+            )}
+          </DragOverlay>
+        </DndContext>
+      )}
+    </div>
+  )
+}

--- a/src/features/recruiting/ui/schedule/InterviewSchedulePage.tsx
+++ b/src/features/recruiting/ui/schedule/InterviewSchedulePage.tsx
@@ -1,0 +1,52 @@
+import { useMemo } from "react"
+
+import { PageLabel } from "@/shared/ui/page-label/PageLabel"
+
+import { INTERVIEW_SCHEDULE_ROUNDS_MOCK } from "../../model/interviewSchedule.mock"
+import { InterviewScheduleRoundCard } from "./InterviewScheduleRoundCard"
+
+import type { InterviewScheduleRound } from "../../model/interviewSchedule.mock"
+
+export function InterviewSchedulePage() {
+  const bySchool = useMemo(() => {
+    const grouped = new Map<string, InterviewScheduleRound[]>()
+    for (const round of INTERVIEW_SCHEDULE_ROUNDS_MOCK) {
+      const bucket = grouped.get(round.schoolName) ?? []
+      bucket.push(round)
+      grouped.set(round.schoolName, bucket)
+    }
+    return [...grouped.entries()]
+  }, [])
+
+  return (
+    <div className="flex w-full max-w-286.5 flex-col">
+      <PageLabel
+        breadcrumb={[
+          { id: "recruiting", label: "리크루팅" },
+          { id: "evaluation-management", label: "평가 관리" },
+          { id: "interview-schedule", label: "면접 스케줄링" },
+        ]}
+        title="면접 스케줄링"
+        description="서류 전형을 합격한 지원자들의 면접 일정을 정합니다."
+        className="pl-3"
+      />
+
+      {bySchool.length === 0 ? (
+        <div className="border-teal-gray-100 text-body-2-regular text-teal-gray-500 mt-8 flex min-h-50 items-center justify-center rounded-[12px] border bg-white">
+          면접을 진행할 모집이 없습니다.
+        </div>
+      ) : (
+        bySchool.map(([schoolName, rounds]) => (
+          <section key={schoolName} className="mt-8 flex flex-col">
+            <h2 className="text-heading-5-semibold px-3 text-teal-700">
+              {schoolName}
+            </h2>
+            {rounds.map((round) => (
+              <InterviewScheduleRoundCard key={round.roundId} round={round} />
+            ))}
+          </section>
+        ))
+      )}
+    </div>
+  )
+}

--- a/src/features/recruiting/ui/schedule/InterviewScheduleRoundCard.tsx
+++ b/src/features/recruiting/ui/schedule/InterviewScheduleRoundCard.tsx
@@ -1,0 +1,67 @@
+import { Link } from "@tanstack/react-router"
+
+import { calcAllocationRate } from "../../model/interviewSchedule"
+
+import type { InterviewScheduleRound } from "../../model/interviewSchedule.mock"
+
+function formatPeriod(startAt: string, endAt: string) {
+  const start = new Date(startAt)
+  const end = new Date(endAt)
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return ""
+
+  const pad = (value: number) => String(value).padStart(2, "0")
+  const stamp = (date: Date, withYear: boolean) =>
+    `${withYear ? `${date.getFullYear()}-` : ""}${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}`
+
+  return `${stamp(start, true)} ~ ${stamp(end, false)}`
+}
+
+interface InterviewScheduleRoundCardProps {
+  round: InterviewScheduleRound
+}
+
+export function InterviewScheduleRoundCard({
+  round,
+}: InterviewScheduleRoundCardProps) {
+  const rate = calcAllocationRate(round.assignedCount, round.totalCount)
+
+  return (
+    <Link
+      to="/recruiting/evaluations/interview-schedule/$roundId"
+      params={{ roundId: round.roundId }}
+      className="shadow-drop-neutral-3 border-teal-gray-100 mt-4 flex items-center justify-between gap-6 rounded-[12px] border bg-white px-8 py-7 transition-colors hover:border-teal-300"
+    >
+      <div className="flex min-w-0 flex-col gap-1">
+        <span className="text-heading-6-semibold text-teal-gray-800 truncate">
+          {round.roundTitle}
+        </span>
+        <div className="text-body-2-regular text-teal-gray-400 flex items-center gap-2">
+          <span>{round.documentClosedLabel}</span>
+          <div className="bg-teal-gray-200 h-3 w-[1px] rounded-[0.5px]" />
+          <span>
+            면접 일정:{" "}
+            {formatPeriod(round.interviewStartAt, round.interviewEndAt)}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex shrink-0 flex-col items-end gap-1.5">
+        <div className="flex items-baseline gap-1.5">
+          <span className="text-body-2-medium text-teal-gray-600">
+            면접 배정률
+          </span>
+          <span className="text-label-1-medium text-teal-gray-400">
+            ({round.assignedCount}/{round.totalCount})
+          </span>
+          <span className="text-heading-6-semibold text-teal-600">{rate}%</span>
+        </div>
+        <div className="bg-teal-gray-100 h-1.5 w-45 overflow-hidden rounded-full">
+          <div
+            className="h-full rounded-full bg-teal-500"
+            style={{ width: `${rate}%` }}
+          />
+        </div>
+      </div>
+    </Link>
+  )
+}

--- a/src/features/recruiting/ui/schedule/ScheduleStepTabs.tsx
+++ b/src/features/recruiting/ui/schedule/ScheduleStepTabs.tsx
@@ -1,0 +1,69 @@
+import { cn } from "@/shared/lib/utils"
+
+export type ScheduleStep = "sessions" | "assignment"
+
+const STEPS: { id: ScheduleStep; label: string }[] = [
+  { id: "sessions", label: "면접 시간 및 장소 등록" },
+  { id: "assignment", label: "지원자 일정 등록" },
+]
+
+interface ScheduleStepTabsProps {
+  value: ScheduleStep
+  onValueChange: (value: ScheduleStep) => void
+  className?: string
+}
+
+export function ScheduleStepTabs({
+  value,
+  onValueChange,
+  className,
+}: ScheduleStepTabsProps) {
+  return (
+    <div
+      role="tablist"
+      className={cn(
+        "bg-teal-gray-100 flex w-full items-center gap-2 rounded-[12px] p-1.5",
+        className,
+      )}
+    >
+      {STEPS.map((step, index) => {
+        const selected = step.id === value
+        return (
+          <button
+            key={step.id}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            onClick={() => onValueChange(step.id)}
+            className={cn(
+              "flex h-11 flex-1 cursor-pointer items-center justify-center gap-2 rounded-[10px] transition-colors",
+              selected
+                ? "border-teal-gray-100 shadow-drop-neutral-3 border bg-white"
+                : "hover:bg-teal-gray-150 bg-transparent",
+            )}
+          >
+            <span
+              className={cn(
+                "flex size-5 shrink-0 items-center justify-center rounded-full text-[13px] leading-none font-semibold",
+                selected
+                  ? "bg-teal-600 text-white"
+                  : "bg-teal-gray-200 text-teal-gray-600",
+              )}
+            >
+              {index + 1}
+            </span>
+            <span
+              className={cn(
+                selected
+                  ? "text-subtitle-3-semibold text-teal-gray-800"
+                  : "text-body-1-medium text-teal-gray-500",
+              )}
+            >
+              {step.label}
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/features/recruiting/ui/schedule/SessionEditorList.tsx
+++ b/src/features/recruiting/ui/schedule/SessionEditorList.tsx
@@ -99,7 +99,14 @@ export function SessionEditorList({
                         : "text-teal-gray-500 hover:bg-teal-gray-100 bg-white",
                     )}
                   >
-                    {selected ? `✓ ${item.label}` : item.label}
+                    {/* aria-checked 가 이미 상태를 알린다. 체크 표시를 라벨에
+                        넣으면 두 번 읽히고 선택할 때마다 버튼 폭이 흔들린다. */}
+                    {selected && (
+                      <span aria-hidden="true" className="mr-1">
+                        ✓
+                      </span>
+                    )}
+                    {item.label}
                   </button>
                 )
               })}

--- a/src/features/recruiting/ui/schedule/SessionEditorList.tsx
+++ b/src/features/recruiting/ui/schedule/SessionEditorList.tsx
@@ -1,0 +1,163 @@
+import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
+import { cn } from "@/shared/lib/utils"
+import { Button } from "@/shared/ui/Button"
+
+import type {
+  InterviewMode,
+  InterviewSession,
+} from "../../model/interviewSchedule"
+
+const MODE_ITEMS: { id: InterviewMode; label: string }[] = [
+  { id: "online", label: "비대면" },
+  { id: "offline", label: "대면" },
+]
+
+const PLACE_PLACEHOLDER: Record<InterviewMode, string> = {
+  online: "지원자들에게 안내될 면접 링크나 노션 링크를 작성해 주세요",
+  offline: "지원자들에게 안내될 면접 위치를 작성해 주세요",
+}
+
+interface SessionEditorListProps {
+  sessions: InterviewSession[]
+  onChange: (sessions: InterviewSession[]) => void
+  onSave: () => void
+}
+
+export function SessionEditorList({
+  sessions,
+  onChange,
+  onSave,
+}: SessionEditorListProps) {
+  const update = (id: string, partial: Partial<InterviewSession>) => {
+    onChange(
+      sessions.map((session) =>
+        session.id === id ? { ...session, ...partial } : session,
+      ),
+    )
+  }
+
+  const add = () => {
+    const nextIndex = sessions.length + 1
+    onChange([
+      ...sessions,
+      {
+        id: `session-${Date.now()}`,
+        name: `면접 ${String.fromCharCode(64 + nextIndex)}`,
+        startTime: "",
+        endTime: "",
+        mode: "online",
+        place: "",
+      },
+    ])
+  }
+
+  return (
+    <div className="shadow-drop-neutral-3 border-teal-gray-100 mt-6 flex flex-col gap-9 rounded-[12px] border bg-white px-8 py-9">
+      {sessions.map((session) => (
+        <div key={session.id} className="flex flex-col gap-3">
+          <input
+            value={session.name}
+            onChange={(event) =>
+              update(session.id, { name: event.target.value })
+            }
+            placeholder="면접 이름을 입력해 주세요"
+            aria-label="면접 이름"
+            className="text-heading-6-semibold text-teal-gray-800 placeholder:text-teal-gray-300 w-full bg-transparent outline-none"
+          />
+
+          <div className="flex items-center gap-3">
+            <TimeField
+              value={session.startTime}
+              onChange={(startTime) => update(session.id, { startTime })}
+              label="시작 시각"
+            />
+            <span className="text-body-1-regular text-teal-gray-400">~</span>
+            <TimeField
+              value={session.endTime}
+              onChange={(endTime) => update(session.id, { endTime })}
+              label="종료 시각"
+            />
+
+            <div
+              role="radiogroup"
+              aria-label="면접 진행 방식"
+              className="border-teal-gray-200 ml-1 flex h-11 items-center overflow-hidden rounded-[10px] border"
+            >
+              {MODE_ITEMS.map((item) => {
+                const selected = session.mode === item.id
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    onClick={() => update(session.id, { mode: item.id })}
+                    className={cn(
+                      "text-label-1-medium h-full w-22 cursor-pointer transition-colors",
+                      selected
+                        ? "bg-teal-50 text-teal-700"
+                        : "text-teal-gray-500 hover:bg-teal-gray-100 bg-white",
+                    )}
+                  >
+                    {selected ? `✓ ${item.label}` : item.label}
+                  </button>
+                )
+              })}
+            </div>
+
+            <input
+              value={session.place}
+              onChange={(event) =>
+                update(session.id, { place: event.target.value })
+              }
+              placeholder={PLACE_PLACEHOLDER[session.mode]}
+              aria-label={session.mode === "online" ? "면접 링크" : "면접 위치"}
+              className="border-teal-gray-200 text-body-2-regular text-teal-gray-700 placeholder:text-teal-gray-300 h-11 flex-1 rounded-[10px] border px-4 outline-none focus:border-teal-500"
+            />
+          </div>
+
+          {session.mode === "offline" && (
+            <span className="text-label-1-medium text-teal-gray-400 pl-1">
+              ex. 한국대학교 유엠관 107호
+            </span>
+          )}
+        </div>
+      ))}
+
+      <button
+        type="button"
+        onClick={add}
+        className="text-body-2-medium text-teal-gray-600 flex w-fit cursor-pointer items-center gap-1 hover:text-teal-700"
+      >
+        <PlusIcon className="size-4" />
+        면접 스케줄 추가
+      </button>
+
+      <div className="flex justify-end">
+        <Button variant="fill" color="primary" size="m" onClick={onSave}>
+          저장하기
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function TimeField({
+  value,
+  onChange,
+  label,
+}: {
+  value: string
+  onChange: (value: string) => void
+  label: string
+}) {
+  return (
+    <input
+      type="time"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      aria-label={label}
+      className="border-teal-gray-200 text-body-2-regular text-teal-gray-700 h-11 w-26 rounded-[10px] border px-4 text-center outline-none focus:border-teal-500"
+    />
+  )
+}

--- a/src/features/recruiting/ui/schedule/SessionSlotBoard.tsx
+++ b/src/features/recruiting/ui/schedule/SessionSlotBoard.tsx
@@ -1,0 +1,93 @@
+import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
+
+import { buildTimeSlots, findAssignment } from "../../model/interviewSchedule"
+import { DroppableSlotRow } from "./DroppableSlotRow"
+
+import type {
+  InterviewApplicant,
+  InterviewSession,
+  SlotAssignment,
+} from "../../model/interviewSchedule"
+
+const MODE_LABEL = { online: "비대면", offline: "대면" } as const
+
+interface SessionSlotBoardProps {
+  sessions: InterviewSession[]
+  assignments: SlotAssignment[]
+  applicantsById: Map<string, InterviewApplicant>
+  onAddSlotTime: (sessionId: string) => void
+}
+
+export function SessionSlotBoard({
+  sessions,
+  assignments,
+  applicantsById,
+  onAddSlotTime,
+}: SessionSlotBoardProps) {
+  if (sessions.length === 0) {
+    return (
+      <div className="shadow-drop-neutral-3 border-teal-gray-100 text-body-2-regular text-teal-gray-500 flex min-h-60 flex-1 items-center justify-center rounded-[12px] border bg-white">
+        먼저 면접 시간과 장소를 등록해주세요.
+      </div>
+    )
+  }
+
+  return (
+    <div className="shadow-drop-neutral-3 border-teal-gray-100 flex flex-1 flex-col gap-10 rounded-[12px] border bg-white px-7 py-7">
+      {sessions.map((session) => {
+        const slots = buildTimeSlots(session.startTime, session.endTime)
+        return (
+          <section key={session.id} className="flex flex-col gap-4">
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex flex-col gap-0.5">
+                <h3 className="text-heading-6-semibold text-teal-gray-800">
+                  {session.name || "이름 없는 면접"}
+                </h3>
+                <span className="text-label-1-medium text-teal-gray-400">
+                  {MODE_LABEL[session.mode]}
+                  {session.place ? ` | ${session.place}` : ""}
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={() => onAddSlotTime(session.id)}
+                className="text-body-2-medium text-teal-gray-600 flex shrink-0 cursor-pointer items-center gap-1 hover:text-teal-700"
+              >
+                <PlusIcon className="size-4" />
+                면접 시간 추가
+              </button>
+            </div>
+
+            {slots.length === 0 ? (
+              <p className="text-body-2-regular text-teal-gray-400 py-6 text-center">
+                시간대를 30분 이상으로 설정하면 슬롯이 만들어집니다.
+              </p>
+            ) : (
+              <div className="flex flex-col gap-2.5">
+                {slots.map((slot) => {
+                  const assignment = findAssignment(
+                    assignments,
+                    session.id,
+                    slot.start,
+                  )
+                  return (
+                    <DroppableSlotRow
+                      key={slot.start}
+                      sessionId={session.id}
+                      slot={slot}
+                      applicant={
+                        assignment
+                          ? applicantsById.get(assignment.applicantId)
+                          : undefined
+                      }
+                    />
+                  )
+                })}
+              </div>
+            )}
+          </section>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -85,6 +85,7 @@ import { Route as ManageCurriculumIndexRouteImport } from './routes/manage/curri
 import { Route as RecruitingRecruitmentsQuotaRouteImport } from './routes/recruiting/recruitments/quota'
 import { Route as RecruitingRecruitmentsNewRouteImport } from './routes/recruiting/recruitments/new'
 import { Route as RecruitingHistoryArchiveRouteImport } from './routes/recruiting/history/archive'
+import { Route as RecruitingEvaluationsInterviewScheduleRouteImport } from './routes/recruiting/evaluations/interview-schedule'
 import { Route as RecruitingEvaluationsInterviewRouteImport } from './routes/recruiting/evaluations/interview'
 import { Route as RecruitingEvaluationsFinalRouteImport } from './routes/recruiting/evaluations/final'
 import { Route as RecruitingEvaluationsDocumentRouteImport } from './routes/recruiting/evaluations/document'
@@ -107,6 +108,7 @@ import { Route as MatchingProjectsAnnounceRouteRouteImport } from './routes/matc
 import { Route as MatchingProjectsAnnounceIndexRouteImport } from './routes/matching/projects/announce/index'
 import { Route as RecruitingRecruitmentsEditRoundIdRouteImport } from './routes/recruiting/recruitments/edit.$roundId'
 import { Route as RecruitingEvaluationsInterviewApplicationIdRouteImport } from './routes/recruiting/evaluations/interview.$applicationId'
+import { Route as RecruitingEvaluationsInterviewScheduleRoundIdRouteImport } from './routes/recruiting/evaluations/interview-schedule.$roundId'
 import { Route as RecruitingEvaluationsDocumentApplicationIdRouteImport } from './routes/recruiting/evaluations/document.$applicationId'
 import { Route as MatchingProjectsEditProjectIdRouteImport } from './routes/matching/projects/edit.$projectId'
 import { Route as MatchingProjectsAnnounceNoticePublishRouteImport } from './routes/matching/projects/announce/notice-publish'
@@ -507,6 +509,12 @@ const RecruitingHistoryArchiveRoute =
     path: '/history/archive',
     getParentRoute: () => RecruitingRouteRoute,
   } as any)
+const RecruitingEvaluationsInterviewScheduleRoute =
+  RecruitingEvaluationsInterviewScheduleRouteImport.update({
+    id: '/evaluations/interview-schedule',
+    path: '/evaluations/interview-schedule',
+    getParentRoute: () => RecruitingRouteRoute,
+  } as any)
 const RecruitingEvaluationsInterviewRoute =
   RecruitingEvaluationsInterviewRouteImport.update({
     id: '/evaluations/interview',
@@ -629,6 +637,12 @@ const RecruitingEvaluationsInterviewApplicationIdRoute =
     path: '/$applicationId',
     getParentRoute: () => RecruitingEvaluationsInterviewRoute,
   } as any)
+const RecruitingEvaluationsInterviewScheduleRoundIdRoute =
+  RecruitingEvaluationsInterviewScheduleRoundIdRouteImport.update({
+    id: '/$roundId',
+    path: '/$roundId',
+    getParentRoute: () => RecruitingEvaluationsInterviewScheduleRoute,
+  } as any)
 const RecruitingEvaluationsDocumentApplicationIdRoute =
   RecruitingEvaluationsDocumentApplicationIdRouteImport.update({
     id: '/$applicationId',
@@ -741,6 +755,7 @@ export interface FileRoutesByFullPath {
   '/recruiting/evaluations/document': typeof RecruitingEvaluationsDocumentRouteWithChildren
   '/recruiting/evaluations/final': typeof RecruitingEvaluationsFinalRoute
   '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRouteWithChildren
+  '/recruiting/evaluations/interview-schedule': typeof RecruitingEvaluationsInterviewScheduleRouteWithChildren
   '/recruiting/history/archive': typeof RecruitingHistoryArchiveRoute
   '/recruiting/recruitments/new': typeof RecruitingRecruitmentsNewRoute
   '/recruiting/recruitments/quota': typeof RecruitingRecruitmentsQuotaRoute
@@ -753,6 +768,7 @@ export interface FileRoutesByFullPath {
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/edit/$projectId': typeof MatchingProjectsEditProjectIdRoute
   '/recruiting/evaluations/document/$applicationId': typeof RecruitingEvaluationsDocumentApplicationIdRoute
+  '/recruiting/evaluations/interview-schedule/$roundId': typeof RecruitingEvaluationsInterviewScheduleRoundIdRoute
   '/recruiting/evaluations/interview/$applicationId': typeof RecruitingEvaluationsInterviewApplicationIdRoute
   '/recruiting/recruitments/edit/$roundId': typeof RecruitingRecruitmentsEditRoundIdRoute
   '/matching/projects/announce/': typeof MatchingProjectsAnnounceIndexRoute
@@ -839,6 +855,7 @@ export interface FileRoutesByTo {
   '/recruiting/evaluations/document': typeof RecruitingEvaluationsDocumentRouteWithChildren
   '/recruiting/evaluations/final': typeof RecruitingEvaluationsFinalRoute
   '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRouteWithChildren
+  '/recruiting/evaluations/interview-schedule': typeof RecruitingEvaluationsInterviewScheduleRouteWithChildren
   '/recruiting/history/archive': typeof RecruitingHistoryArchiveRoute
   '/recruiting/recruitments/new': typeof RecruitingRecruitmentsNewRoute
   '/recruiting/recruitments/quota': typeof RecruitingRecruitmentsQuotaRoute
@@ -851,6 +868,7 @@ export interface FileRoutesByTo {
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/edit/$projectId': typeof MatchingProjectsEditProjectIdRoute
   '/recruiting/evaluations/document/$applicationId': typeof RecruitingEvaluationsDocumentApplicationIdRoute
+  '/recruiting/evaluations/interview-schedule/$roundId': typeof RecruitingEvaluationsInterviewScheduleRoundIdRoute
   '/recruiting/evaluations/interview/$applicationId': typeof RecruitingEvaluationsInterviewApplicationIdRoute
   '/recruiting/recruitments/edit/$roundId': typeof RecruitingRecruitmentsEditRoundIdRoute
   '/matching/projects/announce': typeof MatchingProjectsAnnounceIndexRoute
@@ -944,6 +962,7 @@ export interface FileRoutesById {
   '/recruiting/evaluations/document': typeof RecruitingEvaluationsDocumentRouteWithChildren
   '/recruiting/evaluations/final': typeof RecruitingEvaluationsFinalRoute
   '/recruiting/evaluations/interview': typeof RecruitingEvaluationsInterviewRouteWithChildren
+  '/recruiting/evaluations/interview-schedule': typeof RecruitingEvaluationsInterviewScheduleRouteWithChildren
   '/recruiting/history/archive': typeof RecruitingHistoryArchiveRoute
   '/recruiting/recruitments/new': typeof RecruitingRecruitmentsNewRoute
   '/recruiting/recruitments/quota': typeof RecruitingRecruitmentsQuotaRoute
@@ -956,6 +975,7 @@ export interface FileRoutesById {
   '/matching/projects/announce/notice-publish': typeof MatchingProjectsAnnounceNoticePublishRouteWithChildren
   '/matching/projects/edit/$projectId': typeof MatchingProjectsEditProjectIdRoute
   '/recruiting/evaluations/document/$applicationId': typeof RecruitingEvaluationsDocumentApplicationIdRoute
+  '/recruiting/evaluations/interview-schedule/$roundId': typeof RecruitingEvaluationsInterviewScheduleRoundIdRoute
   '/recruiting/evaluations/interview/$applicationId': typeof RecruitingEvaluationsInterviewApplicationIdRoute
   '/recruiting/recruitments/edit/$roundId': typeof RecruitingRecruitmentsEditRoundIdRoute
   '/matching/projects/announce/': typeof MatchingProjectsAnnounceIndexRoute
@@ -1050,6 +1070,7 @@ export interface FileRouteTypes {
     | '/recruiting/evaluations/document'
     | '/recruiting/evaluations/final'
     | '/recruiting/evaluations/interview'
+    | '/recruiting/evaluations/interview-schedule'
     | '/recruiting/history/archive'
     | '/recruiting/recruitments/new'
     | '/recruiting/recruitments/quota'
@@ -1062,6 +1083,7 @@ export interface FileRouteTypes {
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/edit/$projectId'
     | '/recruiting/evaluations/document/$applicationId'
+    | '/recruiting/evaluations/interview-schedule/$roundId'
     | '/recruiting/evaluations/interview/$applicationId'
     | '/recruiting/recruitments/edit/$roundId'
     | '/matching/projects/announce/'
@@ -1148,6 +1170,7 @@ export interface FileRouteTypes {
     | '/recruiting/evaluations/document'
     | '/recruiting/evaluations/final'
     | '/recruiting/evaluations/interview'
+    | '/recruiting/evaluations/interview-schedule'
     | '/recruiting/history/archive'
     | '/recruiting/recruitments/new'
     | '/recruiting/recruitments/quota'
@@ -1160,6 +1183,7 @@ export interface FileRouteTypes {
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/edit/$projectId'
     | '/recruiting/evaluations/document/$applicationId'
+    | '/recruiting/evaluations/interview-schedule/$roundId'
     | '/recruiting/evaluations/interview/$applicationId'
     | '/recruiting/recruitments/edit/$roundId'
     | '/matching/projects/announce'
@@ -1252,6 +1276,7 @@ export interface FileRouteTypes {
     | '/recruiting/evaluations/document'
     | '/recruiting/evaluations/final'
     | '/recruiting/evaluations/interview'
+    | '/recruiting/evaluations/interview-schedule'
     | '/recruiting/history/archive'
     | '/recruiting/recruitments/new'
     | '/recruiting/recruitments/quota'
@@ -1264,6 +1289,7 @@ export interface FileRouteTypes {
     | '/matching/projects/announce/notice-publish'
     | '/matching/projects/edit/$projectId'
     | '/recruiting/evaluations/document/$applicationId'
+    | '/recruiting/evaluations/interview-schedule/$roundId'
     | '/recruiting/evaluations/interview/$applicationId'
     | '/recruiting/recruitments/edit/$roundId'
     | '/matching/projects/announce/'
@@ -1864,6 +1890,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof RecruitingHistoryArchiveRouteImport
       parentRoute: typeof RecruitingRouteRoute
     }
+    '/recruiting/evaluations/interview-schedule': {
+      id: '/recruiting/evaluations/interview-schedule'
+      path: '/evaluations/interview-schedule'
+      fullPath: '/recruiting/evaluations/interview-schedule'
+      preLoaderRoute: typeof RecruitingEvaluationsInterviewScheduleRouteImport
+      parentRoute: typeof RecruitingRouteRoute
+    }
     '/recruiting/evaluations/interview': {
       id: '/recruiting/evaluations/interview'
       path: '/evaluations/interview'
@@ -2017,6 +2050,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/recruiting/evaluations/interview/$applicationId'
       preLoaderRoute: typeof RecruitingEvaluationsInterviewApplicationIdRouteImport
       parentRoute: typeof RecruitingEvaluationsInterviewRoute
+    }
+    '/recruiting/evaluations/interview-schedule/$roundId': {
+      id: '/recruiting/evaluations/interview-schedule/$roundId'
+      path: '/$roundId'
+      fullPath: '/recruiting/evaluations/interview-schedule/$roundId'
+      preLoaderRoute: typeof RecruitingEvaluationsInterviewScheduleRoundIdRouteImport
+      parentRoute: typeof RecruitingEvaluationsInterviewScheduleRoute
     }
     '/recruiting/evaluations/document/$applicationId': {
       id: '/recruiting/evaluations/document/$applicationId'
@@ -2219,12 +2259,28 @@ const RecruitingEvaluationsInterviewRouteWithChildren =
     RecruitingEvaluationsInterviewRouteChildren,
   )
 
+interface RecruitingEvaluationsInterviewScheduleRouteChildren {
+  RecruitingEvaluationsInterviewScheduleRoundIdRoute: typeof RecruitingEvaluationsInterviewScheduleRoundIdRoute
+}
+
+const RecruitingEvaluationsInterviewScheduleRouteChildren: RecruitingEvaluationsInterviewScheduleRouteChildren =
+  {
+    RecruitingEvaluationsInterviewScheduleRoundIdRoute:
+      RecruitingEvaluationsInterviewScheduleRoundIdRoute,
+  }
+
+const RecruitingEvaluationsInterviewScheduleRouteWithChildren =
+  RecruitingEvaluationsInterviewScheduleRoute._addFileChildren(
+    RecruitingEvaluationsInterviewScheduleRouteChildren,
+  )
+
 interface RecruitingRouteRouteChildren {
   RecruitingDashboardApplicationsRoute: typeof RecruitingDashboardApplicationsRoute
   RecruitingDashboardEvaluationsRoute: typeof RecruitingDashboardEvaluationsRoute
   RecruitingEvaluationsDocumentRoute: typeof RecruitingEvaluationsDocumentRouteWithChildren
   RecruitingEvaluationsFinalRoute: typeof RecruitingEvaluationsFinalRoute
   RecruitingEvaluationsInterviewRoute: typeof RecruitingEvaluationsInterviewRouteWithChildren
+  RecruitingEvaluationsInterviewScheduleRoute: typeof RecruitingEvaluationsInterviewScheduleRouteWithChildren
   RecruitingHistoryArchiveRoute: typeof RecruitingHistoryArchiveRoute
   RecruitingRecruitmentsNewRoute: typeof RecruitingRecruitmentsNewRoute
   RecruitingRecruitmentsQuotaRoute: typeof RecruitingRecruitmentsQuotaRoute
@@ -2241,6 +2297,8 @@ const RecruitingRouteRouteChildren: RecruitingRouteRouteChildren = {
   RecruitingEvaluationsFinalRoute: RecruitingEvaluationsFinalRoute,
   RecruitingEvaluationsInterviewRoute:
     RecruitingEvaluationsInterviewRouteWithChildren,
+  RecruitingEvaluationsInterviewScheduleRoute:
+    RecruitingEvaluationsInterviewScheduleRouteWithChildren,
   RecruitingHistoryArchiveRoute: RecruitingHistoryArchiveRoute,
   RecruitingRecruitmentsNewRoute: RecruitingRecruitmentsNewRoute,
   RecruitingRecruitmentsQuotaRoute: RecruitingRecruitmentsQuotaRoute,

--- a/src/routes/recruiting/evaluations/interview-schedule.$roundId.tsx
+++ b/src/routes/recruiting/evaluations/interview-schedule.$roundId.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { InterviewScheduleBoardPage } from "@/features/recruiting"
+
+export const Route = createFileRoute(
+  "/recruiting/evaluations/interview-schedule/$roundId",
+)({
+  component: InterviewScheduleBoardRoute,
+})
+
+function InterviewScheduleBoardRoute() {
+  const { roundId } = Route.useParams()
+  return <InterviewScheduleBoardPage key={roundId} roundId={roundId} />
+}

--- a/src/routes/recruiting/evaluations/interview-schedule.tsx
+++ b/src/routes/recruiting/evaluations/interview-schedule.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute, Outlet, useMatchRoute } from "@tanstack/react-router"
+
+import { InterviewSchedulePage } from "@/features/recruiting"
+
+export const Route = createFileRoute(
+  "/recruiting/evaluations/interview-schedule",
+)({
+  component: InterviewScheduleListRoute,
+})
+
+function InterviewScheduleListRoute() {
+  const matchRoute = useMatchRoute()
+  const isBoard = Boolean(
+    matchRoute({ to: "/recruiting/evaluations/interview-schedule/$roundId" }),
+  )
+  if (isBoard) return <Outlet />
+  return <InterviewSchedulePage />
+}

--- a/src/shared/config/recruitingNavigation.ts
+++ b/src/shared/config/recruitingNavigation.ts
@@ -64,6 +64,11 @@ export const RECRUITING_SIDEBAR_ITEMS: RecruitingSideBarSection[] = [
         to: "/recruiting/evaluations/document",
       },
       {
+        id: "recruiting-evaluations-interview-schedule",
+        title: "면접 스케줄링",
+        to: "/recruiting/evaluations/interview-schedule",
+      },
+      {
         id: "recruiting-evaluations-interview",
         title: "면접 전형",
         to: "/recruiting/evaluations/interview",


### PR DESCRIPTION
## 📸 작업 내용

- 평가 관리에 **면접 스케줄링** 화면을 추가했습니다. 사이드바 `서류 전형`과 `면접 전형` 사이에 들어갑니다
- 모집 차수별 목록에서 카드를 고르면 배정 보드로 들어갑니다
- 배정 보드는 두 단계입니다. ① 면접 시간·장소 등록 ② 지원자를 시간 슬롯에 배정
- 배정은 드래그앤드롭입니다. 평가 담당자 배정 화면이 쓰는 dnd-kit 패턴을 그대로 따랐습니다

**이 PR 은 목업 데이터로 동작합니다.** 연결할 API 가 아직 없어서, 리크루팅의 다른 화면들과 같은 순서로 UI 를 먼저 올립니다. 자세한 내용은 아래 "API 현황"에 적었습니다.

## 🎞️ 주요 코드 설명

### 배정 규칙을 순수 함수로 분리

```ts
// model/interviewSchedule.ts
// 한 지원자는 한 슬롯에만, 한 슬롯에는 한 명만 들어간다. 옮겨 놓는 동작이므로
// 지원자의 기존 배정과 대상 슬롯의 기존 배정을 모두 걷어낸 뒤 넣는다.
export function assignApplicant(assignments, sessionId, slotStart, applicantId)
```

드래그앤드롭은 화면에서 확인하기 어려운 규칙이 많아, 배정·해제·슬롯 계산을 순수 함수로 빼고 테스트로 고정했습니다. 다른 면접방의 같은 시각은 별개로 세고, 30분을 채우지 못하는 끝자락은 슬롯으로 만들지 않습니다.

### 날짜 탭은 차수의 면접 기간에서 만듭니다

```ts
// 면접 기간의 날짜를 하루 단위로 펼쳐 날짜 탭을 만든다. 시각 부분은 버린다.
export function resolveScheduleDates(interviewStartAt, interviewEndAt)
```

## 🔗 연결된 이슈

- Connected: #672
- Closes #672

## 💬 API 현황

이 화면이 필요로 하는 리소스가 서버에 아직 없습니다. 스펙 전문검색과 GraphQL 계층까지 대조해 확인했습니다.

| 화면 요소 | 현황 |
|---|---|
| 면접 스케줄(이름·시각·방식·장소) | 리소스 없음. 면접 일정이 지원서 단건에 붙어 있고 장소는 문자열 하나 |
| 시간 슬롯 | 리소스 없음 |
| 지원자별 가능 시간 | 제출 경로가 `RECRUITING-SCHEDULE-001` 인데 문서상 "(미구현)" · 응답 501 |
| 면접 배정률 | 집계 없음 |

있는 것은 일정 조회·확정, 요청 재시도, 면접 생략 4종이며 모두 지원서 단건 단위입니다.

서버팀에 설계 방향을 문의해 둔 상태이고, 답변에 따라 배정 보드의 데이터 모델이 달라질 수 있습니다. 특히 **슬롯을 서버가 관리할지 시간대만 저장하고 프론트에서 나눌지**에 따라 `buildTimeSlots` · `assignApplicant` 의 역할이 바뀝니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 평가 관리에 면접 스케줄링 메뉴와 페이지를 추가했습니다.
  * 학교별 면접 라운드, 기간, 진행률과 배정률을 확인할 수 있습니다.
  * 면접 세션의 시간, 방식, 링크 또는 장소를 편집하고 저장할 수 있습니다.
  * 지원자를 드래그 앤 드롭으로 면접 시간대에 배정하거나 대기 목록으로 되돌릴 수 있습니다.
  * 날짜별 일정과 면접 단계 간 이동을 지원합니다.

* **버그 수정**
  * 잘못된 일정·시간·배정 입력을 안전하게 처리합니다.

* **테스트**
  * 일정 생성, 지원자 배정, 진행률 계산 및 경계 조건을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->