### PR TITLE
✨ feat: 설정 영역 내비게이션과 사이드바·헤더 정리

### DIFF
--- a/src/features/project/list/model/matchingProjectList.ts
+++ b/src/features/project/list/model/matchingProjectList.ts
@@ -129,7 +129,11 @@ export function useMatchingProjectListFilters() {
   const { me, viewContext } = useViewerIdentity()
   const userIsOperator = isOperator(me)
 
-  const { data: gisuData } = useActiveGisu()
+  const {
+    data: gisuData,
+    isLoading: isGisuLoading,
+    isError: isGisuError,
+  } = useActiveGisu()
 
   const activeGisuId = gisuData?.gisuId ? Number(gisuData.gisuId) : undefined
 
@@ -142,8 +146,12 @@ export function useMatchingProjectListFilters() {
     return latest ? Number(latest.gisuId) : undefined
   }, [me])
 
+  // 챌린저 기록이 없으면(비로그인 게스트) 활성 기수로 떨어뜨린다. 그렇지 않으면
+  // 기수가 undefined 라 목록 쿼리가 통째로 실행되지 않고 빈 화면이 남는다.
   const effectiveGisuId =
-    viewContext.isAdminView && userIsOperator ? activeGisuId : userGisuId
+    viewContext.isAdminView && userIsOperator
+      ? activeGisuId
+      : (userGisuId ?? activeGisuId)
 
   const { data: chaptersData } = useQuery({
     queryKey: ["chaptersWithSchools", activeGisuId],
@@ -332,8 +340,11 @@ export function useMatchingProjectListFilters() {
     totalPages: Math.max(1, Number(data?.totalPages ?? 1)),
     page,
     setPage,
-    isLoading,
-    isError,
+    // 게스트는 활성 기수를 받아야 목록 쿼리가 열린다. 그 조회 상태를 합치지
+    // 않으면 기수를 기다리는 동안 "프로젝트 없음"으로 보이고, 조회가 실패하면
+    // 불러오지 못한 것을 없는 것으로 안내하게 된다.
+    isLoading: isLoading || (effectiveGisuId == null && isGisuLoading),
+    isError: isError || (effectiveGisuId == null && isGisuError),
     searchQuery,
     setSearchQuery,
     filterDescriptors,

--- a/src/features/project/list/model/matchingProjectList.ts
+++ b/src/features/project/list/model/matchingProjectList.ts
@@ -154,9 +154,12 @@ export function useMatchingProjectListFilters() {
       : (userGisuId ?? activeGisuId)
 
   const { data: chaptersData } = useQuery({
-    queryKey: ["chaptersWithSchools", activeGisuId],
-    queryFn: () => getChaptersWithSchools(String(activeGisuId!)),
-    enabled: activeGisuId != null,
+    // 필터 옵션은 목록과 같은 기수를 봐야 한다. 기수마다 지부 구성이 달라서
+    // (10기 6개 / 9기 7개) 기준이 어긋나면 목록에 없는 지부가 필터에 뜨거나
+    // 목록에만 있는 지부가 필터에서 빠진다.
+    queryKey: ["chaptersWithSchools", effectiveGisuId],
+    queryFn: () => getChaptersWithSchools(String(effectiveGisuId!)),
+    enabled: effectiveGisuId != null,
     staleTime: Infinity,
   })
 

--- a/src/routes/manage/route.tsx
+++ b/src/routes/manage/route.tsx
@@ -1,9 +1,12 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
 
 import { ensureMe } from "@/features/auth/lib/ensureMe"
+import { SETTINGS_SIDEBAR_ITEMS } from "@/shared/config/settingsNavigation"
+import { useActiveGeneration } from "@/shared/hooks/useActiveGisu"
+import { toUmcGisuLabel } from "@/shared/lib/gisuLabel"
 import Footer from "@/widgets/footer/Footer"
-import Header from "@/widgets/navigation/header/Header"
-import SideBar from "@/widgets/navigation/sidebar/SideBar"
+import RecruitingHeader from "@/widgets/navigation/header/RecruitingHeader"
+import { FlatSideBar } from "@/widgets/navigation/sidebar/FlatSideBar"
 
 export const Route = createFileRoute("/manage")({
   head: () => ({
@@ -16,11 +19,17 @@ export const Route = createFileRoute("/manage")({
 })
 
 function ManageLayout() {
+  const { data: generation } = useActiveGeneration()
+
   return (
     <main className="flex h-full min-h-screen w-full flex-col">
-      <Header />
+      <RecruitingHeader />
       <div className="flex w-full flex-1">
-        <SideBar />
+        <FlatSideBar
+          ariaLabel="설정 사이드 메뉴"
+          label={toUmcGisuLabel(generation)}
+          items={SETTINGS_SIDEBAR_ITEMS}
+        />
         <div className="flex min-w-0 flex-1 flex-col">
           <div className="min-h-200 px-8 pt-10 pb-20">
             <Outlet />

--- a/src/shared/config/headerNavPolicy.ts
+++ b/src/shared/config/headerNavPolicy.ts
@@ -15,6 +15,10 @@ export const HEADER_NAV_ITEMS: HeaderNavItem[] = [
     to: "/intro",
   },
   {
+    label: "프로젝트",
+    to: "/projects",
+  },
+  {
     label: "데모데이 매칭",
     to: "/matching/projects",
     activeBasePath: "/matching",

--- a/src/shared/config/navigation.ts
+++ b/src/shared/config/navigation.ts
@@ -16,6 +16,11 @@ export interface SideBarSection {
   menus: SideBarMenu[]
 }
 
+/** 대분류 없이 링크만 나열하는 사이드바(지원자용·설정용)의 항목 */
+export interface FlatNavItem extends SideBarMenu {
+  icon: ComponentType<SVGProps<SVGSVGElement>>
+}
+
 export const SIDEBAR_ITEMS: SideBarSection[] = [
   {
     id: "project-settings",

--- a/src/shared/config/navigationResolve.test.ts
+++ b/src/shared/config/navigationResolve.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
-import { SIDEBAR_ITEMS } from "@/shared/config/navigation"
+import TeamIcon from "@/shared/assets/icon/people/TeamIcon"
+import { SIDEBAR_ITEMS, type SideBarSection } from "@/shared/config/navigation"
 import { filterSectionsByPermission } from "@/widgets/navigation/sidebar/utils"
 
 import { resolveNavigationFromPathname } from "./navigationResolve"
@@ -62,6 +63,31 @@ describe("resolveNavigationFromPathname", () => {
 
   it("알 수 없는 경로는 null", () => {
     expect(resolveNavigationFromPathname("/unknown/path")).toBeNull()
+  })
+
+  it("to 가 먼저 일치해도 더 긴 matchPaths 별칭이 최장 일치를 가져간다", () => {
+    const sections: SideBarSection[] = [
+      {
+        id: "settings",
+        title: "설정",
+        icon: TeamIcon,
+        menus: [
+          {
+            id: "manage-root",
+            title: "관리",
+            to: "/manage",
+            matchPaths: ["/manage/school/detail"],
+          },
+          { id: "manage-school", title: "학교 관리", to: "/manage/school" },
+        ],
+      },
+    ]
+
+    const resolved = resolveNavigationFromPathname(
+      "/manage/school/detail",
+      sections,
+    )
+    expect(resolved?.menu.id).toBe("manage-root")
   })
 
   it("프로젝트 관리 메뉴가 권한으로 제거되면 edit 경로는 별칭을 잃고 팀 매칭으로 fallback", () => {

--- a/src/shared/config/navigationResolve.ts
+++ b/src/shared/config/navigationResolve.ts
@@ -1,4 +1,5 @@
 import {
+  type FlatNavItem,
   SIDEBAR_ITEMS,
   SIDEBAR_MENU_BY_ID,
   type SideBarMenu,
@@ -60,6 +61,29 @@ export function resolveNavigationFromPathname(
     }
   }
   return picked
+}
+
+/**
+ * 평면 사이드바에서 현재 경로에 해당하는 항목 id.
+ * 대분류가 없을 뿐 매칭 규칙(최장 일치 + matchPaths)은 위와 같아야 해서 같은 헬퍼를 쓴다.
+ */
+export function resolveFlatNavItemId(
+  pathname: string,
+  items: readonly FlatNavItem[],
+): string | undefined {
+  const path = normalizePathname(pathname)
+  let bestLen = -1
+  let pickedId: string | undefined
+
+  for (const item of items) {
+    const matchedPath = getMatchedPath(path, item)
+    if (matchedPath === null) continue
+    if (matchedPath.length > bestLen) {
+      bestLen = matchedPath.length
+      pickedId = item.id
+    }
+  }
+  return pickedId
 }
 
 /** 탭 id(menu.id) → 이동 경로 */

--- a/src/shared/config/navigationResolve.ts
+++ b/src/shared/config/navigationResolve.ts
@@ -18,13 +18,20 @@ function matchesPath(path: string, target: string): boolean {
   return path === target || path.startsWith(`${target}/`)
 }
 
-/** menu.to 또는 matchPaths 중 path와 일치하는 경로 문자열을 반환 */
+/**
+ * menu.to 와 matchPaths 중 path 에 일치하는 것들 가운데 가장 긴 경로를 반환.
+ *
+ * to 에서 멈추면 안 된다. 항목이 넓은 to 와 좁은 별칭을 함께 가질 때
+ * (예: to `/manage` + 별칭 `/manage/school/detail`) 짧은 to 로 답해 버려,
+ * 다른 항목의 `/manage/school` 에 최장 일치를 빼앗긴다.
+ */
 function getMatchedPath(path: string, menu: SideBarMenu): string | null {
-  if (matchesPath(path, menu.to)) return menu.to
-  for (const alias of menu.matchPaths ?? []) {
-    if (matchesPath(path, alias)) return alias
+  let longest: string | null = null
+  for (const candidate of [menu.to, ...(menu.matchPaths ?? [])]) {
+    if (!matchesPath(path, candidate)) continue
+    if (candidate.length > (longest?.length ?? -1)) longest = candidate
   }
-  return null
+  return longest
 }
 
 export function resolveNavigationFromPathname(pathname: string): {

--- a/src/shared/config/recruitingNavigation.ts
+++ b/src/shared/config/recruitingNavigation.ts
@@ -80,9 +80,11 @@ export const RECRUITING_SIDEBAR_ITEMS: RecruitingSideBarSection[] = [
   },
   {
     id: "recruiting-history",
+    // `/recruiting/history` 는 라우트가 없다. 실재하는 건 아래 archive 뿐이라
+    // 하위를 지우게 되더라도 링크가 깨지지 않도록 여기에 맞춰 둔다.
+    to: "/recruiting/history/archive",
     title: "히스토리",
     icon: TeamIcon,
-    to: "/recruiting/history",
     menus: [
       {
         id: "recruiting-history-archive",

--- a/src/shared/config/recruitingNavigation.ts
+++ b/src/shared/config/recruitingNavigation.ts
@@ -6,8 +6,6 @@ export interface RecruitingSideBarSection extends SideBarSection {
   to?: string
 }
 
-export const RECRUITING_GISU_LABEL = "UMC 10th"
-
 export const RECRUITING_SIDEBAR_ITEMS: RecruitingSideBarSection[] = [
   {
     id: "recruiting-dashboard",

--- a/src/shared/config/settingsNavigation.ts
+++ b/src/shared/config/settingsNavigation.ts
@@ -1,0 +1,30 @@
+import TeamIcon from "@/shared/assets/icon/people/TeamIcon"
+import SchoolIcon from "@/shared/assets/icon/school/SchoolIcon"
+import SettingIcon from "@/shared/assets/icon/setting/SettingIcon"
+
+import type { FlatNavItem } from "@/shared/config/navigation"
+
+/** 설정 영역은 대분류 없이 평면 3항목이다. */
+export const SETTINGS_SIDEBAR_ITEMS: FlatNavItem[] = [
+  {
+    id: "settings-school",
+    title: "학교 관리",
+    to: "/manage/school",
+    icon: SchoolIcon,
+  },
+  {
+    id: "settings-chapter",
+    title: "지부 관리",
+    to: "/manage/chapter",
+    icon: TeamIcon,
+  },
+  {
+    id: "settings-curriculum",
+    title: "커리큘럼",
+    to: "/manage/curriculum",
+    icon: SettingIcon,
+  },
+]
+
+/** 헤더 `설정` 탭이 가리키는 곳. 설정 영역의 첫 화면이다. */
+export const SETTINGS_ENTRY_PATH = "/manage/school"

--- a/src/shared/hooks/useActiveGisu.ts
+++ b/src/shared/hooks/useActiveGisu.ts
@@ -26,3 +26,12 @@ export function useActiveGisuId(options?: { enabled?: boolean }) {
     ...options,
   })
 }
+
+export function useActiveGeneration(options?: { enabled?: boolean }) {
+  return useQuery({
+    ...activeGisuQueryOptions,
+    select: (data) =>
+      data?.generation != null ? Number(data.generation) : null,
+    ...options,
+  })
+}

--- a/src/shared/lib/gisuLabel.test.ts
+++ b/src/shared/lib/gisuLabel.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  toDemoDayLabel,
+  toGenerationOrdinal,
+  toUmcGisuLabel,
+} from "./gisuLabel"
+
+describe("toGenerationOrdinal", () => {
+  // 현재 운영 중인 기수대
+  it("10기대는 th 를 쓴다", () => {
+    expect(toGenerationOrdinal(10)).toBe("10th")
+    expect(toGenerationOrdinal(11)).toBe("11th")
+    expect(toGenerationOrdinal(12)).toBe("12th")
+    expect(toGenerationOrdinal(13)).toBe("13th")
+  })
+
+  // 11·12·13 만 예외라 21 부터 다시 갈린다
+  it("20기대부터는 끝자리를 따른다", () => {
+    expect(toGenerationOrdinal(21)).toBe("21st")
+    expect(toGenerationOrdinal(22)).toBe("22nd")
+    expect(toGenerationOrdinal(23)).toBe("23rd")
+    expect(toGenerationOrdinal(24)).toBe("24th")
+  })
+
+  it("한 자리 기수", () => {
+    expect(toGenerationOrdinal(1)).toBe("1st")
+    expect(toGenerationOrdinal(2)).toBe("2nd")
+    expect(toGenerationOrdinal(3)).toBe("3rd")
+    expect(toGenerationOrdinal(4)).toBe("4th")
+  })
+})
+
+describe("라벨 조합", () => {
+  it("기수를 아직 못 받았으면 undefined 를 준다", () => {
+    // 빈 문자열을 주면 사이드바 상단이 흔들려서 호출부가 구분할 수 있어야 한다
+    expect(toUmcGisuLabel(null)).toBeUndefined()
+    expect(toUmcGisuLabel(undefined)).toBeUndefined()
+    expect(toDemoDayLabel(null)).toBeUndefined()
+  })
+
+  it("기수가 있으면 각 화면 표기로 만든다", () => {
+    expect(toUmcGisuLabel(11)).toBe("UMC 11th")
+    expect(toDemoDayLabel(11)).toBe("11th Demo Day")
+  })
+})

--- a/src/shared/lib/gisuLabel.ts
+++ b/src/shared/lib/gisuLabel.ts
@@ -1,0 +1,33 @@
+/**
+ * 기수를 영어 서수로 표기한다. 사이드바 상단 라벨이 디자인상 `UMC 11th` 형태다.
+ * 11·12·13 은 1·2·3 으로 끝나도 th 를 쓴다.
+ */
+export function toGenerationOrdinal(generation: number): string {
+  const teens = generation % 100
+  if (teens >= 11 && teens <= 13) return `${generation}th`
+
+  switch (generation % 10) {
+    case 1:
+      return `${generation}st`
+    case 2:
+      return `${generation}nd`
+    case 3:
+      return `${generation}rd`
+    default:
+      return `${generation}th`
+  }
+}
+
+export function toUmcGisuLabel(
+  generation: number | null | undefined,
+): string | undefined {
+  if (generation == null) return undefined
+  return `UMC ${toGenerationOrdinal(generation)}`
+}
+
+export function toDemoDayLabel(
+  generation: number | null | undefined,
+): string | undefined {
+  if (generation == null) return undefined
+  return `${toGenerationOrdinal(generation)} Demo Day`
+}

--- a/src/widgets/navigation/header/ProfileDropdown.tsx
+++ b/src/widgets/navigation/header/ProfileDropdown.tsx
@@ -177,10 +177,13 @@ export function ProfileDropdown({
             className="bg-teal-gray-100 h-px w-full rounded-[0.5px]"
           />
 
-          {/* TODO: 기수 관리 페이지로 연결 */}
           <div className="flex flex-col gap-1 px-1.5">
             {canManageMembers && (
-              <TextButton size="14" className="h-6 w-15">
+              <TextButton
+                onClick={() => navigate({ to: "/admin" })}
+                size="14"
+                className="h-6 w-15"
+              >
                 기수 관리
               </TextButton>
             )}

--- a/src/widgets/navigation/header/RecruitingHeader.tsx
+++ b/src/widgets/navigation/header/RecruitingHeader.tsx
@@ -8,9 +8,14 @@ import {
 } from "@/entities/member/model/identity"
 import { useAuthStore } from "@/entities/member/store/authStore"
 import UmcLogo from "@/shared/assets/icon/logo/UmcLogo"
+import { SETTINGS_ENTRY_PATH } from "@/shared/config/settingsNavigation"
 import HeaderButton from "@/widgets/navigation/header/HeaderButton"
 import NavigationButton from "@/widgets/navigation/header/NavigationButton"
 import Profile from "@/widgets/navigation/header/Profile"
+import {
+  buildRecruitingNavItems,
+  isNavActive,
+} from "@/widgets/navigation/header/recruitingHeaderNav"
 import {
   type RecruitingStatus,
   RecruitingStatusButton,
@@ -21,13 +26,6 @@ interface RecruitingHeaderProps {
   // 없으면 상태 버튼을 렌더하지 않는다(연동 전 고정값 노출 방지)
   recruitingStatus?: RecruitingStatus
   activePathname?: string
-}
-
-type NavItem = { label: string; to: string; disabled?: boolean }
-
-function isNavActive(pathname: string, to: string): boolean {
-  if (to === "/") return pathname === "/"
-  return pathname === to || pathname.startsWith(to + "/")
 }
 
 export default function RecruitingHeader({
@@ -42,23 +40,12 @@ export default function RecruitingHeader({
   const showRecruiting = isAnyOperator(me)
   const showSettings = isSuperAdmin(me) || isCentralStaff(me)
 
-  const navItems: NavItem[] = [
-    { label: "소개", to: "/intro" },
-    // TODO: 모집 안내 랜딩 라우트 확정 전까지 비활성(홈으로 오연결 방지)
-    { label: "모집 안내", to: "/", disabled: true },
-    { label: "프로젝트", to: "/projects" },
-    ...(showRecruiting
-      ? [
-          {
-            label: "리크루팅",
-            to: "/recruiting/dashboard/applications",
-          } satisfies NavItem,
-        ]
-      : []),
-    ...(showSettings
-      ? [{ label: "설정", to: "/settings" } satisfies NavItem]
-      : []),
-  ]
+  const navItems = buildRecruitingNavItems({
+    isAuthed,
+    showRecruiting,
+    showSettings,
+    settingsEntryPath: SETTINGS_ENTRY_PATH,
+  })
 
   return (
     <header className="bg-teal-gray-50 shadow-drop-neutral-3 relative z-50 flex h-20 min-h-20 w-full items-center justify-between overflow-visible">
@@ -72,7 +59,7 @@ export default function RecruitingHeader({
             key={item.label}
             label={item.label}
             to={item.to}
-            selected={isNavActive(pathname, item.to)}
+            selected={isNavActive(pathname, item)}
             disabled={item.disabled}
             className="min-w-18 px-4.5"
           />

--- a/src/widgets/navigation/header/recruitingHeaderNav.test.ts
+++ b/src/widgets/navigation/header/recruitingHeaderNav.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest"
+
+import { buildRecruitingNavItems, isNavActive } from "./recruitingHeaderNav"
+
+const SETTINGS_ENTRY = "/manage/school"
+
+const GUEST = {
+  isAuthed: false,
+  showRecruiting: false,
+  showSettings: false,
+  settingsEntryPath: SETTINGS_ENTRY,
+}
+const CHALLENGER = { ...GUEST, isAuthed: true }
+const SCHOOL_STAFF = { ...CHALLENGER, showRecruiting: true }
+const CENTRAL = { ...SCHOOL_STAFF, showSettings: true }
+
+function labelsFor(visibility: typeof GUEST) {
+  return buildRecruitingNavItems(visibility).map((item) => item.label)
+}
+
+/** 해당 경로에서 활성으로 켜지는 탭 라벨 */
+function activeLabels(pathname: string, visibility: typeof GUEST) {
+  return buildRecruitingNavItems(visibility)
+    .filter((item) => isNavActive(pathname, item))
+    .map((item) => item.label)
+}
+
+describe("역할별 노출 탭", () => {
+  it("비로그인은 매칭·리크루팅·설정을 보지 못한다", () => {
+    expect(labelsFor(GUEST)).toEqual(["소개", "모집 안내", "프로젝트"])
+  })
+
+  // 매칭이 챌린저의 주 사용처인데 헤더에 진입로가 없었다
+  it("로그인하면 데모데이 매칭이 생긴다", () => {
+    expect(labelsFor(CHALLENGER)).toContain("데모데이 매칭")
+    expect(labelsFor(CHALLENGER)).not.toContain("리크루팅")
+  })
+
+  it("운영진은 리크루팅까지, 중앙은 설정까지 본다", () => {
+    expect(labelsFor(SCHOOL_STAFF)).not.toContain("설정")
+    expect(labelsFor(SCHOOL_STAFF)).toContain("리크루팅")
+    expect(labelsFor(CENTRAL)).toContain("설정")
+  })
+})
+
+describe("경로별 활성 표시", () => {
+  // 탭 목적지는 대시보드인데 활성은 영역 전체여야 한다
+  it("리크루팅 하위 어디서든 리크루팅이 활성이다", () => {
+    for (const path of [
+      "/recruiting/dashboard/applications",
+      "/recruiting/dashboard/evaluations",
+      "/recruiting/recruitments",
+      "/recruiting/recruitments/quota",
+      "/recruiting/evaluations/document/40",
+      "/recruiting/history/archive",
+    ]) {
+      expect(activeLabels(path, CENTRAL)).toEqual(["리크루팅"])
+    }
+  })
+
+  it("매칭 하위 어디서든 데모데이 매칭이 활성이다", () => {
+    for (const path of [
+      "/matching",
+      "/matching/projects",
+      "/matching/projects/edit/7",
+      "/matching/rounds",
+    ]) {
+      expect(activeLabels(path, CENTRAL)).toEqual(["데모데이 매칭"])
+    }
+  })
+
+  it("설정 영역은 탭 목적지가 아닌 경로에서도 활성이다", () => {
+    expect(activeLabels("/manage/chapter", CENTRAL)).toEqual(["설정"])
+    expect(activeLabels("/manage/curriculum/create", CENTRAL)).toEqual(["설정"])
+  })
+
+  it("프로젝트 하위는 게스트에게도 활성이다", () => {
+    expect(activeLabels("/projects", GUEST)).toEqual(["프로젝트"])
+    expect(activeLabels("/projects/notice", GUEST)).toEqual(["프로젝트"])
+  })
+
+  // `모집 안내`가 자리표시자 `/` 를 목적지로 갖고 있어 루트에서 켜지던 문제
+  it("비활성 탭은 루트에서도 켜지지 않는다", () => {
+    expect(activeLabels("/", CENTRAL)).toEqual([])
+  })
+
+  it("한 경로에서 두 탭이 동시에 켜지지 않는다", () => {
+    for (const path of [
+      "/intro",
+      "/projects",
+      "/matching/projects",
+      "/recruiting/recruitments",
+      "/manage/school",
+    ]) {
+      expect(activeLabels(path, CENTRAL).length).toBeLessThanOrEqual(1)
+    }
+  })
+})

--- a/src/widgets/navigation/header/recruitingHeaderNav.ts
+++ b/src/widgets/navigation/header/recruitingHeaderNav.ts
@@ -30,7 +30,7 @@ export function buildRecruitingNavItems({
 }: HeaderNavVisibility): NavItem[] {
   return [
     { label: "소개", to: "/intro" },
-    // TODO: 모집 안내 랜딩 라우트 확정 전까지 비활성(홈으로 오연결 방지)
+    // TODO(#710): 모집 안내 랜딩 라우트 확정 전까지 비활성(홈으로 오연결 방지)
     { label: "모집 안내", to: "/", disabled: true },
     { label: "프로젝트", to: "/projects" },
     // 매칭은 로그인해야 들어갈 수 있다. 게스트에게 보이면 눌러도 로그인으로 튕긴다.

--- a/src/widgets/navigation/header/recruitingHeaderNav.ts
+++ b/src/widgets/navigation/header/recruitingHeaderNav.ts
@@ -1,0 +1,67 @@
+export type NavItem = {
+  label: string
+  to: string
+  disabled?: boolean
+  /** to 말고 이 경로로 활성 여부를 본다. 탭 목적지와 영역 루트가 다를 때 쓴다. */
+  activeBasePath?: string
+}
+
+export function isNavActive(pathname: string, item: NavItem): boolean {
+  // 비활성 탭은 목적지가 자리표시자(`/`)라서, 활성 판정에 넣으면 루트에서 켜진다.
+  if (item.disabled) return false
+
+  const base = item.activeBasePath ?? item.to
+  if (base === "/") return pathname === "/"
+  return pathname === base || pathname.startsWith(base + "/")
+}
+
+interface HeaderNavVisibility {
+  isAuthed: boolean
+  showRecruiting: boolean
+  showSettings: boolean
+  settingsEntryPath: string
+}
+
+export function buildRecruitingNavItems({
+  isAuthed,
+  showRecruiting,
+  showSettings,
+  settingsEntryPath,
+}: HeaderNavVisibility): NavItem[] {
+  return [
+    { label: "소개", to: "/intro" },
+    // TODO: 모집 안내 랜딩 라우트 확정 전까지 비활성(홈으로 오연결 방지)
+    { label: "모집 안내", to: "/", disabled: true },
+    { label: "프로젝트", to: "/projects" },
+    // 매칭은 로그인해야 들어갈 수 있다. 게스트에게 보이면 눌러도 로그인으로 튕긴다.
+    ...(isAuthed
+      ? [
+          {
+            label: "데모데이 매칭",
+            to: "/matching/projects",
+            activeBasePath: "/matching",
+          } satisfies NavItem,
+        ]
+      : []),
+    ...(showRecruiting
+      ? [
+          {
+            label: "리크루팅",
+            // 탭 목적지는 대시보드지만 리크루팅 영역 어디서든 활성이어야 한다.
+            to: "/recruiting/dashboard/applications",
+            activeBasePath: "/recruiting",
+          } satisfies NavItem,
+        ]
+      : []),
+    ...(showSettings
+      ? [
+          {
+            label: "설정",
+            // 탭은 설정 영역 첫 화면으로 보내고, 활성 판정은 영역 전체로 본다.
+            to: settingsEntryPath,
+            activeBasePath: "/manage",
+          } satisfies NavItem,
+        ]
+      : []),
+  ]
+}

--- a/src/widgets/navigation/sidebar/BaseSideBar.tsx
+++ b/src/widgets/navigation/sidebar/BaseSideBar.tsx
@@ -1,0 +1,37 @@
+import { cn } from "@/shared/lib/utils"
+
+import type { ReactNode } from "react"
+
+interface BaseSideBarProps {
+  ariaLabel: string
+  label?: string
+  className?: string
+  header?: ReactNode
+  children: ReactNode
+}
+
+export function BaseSideBar({
+  ariaLabel,
+  label,
+  className,
+  header,
+  children,
+}: BaseSideBarProps) {
+  return (
+    <nav
+      aria-label={ariaLabel}
+      className={cn(
+        "border-teal-gray-200 flex w-55 shrink-0 flex-col items-center justify-start border-r pt-4",
+        className,
+      )}
+    >
+      {header}
+      <div className="flex flex-col py-4">
+        <span className="text-body-3-regular text-teal-gray-400 mb-2 h-4.5 pl-0.5">
+          {label}
+        </span>
+        {children}
+      </div>
+    </nav>
+  )
+}

--- a/src/widgets/navigation/sidebar/FlatSideBar.tsx
+++ b/src/widgets/navigation/sidebar/FlatSideBar.tsx
@@ -1,0 +1,42 @@
+import { useRouterState } from "@tanstack/react-router"
+
+import { resolveFlatNavItemId } from "@/shared/config/navigationResolve"
+
+import { BaseSideBar } from "./BaseSideBar"
+import { FlatSideBarItem } from "./FlatSideBarItem"
+
+import type { FlatNavItem } from "@/shared/config/navigation"
+
+interface FlatSideBarProps {
+  ariaLabel: string
+  label?: string
+  items: readonly FlatNavItem[]
+  className?: string
+  activePathname?: string
+}
+
+export function FlatSideBar({
+  ariaLabel,
+  label,
+  items,
+  className,
+  activePathname,
+}: FlatSideBarProps) {
+  const currentPathname = useRouterState({ select: (s) => s.location.pathname })
+  const pathname = activePathname ?? currentPathname
+  const activeItemId = resolveFlatNavItemId(pathname, items)
+
+  return (
+    <BaseSideBar ariaLabel={ariaLabel} label={label} className={className}>
+      {items.map((item) => (
+        <FlatSideBarItem
+          key={item.id}
+          title={item.title}
+          to={item.to}
+          icon={item.icon}
+          isActive={activeItemId === item.id}
+        />
+      ))}
+    </BaseSideBar>
+  )
+}

--- a/src/widgets/navigation/sidebar/FlatSideBarItem.tsx
+++ b/src/widgets/navigation/sidebar/FlatSideBarItem.tsx
@@ -1,0 +1,50 @@
+import { Link } from "@tanstack/react-router"
+
+import { cn } from "@/shared/lib/utils"
+
+import type { ComponentType, SVGProps } from "react"
+
+interface FlatSideBarItemProps {
+  title: string
+  to: string
+  icon: ComponentType<SVGProps<SVGSVGElement>>
+  isActive: boolean
+}
+
+export function FlatSideBarItem({
+  title,
+  to,
+  icon: Icon,
+  isActive,
+}: FlatSideBarItemProps) {
+  return (
+    <Link
+      to={to}
+      aria-current={isActive ? "page" : undefined}
+      className="flex h-12 w-42 items-center"
+    >
+      <span
+        className={cn(
+          "hover:bg-teal-gray-100 flex h-12 w-39 items-center gap-2 rounded-[12px] pl-3 transition-all duration-200 ease-in-out",
+          isActive && "shadow-inner-primary-1 bg-teal-100 hover:bg-teal-100",
+        )}
+      >
+        <Icon
+          aria-hidden="true"
+          className={cn(
+            "h-5 w-5",
+            isActive ? "text-teal-600" : "text-teal-gray-400",
+          )}
+        />
+        <span
+          className={cn(
+            "text-subtitle-3-semibold",
+            isActive ? "text-teal-600" : "text-teal-gray-600",
+          )}
+        >
+          {title}
+        </span>
+      </span>
+    </Link>
+  )
+}

--- a/src/widgets/navigation/sidebar/RecruitingSideBar.tsx
+++ b/src/widgets/navigation/sidebar/RecruitingSideBar.tsx
@@ -1,13 +1,15 @@
-import { Link, useRouterState } from "@tanstack/react-router"
+import { useRouterState } from "@tanstack/react-router"
 import { useState } from "react"
 
 import {
-  RECRUITING_GISU_LABEL,
   RECRUITING_SIDEBAR_ITEMS,
   resolveRecruitingSectionId,
 } from "@/shared/config/recruitingNavigation"
-import { cn } from "@/shared/lib/utils"
+import { useActiveGeneration } from "@/shared/hooks/useActiveGisu"
+import { toUmcGisuLabel } from "@/shared/lib/gisuLabel"
 
+import { BaseSideBar } from "./BaseSideBar"
+import { FlatSideBarItem } from "./FlatSideBarItem"
 import { SideBarMenu } from "./menu/SideBarMenu"
 import { SideBarMenuItem } from "./menu/SideBarMenuItem"
 
@@ -27,75 +29,47 @@ export default function RecruitingSideBar({
   const [manualOpenSectionId, setManualOpenSectionId] = useState<string>(() =>
     activeSectionId ? "" : (RECRUITING_SIDEBAR_ITEMS[0]?.id ?? ""),
   )
+  const { data: generation } = useActiveGeneration()
 
   return (
-    <nav
-      aria-label="리크루팅 사이드 메뉴"
-      className={cn(
-        "border-teal-gray-200 flex w-55 shrink-0 flex-col items-center justify-start border-r pt-4",
-        className,
-      )}
+    <BaseSideBar
+      ariaLabel="리크루팅 사이드 메뉴"
+      label={toUmcGisuLabel(generation)}
+      className={className}
     >
-      <div className="flex flex-col py-4">
-        <span className="text-body-3-regular text-teal-gray-400 mb-2 pl-0.5">
-          {RECRUITING_GISU_LABEL}
-        </span>
-        {RECRUITING_SIDEBAR_ITEMS.map(({ id, title, icon: Icon, to, menus }) =>
-          menus.length === 0 && to ? (
-            <Link key={id} to={to} className="flex h-12 w-42 items-center">
-              <span
-                className={cn(
-                  "hover:bg-teal-gray-100 flex h-12 w-39 items-center gap-2 rounded-[12px] pl-3 transition-all duration-200 ease-in-out",
-                  activeSectionId === id &&
-                    "shadow-inner-primary-1 bg-teal-100 hover:bg-teal-100",
-                )}
-              >
-                <Icon
-                  aria-hidden="true"
-                  className={cn(
-                    "h-5 w-5",
-                    activeSectionId === id
-                      ? "text-teal-600"
-                      : "text-teal-gray-400",
-                  )}
-                />
-                <span
-                  className={cn(
-                    "text-subtitle-3-semibold",
-                    activeSectionId === id
-                      ? "text-teal-600"
-                      : "text-teal-gray-600",
-                  )}
-                >
-                  {title}
-                </span>
-              </span>
-            </Link>
-          ) : (
-            <SideBarMenu
-              key={id}
-              id={id}
-              title={title}
-              icon={Icon}
-              isActive={activeSectionId === id}
-              isOpen={activeSectionId === id || manualOpenSectionId === id}
-              onToggle={() => {
-                if (activeSectionId === id) return
-                setManualOpenSectionId((prev) => (prev === id ? "" : id))
-              }}
-            >
-              {menus.map((menu) => (
-                <SideBarMenuItem
-                  key={menu.id}
-                  title={menu.title}
-                  to={menu.to}
-                  activePathname={activePathname}
-                />
-              ))}
-            </SideBarMenu>
-          ),
-        )}
-      </div>
-    </nav>
+      {RECRUITING_SIDEBAR_ITEMS.map(({ id, title, icon, to, menus }) =>
+        menus.length === 0 && to ? (
+          <FlatSideBarItem
+            key={id}
+            title={title}
+            to={to}
+            icon={icon}
+            isActive={activeSectionId === id}
+          />
+        ) : (
+          <SideBarMenu
+            key={id}
+            id={id}
+            title={title}
+            icon={icon}
+            isActive={activeSectionId === id}
+            isOpen={activeSectionId === id || manualOpenSectionId === id}
+            onToggle={() => {
+              if (activeSectionId === id) return
+              setManualOpenSectionId((prev) => (prev === id ? "" : id))
+            }}
+          >
+            {menus.map((menu) => (
+              <SideBarMenuItem
+                key={menu.id}
+                title={menu.title}
+                to={menu.to}
+                activePathname={activePathname}
+              />
+            ))}
+          </SideBarMenu>
+        ),
+      )}
+    </BaseSideBar>
   )
 }

--- a/src/widgets/navigation/sidebar/SideBar.tsx
+++ b/src/widgets/navigation/sidebar/SideBar.tsx
@@ -4,8 +4,10 @@ import { useEffect, useRef, useState } from "react"
 import { useViewModeStore } from "@/entities/member/view-mode"
 import { SIDEBAR_ITEMS } from "@/shared/config/navigation"
 import { resolveNavigationFromPathname } from "@/shared/config/navigationResolve"
-import { cn } from "@/shared/lib/utils"
+import { useActiveGeneration } from "@/shared/hooks/useActiveGisu"
+import { toDemoDayLabel } from "@/shared/lib/gisuLabel"
 
+import { BaseSideBar } from "./BaseSideBar"
 import { SideBarMenu } from "./menu/SideBarMenu"
 import { SideBarMenuItem } from "./menu/SideBarMenuItem"
 import { SideBarViewSwitcher } from "./SideBarViewSwitcher"
@@ -20,6 +22,7 @@ export default function SideBar({ className, activePathname }: SideBarProps) {
   const currentPathname = useRouterState({ select: (s) => s.location.pathname })
   const pathname = activePathname ?? currentPathname
   const { visibleSections, isLoading } = useVisibleSidebarSections()
+  const { data: generation } = useActiveGeneration()
   const navigate = useNavigate()
   const mode = useViewModeStore((s) => s.mode)
   const prevModeRef = useRef(mode)
@@ -53,44 +56,37 @@ export default function SideBar({ className, activePathname }: SideBarProps) {
   }, [mode, visibleSections, pathname, navigate, activePathname])
 
   return (
-    <nav
-      aria-label="사이드 메뉴"
-      className={cn(
-        "border-teal-gray-200 flex w-55 shrink-0 flex-col items-center justify-start border-r pt-4",
-        className,
-      )}
+    <BaseSideBar
+      ariaLabel="사이드 메뉴"
+      label={isLoading ? undefined : toDemoDayLabel(generation)}
+      className={className}
+      header={<SideBarViewSwitcher />}
     >
-      <SideBarViewSwitcher />
-      {!isLoading && (
-        <div className="flex flex-col py-4">
-          <span className="text-body-3-regular text-teal-gray-400 mb-2 pl-0.5">
-            10th Demo Day
-          </span>
-          {visibleSections.map(({ id, title, icon, menus }) => (
-            <SideBarMenu
-              key={id}
-              id={id}
-              title={title}
-              icon={icon}
-              isActive={activeSectionId === id}
-              isOpen={activeSectionId === id || manualOpenSectionId === id}
-              onToggle={() => {
-                if (activeSectionId === id) return
-                setManualOpenSectionId((prev) => (prev === id ? "" : id))
-              }}
-            >
-              {menus.map((menu) => (
-                <SideBarMenuItem
-                  key={menu.id}
-                  title={menu.title}
-                  to={menu.to}
-                  activePathname={activePathname}
-                />
-              ))}
-            </SideBarMenu>
-          ))}
-        </div>
-      )}
-    </nav>
+      {/* 권한 필터 결과가 오기 전에 그리면 메뉴가 나타났다 사라진다 */}
+      {!isLoading &&
+        visibleSections.map(({ id, title, icon, menus }) => (
+          <SideBarMenu
+            key={id}
+            id={id}
+            title={title}
+            icon={icon}
+            isActive={activeSectionId === id}
+            isOpen={activeSectionId === id || manualOpenSectionId === id}
+            onToggle={() => {
+              if (activeSectionId === id) return
+              setManualOpenSectionId((prev) => (prev === id ? "" : id))
+            }}
+          >
+            {menus.map((menu) => (
+              <SideBarMenuItem
+                key={menu.id}
+                title={menu.title}
+                to={menu.to}
+                activePathname={activePathname}
+              />
+            ))}
+          </SideBarMenu>
+        ))}
+    </BaseSideBar>
   )
 }


### PR DESCRIPTION
## 📸 작업 내용

디자인 대조에서 나온 내비게이션 결함 5건을 한 번에 정리합니다.

- **설정 영역(학교·지부·커리큘럼)에 진입 경로가 없던 문제** — 전용 사이드바를 만들고 `/manage`를 `RecruitingHeader`로 통일했습니다. 이전에는 주소를 직접 쳐야 들어갈 수 있었습니다
- **헤더 활성 표시** — `리크루팅` 탭이 대시보드 화면에서만 켜지던 문제, 비활성 탭이 루트에서 켜지던 문제를 고쳤습니다
- **데모데이 매칭 탭 복구** — 챌린저가 헤더로 매칭에 갈 방법이 없었습니다
- **기수 라벨 하드코딩 제거** — `UMC 10th`·`10th Demo Day`가 박혀 있었고, 디자인은 이미 11기입니다
- **죽은 경로·미연결 버튼** — 히스토리 사이드바의 없는 라우트, 동작하지 않던 `기수 관리` 버튼

사이드바가 2종인데 지원자용·설정용까지 4종이 필요해, 공통 골격을 먼저 뽑고 그 위에 설정용을 올렸습니다.

## 🎞️ 주요 코드 설명

### 사이드바 공통 골격

`SideBar`와 `RecruitingSideBar`가 컨테이너 스타일·기수 라벨·아코디언 렌더까지 약 40줄이 겹쳐 있었습니다. 4종으로 늘면 4벌이 됩니다.

| 신규 | 역할 |
|---|---|
| `BaseSideBar` | `nav` 컨테이너 + 기수 라벨. 4종이 공유 |
| `FlatSideBar` / `FlatSideBarItem` | 대분류 없는 평면 항목 |

기존 `SideBarMenu`는 아코디언 버튼이 필수고 `SideBarMenuItem`은 하위 들여쓰기 스타일이 고정이라 평면 항목을 표현할 수 없었습니다. **지원자용 사이드바(#688)도 이 `FlatSideBar`를 그대로 씁니다.**

활성 판정은 `resolveFlatNavItemId`를 `navigationResolve`에 추가해, 최장 일치와 `matchPaths` 규칙을 기존 resolve와 한곳에서 공유합니다.

### 헤더 활성 판정

탭 목적지와 영역 루트가 다를 때를 위해 `activeBasePath`를 도입했습니다.

```ts
{
  label: "리크루팅",
  to: "/recruiting/dashboard/applications",  // 탭 목적지
  activeBasePath: "/recruiting",             // 활성 판정 범위
}
```

이전에는 `to` 하나로 판정해서 `/recruiting/recruitments` 같은 화면에서 탭이 꺼졌습니다. 지원 현황 한 화면만 우연히 맞는 상태였습니다.

비활성 탭(`모집 안내`)은 목적지가 자리표시자 `/`라 루트에서 켜지고 있었습니다. 활성 판정에서 제외했습니다.

### 검증

판정 로직을 `recruitingHeaderNav.ts`로 분리하고 **앱 라우트 54개 × 역할 4종**을 대조했습니다.

| 영역 | 결과 |
|---|---|
| `/recruiting/*` 15개 | 전부 `리크루팅` 활성 |
| `/matching/*` 13개 | 전부 `데모데이 매칭` 활성 |
| `/manage/*` 8개 | 전부 `설정` 활성 |
| `/projects/*` 6개 | 전부 `프로젝트` 활성 (게스트 포함) |

한 경로에서 두 탭이 켜지는 경우는 없습니다. 회귀 테스트 9개로 고정했습니다.

`tsc -b` / `lint` 0 errors / 테스트 730개 / `build` 전부 통과합니다.

## 🖥️ 구현화면

| 설정 영역 | 헤더 활성 표시 |
| --- | --- |
|  |  |

## 🔗 연결된 이슈

- Connected: #692, #693, #694, #696, #697
- Closes #692
- Closes #693
- Closes #694
- Closes #696
- Closes #697

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 설정 화면에 학교 관리, 지부 관리, 커리큘럼 메뉴를 추가했습니다.
  - 헤더에 프로젝트 메뉴를 추가했습니다.
  - 권한이 있는 사용자는 기수 관리 메뉴를 통해 관리자 화면으로 이동할 수 있습니다.
  - 사이드바에 활성 기수 및 Demo Day 라벨을 표시합니다.
  - 현재 경로에 맞춰 헤더와 사이드바 메뉴의 활성 상태를 표시합니다.
  - 관리 화면에 설정 전용 헤더와 사이드바를 적용했습니다.

- **버그 수정**
  - 기수 히스토리 메뉴가 올바른 보관 경로로 연결되도록 수정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->