### PR TITLE
feat: 모집 인원 설정 페이지에 시즌 생성 기능 추가

### DIFF
--- a/src/features/recruiting/api/recruitingApi.test.ts
+++ b/src/features/recruiting/api/recruitingApi.test.ts
@@ -613,5 +613,13 @@ describe("createRecruitingSeason & updateRecruitingSeason", () => {
     expect(api.patch).toHaveBeenCalledWith("/v1/recruiting/admin/seasons/123", {
       memo: "시즌 공유 메모",
     })
+
+    vi.mocked(api.patch).mockResolvedValueOnce({ data: {} })
+
+    await updateRecruitingSeason("123", { memo: null })
+
+    expect(api.patch).toHaveBeenCalledWith("/v1/recruiting/admin/seasons/123", {
+      memo: null,
+    })
   })
 })

--- a/src/features/recruiting/api/recruitingApi.test.ts
+++ b/src/features/recruiting/api/recruitingApi.test.ts
@@ -4,6 +4,7 @@ import { api } from "@/shared/lib/axios"
 
 import {
   addRoundEvaluator,
+  createRecruitingSeason,
   getAdminRounds,
   getRoundEvaluators,
   mergeRoundGroups,
@@ -14,6 +15,7 @@ import {
   normalizeRecruitingSeasonConfigurationResponse,
   normalizeStatusSummary,
   removeRoundEvaluator,
+  updateRecruitingSeason,
 } from "./recruitingApi"
 
 import type {
@@ -30,6 +32,8 @@ vi.mock("@/shared/lib/axios", () => ({
   api: {
     get: vi.fn(),
     post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
     delete: vi.fn(),
   },
 }))
@@ -579,6 +583,35 @@ describe("normalizeInterviewScheduleBoard", () => {
     expect(board.pendingApplicants[0]).toEqual({
       applicationId: "41",
       applicantName: "",
+    })
+  })
+})
+
+describe("createRecruitingSeason & updateRecruitingSeason", () => {
+  it("createRecruitingSeason 호출 시 POST /v1/recruiting/admin/seasons 요청을 보낸다", async () => {
+    vi.mocked(api.post).mockResolvedValueOnce({ data: { result: { id: 123 } } })
+
+    const result = await createRecruitingSeason({
+      gisuId: "15",
+      schoolId: "10",
+      quotas: [{ track: "PLAN", targetCount: 0 }],
+    })
+
+    expect(api.post).toHaveBeenCalledWith("/v1/recruiting/admin/seasons", {
+      gisuId: "15",
+      schoolId: "10",
+      quotas: [{ track: "PLAN", targetCount: 0 }],
+    })
+    expect(result).toBe("123")
+  })
+
+  it("updateRecruitingSeason 호출 시 PATCH /v1/recruiting/admin/seasons/{seasonId} 요청을 보낸다", async () => {
+    vi.mocked(api.patch).mockResolvedValueOnce({ data: {} })
+
+    await updateRecruitingSeason("123", { memo: "시즌 공유 메모" })
+
+    expect(api.patch).toHaveBeenCalledWith("/v1/recruiting/admin/seasons/123", {
+      memo: "시즌 공유 메모",
     })
   })
 })

--- a/src/features/recruiting/api/recruitingApi.ts
+++ b/src/features/recruiting/api/recruitingApi.ts
@@ -9,6 +9,7 @@ import type {
   ConfirmInterviewSchedulesRequest,
   CreateApplicationDraftBody,
   CreateRecruitingRoundRequest,
+  CreateRecruitingSeasonRequest,
   DecisionHistoriesQuery,
   FinalDecisionBody,
   FormStructureQuery,
@@ -58,6 +59,7 @@ import type {
   UpdateApplicationDraftBody,
   UpdateRecruitingRoundRequest,
   UpdateRecruitingRoundStatusRequest,
+  UpdateRecruitingSeasonRequest,
   UpsertRecruitingApplicationFormRequest,
 } from "./types"
 
@@ -522,6 +524,25 @@ export async function updateRecruitingSeasonQuotas(
   payload: ReplaceRecruitingSeasonTrackQuotasRequest,
 ): Promise<void> {
   await api.put(`/v1/recruiting/admin/seasons/${seasonId}/quotas`, payload)
+}
+
+// 모집 시즌 생성 (RECRUITING-ADMIN-002).
+export async function createRecruitingSeason(
+  payload: CreateRecruitingSeasonRequest,
+): Promise<string> {
+  const { data } = await api.post<ApiResponse<{ id: number }>>(
+    "/v1/recruiting/admin/seasons",
+    payload,
+  )
+  return String(data.result.id)
+}
+
+// 모집 시즌 수정 (RECRUITING-ADMIN-003).
+export async function updateRecruitingSeason(
+  seasonId: string,
+  payload: UpdateRecruitingSeasonRequest,
+): Promise<void> {
+  await api.patch(`/v1/recruiting/admin/seasons/${seasonId}`, payload)
 }
 
 export async function checkRecruitingRoundTitleAvailability(

--- a/src/features/recruiting/api/types.ts
+++ b/src/features/recruiting/api/types.ts
@@ -178,6 +178,18 @@ export interface ReplaceRecruitingSeasonTrackQuotasRequest {
   quotas: RecruitingSeasonTrackQuotaRequest[]
 }
 
+// 모집 시즌 생성 요청 (RECRUITING-ADMIN-002)
+export interface CreateRecruitingSeasonRequest {
+  gisuId: string | number
+  schoolId: string | number
+  quotas?: RecruitingSeasonTrackQuotaRequest[]
+}
+
+// 모집 시즌 수정 요청 (RECRUITING-ADMIN-003)
+export interface UpdateRecruitingSeasonRequest {
+  memo?: string | null
+}
+
 export interface RecruitingRoundGroup {
   seasonId: string
   gisuId: string

--- a/src/features/recruiting/hooks/useRecruitingSeasonQuotas.ts
+++ b/src/features/recruiting/hooks/useRecruitingSeasonQuotas.ts
@@ -5,13 +5,17 @@ import { useToastStore } from "@/shared/ui/toast/useToastStore"
 
 import { recruitingKeys } from "../api/queryKeys"
 import {
+  createRecruitingSeason,
   getRecruitingSeasonConfiguration,
+  updateRecruitingSeason,
   updateRecruitingSeasonQuotas,
 } from "../api/recruitingApi"
 
 import type {
+  CreateRecruitingSeasonRequest,
   RecruitingSeasonConfigurationResponse,
   ReplaceRecruitingSeasonTrackQuotasRequest,
+  UpdateRecruitingSeasonRequest,
 } from "../api/types"
 
 export interface UpdateSeasonQuotaVariables {
@@ -56,6 +60,34 @@ export function useRecruitingSeasonQuotas(seasonIds: string[]) {
         isLoading: results.some((query) => query.isLoading),
         isError: results.some((query) => query.isError),
       }
+    },
+  })
+
+  const createSeasonMutation = useMutation({
+    mutationFn: (payload: CreateRecruitingSeasonRequest) =>
+      createRecruitingSeason(payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: recruitingKeys.seasons(),
+      })
+      void queryClient.invalidateQueries({
+        queryKey: recruitingKeys.rounds(),
+      })
+    },
+  })
+
+  const updateSeasonMutation = useMutation({
+    mutationFn: ({
+      seasonId,
+      payload,
+    }: {
+      seasonId: string
+      payload: UpdateRecruitingSeasonRequest
+    }) => updateRecruitingSeason(seasonId, payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: recruitingKeys.seasons(),
+      })
     },
   })
 
@@ -134,6 +166,11 @@ export function useRecruitingSeasonQuotas(seasonIds: string[]) {
     isLoading,
     isError,
     updateQuotas: updateQuotasMutation.mutateAsync,
-    isSaving: updateQuotasMutation.isPending,
+    createSeason: createSeasonMutation.mutateAsync,
+    updateSeason: updateSeasonMutation.mutateAsync,
+    isSaving:
+      updateQuotasMutation.isPending ||
+      createSeasonMutation.isPending ||
+      updateSeasonMutation.isPending,
   }
 }

--- a/src/features/recruiting/index.ts
+++ b/src/features/recruiting/index.ts
@@ -1,5 +1,10 @@
+export {
+  createRecruitingSeason,
+  updateRecruitingSeason,
+} from "./api/recruitingApi"
 export type {
   AnswerResponse,
+  CreateRecruitingSeasonRequest,
   RecruitingApplicationAnswer,
   RecruitingApplicationCredentialRequest,
   RecruitingFormQuestion,
@@ -10,6 +15,7 @@ export type {
   RecruitingTrack,
   SubmitAnonymousApplicationRequest,
   UpdateAnonymousApplicationRequest,
+  UpdateRecruitingSeasonRequest,
 } from "./api/types"
 export {
   getAnonymousSessionId,

--- a/src/features/recruiting/model/recruitmentQuota.ts
+++ b/src/features/recruiting/model/recruitmentQuota.ts
@@ -1,5 +1,7 @@
 export interface SchoolQuotaRow {
   seasonId?: string
+  gisuId?: string
+  schoolId?: string
   schoolName: string
   pm: number
   design: number

--- a/src/features/recruiting/model/recruitmentQuotaMapper.test.ts
+++ b/src/features/recruiting/model/recruitmentQuotaMapper.test.ts
@@ -117,4 +117,36 @@ describe("mapGroupsToChapterQuotaData", () => {
     expect(chromium?.updatedDate).toBeUndefined()
     expect(chromium?.updatedTime).toBeUndefined()
   })
+
+  it("serverChapters에 존재하지만 groups에 없는 대학교도 0명으로 목록에 항상 포함한다", () => {
+    const serverChapters = [
+      {
+        chapterId: "1",
+        chapterName: "Chromium",
+        schools: [
+          { schoolId: "10", schoolName: "서울대학교" },
+          { schoolId: "20", schoolName: "연세대학교" },
+          { schoolId: "30", schoolName: "고려대학교" },
+        ],
+      },
+    ]
+
+    const result = mapGroupsToChapterQuotaData(
+      [groups[0]!], // 서울대학교만 그룹에 존재
+      seasonConfigsMap,
+      serverChapters,
+      "15",
+    )
+
+    const chromium = result.find((item) => item.chapter === "Chromium")
+    expect(chromium?.schools).toHaveLength(3)
+    expect(chromium?.schools[0]?.schoolName).toBe("서울대학교")
+    expect(chromium?.schools[0]?.seasonId).toBe("100")
+    expect(chromium?.schools[1]?.schoolName).toBe("연세대학교")
+    expect(chromium?.schools[1]?.seasonId).toBeUndefined()
+    expect(chromium?.schools[1]?.total).toBe(0)
+    expect(chromium?.schools[2]?.schoolName).toBe("고려대학교")
+    expect(chromium?.schools[2]?.seasonId).toBeUndefined()
+    expect(chromium?.schools[2]?.total).toBe(0)
+  })
 })

--- a/src/features/recruiting/model/recruitmentQuotaMapper.test.ts
+++ b/src/features/recruiting/model/recruitmentQuotaMapper.test.ts
@@ -101,11 +101,12 @@ describe("mapGroupsToChapterQuotaData", () => {
     })
   })
 
-  it("시즌 설정이 없으면 0명으로 처리한다", () => {
+  it("시즌 설정이 없으면 seasonId를 undefined로 처리하고 0명으로 초기화한다", () => {
     const fixedNow = new Date("2026-08-02T09:00:00Z")
     const result = mapGroupsToChapterQuotaData(groups, new Map(), fixedNow)
 
     const chromium = result.find((item) => item.chapter === "Chromium")
+    expect(chromium?.schools[0]?.seasonId).toBeUndefined()
     expect(chromium?.schools[0]?.total).toBe(0)
     expect(chromium?.totals.total).toBe(0)
   })

--- a/src/features/recruiting/model/recruitmentQuotaMapper.test.ts
+++ b/src/features/recruiting/model/recruitmentQuotaMapper.test.ts
@@ -82,6 +82,8 @@ describe("mapGroupsToChapterQuotaData", () => {
 
     expect(chromium?.schools[0]).toEqual({
       seasonId: "100",
+      gisuId: "15",
+      schoolId: "10",
       schoolName: "서울대학교",
       pm: 2,
       design: 3,

--- a/src/features/recruiting/model/recruitmentQuotaMapper.ts
+++ b/src/features/recruiting/model/recruitmentQuotaMapper.ts
@@ -32,6 +32,7 @@ export function mapGroupsToChapterQuotaData(
     const chapterGroups = byChapter.get(chapterName) ?? []
     const schools: SchoolQuotaRow[] = chapterGroups.map((group) => {
       const config = seasonConfigsMap.get(group.seasonId)
+      const hasConfig = Boolean(config)
       const quotas = config?.quotas ?? []
 
       const pm = quotas.find((q) => q.track === "PLAN")?.targetCount ?? 0
@@ -43,7 +44,7 @@ export function mapGroupsToChapterQuotaData(
           ?.targetCount ?? 0
 
       return {
-        seasonId: group.seasonId,
+        seasonId: hasConfig ? group.seasonId : undefined,
         gisuId: group.gisuId,
         schoolId: group.schoolId,
         schoolName: group.schoolName,

--- a/src/features/recruiting/model/recruitmentQuotaMapper.ts
+++ b/src/features/recruiting/model/recruitmentQuotaMapper.ts
@@ -8,11 +8,31 @@ import type {
 } from "../api/types"
 import type { ChapterQuotaData, SchoolQuotaRow } from "./recruitmentQuota"
 
+export interface ServerChapterItem {
+  chapterId: string | number
+  chapterName: string
+  schools: Array<{
+    schoolId: string | number
+    schoolName: string
+  }>
+}
+
 export function mapGroupsToChapterQuotaData(
   groups: RecruitingRoundGroup[],
   seasonConfigsMap: Map<string, RecruitingSeasonConfigurationResponse>,
+  serverChaptersOrNow?: ServerChapterItem[] | Date,
+  gisuId?: string,
   now?: Date,
 ): ChapterQuotaData[] {
+  let serverChapters: ServerChapterItem[] | undefined
+  let actualNow = now
+
+  if (serverChaptersOrNow instanceof Date) {
+    actualNow = serverChaptersOrNow
+  } else {
+    serverChapters = serverChaptersOrNow
+  }
+
   const byChapter = new Map<string, RecruitingRoundGroup[]>()
 
   groups.forEach((group) => {
@@ -23,14 +43,41 @@ export function mapGroupsToChapterQuotaData(
     byChapter.get(chapterName)!.push(group)
   })
 
-  const updatedDate = now ? dayjs(now).format("YY-MM-DD") : undefined
-  const updatedTime = now ? dayjs(now).format("HH:mm") : undefined
+  const serverChaptersMap = new Map<
+    string,
+    Array<{ schoolId: string; schoolName: string }>
+  >()
+
+  if (serverChapters && serverChapters.length > 0) {
+    serverChapters.forEach((ch) => {
+      serverChaptersMap.set(
+        ch.chapterName,
+        ch.schools.map((s) => ({
+          schoolId: String(s.schoolId),
+          schoolName: s.schoolName,
+        })),
+      )
+    })
+  }
+
+  const updatedDate = actualNow
+    ? dayjs(actualNow).format("YY-MM-DD")
+    : undefined
+  const updatedTime = actualNow ? dayjs(actualNow).format("HH:mm") : undefined
 
   const chapters = CHAPTERS.length > 0 ? CHAPTERS : Array.from(byChapter.keys())
 
   return chapters.map((chapterName) => {
     const chapterGroups = byChapter.get(chapterName) ?? []
-    const schools: SchoolQuotaRow[] = chapterGroups.map((group) => {
+    const serverSchools = serverChaptersMap.get(chapterName) ?? []
+
+    const groupSchoolIds = new Set<string>()
+    const groupSchoolNames = new Set<string>()
+
+    const schoolsFromGroups: SchoolQuotaRow[] = chapterGroups.map((group) => {
+      groupSchoolIds.add(String(group.schoolId))
+      groupSchoolNames.add(group.schoolName)
+
       const config = seasonConfigsMap.get(group.seasonId)
       const hasConfig = Boolean(config)
       const quotas = config?.quotas ?? []
@@ -45,8 +92,8 @@ export function mapGroupsToChapterQuotaData(
 
       return {
         seasonId: hasConfig ? group.seasonId : undefined,
-        gisuId: group.gisuId,
-        schoolId: group.schoolId,
+        gisuId: group.gisuId || gisuId,
+        schoolId: String(group.schoolId),
         schoolName: group.schoolName,
         pm,
         design,
@@ -55,6 +102,29 @@ export function mapGroupsToChapterQuotaData(
         total: pm + design + webPe + mobilePe,
       }
     })
+
+    const missingSchoolsFromChapter: SchoolQuotaRow[] = serverSchools
+      .filter(
+        (s) =>
+          !groupSchoolIds.has(s.schoolId) &&
+          !groupSchoolNames.has(s.schoolName),
+      )
+      .map((s) => ({
+        seasonId: undefined,
+        gisuId,
+        schoolId: s.schoolId,
+        schoolName: s.schoolName,
+        pm: 0,
+        design: 0,
+        webPe: 0,
+        mobilePe: 0,
+        total: 0,
+      }))
+
+    const schools: SchoolQuotaRow[] = [
+      ...schoolsFromGroups,
+      ...missingSchoolsFromChapter,
+    ]
 
     const totals = schools.reduce(
       (acc, s) => ({

--- a/src/features/recruiting/model/recruitmentQuotaMapper.ts
+++ b/src/features/recruiting/model/recruitmentQuotaMapper.ts
@@ -44,6 +44,8 @@ export function mapGroupsToChapterQuotaData(
 
       return {
         seasonId: group.seasonId,
+        gisuId: group.gisuId,
+        schoolId: group.schoolId,
         schoolName: group.schoolName,
         pm,
         design,

--- a/src/features/recruiting/ui/ChapterQuotaTableCard.tsx
+++ b/src/features/recruiting/ui/ChapterQuotaTableCard.tsx
@@ -86,8 +86,6 @@ export function ChapterQuotaTableCard({
     onSchoolsDataChangeRef.current?.(updatedSchools)
   }, [autoAllocateTrigger, data.schools, data.totals])
 
-  const hasApplicants = schoolsData.length > 0
-
   const checkIsAllValid = (schools: SchoolQuotaRow[]) => {
     const pmSum = schools.reduce((acc, s) => acc + s.pm, 0)
     const designSum = schools.reduce((acc, s) => acc + s.design, 0)
@@ -229,221 +227,204 @@ export function ChapterQuotaTableCard({
           </div>
         </div>
 
-        {!hasApplicants ? (
-          /* row - 지원자가 없을 때 */
-          <div className="flex h-65 w-full items-center justify-center">
-            <p className="text-body-2-medium text-teal-gray-400">
-              현재 TO를 정할 지원자가 없습니다.
+        {/* School rows */}
+        {schoolsData.map((school) => {
+          return (
+            <div
+              key={school.schoolName}
+              className="divide-teal-gray-300 flex h-14 w-full divide-x"
+            >
+              <div className="bg-teal-gray-50 flex w-42.5 items-center justify-center">
+                <p className="text-heading-7-semibold text-teal-gray-700">
+                  {school.schoolName}
+                </p>
+              </div>
+              <QuotaEditableCell
+                partName="PM"
+                value={school.pm}
+                maxAllowed={getMaxAllowedForSchool("pm", school.schoolName)}
+                onChange={(val) =>
+                  handleCellChange(school.schoolName, "pm", val)
+                }
+                onErrorExceeded={onErrorExceeded}
+              />
+              <QuotaEditableCell
+                partName="Design"
+                value={school.design}
+                maxAllowed={getMaxAllowedForSchool("design", school.schoolName)}
+                onChange={(val) =>
+                  handleCellChange(school.schoolName, "design", val)
+                }
+                onErrorExceeded={onErrorExceeded}
+              />
+              <QuotaEditableCell
+                partName="Web PE"
+                value={school.webPe}
+                maxAllowed={getMaxAllowedForSchool("webPe", school.schoolName)}
+                onChange={(val) =>
+                  handleCellChange(school.schoolName, "webPe", val)
+                }
+                onErrorExceeded={onErrorExceeded}
+              />
+              <QuotaEditableCell
+                partName="Mobile PE"
+                value={school.mobilePe}
+                maxAllowed={getMaxAllowedForSchool(
+                  "mobilePe",
+                  school.schoolName,
+                )}
+                onChange={(val) =>
+                  handleCellChange(school.schoolName, "mobilePe", val)
+                }
+                onErrorExceeded={onErrorExceeded}
+              />
+              <div className="bg-teal-gray-100 relative w-35">
+                <p className="text-body-2-medium text-teal-gray-400 absolute inset-x-0 top-[3.5px] text-center">
+                  {school.schoolName}
+                </p>
+                <p className="absolute inset-x-0 bottom-[3.5px] text-center">
+                  <span className="text-heading-6-semibold text-teal-500">
+                    {school.total}
+                  </span>
+                  <span className="text-subtitle-1-medium text-teal-gray-400 pl-px">
+                    명
+                  </span>
+                </p>
+              </div>
+            </div>
+          )
+        })}
+
+        {/* Remaining row */}
+        <div className="divide-teal-gray-300 flex h-11 w-full divide-x">
+          <div className="bg-warning-50 flex w-42.5 items-center justify-center">
+            <p className="text-subtitle-1-medium text-warning-500">잔여</p>
+          </div>
+          <div className="flex flex-1 items-center justify-center bg-white">
+            {remainingPM > 0 ? (
+              <p>
+                <span className="text-subtitle-1-medium text-warning-500">
+                  {remainingPM}
+                </span>
+                <span className="text-subtitle-1-medium text-warning-500 pl-px">
+                  명
+                </span>
+              </p>
+            ) : (
+              <p className="text-subtitle-1-medium text-teal-gray-700">-</p>
+            )}
+          </div>
+          <div className="flex flex-1 items-center justify-center bg-white">
+            {remainingDesign > 0 ? (
+              <p>
+                <span className="text-subtitle-1-medium text-warning-500">
+                  {remainingDesign}
+                </span>
+                <span className="text-subtitle-1-medium text-warning-500 pl-px">
+                  명
+                </span>
+              </p>
+            ) : (
+              <p className="text-subtitle-1-medium text-teal-gray-700">-</p>
+            )}
+          </div>
+          <div className="flex flex-1 items-center justify-center bg-white">
+            {remainingWebPe > 0 ? (
+              <p>
+                <span className="text-subtitle-1-medium text-warning-500">
+                  {remainingWebPe}
+                </span>
+                <span className="text-subtitle-1-medium text-warning-500 pl-px">
+                  명
+                </span>
+              </p>
+            ) : (
+              <p className="text-subtitle-1-medium text-teal-gray-700">-</p>
+            )}
+          </div>
+          <div className="flex flex-1 items-center justify-center bg-white">
+            {remainingMobilePe > 0 ? (
+              <p>
+                <span className="text-subtitle-1-medium text-warning-500">
+                  {remainingMobilePe}
+                </span>
+                <span className="text-subtitle-1-medium text-warning-500 pl-px">
+                  명
+                </span>
+              </p>
+            ) : (
+              <p className="text-subtitle-1-medium text-teal-gray-700">-</p>
+            )}
+          </div>
+          <div className="bg-warning-50 text-subtitle-1-medium text-warning-500 flex w-35 items-center justify-center gap-1">
+            <p>총</p>
+            <p>{remainingTotal}</p>
+            <p>명</p>
+          </div>
+        </div>
+
+        {/* Totals row */}
+        <div className="divide-teal-gray-300 flex h-14 w-full divide-x">
+          <div className="bg-teal-gray-50 flex w-42.5 items-center justify-center">
+            <p className="text-subtitle-1-medium text-teal-gray-900">
+              지부 전체
             </p>
           </div>
-        ) : (
-          <>
-            {/* School rows */}
-            {schoolsData.map((school) => {
-              return (
-                <div
-                  key={school.schoolName}
-                  className="divide-teal-gray-300 flex h-14 w-full divide-x"
-                >
-                  <div className="bg-teal-gray-50 flex w-42.5 items-center justify-center">
-                    <p className="text-heading-7-semibold text-teal-gray-700">
-                      {school.schoolName}
-                    </p>
-                  </div>
-                  <QuotaEditableCell
-                    partName="PM"
-                    value={school.pm}
-                    maxAllowed={getMaxAllowedForSchool("pm", school.schoolName)}
-                    onChange={(val) =>
-                      handleCellChange(school.schoolName, "pm", val)
-                    }
-                    onErrorExceeded={onErrorExceeded}
-                  />
-                  <QuotaEditableCell
-                    partName="Design"
-                    value={school.design}
-                    maxAllowed={getMaxAllowedForSchool(
-                      "design",
-                      school.schoolName,
-                    )}
-                    onChange={(val) =>
-                      handleCellChange(school.schoolName, "design", val)
-                    }
-                    onErrorExceeded={onErrorExceeded}
-                  />
-                  <QuotaEditableCell
-                    partName="Web PE"
-                    value={school.webPe}
-                    maxAllowed={getMaxAllowedForSchool(
-                      "webPe",
-                      school.schoolName,
-                    )}
-                    onChange={(val) =>
-                      handleCellChange(school.schoolName, "webPe", val)
-                    }
-                    onErrorExceeded={onErrorExceeded}
-                  />
-                  <QuotaEditableCell
-                    partName="Mobile PE"
-                    value={school.mobilePe}
-                    maxAllowed={getMaxAllowedForSchool(
-                      "mobilePe",
-                      school.schoolName,
-                    )}
-                    onChange={(val) =>
-                      handleCellChange(school.schoolName, "mobilePe", val)
-                    }
-                    onErrorExceeded={onErrorExceeded}
-                  />
-                  <div className="bg-teal-gray-100 relative w-35">
-                    <p className="text-body-2-medium text-teal-gray-400 absolute inset-x-0 top-[3.5px] text-center">
-                      {school.schoolName}
-                    </p>
-                    <p className="absolute inset-x-0 bottom-[3.5px] text-center">
-                      <span className="text-heading-6-semibold text-teal-500">
-                        {school.total}
-                      </span>
-                      <span className="text-subtitle-1-medium text-teal-gray-400 pl-px">
-                        명
-                      </span>
-                    </p>
-                  </div>
-                </div>
-              )
-            })}
+          <div className="flex flex-1 items-center justify-center bg-teal-100">
+            <p>
+              <span className="text-heading-6-semibold text-teal-600">
+                {fixedTotals.pm}
+              </span>
+              <span className="text-subtitle-1-medium text-teal-gray-400 pl-0.5">
+                명
+              </span>
+            </p>
+          </div>
+          <div className="flex flex-1 items-center justify-center bg-teal-100">
+            <p>
+              <span className="text-heading-6-semibold text-teal-600">
+                {fixedTotals.design}
+              </span>
+              <span className="text-subtitle-1-medium text-teal-gray-400 pl-0.5">
+                명
+              </span>
+            </p>
+          </div>
+          <div className="flex flex-1 items-center justify-center bg-teal-100">
+            <p>
+              <span className="text-heading-6-semibold text-teal-600">
+                {fixedTotals.webPe}
+              </span>
+              <span className="text-subtitle-1-medium text-teal-gray-400 pl-0.5">
+                명
+              </span>
+            </p>
+          </div>
+          <div className="flex flex-1 items-center justify-center bg-teal-100">
+            <p>
+              <span className="text-heading-6-semibold text-teal-600">
+                {fixedTotals.mobilePe}
+              </span>
+              <span className="text-subtitle-1-medium text-teal-gray-400 pl-0.5">
+                명
+              </span>
+            </p>
+          </div>
 
-            {/* Remaining row */}
-            <div className="divide-teal-gray-300 flex h-11 w-full divide-x">
-              <div className="bg-warning-50 flex w-42.5 items-center justify-center">
-                <p className="text-subtitle-1-medium text-warning-500">잔여</p>
-              </div>
-              <div className="flex flex-1 items-center justify-center bg-white">
-                {remainingPM > 0 ? (
-                  <p>
-                    <span className="text-subtitle-1-medium text-warning-500">
-                      {remainingPM}
-                    </span>
-                    <span className="text-subtitle-1-medium text-warning-500 pl-px">
-                      명
-                    </span>
-                  </p>
-                ) : (
-                  <p className="text-subtitle-1-medium text-teal-gray-700">-</p>
-                )}
-              </div>
-              <div className="flex flex-1 items-center justify-center bg-white">
-                {remainingDesign > 0 ? (
-                  <p>
-                    <span className="text-subtitle-1-medium text-warning-500">
-                      {remainingDesign}
-                    </span>
-                    <span className="text-subtitle-1-medium text-warning-500 pl-px">
-                      명
-                    </span>
-                  </p>
-                ) : (
-                  <p className="text-subtitle-1-medium text-teal-gray-700">-</p>
-                )}
-              </div>
-              <div className="flex flex-1 items-center justify-center bg-white">
-                {remainingWebPe > 0 ? (
-                  <p>
-                    <span className="text-subtitle-1-medium text-warning-500">
-                      {remainingWebPe}
-                    </span>
-                    <span className="text-subtitle-1-medium text-warning-500 pl-px">
-                      명
-                    </span>
-                  </p>
-                ) : (
-                  <p className="text-subtitle-1-medium text-teal-gray-700">-</p>
-                )}
-              </div>
-              <div className="flex flex-1 items-center justify-center bg-white">
-                {remainingMobilePe > 0 ? (
-                  <p>
-                    <span className="text-subtitle-1-medium text-warning-500">
-                      {remainingMobilePe}
-                    </span>
-                    <span className="text-subtitle-1-medium text-warning-500 pl-px">
-                      명
-                    </span>
-                  </p>
-                ) : (
-                  <p className="text-subtitle-1-medium text-teal-gray-700">-</p>
-                )}
-              </div>
-              <div className="bg-warning-50 text-subtitle-1-medium text-warning-500 flex w-35 items-center justify-center gap-1">
-                <p>총</p>
-                <p>{remainingTotal}</p>
-                <p>명</p>
-              </div>
-            </div>
-
-            {/* Totals row */}
-            <div className="divide-teal-gray-300 flex h-14 w-full divide-x">
-              <div className="bg-teal-gray-50 flex w-42.5 items-center justify-center">
-                <p className="text-subtitle-1-medium text-teal-gray-900">
-                  지부 전체
-                </p>
-              </div>
-              <div className="flex flex-1 items-center justify-center bg-teal-100">
-                <p>
-                  <span className="text-heading-6-semibold text-teal-600">
-                    {fixedTotals.pm}
-                  </span>
-                  <span className="text-subtitle-1-medium text-teal-gray-400 pl-0.5">
-                    명
-                  </span>
-                </p>
-              </div>
-              <div className="flex flex-1 items-center justify-center bg-teal-100">
-                <p>
-                  <span className="text-heading-6-semibold text-teal-600">
-                    {fixedTotals.design}
-                  </span>
-                  <span className="text-subtitle-1-medium text-teal-gray-400 pl-0.5">
-                    명
-                  </span>
-                </p>
-              </div>
-              <div className="flex flex-1 items-center justify-center bg-teal-100">
-                <p>
-                  <span className="text-heading-6-semibold text-teal-600">
-                    {fixedTotals.webPe}
-                  </span>
-                  <span className="text-subtitle-1-medium text-teal-gray-400 pl-0.5">
-                    명
-                  </span>
-                </p>
-              </div>
-              <div className="flex flex-1 items-center justify-center bg-teal-100">
-                <p>
-                  <span className="text-heading-6-semibold text-teal-600">
-                    {fixedTotals.mobilePe}
-                  </span>
-                  <span className="text-subtitle-1-medium text-teal-gray-400 pl-0.5">
-                    명
-                  </span>
-                </p>
-              </div>
-
-              <div
-                className="flex h-14 w-35 shrink-0 items-center justify-center gap-1"
-                style={{
-                  background:
-                    "linear-gradient(0deg, rgba(199, 235, 230, 0.4), rgba(199, 235, 230, 0.4)), #E5F5F2",
-                }}
-              >
-                <p className="text-heading-6-semibold text-teal-600">총</p>
-                <p className="text-heading-6-semibold text-teal-600">
-                  {fixedTotals.total}
-                </p>
-                <p className="text-subtitle-1-medium text-teal-gray-400">명</p>
-              </div>
-            </div>
-          </>
-        )}
+          <div
+            className="flex h-14 w-35 shrink-0 items-center justify-center gap-1"
+            style={{
+              background:
+                "linear-gradient(0deg, rgba(199, 235, 230, 0.4), rgba(199, 235, 230, 0.4)), #E5F5F2",
+            }}
+          >
+            <p className="text-heading-6-semibold text-teal-600">총</p>
+            <p className="text-heading-6-semibold text-teal-600">
+              {fixedTotals.total}
+            </p>
+            <p className="text-subtitle-1-medium text-teal-gray-400">명</p>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/src/features/recruiting/ui/ChapterQuotaTableCard.tsx
+++ b/src/features/recruiting/ui/ChapterQuotaTableCard.tsx
@@ -38,15 +38,24 @@ export function ChapterQuotaTableCard({
     SchoolQuotaRow[]
   >(data.schools)
 
+  const isTotalsEditedRef = useRef(false)
+  const prevSchoolsRef = useRef(data.schools)
+
   const onSchoolsDataChangeRef = useRef(onSchoolsDataChange)
   useEffect(() => {
     onSchoolsDataChangeRef.current = onSchoolsDataChange
   }, [onSchoolsDataChange])
 
   useEffect(() => {
-    setSchoolsData(data.schools)
-    setLastValidSchoolsData(data.schools)
-    setChapterTotals(data.totals)
+    if (prevSchoolsRef.current !== data.schools) {
+      prevSchoolsRef.current = data.schools
+      isTotalsEditedRef.current = false
+      setSchoolsData(data.schools)
+      setLastValidSchoolsData(data.schools)
+      setChapterTotals(data.totals)
+    } else if (!isTotalsEditedRef.current) {
+      setChapterTotals(data.totals)
+    }
   }, [data.schools, data.totals])
 
   // Execute Auto Allocation when triggered
@@ -106,6 +115,7 @@ export function ChapterQuotaTableCard({
     partKey: "pm" | "design" | "webPe" | "mobilePe",
     newTotal: number,
   ) => {
+    isTotalsEditedRef.current = true
     const updatedTotals = { ...chapterTotals, [partKey]: newTotal }
     updatedTotals.total =
       updatedTotals.pm +
@@ -114,32 +124,9 @@ export function ChapterQuotaTableCard({
       updatedTotals.mobilePe
 
     setChapterTotals(updatedTotals)
-
-    const N = schoolsData.length
-    if (N > 0) {
-      const base = Math.floor(newTotal / N)
-      const rem = newTotal % N
-
-      const updatedSchools = schoolsData.map((school, index) => {
-        const allocatedPartValue = base + (index < rem ? 1 : 0)
-        const updatedSchool = {
-          ...school,
-          [partKey]: allocatedPartValue,
-        }
-        const total =
-          updatedSchool.pm +
-          updatedSchool.design +
-          updatedSchool.webPe +
-          updatedSchool.mobilePe
-        return { ...updatedSchool, total }
-      })
-
-      setSchoolsData(updatedSchools)
-      setLastValidSchoolsData(updatedSchools)
-      onDirtyChange?.(true)
-      onManualEdit?.()
-      onSchoolsDataChange?.(updatedSchools)
-    }
+    onDirtyChange?.(true)
+    onManualEdit?.()
+    onSchoolsDataChange?.(schoolsData)
   }
 
   const handleCellChange = (
@@ -155,6 +142,7 @@ export function ChapterQuotaTableCard({
       return { ...updated, total }
     })
 
+    prevSchoolsRef.current = nextSchoolsData
     setSchoolsData(nextSchoolsData)
 
     const newSum = nextSchoolsData.reduce((acc, s) => acc + s[partKey], 0)

--- a/src/features/recruiting/ui/ChapterQuotaTableCard.tsx
+++ b/src/features/recruiting/ui/ChapterQuotaTableCard.tsx
@@ -33,6 +33,7 @@ export function ChapterQuotaTableCard({
   className,
 }: ChapterQuotaTableCardProps) {
   const [schoolsData, setSchoolsData] = useState<SchoolQuotaRow[]>(data.schools)
+  const [chapterTotals, setChapterTotals] = useState(data.totals)
   const [lastValidSchoolsData, setLastValidSchoolsData] = useState<
     SchoolQuotaRow[]
   >(data.schools)
@@ -45,17 +46,18 @@ export function ChapterQuotaTableCard({
   useEffect(() => {
     setSchoolsData(data.schools)
     setLastValidSchoolsData(data.schools)
-  }, [data.schools])
+    setChapterTotals(data.totals)
+  }, [data.schools, data.totals])
 
   // Execute Auto Allocation when triggered
   useEffect(() => {
     if (!autoAllocateTrigger || data.schools.length === 0) return
 
     const N = data.schools.length
-    const tPM = data.totals.pm
-    const tDesign = data.totals.design
-    const tWebPe = data.totals.webPe
-    const tMobilePe = data.totals.mobilePe
+    const tPM = chapterTotals.pm
+    const tDesign = chapterTotals.design
+    const tWebPe = chapterTotals.webPe
+    const tMobilePe = chapterTotals.mobilePe
 
     const maxPM = Math.floor(tPM / N)
     const maxDesign = Math.floor(tDesign / N)
@@ -84,7 +86,7 @@ export function ChapterQuotaTableCard({
     setSchoolsData(updatedSchools)
     setLastValidSchoolsData(updatedSchools)
     onSchoolsDataChangeRef.current?.(updatedSchools)
-  }, [autoAllocateTrigger, data.schools, data.totals])
+  }, [autoAllocateTrigger, data.schools, chapterTotals])
 
   const checkIsAllValid = (schools: SchoolQuotaRow[]) => {
     const pmSum = schools.reduce((acc, s) => acc + s.pm, 0)
@@ -93,11 +95,51 @@ export function ChapterQuotaTableCard({
     const mobilePeSum = schools.reduce((acc, s) => acc + s.mobilePe, 0)
 
     return (
-      pmSum <= data.totals.pm &&
-      designSum <= data.totals.design &&
-      webPeSum <= data.totals.webPe &&
-      mobilePeSum <= data.totals.mobilePe
+      pmSum <= chapterTotals.pm &&
+      designSum <= chapterTotals.design &&
+      webPeSum <= chapterTotals.webPe &&
+      mobilePeSum <= chapterTotals.mobilePe
     )
+  }
+
+  const handleChapterTotalChange = (
+    partKey: "pm" | "design" | "webPe" | "mobilePe",
+    newTotal: number,
+  ) => {
+    const updatedTotals = { ...chapterTotals, [partKey]: newTotal }
+    updatedTotals.total =
+      updatedTotals.pm +
+      updatedTotals.design +
+      updatedTotals.webPe +
+      updatedTotals.mobilePe
+
+    setChapterTotals(updatedTotals)
+
+    const N = schoolsData.length
+    if (N > 0) {
+      const base = Math.floor(newTotal / N)
+      const rem = newTotal % N
+
+      const updatedSchools = schoolsData.map((school, index) => {
+        const allocatedPartValue = base + (index < rem ? 1 : 0)
+        const updatedSchool = {
+          ...school,
+          [partKey]: allocatedPartValue,
+        }
+        const total =
+          updatedSchool.pm +
+          updatedSchool.design +
+          updatedSchool.webPe +
+          updatedSchool.mobilePe
+        return { ...updatedSchool, total }
+      })
+
+      setSchoolsData(updatedSchools)
+      setLastValidSchoolsData(updatedSchools)
+      onDirtyChange?.(true)
+      onManualEdit?.()
+      onSchoolsDataChange?.(updatedSchools)
+    }
   }
 
   const handleCellChange = (
@@ -114,6 +156,15 @@ export function ChapterQuotaTableCard({
     })
 
     setSchoolsData(nextSchoolsData)
+
+    const newSum = nextSchoolsData.reduce((acc, s) => acc + s[partKey], 0)
+    if (newSum > chapterTotals[partKey]) {
+      setChapterTotals((prev) => {
+        const next = { ...prev, [partKey]: newSum }
+        next.total = next.pm + next.design + next.webPe + next.mobilePe
+        return next
+      })
+    }
 
     if (checkIsAllValid(nextSchoolsData)) {
       setLastValidSchoolsData(nextSchoolsData)
@@ -132,7 +183,7 @@ export function ChapterQuotaTableCard({
     0,
   )
 
-  const fixedTotals = data.totals
+  const fixedTotals = chapterTotals
 
   const remainingPM = fixedTotals.pm - currentPMTotal
   const remainingDesign = fixedTotals.design - currentDesignTotal
@@ -370,46 +421,30 @@ export function ChapterQuotaTableCard({
               지부 전체
             </p>
           </div>
-          <div className="flex flex-1 items-center justify-center bg-teal-100">
-            <p>
-              <span className="text-heading-6-semibold text-teal-600">
-                {fixedTotals.pm}
-              </span>
-              <span className="text-subtitle-1-medium text-teal-gray-400 pl-0.5">
-                명
-              </span>
-            </p>
-          </div>
-          <div className="flex flex-1 items-center justify-center bg-teal-100">
-            <p>
-              <span className="text-heading-6-semibold text-teal-600">
-                {fixedTotals.design}
-              </span>
-              <span className="text-subtitle-1-medium text-teal-gray-400 pl-0.5">
-                명
-              </span>
-            </p>
-          </div>
-          <div className="flex flex-1 items-center justify-center bg-teal-100">
-            <p>
-              <span className="text-heading-6-semibold text-teal-600">
-                {fixedTotals.webPe}
-              </span>
-              <span className="text-subtitle-1-medium text-teal-gray-400 pl-0.5">
-                명
-              </span>
-            </p>
-          </div>
-          <div className="flex flex-1 items-center justify-center bg-teal-100">
-            <p>
-              <span className="text-heading-6-semibold text-teal-600">
-                {fixedTotals.mobilePe}
-              </span>
-              <span className="text-subtitle-1-medium text-teal-gray-400 pl-0.5">
-                명
-              </span>
-            </p>
-          </div>
+          <QuotaEditableCell
+            partName="지부 전체 PM"
+            value={chapterTotals.pm}
+            onChange={(val) => handleChapterTotalChange("pm", val)}
+            className="bg-teal-100"
+          />
+          <QuotaEditableCell
+            partName="지부 전체 Design"
+            value={chapterTotals.design}
+            onChange={(val) => handleChapterTotalChange("design", val)}
+            className="bg-teal-100"
+          />
+          <QuotaEditableCell
+            partName="지부 전체 Web PE"
+            value={chapterTotals.webPe}
+            onChange={(val) => handleChapterTotalChange("webPe", val)}
+            className="bg-teal-100"
+          />
+          <QuotaEditableCell
+            partName="지부 전체 Mobile PE"
+            value={chapterTotals.mobilePe}
+            onChange={(val) => handleChapterTotalChange("mobilePe", val)}
+            className="bg-teal-100"
+          />
 
           <div
             className="flex h-14 w-35 shrink-0 items-center justify-center gap-1"
@@ -420,7 +455,7 @@ export function ChapterQuotaTableCard({
           >
             <p className="text-heading-6-semibold text-teal-600">총</p>
             <p className="text-heading-6-semibold text-teal-600">
-              {fixedTotals.total}
+              {chapterTotals.total}
             </p>
             <p className="text-subtitle-1-medium text-teal-gray-400">명</p>
           </div>

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.test.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.test.tsx
@@ -1,0 +1,113 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { useAdminRecruitingRounds } from "../hooks/useAdminRecruitingRounds"
+import { useRecruitingSeasonQuotas } from "../hooks/useRecruitingSeasonQuotas"
+import { RecruitmentQuotaPage } from "./RecruitmentQuotaPage"
+
+vi.mock("../hooks/useAdminRecruitingRounds")
+vi.mock("../hooks/useRecruitingSeasonQuotas")
+vi.mock("@/shared/ui/toast/useToastStore", () => ({
+  useToastStore: () => vi.fn(),
+}))
+
+vi.mock("./ChapterQuotaTableCard", () => ({
+  ChapterQuotaTableCard: vi.fn(({ onSchoolsDataChange, onDirtyChange }) => (
+    <div>
+      <button
+        type="button"
+        data-testid="edit-school-btn"
+        onClick={() => {
+          onDirtyChange()
+          onSchoolsDataChange([
+            {
+              seasonId: undefined,
+              gisuId: "15",
+              schoolId: "10",
+              schoolName: "서울대학교",
+              pm: 2,
+              design: 2,
+              webPe: 5,
+              mobilePe: 5,
+              total: 14,
+            },
+          ])
+        }}
+      >
+        Trigger Edit
+      </button>
+    </div>
+  )),
+}))
+
+describe("RecruitmentQuotaPage 저장 경로 분류", () => {
+  it("시즌 설정이 없는 행(seasonId가 없는 행)을 저장하면 updateQuotas 대신 createSeason(POST)을 호출한다", async () => {
+    const mockCreateSeason = vi.fn().mockResolvedValue("new-season-999")
+    const mockUpdateQuotas = vi.fn().mockResolvedValue({
+      successfulVariables: [],
+      failedVariables: [],
+      fulfilledCount: 0,
+      failedCount: 0,
+    })
+
+    vi.mocked(useAdminRecruitingRounds).mockReturnValue({
+      groups: [
+        {
+          seasonId: "unconfigured-season-123",
+          gisuId: "15",
+          chapterId: "1",
+          chapterName: "Chromium",
+          schoolId: "10",
+          schoolName: "서울대학교",
+          rounds: [],
+        },
+      ],
+      generation: 15,
+      isLoading: false,
+      isError: false,
+      isForbidden: false,
+    } as ReturnType<typeof useAdminRecruitingRounds>)
+
+    // seasonConfigsMap에 unconfigured-season-123 설정이 없음
+    vi.mocked(useRecruitingSeasonQuotas).mockReturnValue({
+      seasonConfigsMap: new Map(),
+      updateQuotas: mockUpdateQuotas,
+      createSeason: mockCreateSeason,
+      updateSeason: vi.fn(),
+      isSaving: false,
+      isLoading: false,
+      isError: false,
+    })
+
+    const queryClient = new QueryClient()
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <RecruitmentQuotaPage />
+      </QueryClientProvider>,
+    )
+
+    // 수정 트리거 발생
+    fireEvent.click(screen.getAllByTestId("edit-school-btn")[0])
+
+    const saveButton = screen.getByRole("button", { name: "저장" })
+    expect(saveButton).not.toBeDisabled()
+
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(mockCreateSeason).toHaveBeenCalledWith({
+        gisuId: "15",
+        schoolId: "10",
+        quotas: [
+          { track: "PLAN", targetCount: 2 },
+          { track: "DESIGN", targetCount: 2 },
+          { track: "WEB_PRODUCT_ENGINEER", targetCount: 5 },
+          { track: "MOBILE_PRODUCT_ENGINEER", targetCount: 5 },
+        ],
+      })
+      expect(mockUpdateQuotas).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -44,10 +44,10 @@ export function RecruitmentQuotaPage() {
     () => [...new Set(activeTabGroups.map((g) => g.seasonId))],
     [activeTabGroups],
   )
-  const { seasonConfigsMap, updateQuotas, isSaving, isLoading } =
+  const { seasonConfigsMap, updateQuotas, createSeason, isSaving, isLoading } =
     useRecruitingSeasonQuotas(seasonIds)
 
-  // TO 조회 결과가 null인 시즌에 대해 자동으로 0명 저장 요청 전송
+  // TO 조회 결과가 null이거나 시즌이 생성이 안 된 경우 자동으로 생성/0명 저장 요청 전송
   const autoSavedSeasonsRef = useRef<Set<string>>(new Set())
 
   useEffect(() => {
@@ -68,30 +68,70 @@ export function RecruitmentQuotaPage() {
       }
     }> = []
 
+    const missingSeasonGroups: Array<{
+      gisuId: string
+      schoolId: string
+      key: string
+    }> = []
+
     groups.forEach((group) => {
-      if (!group.seasonId || autoSavedSeasonsRef.current.has(group.seasonId))
-        return
+      const key = group.seasonId || `${group.gisuId}-${group.schoolId}`
+      if (autoSavedSeasonsRef.current.has(key)) return
 
-      const config = seasonConfigsMap.get(group.seasonId)
-      if (!config) return
+      if (!group.seasonId) {
+        if (group.gisuId && group.schoolId) {
+          missingSeasonGroups.push({
+            gisuId: group.gisuId,
+            schoolId: group.schoolId,
+            key,
+          })
+        }
+      } else {
+        const config = seasonConfigsMap.get(group.seasonId)
+        if (!config) return
 
-      const hasQuotas = config.quotas.length > 0
+        const hasQuotas = config.quotas.length > 0
 
-      if (!hasQuotas) {
-        nullQuotaPayloads.push({
-          seasonId: group.seasonId,
-          schoolName: group.schoolName,
-          payload: {
+        if (!hasQuotas) {
+          nullQuotaPayloads.push({
+            seasonId: group.seasonId,
+            schoolName: group.schoolName,
+            payload: {
+              quotas: [
+                { track: "PLAN", targetCount: 0 },
+                { track: "DESIGN", targetCount: 0 },
+                { track: "WEB_PRODUCT_ENGINEER", targetCount: 0 },
+                { track: "MOBILE_PRODUCT_ENGINEER", targetCount: 0 },
+              ],
+            },
+          })
+        }
+      }
+    })
+
+    if (missingSeasonGroups.length > 0) {
+      void Promise.allSettled(
+        missingSeasonGroups.map(async (item) => {
+          await createSeason({
+            gisuId: item.gisuId,
+            schoolId: item.schoolId,
             quotas: [
               { track: "PLAN", targetCount: 0 },
               { track: "DESIGN", targetCount: 0 },
               { track: "WEB_PRODUCT_ENGINEER", targetCount: 0 },
               { track: "MOBILE_PRODUCT_ENGINEER", targetCount: 0 },
             ],
-          },
+          })
+          return item.key
+        }),
+      ).then((results) => {
+        results.forEach((res) => {
+          if (res.status === "fulfilled") {
+            autoSavedSeasonsRef.current.add(res.value)
+          }
         })
-      }
-    })
+      })
+    }
 
     if (nullQuotaPayloads.length > 0) {
       void updateQuotas(nullQuotaPayloads).then((result) => {
@@ -100,7 +140,14 @@ export function RecruitmentQuotaPage() {
         })
       })
     }
-  }, [isLoading, isSaving, groups, seasonConfigsMap, updateQuotas])
+  }, [
+    isLoading,
+    isSaving,
+    groups,
+    seasonConfigsMap,
+    updateQuotas,
+    createSeason,
+  ])
 
   const allChaptersData = useMemo(
     () => mapGroupsToChapterQuotaData(groups, seasonConfigsMap),
@@ -150,8 +197,9 @@ export function RecruitmentQuotaPage() {
           duration: 3000,
         })
       }
-      return "임의 배정 중"
+      return "직접 수정 중"
     })
+    setIsDirty(true)
   }, [addToast])
 
   const handleErrorExceeded = useCallback(
@@ -188,56 +236,83 @@ export function RecruitmentQuotaPage() {
       (c) => editedSchoolsMap.get(c.chapter) ?? c.schools,
     )
 
-    const payloadList = rawRows
-      .filter((row): row is SchoolQuotaRow & { seasonId: string } =>
+    const existingSeasonRows = rawRows.filter(
+      (row): row is SchoolQuotaRow & { seasonId: string } =>
         Boolean(row.seasonId),
-      )
-      .map((row) => ({
-        seasonId: row.seasonId,
-        schoolName: row.schoolName,
-        payload: {
-          quotas: [
-            { track: "PLAN" as const, targetCount: row.pm },
-            { track: "DESIGN" as const, targetCount: row.design },
-            { track: "WEB_PRODUCT_ENGINEER" as const, targetCount: row.webPe },
-            {
-              track: "MOBILE_PRODUCT_ENGINEER" as const,
-              targetCount: row.mobilePe,
-            },
-          ],
-        },
-      }))
+    )
+    const newSeasonRows = rawRows.filter(
+      (row): row is SchoolQuotaRow & { gisuId: string; schoolId: string } =>
+        !row.seasonId && Boolean(row.gisuId) && Boolean(row.schoolId),
+    )
 
-    if (payloadList.length === 0) return
+    const payloadList = existingSeasonRows.map((row) => ({
+      seasonId: row.seasonId,
+      schoolName: row.schoolName,
+      payload: {
+        quotas: [
+          { track: "PLAN" as const, targetCount: row.pm },
+          { track: "DESIGN" as const, targetCount: row.design },
+          { track: "WEB_PRODUCT_ENGINEER" as const, targetCount: row.webPe },
+          {
+            track: "MOBILE_PRODUCT_ENGINEER" as const,
+            targetCount: row.mobilePe,
+          },
+        ],
+      },
+    }))
+
+    if (payloadList.length === 0 && newSeasonRows.length === 0) return
 
     try {
-      const result = await updateQuotas(payloadList)
+      if (newSeasonRows.length > 0) {
+        await Promise.all(
+          newSeasonRows.map((row) =>
+            createSeason({
+              gisuId: row.gisuId,
+              schoolId: row.schoolId,
+              quotas: [
+                { track: "PLAN", targetCount: row.pm },
+                { track: "DESIGN", targetCount: row.design },
+                { track: "WEB_PRODUCT_ENGINEER", targetCount: row.webPe },
+                { track: "MOBILE_PRODUCT_ENGINEER", targetCount: row.mobilePe },
+              ],
+            }),
+          ),
+        )
+      }
 
-      if (result.failedCount === 0) {
+      if (payloadList.length > 0) {
+        const result = await updateQuotas(payloadList)
+
+        if (result.failedCount === 0) {
+          setIsDirty(false)
+          setEditedSchoolsMap(new Map())
+        } else {
+          const successfulSchoolNames = new Set(
+            result.successfulVariables
+              .map((v) => v.schoolName)
+              .filter((name): name is string => Boolean(name)),
+          )
+
+          setEditedSchoolsMap((prev) => {
+            const next = new Map<string, SchoolQuotaRow[]>()
+            prev.forEach((rows, chapter) => {
+              const remainingRows = rows.filter(
+                (r) => !successfulSchoolNames.has(r.schoolName),
+              )
+              if (remainingRows.length > 0) {
+                next.set(chapter, remainingRows)
+              }
+            })
+            if (next.size === 0) {
+              setIsDirty(false)
+            }
+            return next
+          })
+        }
+      } else if (newSeasonRows.length > 0) {
         setIsDirty(false)
         setEditedSchoolsMap(new Map())
-      } else {
-        const successfulSchoolNames = new Set(
-          result.successfulVariables
-            .map((v) => v.schoolName)
-            .filter((name): name is string => Boolean(name)),
-        )
-
-        setEditedSchoolsMap((prev) => {
-          const next = new Map<string, SchoolQuotaRow[]>()
-          prev.forEach((rows, chapter) => {
-            const remainingRows = rows.filter(
-              (r) => !successfulSchoolNames.has(r.schoolName),
-            )
-            if (remainingRows.length > 0) {
-              next.set(chapter, remainingRows)
-            }
-          })
-          if (next.size === 0) {
-            setIsDirty(false)
-          }
-          return next
-        })
       }
     } catch {
       // 에러 토스트는 useRecruitingSeasonQuotas 훅에서 처리됨

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -162,10 +162,12 @@ export function RecruitmentQuotaPage() {
     if (payloadList.length === 0 && newSeasonRows.length === 0) return
 
     try {
+      const successfulSchoolNames = new Set<string>()
+
       if (newSeasonRows.length > 0) {
-        await Promise.all(
-          newSeasonRows.map((row) =>
-            createSeason({
+        const createResults = await Promise.allSettled(
+          newSeasonRows.map(async (row) => {
+            await createSeason({
               gisuId: row.gisuId,
               schoolId: row.schoolId,
               quotas: [
@@ -174,46 +176,70 @@ export function RecruitmentQuotaPage() {
                 { track: "WEB_PRODUCT_ENGINEER", targetCount: row.webPe },
                 { track: "MOBILE_PRODUCT_ENGINEER", targetCount: row.mobilePe },
               ],
-            }),
-          ),
+            })
+            return row
+          }),
         )
+
+        const failedCreateSchoolNames: string[] = []
+
+        createResults.forEach((result, index) => {
+          const row = newSeasonRows[index]
+          if (!row) return
+
+          if (result.status === "fulfilled") {
+            successfulSchoolNames.add(row.schoolName)
+          } else {
+            failedCreateSchoolNames.push(row.schoolName)
+          }
+        })
+
+        if (failedCreateSchoolNames.length > 0) {
+          addToast({
+            message: `${failedCreateSchoolNames.join(", ")} 시즌 생성에 실패했습니다. 잠시 후 다시 시도해주세요.`,
+            color: "red",
+            variant: "deep",
+            type: "default",
+            duration: 3000,
+          })
+        }
       }
 
       if (payloadList.length > 0) {
-        const result = await updateQuotas(payloadList)
+        const updateResult = await updateQuotas(payloadList)
 
-        if (result.failedCount === 0) {
-          setIsDirty(false)
-          setEditedSchoolsMap(new Map())
-        } else {
-          const successfulSchoolNames = new Set(
-            result.successfulVariables
-              .map((v) => v.schoolName)
-              .filter((name): name is string => Boolean(name)),
-          )
+        updateResult.successfulVariables.forEach((v) => {
+          if (v.schoolName) {
+            successfulSchoolNames.add(v.schoolName)
+          }
+        })
+      }
 
-          setEditedSchoolsMap((prev) => {
-            const next = new Map<string, SchoolQuotaRow[]>()
-            prev.forEach((rows, chapter) => {
-              const remainingRows = rows.filter(
-                (r) => !successfulSchoolNames.has(r.schoolName),
-              )
-              if (remainingRows.length > 0) {
-                next.set(chapter, remainingRows)
-              }
-            })
-            if (next.size === 0) {
-              setIsDirty(false)
+      if (successfulSchoolNames.size > 0) {
+        setEditedSchoolsMap((prev) => {
+          const next = new Map<string, SchoolQuotaRow[]>()
+          prev.forEach((rows, chapter) => {
+            const remainingRows = rows.filter(
+              (r) => !successfulSchoolNames.has(r.schoolName),
+            )
+            if (remainingRows.length > 0) {
+              next.set(chapter, remainingRows)
             }
-            return next
           })
-        }
-      } else if (newSeasonRows.length > 0) {
-        setIsDirty(false)
-        setEditedSchoolsMap(new Map())
+          if (next.size === 0) {
+            setIsDirty(false)
+          }
+          return next
+        })
       }
     } catch {
-      // 에러 토스트는 useRecruitingSeasonQuotas 훅에서 처리됨
+      addToast({
+        message: "저장 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
     }
   }
 

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -73,10 +73,11 @@ export function RecruitmentQuotaPage() {
         return
 
       const config = seasonConfigsMap.get(group.seasonId)
-      const hasQuotas = Boolean(config?.quotas && config.quotas.length > 0)
+      if (!config) return
+
+      const hasQuotas = config.quotas.length > 0
 
       if (!hasQuotas) {
-        autoSavedSeasonsRef.current.add(group.seasonId)
         nullQuotaPayloads.push({
           seasonId: group.seasonId,
           schoolName: group.schoolName,
@@ -93,7 +94,11 @@ export function RecruitmentQuotaPage() {
     })
 
     if (nullQuotaPayloads.length > 0) {
-      void updateQuotas(nullQuotaPayloads)
+      void updateQuotas(nullQuotaPayloads).then((result) => {
+        result?.successfulVariables.forEach((item) => {
+          autoSavedSeasonsRef.current.add(item.seasonId)
+        })
+      })
     }
   }, [isLoading, isSaving, groups, seasonConfigsMap, updateQuotas])
 

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -131,7 +131,7 @@ export function RecruitmentQuotaPage() {
       : chaptersDataWithEdits.filter((c) => c.chapter === chapterTab)
 
     const rawRows = targetChapters.flatMap(
-      (c) => editedSchoolsMap.get(c.chapter) ?? c.schools,
+      (c) => editedSchoolsMap.get(c.chapter) ?? [],
     )
 
     const existingSeasonRows = rawRows.filter(

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import ResetIcon from "@/shared/assets/icon/reset/ResetIcon"
 import { Button } from "@/shared/ui/Button"
@@ -44,8 +44,58 @@ export function RecruitmentQuotaPage() {
     () => [...new Set(activeTabGroups.map((g) => g.seasonId))],
     [activeTabGroups],
   )
-  const { seasonConfigsMap, updateQuotas, isSaving } =
+  const { seasonConfigsMap, updateQuotas, isSaving, isLoading } =
     useRecruitingSeasonQuotas(seasonIds)
+
+  // TO 조회 결과가 null인 시즌에 대해 자동으로 0명 저장 요청 전송
+  const autoSavedSeasonsRef = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    if (isLoading || isSaving || groups.length === 0) return
+
+    const nullQuotaPayloads: Array<{
+      seasonId: string
+      schoolName?: string
+      payload: {
+        quotas: Array<{
+          track:
+            | "PLAN"
+            | "DESIGN"
+            | "WEB_PRODUCT_ENGINEER"
+            | "MOBILE_PRODUCT_ENGINEER"
+          targetCount: number
+        }>
+      }
+    }> = []
+
+    groups.forEach((group) => {
+      if (!group.seasonId || autoSavedSeasonsRef.current.has(group.seasonId))
+        return
+
+      const config = seasonConfigsMap.get(group.seasonId)
+      const hasQuotas = Boolean(config?.quotas && config.quotas.length > 0)
+
+      if (!hasQuotas) {
+        autoSavedSeasonsRef.current.add(group.seasonId)
+        nullQuotaPayloads.push({
+          seasonId: group.seasonId,
+          schoolName: group.schoolName,
+          payload: {
+            quotas: [
+              { track: "PLAN", targetCount: 0 },
+              { track: "DESIGN", targetCount: 0 },
+              { track: "WEB_PRODUCT_ENGINEER", targetCount: 0 },
+              { track: "MOBILE_PRODUCT_ENGINEER", targetCount: 0 },
+            ],
+          },
+        })
+      }
+    })
+
+    if (nullQuotaPayloads.length > 0) {
+      void updateQuotas(nullQuotaPayloads)
+    }
+  }, [isLoading, isSaving, groups, seasonConfigsMap, updateQuotas])
 
   const allChaptersData = useMemo(
     () => mapGroupsToChapterQuotaData(groups, seasonConfigsMap),
@@ -125,8 +175,16 @@ export function RecruitmentQuotaPage() {
   )
 
   const handleSave = async () => {
-    const allEditedRows = Array.from(editedSchoolsMap.values()).flat()
-    const payloadList = allEditedRows
+    const targetChapters = isAll
+      ? chaptersDataWithEdits
+      : chaptersDataWithEdits.filter((c) => c.chapter === chapterTab)
+
+    const rawRows =
+      editedSchoolsMap.size > 0
+        ? Array.from(editedSchoolsMap.values()).flat()
+        : targetChapters.flatMap((c) => c.schools)
+
+    const payloadList = rawRows
       .filter((row): row is SchoolQuotaRow & { seasonId: string } =>
         Boolean(row.seasonId),
       )
@@ -203,14 +261,8 @@ export function RecruitmentQuotaPage() {
       )
     : selectedChapterData.totals
 
-  const totalApplicants = isAll
-    ? chaptersDataWithEdits.reduce((acc, item) => acc + item.totals.total, 0)
-    : selectedChapterData.totals.total
-
-  const hasApplicants = totalApplicants > 0
-
-  const showAutoAllocateButton = !isAll && hasApplicants
-  const showSaveButton = hasApplicants
+  const showAutoAllocateButton = !isAll
+  const showSaveButton = true
 
   const pageTitle = isAll ? "UMC 11th" : chapterTab
   const statusCardTitle = isAll ? "전체 지원자 현황" : "지부 지원자 현황"
@@ -298,47 +350,39 @@ export function RecruitmentQuotaPage() {
               </p>
             </div>
 
-            {!isAll && !hasApplicants ? (
-              <div className="flex h-65 w-full items-center justify-center">
-                <p className="text-body-2-medium text-teal-gray-400">
-                  현재 TO를 정할 지원자가 없습니다.
-                </p>
-              </div>
-            ) : (
-              <div className="flex w-full flex-col gap-10">
-                {isAll ? (
-                  chaptersDataWithEdits.map((chapterData) => (
-                    <ChapterQuotaTableCard
-                      key={chapterData.chapter}
-                      data={chapterData}
-                      status={allocationStatus}
-                      onDirtyChange={() => setIsDirty(true)}
-                      onManualEdit={handleManualEdit}
-                      onErrorExceeded={handleErrorExceeded}
-                      onSchoolsDataChange={(schools) =>
-                        handleSchoolsDataChange(chapterData.chapter, schools)
-                      }
-                      autoAllocateTrigger={autoAllocateTrigger}
-                    />
-                  ))
-                ) : (
+            <div className="flex w-full flex-col gap-10">
+              {isAll ? (
+                chaptersDataWithEdits.map((chapterData) => (
                   <ChapterQuotaTableCard
-                    data={selectedChapterData}
+                    key={chapterData.chapter}
+                    data={chapterData}
                     status={allocationStatus}
                     onDirtyChange={() => setIsDirty(true)}
                     onManualEdit={handleManualEdit}
                     onErrorExceeded={handleErrorExceeded}
                     onSchoolsDataChange={(schools) =>
-                      handleSchoolsDataChange(
-                        selectedChapterData.chapter,
-                        schools,
-                      )
+                      handleSchoolsDataChange(chapterData.chapter, schools)
                     }
                     autoAllocateTrigger={autoAllocateTrigger}
                   />
-                )}
-              </div>
-            )}
+                ))
+              ) : (
+                <ChapterQuotaTableCard
+                  data={selectedChapterData}
+                  status={allocationStatus}
+                  onDirtyChange={() => setIsDirty(true)}
+                  onManualEdit={handleManualEdit}
+                  onErrorExceeded={handleErrorExceeded}
+                  onSchoolsDataChange={(schools) =>
+                    handleSchoolsDataChange(
+                      selectedChapterData.chapter,
+                      schools,
+                    )
+                  }
+                  autoAllocateTrigger={autoAllocateTrigger}
+                />
+              )}
+            </div>
           </div>
 
           {/* 자동 배정 확인 CtaModal */}

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -184,10 +184,9 @@ export function RecruitmentQuotaPage() {
       ? chaptersDataWithEdits
       : chaptersDataWithEdits.filter((c) => c.chapter === chapterTab)
 
-    const rawRows =
-      editedSchoolsMap.size > 0
-        ? Array.from(editedSchoolsMap.values()).flat()
-        : targetChapters.flatMap((c) => c.schools)
+    const rawRows = targetChapters.flatMap(
+      (c) => editedSchoolsMap.get(c.chapter) ?? c.schools,
+    )
 
     const payloadList = rawRows
       .filter((row): row is SchoolQuotaRow & { seasonId: string } =>

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -216,21 +216,25 @@ export function RecruitmentQuotaPage() {
       }
 
       if (successfulSchoolNames.size > 0) {
-        setEditedSchoolsMap((prev) => {
-          const next = new Map<string, SchoolQuotaRow[]>()
-          prev.forEach((rows, chapter) => {
-            const remainingRows = rows.filter(
-              (r) => !successfulSchoolNames.has(r.schoolName),
-            )
-            if (remainingRows.length > 0) {
-              next.set(chapter, remainingRows)
-            }
-          })
-          if (next.size === 0) {
-            setIsDirty(false)
+        let remainingCount = 0
+        const nextMap = new Map<string, SchoolQuotaRow[]>()
+
+        editedSchoolsMap.forEach((rows, chapter) => {
+          const remainingRows = rows.filter(
+            (r) => !successfulSchoolNames.has(r.schoolName),
+          )
+          if (remainingRows.length > 0) {
+            nextMap.set(chapter, remainingRows)
+            remainingCount += remainingRows.length
           }
-          return next
         })
+
+        if (remainingCount === 0) {
+          setIsDirty(false)
+          setEditedSchoolsMap(new Map())
+        } else {
+          setEditedSchoolsMap(nextMap)
+        }
       }
     } catch {
       addToast({

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useMemo, useState } from "react"
 
+import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import ResetIcon from "@/shared/assets/icon/reset/ResetIcon"
+import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
 import { Button } from "@/shared/ui/Button"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
 import { PageLabel } from "@/shared/ui/page-label/PageLabel"
@@ -33,6 +35,12 @@ export function RecruitmentQuotaPage() {
   const addToast = useToastStore((state) => state.addToast)
 
   const { groups } = useAdminRecruitingRounds()
+  const { chapters: serverChapters } = useSchoolChapterMap()
+  const { data: activeGisuData } = useActiveGisu()
+  const activeGisuId = activeGisuData?.gisuId
+    ? String(activeGisuData.gisuId)
+    : undefined
+
   const activeTabGroups = useMemo(
     () =>
       chapterTab === "all"
@@ -48,8 +56,14 @@ export function RecruitmentQuotaPage() {
     useRecruitingSeasonQuotas(seasonIds)
 
   const allChaptersData = useMemo(
-    () => mapGroupsToChapterQuotaData(groups, seasonConfigsMap),
-    [groups, seasonConfigsMap],
+    () =>
+      mapGroupsToChapterQuotaData(
+        groups,
+        seasonConfigsMap,
+        serverChapters,
+        activeGisuId,
+      ),
+    [groups, seasonConfigsMap, serverChapters, activeGisuId],
   )
 
   const chaptersDataWithEdits = useMemo(() => {

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -195,6 +195,7 @@ export function RecruitmentQuotaPage() {
           }),
         )
 
+        let isAlreadyExistsError = false
         const failedCreateSchoolNames: string[] = []
 
         createResults.forEach((result, index) => {
@@ -205,12 +206,30 @@ export function RecruitmentQuotaPage() {
             successfulSchoolNames.add(row.schoolName)
           } else {
             failedCreateSchoolNames.push(row.schoolName)
+            const err = result.reason as {
+              code?: string
+              response?: { data?: { code?: string; message?: string } }
+              message?: string
+            }
+            if (
+              err?.code === "RECRUITING-0103" ||
+              err?.response?.data?.code === "RECRUITING-0103" ||
+              err?.response?.data?.message?.includes(
+                "이미 같은 학교와 기수의 모집 시즌이 있어요",
+              )
+            ) {
+              isAlreadyExistsError = true
+            }
           }
         })
 
         if (failedCreateSchoolNames.length > 0) {
+          const message = isAlreadyExistsError
+            ? `${failedCreateSchoolNames.join(", ")} 대학교는 이미 모집 시즌이 존재합니다. 페이지를 새로고침 해주세요.`
+            : `${failedCreateSchoolNames.join(", ")} 시즌 생성에 실패했습니다. 잠시 후 다시 시도해주세요.`
+
           addToast({
-            message: `${failedCreateSchoolNames.join(", ")} 시즌 생성에 실패했습니다. 잠시 후 다시 시도해주세요.`,
+            message,
             color: "red",
             variant: "deep",
             type: "default",

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 
 import ResetIcon from "@/shared/assets/icon/reset/ResetIcon"
 import { Button } from "@/shared/ui/Button"
@@ -44,110 +44,8 @@ export function RecruitmentQuotaPage() {
     () => [...new Set(activeTabGroups.map((g) => g.seasonId))],
     [activeTabGroups],
   )
-  const { seasonConfigsMap, updateQuotas, createSeason, isSaving, isLoading } =
+  const { seasonConfigsMap, updateQuotas, createSeason, isSaving } =
     useRecruitingSeasonQuotas(seasonIds)
-
-  // TO 조회 결과가 null이거나 시즌이 생성이 안 된 경우 자동으로 생성/0명 저장 요청 전송
-  const autoSavedSeasonsRef = useRef<Set<string>>(new Set())
-
-  useEffect(() => {
-    if (isLoading || isSaving || groups.length === 0) return
-
-    const nullQuotaPayloads: Array<{
-      seasonId: string
-      schoolName?: string
-      payload: {
-        quotas: Array<{
-          track:
-            | "PLAN"
-            | "DESIGN"
-            | "WEB_PRODUCT_ENGINEER"
-            | "MOBILE_PRODUCT_ENGINEER"
-          targetCount: number
-        }>
-      }
-    }> = []
-
-    const missingSeasonGroups: Array<{
-      gisuId: string
-      schoolId: string
-      key: string
-    }> = []
-
-    groups.forEach((group) => {
-      const key = group.seasonId || `${group.gisuId}-${group.schoolId}`
-      if (autoSavedSeasonsRef.current.has(key)) return
-
-      if (!group.seasonId) {
-        if (group.gisuId && group.schoolId) {
-          missingSeasonGroups.push({
-            gisuId: group.gisuId,
-            schoolId: group.schoolId,
-            key,
-          })
-        }
-      } else {
-        const config = seasonConfigsMap.get(group.seasonId)
-        if (!config) return
-
-        const hasQuotas = config.quotas.length > 0
-
-        if (!hasQuotas) {
-          nullQuotaPayloads.push({
-            seasonId: group.seasonId,
-            schoolName: group.schoolName,
-            payload: {
-              quotas: [
-                { track: "PLAN", targetCount: 0 },
-                { track: "DESIGN", targetCount: 0 },
-                { track: "WEB_PRODUCT_ENGINEER", targetCount: 0 },
-                { track: "MOBILE_PRODUCT_ENGINEER", targetCount: 0 },
-              ],
-            },
-          })
-        }
-      }
-    })
-
-    if (missingSeasonGroups.length > 0) {
-      void Promise.allSettled(
-        missingSeasonGroups.map(async (item) => {
-          await createSeason({
-            gisuId: item.gisuId,
-            schoolId: item.schoolId,
-            quotas: [
-              { track: "PLAN", targetCount: 0 },
-              { track: "DESIGN", targetCount: 0 },
-              { track: "WEB_PRODUCT_ENGINEER", targetCount: 0 },
-              { track: "MOBILE_PRODUCT_ENGINEER", targetCount: 0 },
-            ],
-          })
-          return item.key
-        }),
-      ).then((results) => {
-        results.forEach((res) => {
-          if (res.status === "fulfilled") {
-            autoSavedSeasonsRef.current.add(res.value)
-          }
-        })
-      })
-    }
-
-    if (nullQuotaPayloads.length > 0) {
-      void updateQuotas(nullQuotaPayloads).then((result) => {
-        result?.successfulVariables.forEach((item) => {
-          autoSavedSeasonsRef.current.add(item.seasonId)
-        })
-      })
-    }
-  }, [
-    isLoading,
-    isSaving,
-    groups,
-    seasonConfigsMap,
-    updateQuotas,
-    createSeason,
-  ])
 
   const allChaptersData = useMemo(
     () => mapGroupsToChapterQuotaData(groups, seasonConfigsMap),


### PR DESCRIPTION
## 📸 작업 내용

TO 조회 결과가 null일 때 0명으로 간주하여 UI 표시 및 서버 자동 저장 요청을 전송하도록 처리하고, 미정의된 모집 시즌 API/DTO 추가 및 "현재 TO를 정할 지원자가 없습니다." 문구를 제거하였습니다.

- **TO null 0명 매핑 및 서버 자동 저장**: TO 조회 결과(`quotas`)가 null/empty인 시즌에 대해 0명(`targetCount: 0`)으로 UI 표시함과 동시에 서버로 0명 TO 저장 요청(`updateQuotas`)을 자동 발송하여 모집 시즌 생성이 가능하도록 조치하였습니다.
- **모집 인원 설정 UI 및 저장 버튼 활성화**: TO가 0명이거나 null이더라도 저장 및 자동 배정 버튼이 활성화되도록 변경하고, `editedSchoolsMap` 미수정 시에도 `chaptersDataWithEdits` 폴백을 통해 저장할 수 있도록 개선하였습니다.
- **"현재 TO를 정할 지원자가 없습니다." 안내 문구 삭제**: TO 조회 결과가 null이더라도 0명으로 처리되므로 해당 문구와 조건부 렌더링 블록을 완전히 제거하였습니다.
- **미정의 모집 시즌 API 및 DTO 신규 추가**: OpenAPI 스펙 기준 미정의 상태였던 모집 시즌 생성(`createRecruitingSeason` - `POST /v1/recruiting/admin/seasons`) 및 수정(`updateRecruitingSeason` - `PATCH /v1/recruiting/admin/seasons/{seasonId}`) API 함수와 `CreateRecruitingSeasonRequest`, `UpdateRecruitingSeasonRequest` DTO를 정의하고 export 하였습니다.

## 🎞️ 주요 코드 설명

### 주제 1: TO null 감지 시 0명 서버 자동 저장 로직

```TypeScript
// RecruitmentQuotaPage.tsx
const autoSavedSeasonsRef = useRef<Set<string>>(new Set())

useEffect(() => {
  if (isLoading || isSaving || groups.length === 0) return

  const nullQuotaPayloads: Array<{
    seasonId: string
    schoolName?: string
    payload: {
      quotas: Array<{
        track: "PLAN" | "DESIGN" | "WEB_PRODUCT_ENGINEER" | "MOBILE_PRODUCT_ENGINEER"
        targetCount: number
      }>
    }
  }> = []

  groups.forEach((group) => {
    if (!group.seasonId || autoSavedSeasonsRef.current.has(group.seasonId)) return

    const config = seasonConfigsMap.get(group.seasonId)
    const hasQuotas = Boolean(config?.quotas && config.quotas.length > 0)

    if (!hasQuotas) {
      autoSavedSeasonsRef.current.add(group.seasonId)
      nullQuotaPayloads.push({
        seasonId: group.seasonId,
        schoolName: group.schoolName,
        payload: {
          quotas: [
            { track: "PLAN", targetCount: 0 },
            { track: "DESIGN", targetCount: 0 },
            { track: "WEB_PRODUCT_ENGINEER", targetCount: 0 },
            { track: "MOBILE_PRODUCT_ENGINEER", targetCount: 0 },
          ],
        },
      })
    }
  })

  if (nullQuotaPayloads.length > 0) {
    void updateQuotas(nullQuotaPayloads)
  }
}, [isLoading, isSaving, groups, seasonConfigsMap, updateQuotas])
```

- TO 조회 결과가 없는 시즌에 대해 모든 트랙(`PLAN`, `DESIGN`, `WEB_PE`, `MOBILE_PE`)의 `targetCount`를 0으로 구성하여 서버로 최초 1회 자동 저장 요청을 전송합니다.

### 주제 2: 미정의 모집 시즌 생성 및 수정 API / DTO 구현

```TypeScript
// recruitingApi.ts
// 모집 시즌 생성 (RECRUITING-ADMIN-002)
export async function createRecruitingSeason(
  payload: CreateRecruitingSeasonRequest,
): Promise<string> {
  const { data } = await api.post<ApiResponse<{ id: number }>>(
    "/v1/recruiting/admin/seasons",
    payload,
  )
  return String(data.result.id)
}

// 모집 시즌 수정 (RECRUITING-ADMIN-003)
export async function updateRecruitingSeason(
  seasonId: string,
  payload: UpdateRecruitingSeasonRequest,
): Promise<void> {
  await api.patch(`/v1/recruiting/admin/seasons/${seasonId}`, payload)
}
```

- `RECRUITING-ADMIN-002` 및 `RECRUITING-ADMIN-003` 스펙에 맞추어 POST 및 PATCH API 함수와 DTO를 추가하였습니다.

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #689 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 모집 시즌을 생성하고 기존 시즌 정보를 수정할 수 있습니다.
  - 시즌별 기수, 학교, 트랙별 정원 및 메모를 설정할 수 있습니다.
  - 시즌별 정원 정보가 없으면 각 파트의 목표 인원이 자동으로 0명으로 저장됩니다.

- **개선**
  - 전체 또는 선택한 지부만 정원 정보를 저장할 수 있습니다.
  - 지원자가 없는 지부에서도 정원표와 학교별·잔여·전체 합계 행을 확인할 수 있습니다.
  - 학교별 정원 편집에 따라 지부 총원이 자동으로 조정됩니다.
  - 지원자 유무와 관계없이 정원 자동 배정 및 저장 기능을 사용할 수 있습니다.
  - 정원 저장 상태와 신규 시즌 저장 처리가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->