### PR TITLE
✨ feat: /projects 프로젝트 목록 화면 연결

### DIFF
--- a/src/entities/project/api/matchingProject.ts
+++ b/src/entities/project/api/matchingProject.ts
@@ -2,15 +2,20 @@ import { api } from "@/shared/lib/axios"
 
 import type { ApiResponse } from "@/shared/lib/apiResponse"
 
-export type ProjectPart =
-  | "PLAN"
-  | "DESIGN"
-  | "WEB"
-  | "ANDROID"
-  | "IOS"
-  | "NODEJS"
-  | "SPRINGBOOT"
-  | "ADMIN"
+// 값 목록을 단일 출처로 두고 타입을 파생시킨다. 목록과 유니온을 따로 적으면
+// 파트를 추가했을 때 목록이 조용히 뒤처져 새 파트가 필터에서 사라진다.
+export const PROJECT_PARTS = [
+  "PLAN",
+  "DESIGN",
+  "WEB",
+  "ANDROID",
+  "IOS",
+  "NODEJS",
+  "SPRINGBOOT",
+  "ADMIN",
+] as const
+
+export type ProjectPart = (typeof PROJECT_PARTS)[number]
 
 export type PartQuotaStatus = "RECRUITING" | "COMPLETED"
 

--- a/src/features/project/list/index.ts
+++ b/src/features/project/list/index.ts
@@ -4,6 +4,7 @@ export type {
   MatchingProjectListFilterId,
   ProjectListSearch,
 } from "./model/matchingProjectList"
+export { validateProjectListSearch } from "./model/projectListSearch"
 export { MatchingProjectCard } from "./ui/MatchingProjectCard"
 export type { MatchingProjectCardVariant } from "./ui/MatchingProjectCard"
 export { MatchingProjectsListPage } from "./ui/MatchingProjectsListPage"

--- a/src/features/project/list/model/projectListSearch.test.ts
+++ b/src/features/project/list/model/projectListSearch.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest"
+
+import { validateProjectListSearch } from "./projectListSearch"
+
+// 이 파서가 /matching/projects 와 /projects 두 경로의 URL 계약을 함께 정한다.
+// 여기서 규칙이 바뀌면 두 화면이 동시에 영향을 받는다.
+describe("validateProjectListSearch", () => {
+  describe("parts", () => {
+    it("단일 값을 배열로 감싼다", () => {
+      expect(validateProjectListSearch({ parts: "PLAN" }).parts).toEqual([
+        "PLAN",
+      ])
+    })
+
+    it("배열은 유효한 값만 남긴다", () => {
+      expect(
+        validateProjectListSearch({ parts: ["PLAN", "NOPE", "DESIGN"] }).parts,
+      ).toEqual(["PLAN", "DESIGN"])
+    })
+
+    // 고른 파트가 없다는 뜻은 undefined 하나로만 표현한다.
+    it("남는 값이 없으면 undefined 다", () => {
+      expect(
+        validateProjectListSearch({ parts: ["NOPE"] }).parts,
+      ).toBeUndefined()
+      expect(validateProjectListSearch({ parts: [] }).parts).toBeUndefined()
+      expect(validateProjectListSearch({ parts: "NOPE" }).parts).toBeUndefined()
+      expect(validateProjectListSearch({}).parts).toBeUndefined()
+    })
+
+    it("파트 목록 전체를 통과시킨다", () => {
+      const all = [
+        "PLAN",
+        "DESIGN",
+        "WEB",
+        "ANDROID",
+        "IOS",
+        "NODEJS",
+        "SPRINGBOOT",
+        "ADMIN",
+      ]
+
+      expect(validateProjectListSearch({ parts: all }).parts).toEqual(all)
+    })
+  })
+
+  describe("page", () => {
+    it("문자열과 숫자를 모두 읽는다", () => {
+      expect(validateProjectListSearch({ page: "3" }).page).toBe(3)
+      expect(validateProjectListSearch({ page: 3 }).page).toBe(3)
+    })
+
+    // 페이지는 1부터다. 0 이나 음수가 그대로 넘어가면 조회가 빈 결과가 된다.
+    it("1 미만이거나 읽을 수 없으면 1 로 되돌린다", () => {
+      expect(validateProjectListSearch({ page: 0 }).page).toBe(1)
+      expect(validateProjectListSearch({ page: -2 }).page).toBe(1)
+      expect(validateProjectListSearch({ page: "abc" }).page).toBe(1)
+      expect(validateProjectListSearch({}).page).toBe(1)
+    })
+
+    it("소수는 내림한다", () => {
+      expect(validateProjectListSearch({ page: 2.9 }).page).toBe(2)
+    })
+  })
+
+  describe("status", () => {
+    it("정해진 값만 통과시킨다", () => {
+      expect(validateProjectListSearch({ status: "RECRUITING" }).status).toBe(
+        "RECRUITING",
+      )
+      expect(validateProjectListSearch({ status: "COMPLETED" }).status).toBe(
+        "COMPLETED",
+      )
+    })
+
+    it("그 밖의 값은 버린다", () => {
+      expect(
+        validateProjectListSearch({ status: "DONE" }).status,
+      ).toBeUndefined()
+      expect(validateProjectListSearch({ status: 1 }).status).toBeUndefined()
+    })
+  })
+
+  describe("문자열 필터", () => {
+    it("문자열만 받는다", () => {
+      const search = validateProjectListSearch({
+        branch: "Chromium",
+        school: "가천대학교",
+        keyword: "디자인",
+      })
+
+      expect(search.branch).toBe("Chromium")
+      expect(search.school).toBe("가천대학교")
+      expect(search.keyword).toBe("디자인")
+    })
+
+    it("문자열이 아니면 버린다", () => {
+      const search = validateProjectListSearch({
+        branch: 1,
+        school: ["가천대학교"],
+        keyword: null,
+      })
+
+      expect(search.branch).toBeUndefined()
+      expect(search.school).toBeUndefined()
+      expect(search.keyword).toBeUndefined()
+    })
+  })
+
+  describe("mock", () => {
+    it("projects 만 통과시킨다", () => {
+      expect(validateProjectListSearch({ mock: "projects" }).mock).toBe(
+        "projects",
+      )
+      expect(validateProjectListSearch({ mock: "true" }).mock).toBeUndefined()
+      expect(validateProjectListSearch({}).mock).toBeUndefined()
+    })
+  })
+})

--- a/src/features/project/list/model/projectListSearch.ts
+++ b/src/features/project/list/model/projectListSearch.ts
@@ -27,11 +27,14 @@ function parsePage(value: unknown): number {
 export function validateProjectListSearch(
   search: Record<string, unknown>,
 ): ProjectListSearch {
+  // 고른 파트가 없다는 뜻은 undefined 하나로만 표현한다. 걸러 낸 결과가 빈 배열로
+  // 남으면 같은 의미를 두 가지 값으로 흘려보내게 된다.
   let parts: ProjectPart[] | undefined
   if (isProjectPart(search.parts)) {
     parts = [search.parts]
   } else if (Array.isArray(search.parts)) {
-    parts = search.parts.filter(isProjectPart)
+    const valid = search.parts.filter(isProjectPart)
+    parts = valid.length > 0 ? valid : undefined
   }
 
   return {

--- a/src/features/project/list/model/projectListSearch.ts
+++ b/src/features/project/list/model/projectListSearch.ts
@@ -1,17 +1,12 @@
+import { PROJECT_PARTS } from "@/entities/project/api/matchingProject"
+
 import type { ProjectPart } from "@/entities/project/api/matchingProject"
 
 import type { ProjectListSearch } from "./matchingProjectList"
 
-const VALID_PARTS = new Set<string>([
-  "PLAN",
-  "DESIGN",
-  "WEB",
-  "ANDROID",
-  "IOS",
-  "NODEJS",
-  "SPRINGBOOT",
-  "ADMIN",
-])
+// 파트 목록은 타입과 같은 출처에서 온다. 여기에 다시 나열하면 파트가 늘었을 때
+// 타입 검사에 걸리지 않은 채 새 파트만 조용히 빠진다.
+const VALID_PARTS = new Set<string>(PROJECT_PARTS)
 
 function isProjectPart(value: unknown): value is ProjectPart {
   return typeof value === "string" && VALID_PARTS.has(value)

--- a/src/features/project/list/model/projectListSearch.ts
+++ b/src/features/project/list/model/projectListSearch.ts
@@ -1,0 +1,54 @@
+import type { ProjectPart } from "@/entities/project/api/matchingProject"
+
+import type { ProjectListSearch } from "./matchingProjectList"
+
+const VALID_PARTS = new Set<string>([
+  "PLAN",
+  "DESIGN",
+  "WEB",
+  "ANDROID",
+  "IOS",
+  "NODEJS",
+  "SPRINGBOOT",
+  "ADMIN",
+])
+
+function isProjectPart(value: unknown): value is ProjectPart {
+  return typeof value === "string" && VALID_PARTS.has(value)
+}
+
+function parsePage(value: unknown): number {
+  const parsed =
+    typeof value === "string"
+      ? Number.parseInt(value, 10)
+      : typeof value === "number"
+        ? value
+        : 1
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 1
+}
+
+// 프로젝트 목록은 매칭(/matching/projects)과 지원자용(/projects) 두 경로에서
+// 같은 필터·페이지 파라미터를 쓴다. 파서를 한 곳에 둬서 두 화면이 갈라지지 않게 한다.
+export function validateProjectListSearch(
+  search: Record<string, unknown>,
+): ProjectListSearch {
+  let parts: ProjectPart[] | undefined
+  if (isProjectPart(search.parts)) {
+    parts = [search.parts]
+  } else if (Array.isArray(search.parts)) {
+    parts = search.parts.filter(isProjectPart)
+  }
+
+  return {
+    mock: search.mock === "projects" ? "projects" : undefined,
+    branch: typeof search.branch === "string" ? search.branch : undefined,
+    school: typeof search.school === "string" ? search.school : undefined,
+    parts,
+    status:
+      search.status === "RECRUITING" || search.status === "COMPLETED"
+        ? search.status
+        : undefined,
+    keyword: typeof search.keyword === "string" ? search.keyword : undefined,
+    page: parsePage(search.page),
+  }
+}

--- a/src/routes/matching/projects/index.tsx
+++ b/src/routes/matching/projects/index.tsx
@@ -1,61 +1,13 @@
 // 프로젝트 목록 페이지
 import { createFileRoute } from "@tanstack/react-router"
 
-import { MatchingProjectsListPage } from "@/features/project/list"
-
-import type { ProjectPart } from "@/entities/project/api/matchingProject"
-import type { ProjectListSearch } from "@/features/project/list"
-
-const VALID_PARTS = new Set<string>([
-  "PLAN",
-  "DESIGN",
-  "WEB",
-  "ANDROID",
-  "IOS",
-  "NODEJS",
-  "SPRINGBOOT",
-  "ADMIN",
-])
-
-function isProjectPart(value: unknown): value is ProjectPart {
-  return typeof value === "string" && VALID_PARTS.has(value)
-}
-
-function parsePage(value: unknown): number {
-  const parsedPage =
-    typeof value === "string"
-      ? Number.parseInt(value, 10)
-      : typeof value === "number"
-        ? value
-        : 1
-
-  return Number.isFinite(parsedPage) && parsedPage > 0
-    ? Math.floor(parsedPage)
-    : 1
-}
+import {
+  MatchingProjectsListPage,
+  validateProjectListSearch,
+} from "@/features/project/list"
 
 export const Route = createFileRoute("/matching/projects/")({
-  validateSearch: (search: Record<string, unknown>): ProjectListSearch => {
-    let parts: ProjectPart[] | undefined
-    if (isProjectPart(search.parts)) {
-      parts = [search.parts]
-    } else if (Array.isArray(search.parts)) {
-      parts = search.parts.filter(isProjectPart)
-    }
-
-    return {
-      mock: search.mock === "projects" ? "projects" : undefined,
-      branch: typeof search.branch === "string" ? search.branch : undefined,
-      school: typeof search.school === "string" ? search.school : undefined,
-      parts,
-      status:
-        search.status === "RECRUITING" || search.status === "COMPLETED"
-          ? search.status
-          : undefined,
-      keyword: typeof search.keyword === "string" ? search.keyword : undefined,
-      page: parsePage(search.page),
-    }
-  },
+  validateSearch: validateProjectListSearch,
   component: MatchingProjectsRoute,
 })
 

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -1,9 +1,16 @@
 import { createFileRoute } from "@tanstack/react-router"
 
+import {
+  MatchingProjectsListPage,
+  validateProjectListSearch,
+} from "@/features/project/list"
+
 export const Route = createFileRoute("/projects/")({
-  component: ApplyMethodPage,
+  validateSearch: validateProjectListSearch,
+  component: ProjectsListRoute,
 })
 
-function ApplyMethodPage() {
-  return <div>{/* 지원 방법 */}</div>
+function ProjectsListRoute() {
+  const { mock } = Route.useSearch()
+  return <MatchingProjectsListPage useMockData={mock === "projects"} />
 }

--- a/src/routes/projects/route.tsx
+++ b/src/routes/projects/route.tsx
@@ -16,22 +16,30 @@ function ProjectsLayout() {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const normalizedPathname = pathname.replace(/\/$/, "") || "/projects"
 
-  let breadcrumb = ""
+  // 프로젝트 목록은 지원하기 흐름이 아니라 독립 화면이라 상위 경로가 다르다.
+  let trail: string[] = []
   let title = ""
   let description: string | undefined = undefined
 
-  if (normalizedPathname === "/projects/notice") {
-    breadcrumb = "모집 공고"
+  if (normalizedPathname === "/projects") {
+    trail = ["프로젝트"]
+    title = "프로젝트"
+    description = "UMC 에서 진행 중인 프로젝트를 확인할 수 있습니다."
+  } else if (normalizedPathname === "/projects/notice") {
+    trail = ["리크루팅", "지원하기", "모집 공고"]
     title = "모집 공고"
     description = "학교별 모집 공고를 확인하고 지원할 수 있습니다."
+  } else if (normalizedPathname.startsWith("/projects/apply")) {
+    trail = ["리크루팅", "지원하기", "지원서 작성"]
+    title = "지원서 작성"
+    description = "모집 문항에 답해 지원서를 제출합니다."
   } else if (normalizedPathname.startsWith("/projects/application")) {
-    breadcrumb = "내 지원서"
+    trail = ["리크루팅", "지원하기", "내 지원서"]
     title = "내 지원서"
     description = "이메일과 지원 코드로 내 지원서를 확인할 수 있습니다."
   } else {
-    // Default fallback for /projects and other sub-paths
-    breadcrumb = "지원 방법"
-    title = "지원 방법"
+    trail = ["리크루팅", "지원하기"]
+    title = "지원하기"
     description = undefined
   }
 
@@ -44,17 +52,16 @@ function ProjectsLayout() {
           <div className="min-h-200 px-8 pt-10">
             <div className="flex flex-col gap-6.5 pl-3">
               <div className="flex h-5.5 items-center gap-1">
-                <p className="text-body-2-medium text-teal-gray-400">
-                  리크루팅
-                </p>
-                <RightChevronIconFilled className="text-teal-gray-300 h-4 w-4" />
-                <p className="text-body-2-medium text-teal-gray-400">
-                  지원하기
-                </p>
-                <RightChevronIconFilled className="text-teal-gray-300 h-4 w-4" />
-                <p className="text-body-2-medium text-teal-gray-400">
-                  {breadcrumb}
-                </p>
+                {trail.map((crumb, index) => (
+                  <div key={crumb} className="flex items-center gap-1">
+                    {index > 0 && (
+                      <RightChevronIconFilled className="text-teal-gray-300 h-4 w-4" />
+                    )}
+                    <p className="text-body-2-medium text-teal-gray-400">
+                      {crumb}
+                    </p>
+                  </div>
+                ))}
               </div>
 
               <div className="flex flex-col gap-3">

--- a/src/widgets/navigation/header/RecruitingHeader.tsx
+++ b/src/widgets/navigation/header/RecruitingHeader.tsx
@@ -46,7 +46,6 @@ export default function RecruitingHeader({
     { label: "소개", to: "/intro" },
     // TODO: 모집 안내 랜딩 라우트 확정 전까지 비활성(홈으로 오연결 방지)
     { label: "모집 안내", to: "/", disabled: true },
-    // TODO: 프로젝트 라우트 확정(/projects vs /matching/projects)
     { label: "프로젝트", to: "/projects" },
     ...(showRecruiting
       ? [


### PR DESCRIPTION
## 📸 작업 내용

- 비어 있던 `/projects` 를 프로젝트 목록 화면으로 채웠습니다. 매칭 화면과 같은 목록 컴포넌트를 씁니다
- 프로젝트 목록 검색 파라미터 파서를 모델 계층으로 옮겨, 매칭 경로와 지원자용 경로가 같은 규칙을 보게 했습니다
- 브레드크럼을 경로별로 잡도록 바꿨습니다. 프로젝트 목록은 지원하기 흐름이 아니라 독립 화면이라 상위 경로가 없습니다
- 헤더의 프로젝트 메뉴는 라우트가 확정돼 TODO 를 걷어냈습니다

## 🎞️ 주요 코드 설명

매칭 라우트 안에 있던 파서를 그대로 옮겼습니다. 파트 화이트리스트, 배열·단일 값 처리, 페이지 하한 1 모두 기존 동작 그대로라 매칭 화면의 동작 변화는 없습니다.

```TypeScript
// 프로젝트 목록은 매칭(/matching/projects)과 지원자용(/projects) 두 경로에서
// 같은 필터·페이지 파라미터를 쓴다. 파서를 한 곳에 둬서 두 화면이 갈라지지 않게 한다.
export function validateProjectListSearch(
  search: Record<string, unknown>,
): ProjectListSearch {
```

## 💬 기타 더 이야기해볼 점

**게스트(비로그인) 노출은 아직입니다.** 프로젝트 목록 조회가 현재 비로그인 401 이라, 이 화면은 로그인 상태에서만 데이터가 뜹니다. 비로그인 허용으로 바뀌면 게스트 시안(카드 크기, 헤더 로그인·회원가입 버튼)에 맞추는 작업을 이어서 하겠습니다.

- `tsc -b` 통과
- `lint` 0 errors / 13 warnings (baseline 유지)
- `test:run` 81 files / 667 tests 통과
- `build` 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 프로젝트 목록 페이지가 `/projects` 경로에서 제공됩니다.
  * 프로젝트 목록 검색 조건이 자동으로 검증·정규화됩니다.
  * 프로젝트, 공고, 지원서 관련 페이지의 breadcrumb와 제목이 경로에 맞게 표시됩니다.
* **개선**
  * 프로젝트 목록 라우트의 검색 조건 처리 방식이 통합되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->