### PR TITLE
🐛 fix: 리크루팅 역할 기반 접근 제어와 편집 잠금

### DIFF
--- a/src/entities/member/model/identity.ts
+++ b/src/entities/member/model/identity.ts
@@ -55,6 +55,11 @@ export function isCentralStaff(me: MemberInfoResponse | undefined): boolean {
   return hasAnyRoleType(me, CENTRAL_ROLE_TYPES)
 }
 
+/** 설정(학교·지부·커리큘럼) 영역을 쓸 수 있는 범위. 헤더 `설정` 탭 노출 조건과 같다. */
+export function isCentralAdmin(me: MemberInfoResponse | undefined): boolean {
+  return isSuperAdmin(me) || isCentralStaff(me)
+}
+
 export function isCentralCore(me: MemberInfoResponse | undefined): boolean {
   return hasAnyRoleType(me, CENTRAL_CORE_ROLE_TYPES)
 }

--- a/src/features/recruiting/model/recruitingEditLock.ts
+++ b/src/features/recruiting/model/recruitingEditLock.ts
@@ -1,0 +1,49 @@
+/**
+ * 리크루팅 화면의 편집 잠금 판정.
+ *
+ * 권한은 시즌(학교×기수) 단위라 역할 타입으로 흉내 내면 서버가 허용하는 범위와
+ * 어긋난다. 그래서 서버 권한 조회 결과(permittedSeasonIds)를 그대로 기준으로 쓴다.
+ * 평가 화면의 잠금 패턴(사유 코드 + 문구 맵)을 따른다.
+ */
+export type EditLockReason = "permissionLoading" | "noEditPermission"
+
+export const EDIT_LOCK_MESSAGE: Record<EditLockReason, string> = {
+  permissionLoading: "권한을 확인하는 중입니다.",
+  noEditPermission: "이 시즌을 수정할 권한이 없어 읽기 전용으로 표시됩니다.",
+}
+
+export interface EditEligibility {
+  canEdit: boolean
+  reason: EditLockReason | null
+}
+
+const EDITABLE: EditEligibility = { canEdit: true, reason: null }
+
+/**
+ * 특정 시즌을 편집할 수 있는지.
+ * 권한 조회가 끝나기 전에는 잠가 둔다. 열어 두면 못 고칠 값을 고치게 되고
+ * 저장 시점에야 거부당한다.
+ */
+export function resolveSeasonEditEligibility(
+  seasonId: string | null | undefined,
+  permittedSeasonIds: ReadonlySet<string>,
+  isPermissionLoading: boolean,
+): EditEligibility {
+  if (isPermissionLoading) {
+    return { canEdit: false, reason: "permissionLoading" }
+  }
+  if (!seasonId || !permittedSeasonIds.has(String(seasonId))) {
+    return { canEdit: false, reason: "noEditPermission" }
+  }
+  return EDITABLE
+}
+
+/** 화면에 보이는 시즌 중 하나라도 편집 가능한지. 저장 버튼 노출에 쓴다. */
+export function hasAnyEditableSeason(
+  seasonIds: readonly (string | null | undefined)[],
+  permittedSeasonIds: ReadonlySet<string>,
+): boolean {
+  return seasonIds.some(
+    (id) => id != null && permittedSeasonIds.has(String(id)),
+  )
+}

--- a/src/features/recruiting/ui/ChapterQuotaTableCard.tsx
+++ b/src/features/recruiting/ui/ChapterQuotaTableCard.tsx
@@ -18,7 +18,8 @@ interface ChapterQuotaTableCardProps {
   onManualEdit?: () => void
   onErrorExceeded?: (partName: string, maxAllowed: number) => void
   onSchoolsDataChange?: (schools: SchoolQuotaRow[]) => void
-  autoAllocateTrigger?: number
+  /** 자동 배정 요청. 대상 지부가 자기 자신일 때만 한 번 실행한다. */
+  autoAllocateRequest?: { id: number; chapter: string } | null
   /** 시즌별 편집 가능 여부. 없으면 전부 편집 가능으로 본다. */
   canEditSeason?: (seasonId: string | undefined) => boolean
   className?: string
@@ -31,7 +32,7 @@ export function ChapterQuotaTableCard({
   onManualEdit,
   onErrorExceeded,
   onSchoolsDataChange,
-  autoAllocateTrigger,
+  autoAllocateRequest,
   canEditSeason,
   className,
 }: ChapterQuotaTableCardProps) {
@@ -45,7 +46,7 @@ export function ChapterQuotaTableCard({
     onSchoolsDataChangeRef.current = onSchoolsDataChange
   }, [onSchoolsDataChange])
 
-  // 자동 배정 effect 는 trigger 로만 돌아야 해서 의존성에 넣지 않는다.
+  // 자동 배정 effect 는 요청으로만 돌아야 해서 의존성에 넣지 않는다.
   const canEditSeasonRef = useRef(canEditSeason)
   useEffect(() => {
     canEditSeasonRef.current = canEditSeason
@@ -56,9 +57,17 @@ export function ChapterQuotaTableCard({
     setLastValidSchoolsData(data.schools)
   }, [data.schools])
 
+  // 처리한 요청 id. 같은 요청으로 두 번 배정하지 않는다.
+  const handledAutoAllocateIdRef = useRef(0)
+
   // Execute Auto Allocation when triggered
   useEffect(() => {
-    if (!autoAllocateTrigger || data.schools.length === 0) return
+    if (!autoAllocateRequest || data.schools.length === 0) return
+    // 요청은 누른 지부에만 적용한다. 지부 카운터 하나로 두면 탭을 옮기거나
+    // 전체 탭으로 갔을 때 다른 지부 카드가 마운트되며 같이 배정된다.
+    if (autoAllocateRequest.chapter !== data.chapter) return
+    if (handledAutoAllocateIdRef.current === autoAllocateRequest.id) return
+    handledAutoAllocateIdRef.current = autoAllocateRequest.id
 
     const N = data.schools.length
     const tPM = data.totals.pm
@@ -101,7 +110,7 @@ export function ChapterQuotaTableCard({
     setSchoolsData(updatedSchools)
     setLastValidSchoolsData(updatedSchools)
     onSchoolsDataChangeRef.current?.(updatedSchools)
-  }, [autoAllocateTrigger, data.schools, data.totals])
+  }, [autoAllocateRequest, data.chapter, data.schools, data.totals])
 
   const hasApplicants = schoolsData.length > 0
 

--- a/src/features/recruiting/ui/ChapterQuotaTableCard.tsx
+++ b/src/features/recruiting/ui/ChapterQuotaTableCard.tsx
@@ -45,6 +45,12 @@ export function ChapterQuotaTableCard({
     onSchoolsDataChangeRef.current = onSchoolsDataChange
   }, [onSchoolsDataChange])
 
+  // 자동 배정 effect 는 trigger 로만 돌아야 해서 의존성에 넣지 않는다.
+  const canEditSeasonRef = useRef(canEditSeason)
+  useEffect(() => {
+    canEditSeasonRef.current = canEditSeason
+  }, [canEditSeason])
+
   useEffect(() => {
     setSchoolsData(data.schools)
     setLastValidSchoolsData(data.schools)
@@ -72,7 +78,15 @@ export function ChapterQuotaTableCard({
     const allocWebPe = Math.floor(u * 2.5)
     const allocMobilePe = Math.floor(u * 2.5)
 
+    // 잠긴 행은 원래 값을 유지한다. 버튼을 가려도 이 effect 가 단독으로 돌 수
+    // 있어, 여기서도 막지 않으면 권한 없는 시즌 값이 바뀐 채 저장에 실린다.
     const updatedSchools = data.schools.map((school) => {
+      if (
+        canEditSeasonRef.current &&
+        !canEditSeasonRef.current(school.seasonId)
+      ) {
+        return school
+      }
       const total = allocPM + allocDesign + allocWebPe + allocMobilePe
       return {
         ...school,

--- a/src/features/recruiting/ui/ChapterQuotaTableCard.tsx
+++ b/src/features/recruiting/ui/ChapterQuotaTableCard.tsx
@@ -19,6 +19,8 @@ interface ChapterQuotaTableCardProps {
   onErrorExceeded?: (partName: string, maxAllowed: number) => void
   onSchoolsDataChange?: (schools: SchoolQuotaRow[]) => void
   autoAllocateTrigger?: number
+  /** 시즌별 편집 가능 여부. 없으면 전부 편집 가능으로 본다. */
+  canEditSeason?: (seasonId: string | undefined) => boolean
   className?: string
 }
 
@@ -30,6 +32,7 @@ export function ChapterQuotaTableCard({
   onErrorExceeded,
   onSchoolsDataChange,
   autoAllocateTrigger,
+  canEditSeason,
   className,
 }: ChapterQuotaTableCardProps) {
   const [schoolsData, setSchoolsData] = useState<SchoolQuotaRow[]>(data.schools)
@@ -240,6 +243,9 @@ export function ChapterQuotaTableCard({
           <>
             {/* School rows */}
             {schoolsData.map((school) => {
+              const readOnly = canEditSeason
+                ? !canEditSeason(school.seasonId)
+                : false
               return (
                 <div
                   key={school.schoolName}
@@ -252,6 +258,7 @@ export function ChapterQuotaTableCard({
                   </div>
                   <QuotaEditableCell
                     partName="PM"
+                    readOnly={readOnly}
                     value={school.pm}
                     maxAllowed={getMaxAllowedForSchool("pm", school.schoolName)}
                     onChange={(val) =>
@@ -261,6 +268,7 @@ export function ChapterQuotaTableCard({
                   />
                   <QuotaEditableCell
                     partName="Design"
+                    readOnly={readOnly}
                     value={school.design}
                     maxAllowed={getMaxAllowedForSchool(
                       "design",
@@ -273,6 +281,7 @@ export function ChapterQuotaTableCard({
                   />
                   <QuotaEditableCell
                     partName="Web PE"
+                    readOnly={readOnly}
                     value={school.webPe}
                     maxAllowed={getMaxAllowedForSchool(
                       "webPe",
@@ -285,6 +294,7 @@ export function ChapterQuotaTableCard({
                   />
                   <QuotaEditableCell
                     partName="Mobile PE"
+                    readOnly={readOnly}
                     value={school.mobilePe}
                     maxAllowed={getMaxAllowedForSchool(
                       "mobilePe",

--- a/src/features/recruiting/ui/QuotaEditableCell.tsx
+++ b/src/features/recruiting/ui/QuotaEditableCell.tsx
@@ -8,6 +8,7 @@ interface QuotaEditableCellProps {
   maxAllowed?: number
   onChange: (newValue: number) => void
   onErrorExceeded?: (partName: string, maxAllowed: number) => void
+  readOnly?: boolean
   className?: string
 }
 
@@ -17,6 +18,7 @@ export function QuotaEditableCell({
   maxAllowed = 9999,
   onChange,
   onErrorExceeded,
+  readOnly = false,
   className,
 }: QuotaEditableCellProps) {
   const [inputValue, setInputValue] = useState(String(value))
@@ -81,13 +83,16 @@ export function QuotaEditableCell({
           maxLength={4}
           value={inputValue}
           aria-label={`${partName} TO`}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
-          onChange={handleChange}
+          readOnly={readOnly}
+          tabIndex={readOnly ? -1 : undefined}
+          onFocus={readOnly ? undefined : handleFocus}
+          onBlur={readOnly ? undefined : handleBlur}
+          onChange={readOnly ? undefined : handleChange}
           style={{ width: `${charLength}ch` }}
           className={cn(
             "text-heading-6-semibold min-w-[1ch] bg-transparent text-right outline-none focus:outline-none",
             isError ? "text-error-500" : "text-teal-500",
+            readOnly && "text-teal-gray-500 cursor-default",
           )}
         />
         <span

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -7,7 +7,9 @@ import { PageLabel } from "@/shared/ui/page-label/PageLabel"
 import { useToastStore } from "@/shared/ui/toast/useToastStore"
 
 import { useAdminRecruitingRounds } from "../hooks/useAdminRecruitingRounds"
+import { useRecruitingPermissions } from "../hooks/useRecruitingPermissions"
 import { useRecruitingSeasonQuotas } from "../hooks/useRecruitingSeasonQuotas"
+import { hasAnyEditableSeason } from "../model/recruitingEditLock"
 import { mapGroupsToChapterQuotaData } from "../model/recruitmentQuotaMapper"
 import {
   type AllocationStatus,
@@ -46,6 +48,20 @@ export function RecruitmentQuotaPage() {
   )
   const { seasonConfigsMap, updateQuotas, isSaving } =
     useRecruitingSeasonQuotas(seasonIds)
+
+  // 편집 권한은 시즌 단위라 서버 조회 결과를 그대로 쓴다. 권한을 확인하기
+  // 전에는 잠가 둔다. 열어 두면 못 고칠 값을 고치고 저장에서야 거부당한다.
+  const { permittedSeasonIds, isLoading: isPermissionLoading } =
+    useRecruitingPermissions(seasonIds)
+  const canEditSeason = useCallback(
+    (seasonId: string | undefined) =>
+      !isPermissionLoading &&
+      seasonId != null &&
+      permittedSeasonIds.has(String(seasonId)),
+    [permittedSeasonIds, isPermissionLoading],
+  )
+  const canEditAny =
+    !isPermissionLoading && hasAnyEditableSeason(seasonIds, permittedSeasonIds)
 
   const allChaptersData = useMemo(
     () => mapGroupsToChapterQuotaData(groups, seasonConfigsMap),
@@ -209,8 +225,8 @@ export function RecruitmentQuotaPage() {
 
   const hasApplicants = totalApplicants > 0
 
-  const showAutoAllocateButton = !isAll && hasApplicants
-  const showSaveButton = hasApplicants
+  const showAutoAllocateButton = !isAll && hasApplicants && canEditAny
+  const showSaveButton = hasApplicants && canEditAny
 
   const pageTitle = isAll ? "UMC 11th" : chapterTab
   const statusCardTitle = isAll ? "전체 지원자 현황" : "지부 지원자 현황"
@@ -315,6 +331,7 @@ export function RecruitmentQuotaPage() {
                       onDirtyChange={() => setIsDirty(true)}
                       onManualEdit={handleManualEdit}
                       onErrorExceeded={handleErrorExceeded}
+                      canEditSeason={canEditSeason}
                       onSchoolsDataChange={(schools) =>
                         handleSchoolsDataChange(chapterData.chapter, schools)
                       }
@@ -328,6 +345,7 @@ export function RecruitmentQuotaPage() {
                     onDirtyChange={() => setIsDirty(true)}
                     onManualEdit={handleManualEdit}
                     onErrorExceeded={handleErrorExceeded}
+                    canEditSeason={canEditSeason}
                     onSchoolsDataChange={(schools) =>
                       handleSchoolsDataChange(
                         selectedChapterData.chapter,

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -54,8 +54,16 @@ export function RecruitmentQuotaPage() {
 
   // 편집 권한은 시즌 단위라 서버 조회 결과를 그대로 쓴다. 권한을 확인하기
   // 전에는 잠가 둔다. 열어 두면 못 고칠 값을 고치고 저장에서야 거부당한다.
+  //
+  // 조회 범위는 현재 탭이 아니라 지부 전체다. 저장은 탭을 옮겨 다니며 쌓인
+  // editedSchoolsMap 을 통째로 보내는데, 현재 탭 시즌만 조회하면 다른 지부에서
+  // 고친 값이 권한 없음으로 판정돼 조용히 빠진다.
+  const allSeasonIds = useMemo(
+    () => [...new Set(groups.map((g) => g.seasonId))],
+    [groups],
+  )
   const { permittedSeasonIds, isLoading: isPermissionLoading } =
-    useRecruitingPermissions(seasonIds)
+    useRecruitingPermissions(allSeasonIds)
   const canEditSeason = useCallback(
     (seasonId: string | undefined) =>
       !isPermissionLoading &&

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -26,7 +26,10 @@ export function RecruitmentQuotaPage() {
   const [allocationStatus, setAllocationStatus] =
     useState<AllocationStatus>("TO 설정 전")
   const [autoModalOpen, setAutoModalOpen] = useState(false)
-  const [autoAllocateTrigger, setAutoAllocateTrigger] = useState(0)
+  const [autoAllocateRequest, setAutoAllocateRequest] = useState<{
+    id: number
+    chapter: string
+  } | null>(null)
 
   const [editedSchoolsMap, setEditedSchoolsMap] = useState<
     Map<string, SchoolQuotaRow[]>
@@ -89,11 +92,18 @@ export function RecruitmentQuotaPage() {
 
   const handleTabChange = (nextValue: string) => {
     setChapterTab(nextValue)
+    // 지부를 옮기면 앞선 요청은 끝난 것으로 본다. 남겨 두면 새 지부 카드가
+    // 마운트되면서 누른 적 없는 자동 배정이 걸린다.
+    setAutoAllocateRequest(null)
   }
 
   const handleConfirmAutoAllocate = () => {
     setAutoModalOpen(false)
-    setAutoAllocateTrigger((prev) => prev + 1)
+    // 자동 배정은 전체 탭에서 막혀 있어 여기서는 항상 선택된 지부가 대상이다.
+    setAutoAllocateRequest((prev) => ({
+      id: (prev?.id ?? 0) + 1,
+      chapter: chapterTab,
+    }))
     setAllocationStatus("자동 배정 중")
     setIsDirty(true)
 
@@ -344,7 +354,7 @@ export function RecruitmentQuotaPage() {
                       onSchoolsDataChange={(schools) =>
                         handleSchoolsDataChange(chapterData.chapter, schools)
                       }
-                      autoAllocateTrigger={autoAllocateTrigger}
+                      autoAllocateRequest={autoAllocateRequest}
                     />
                   ))
                 ) : (
@@ -361,7 +371,7 @@ export function RecruitmentQuotaPage() {
                         schools,
                       )
                     }
-                    autoAllocateTrigger={autoAllocateTrigger}
+                    autoAllocateRequest={autoAllocateRequest}
                   />
                 )}
               </div>

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -62,6 +62,12 @@ export function RecruitmentQuotaPage() {
   )
   const canEditAny =
     !isPermissionLoading && hasAnyEditableSeason(seasonIds, permittedSeasonIds)
+  // 자동 배정은 화면의 모든 학교 행을 한꺼번에 덮어쓴다. 일부만 편집 가능한
+  // 지부에서 열어 두면 잠긴 행까지 값이 바뀌고 저장에 실려 나간다.
+  const canEditEverySeason =
+    !isPermissionLoading &&
+    seasonIds.length > 0 &&
+    seasonIds.every((id) => permittedSeasonIds.has(String(id)))
 
   const allChaptersData = useMemo(
     () => mapGroupsToChapterQuotaData(groups, seasonConfigsMap),
@@ -143,8 +149,11 @@ export function RecruitmentQuotaPage() {
   const handleSave = async () => {
     const allEditedRows = Array.from(editedSchoolsMap.values()).flat()
     const payloadList = allEditedRows
-      .filter((row): row is SchoolQuotaRow & { seasonId: string } =>
-        Boolean(row.seasonId),
+      // 편집 대상은 학교 행 단위인데 저장은 지부 전체 행을 모아 보낸다.
+      // 권한 없는 시즌이 섞이면 그 건은 서버가 거부해 부분 실패로 남는다.
+      .filter(
+        (row): row is SchoolQuotaRow & { seasonId: string } =>
+          Boolean(row.seasonId) && canEditSeason(row.seasonId),
       )
       .map((row) => ({
         seasonId: row.seasonId,
@@ -225,7 +234,7 @@ export function RecruitmentQuotaPage() {
 
   const hasApplicants = totalApplicants > 0
 
-  const showAutoAllocateButton = !isAll && hasApplicants && canEditAny
+  const showAutoAllocateButton = !isAll && hasApplicants && canEditEverySeason
   const showSaveButton = hasApplicants && canEditAny
 
   const pageTitle = isAll ? "UMC 11th" : chapterTab

--- a/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
+++ b/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
@@ -18,6 +18,7 @@ import {
   useSaveEvaluatorAllocation,
   useSchoolStaff,
 } from "../../hooks/useEvaluatorAllocation"
+import { useRecruitingPermissions } from "../../hooks/useRecruitingPermissions"
 import {
   isStaff,
   RECRUITMENT_BOX_ID,
@@ -44,6 +45,15 @@ export function EvaluatorAllocationPage({
         group.rounds.some((r) => String(r.roundId) === String(activeRoundId)),
       ) ?? groups[0])
     : groups[0]
+
+  // 배정 권한은 시즌 단위다. 권한을 확인하기 전에는 잠가 둔다.
+  const seasonIds = activeGroup?.seasonId ? [activeGroup.seasonId] : []
+  const { permittedSeasonIds, isLoading: isPermissionLoading } =
+    useRecruitingPermissions(seasonIds)
+  const canEdit =
+    !isPermissionLoading &&
+    activeGroup?.seasonId != null &&
+    permittedSeasonIds.has(String(activeGroup.seasonId))
 
   const schoolId = activeGroup?.schoolId
   const gisuId = activeGroup?.gisuId
@@ -115,7 +125,7 @@ export function EvaluatorAllocationPage({
     setActiveItem: setActiveStaff,
   } = useChipAssignment<Staff>({
     onRemoveSelected: (chipId) => {
-      if (!isInitialized) return
+      if (!isInitialized || !canEdit) return
       setAssignedEvaluators((prev) =>
         prev.filter((staff) => staff.id !== chipId),
       )
@@ -151,7 +161,7 @@ export function EvaluatorAllocationPage({
   }
 
   function handleDragStart(event: DragStartEvent) {
-    if (!isInitialized) return
+    if (!isInitialized || !canEdit) return
     const staff = event.active.data.current
     if (!isStaff(staff)) return
     setActiveStaff(staff)
@@ -162,7 +172,7 @@ export function EvaluatorAllocationPage({
   }
 
   function handleDragEnd(event: DragEndEvent) {
-    if (!isInitialized) return
+    if (!isInitialized || !canEdit) return
     const { active, over } = event
     setActiveStaff(null)
 
@@ -228,13 +238,13 @@ export function EvaluatorAllocationPage({
           <div className="absolute -top-10.5 right-0.5 flex gap-2">
             <button
               onClick={(e) => {
-                if (!isInitialized) return
+                if (!isInitialized || !canEdit) return
                 e.stopPropagation()
                 setAssignedEvaluators([])
                 setIsDirty(true)
                 setSelectedChipId(null)
               }}
-              disabled={!isInitialized}
+              disabled={!isInitialized || !canEdit}
               className="border-teal-gray-400/15 box-border flex h-8.5 items-center gap-1 rounded-[10px] border bg-white px-3 py-1 pl-2.5 disabled:cursor-not-allowed disabled:opacity-50"
             >
               <ResetIcon className="h-4 w-4" />
@@ -247,7 +257,7 @@ export function EvaluatorAllocationPage({
               size="xs"
               color="primary"
               variant="fill"
-              disabled={saveMutation.isPending || !isInitialized}
+              disabled={saveMutation.isPending || !isInitialized || !canEdit}
               onClick={handleSave}
               className="w-fit rounded-[8px] px-3 py-1.5"
             >
@@ -266,7 +276,7 @@ export function EvaluatorAllocationPage({
                 selectedChipId={selectedChipId}
                 onSelectChip={setSelectedChipId}
                 onClear={() => {
-                  if (!isInitialized) return
+                  if (!isInitialized || !canEdit) return
                   setAssignedEvaluators([])
                   setIsDirty(true)
                   setSelectedChipId(null)

--- a/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
+++ b/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
@@ -240,6 +240,9 @@ export function EvaluatorAllocationPage({
               onClick={(e) => {
                 if (!isInitialized || !canEdit) return
                 e.stopPropagation()
+                // 저장 요청 중에 비우면, 앞선 요청의 성공 콜백이 이전 스냅샷을
+                // 되살린다. 다른 편집 경로처럼 새 편집으로 표시한다.
+                editRevisionRef.current += 1
                 setAssignedEvaluators([])
                 setIsDirty(true)
                 setSelectedChipId(null)
@@ -277,6 +280,7 @@ export function EvaluatorAllocationPage({
                 onSelectChip={setSelectedChipId}
                 onClear={() => {
                   if (!isInitialized || !canEdit) return
+                  editRevisionRef.current += 1
                   setAssignedEvaluators([])
                   setIsDirty(true)
                   setSelectedChipId(null)

--- a/src/routes/admin/route.tsx
+++ b/src/routes/admin/route.tsx
@@ -8,6 +8,7 @@ import {
 
 import { isOperator } from "@/entities/member/model/identity"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
+import { notifyAccessDenied } from "@/shared/lib/accessDenied"
 import { cn } from "@/shared/lib/utils"
 import RecruitingHeader from "@/widgets/navigation/header/RecruitingHeader"
 
@@ -17,7 +18,10 @@ export const Route = createFileRoute("/admin")({
   }),
   beforeLoad: async ({ context }) => {
     const me = await ensureMe(context.queryClient)
-    if (!isOperator(me)) throw redirect({ to: "/" })
+    if (!isOperator(me)) {
+      notifyAccessDenied()
+      throw redirect({ to: "/" })
+    }
   },
   component: AdminLayout,
 })

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,44 +2,37 @@ import { createFileRoute, redirect } from "@tanstack/react-router"
 
 import {
   getViewerBranch,
-  isCurrentTermPm,
-  isOperator,
+  isAnyOperator,
 } from "@/entities/member/model/identity"
 import { useAuthStore } from "@/entities/member/store/authStore"
-import { CHAPTERS, isChapter } from "@/entities/organization/model/chapters"
+import { isChapter } from "@/entities/organization/model/chapters"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
+import {
+  CHALLENGER_LANDING_PATH,
+  GUEST_LANDING_PATH,
+  OPERATOR_LANDING_PATH,
+} from "@/shared/config/landingPolicy"
 
 export const Route = createFileRoute("/")({
   beforeLoad: async ({ context }) => {
     if (!useAuthStore.getState().isAuthed) {
-      throw redirect({ to: "/intro" })
+      throw redirect({ to: GUEST_LANDING_PATH })
     }
 
     const me = await ensureMe(context.queryClient)
 
-    if (isOperator(me)) {
-      throw redirect({ to: "/matching/projects" })
+    // 학교 운영진까지 포함한다. isOperator 는 학교 역할을 빼고 있어서, 교내
+    // 회장이 리크루팅을 쓰는데도 매칭으로 떨어지고 있었다.
+    if (isAnyOperator(me)) {
+      throw redirect({ to: OPERATOR_LANDING_PATH })
     }
 
-    if (isCurrentTermPm(me)) {
-      const pmChapter = getViewerBranch(me)
-      throw redirect({
-        to: "/matching/projects/announce",
-        search: {
-          chapter: isChapter(pmChapter) ? pmChapter : CHAPTERS[0],
-          page: 1,
-        },
-      })
+    // 지부가 없으면 아직 챌린저 인증을 마치지 않은 계정이다. 온보딩을 건너뛰면
+    // 인증할 기회가 사라지므로 목적지 정책보다 먼저 본다.
+    if (!isChapter(getViewerBranch(me))) {
+      throw redirect({ to: "/challenger-verification" })
     }
 
-    const userChapter = getViewerBranch(me)
-    if (isChapter(userChapter)) {
-      throw redirect({
-        to: "/matching",
-        search: { chapter: userChapter, page: 1 },
-      })
-    }
-
-    throw redirect({ to: "/challenger-verification" })
+    throw redirect({ to: CHALLENGER_LANDING_PATH })
   },
 })

--- a/src/routes/manage/route.tsx
+++ b/src/routes/manage/route.tsx
@@ -1,8 +1,10 @@
-import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
 
+import { isCentralAdmin } from "@/entities/member/model/identity"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
 import { SETTINGS_SIDEBAR_ITEMS } from "@/shared/config/settingsNavigation"
 import { useActiveGeneration } from "@/shared/hooks/useActiveGisu"
+import { notifyAccessDenied } from "@/shared/lib/accessDenied"
 import { toUmcGisuLabel } from "@/shared/lib/gisuLabel"
 import Footer from "@/widgets/footer/Footer"
 import RecruitingHeader from "@/widgets/navigation/header/RecruitingHeader"
@@ -13,7 +15,13 @@ export const Route = createFileRoute("/manage")({
     meta: [{ name: "robots", content: "noindex, nofollow" }],
   }),
   beforeLoad: async ({ context, location }) => {
-    await ensureMe(context.queryClient, location.href)
+    const me = await ensureMe(context.queryClient, location.href)
+    // 헤더 `설정` 탭은 중앙 운영진에게만 보이지만, 탭을 감추는 것만으로는
+    // 주소를 직접 친 진입을 막지 못한다.
+    if (!isCentralAdmin(me)) {
+      notifyAccessDenied()
+      throw redirect({ to: "/" })
+    }
   },
   component: ManageLayout,
 })

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -31,6 +31,7 @@ import { BranchSelector } from "@/features/matching/ui/BranchSelector"
 import { CalendarScheduleList } from "@/features/matching/ui/CalendarScheduleList"
 import { RoundForm } from "@/features/matching/ui/RoundForm"
 import InfoCircleIcon from "@/shared/assets/icon/infomation/InfoCircleIcon"
+import { notifyAccessDenied } from "@/shared/lib/accessDenied"
 import { Button } from "@/shared/ui/Button"
 import { Calendar } from "@/shared/ui/calendar/Calendar"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
@@ -44,7 +45,10 @@ import type { AxiosError } from "axios"
 export const Route = createFileRoute("/matching/rounds")({
   beforeLoad: async ({ context }) => {
     const me = await ensureMe(context.queryClient)
-    if (!canManageMatchingRounds(me)) throw redirect({ to: "/" })
+    if (!canManageMatchingRounds(me)) {
+      notifyAccessDenied()
+      throw redirect({ to: "/" })
+    }
   },
   component: MatchingRoundsPage,
 })

--- a/src/routes/recruiting/route.tsx
+++ b/src/routes/recruiting/route.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
 
 import { isAnyOperator } from "@/entities/member/model/identity"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
+import { notifyAccessDenied } from "@/shared/lib/accessDenied"
 import Footer from "@/widgets/footer/Footer"
 import RecruitingHeader from "@/widgets/navigation/header/RecruitingHeader"
 import RecruitingSideBar from "@/widgets/navigation/sidebar/RecruitingSideBar"
@@ -15,6 +16,7 @@ export const Route = createFileRoute("/recruiting")({
     // 리크루팅은 운영진 전용이다. 헤더에서 탭을 감추는 것만으로는 주소를 직접
     // 친 진입을 막지 못해, 역할이 없는 챌린저까지 들어오고 있었다.
     if (!isAnyOperator(me)) {
+      notifyAccessDenied()
       throw redirect({ to: "/" })
     }
   },

--- a/src/routes/recruiting/route.tsx
+++ b/src/routes/recruiting/route.tsx
@@ -1,5 +1,6 @@
-import { createFileRoute, Outlet } from "@tanstack/react-router"
+import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
 
+import { isAnyOperator } from "@/entities/member/model/identity"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
 import Footer from "@/widgets/footer/Footer"
 import RecruitingHeader from "@/widgets/navigation/header/RecruitingHeader"
@@ -10,7 +11,12 @@ export const Route = createFileRoute("/recruiting")({
     meta: [{ name: "robots", content: "noindex, nofollow" }],
   }),
   beforeLoad: async ({ context, location }) => {
-    await ensureMe(context.queryClient, location.href)
+    const me = await ensureMe(context.queryClient, location.href)
+    // 리크루팅은 운영진 전용이다. 헤더에서 탭을 감추는 것만으로는 주소를 직접
+    // 친 진입을 막지 못해, 역할이 없는 챌린저까지 들어오고 있었다.
+    if (!isAnyOperator(me)) {
+      throw redirect({ to: "/" })
+    }
   },
   component: RecruitingLayout,
 })

--- a/src/shared/config/landingPolicy.test.ts
+++ b/src/shared/config/landingPolicy.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  CHALLENGER_LANDING_PATH,
+  GUEST_LANDING_PATH,
+  OPERATOR_LANDING_PATH,
+} from "./landingPolicy"
+
+// 목적지는 시즌 성격에 따라 바뀐다. 바꿀 때 여기가 같이 깨져서, 무엇이
+// 달라졌는지 눈에 보이게 한다.
+describe("루트 진입 목적지 (리크루팅 기간)", () => {
+  it("운영진은 리크루팅으로 간다", () => {
+    expect(OPERATOR_LANDING_PATH).toBe("/recruiting/dashboard/applications")
+  })
+
+  it("일반 챌린저와 비로그인은 프로젝트로 간다", () => {
+    expect(CHALLENGER_LANDING_PATH).toBe("/projects")
+    expect(GUEST_LANDING_PATH).toBe("/projects")
+  })
+
+  it("운영진 목적지는 리크루팅 영역 안이어야 한다", () => {
+    // 헤더 활성 판정이 /recruiting 접두사로 도는데, 목적지가 밖이면 탭이 꺼진다
+    expect(OPERATOR_LANDING_PATH.startsWith("/recruiting/")).toBe(true)
+  })
+})

--- a/src/shared/config/landingPolicy.ts
+++ b/src/shared/config/landingPolicy.ts
@@ -1,0 +1,22 @@
+/**
+ * 루트(`/`) 진입 시 역할별로 어디로 보낼지.
+ *
+ * 목적지는 시즌 성격에 따라 달라진다(리크루팅 기간 / 데모데이 기간). 서버가
+ * 모집 상태를 내려주기 전까지는 상수로 고정하고, 기간이 바뀌면 이 파일만 고친다.
+ *
+ * 현재: 리크루팅 기간
+ */
+
+/** 운영진(학교 운영진 이상)의 기본 화면 */
+export const OPERATOR_LANDING_PATH = "/recruiting/dashboard/applications"
+
+/** 일반 챌린저의 기본 화면 */
+export const CHALLENGER_LANDING_PATH = "/projects"
+
+/**
+ * 비로그인 방문자의 기본 화면. 프로젝트를 먼저 둘러보게 해 유입 단계 이탈을 줄인다(#688).
+ *
+ * 프로젝트 목록·상세 조회의 비인증 허용이 선행돼야 한다. 그 전에는 목록이
+ * 비어 보인다.
+ */
+export const GUEST_LANDING_PATH = "/projects"

--- a/src/shared/lib/accessDenied.ts
+++ b/src/shared/lib/accessDenied.ts
@@ -1,0 +1,23 @@
+import { useToastStore } from "@/shared/ui/toast/useToastStore"
+
+export const ACCESS_DENIED_MESSAGE = "접근 권한이 없는 화면입니다."
+
+/**
+ * 라우트 가드에서 권한 부족으로 되돌려 보낼 때 쓴다.
+ *
+ * 리다이렉트만 하면 사용자는 주소를 눌렀는데 엉뚱한 화면에 도착한 것으로만
+ * 보인다. 링크가 잘못된 건지, 권한이 없는 건지, 로그인이 풀린 건지 구분할 수
+ * 없다. 운영진끼리 링크를 공유할 때 특히 헷갈린다.
+ *
+ * 토스트 스토어는 모듈 전역이라 렌더 밖(beforeLoad)에서도 넣을 수 있고,
+ * 도착 화면이 그려질 때 ToastProvider 가 꺼내 보여준다.
+ */
+export function notifyAccessDenied(message: string = ACCESS_DENIED_MESSAGE) {
+  useToastStore.getState().addToast({
+    message,
+    color: "red",
+    variant: "weak",
+    type: "default",
+    duration: 3000,
+  })
+}

--- a/src/widgets/navigation/header/RecruitingHeader.tsx
+++ b/src/widgets/navigation/header/RecruitingHeader.tsx
@@ -1,11 +1,7 @@
 import { Link, useLocation } from "@tanstack/react-router"
 
 import { useMe } from "@/entities/member/hooks/useMe"
-import {
-  isAnyOperator,
-  isCentralStaff,
-  isSuperAdmin,
-} from "@/entities/member/model/identity"
+import { isAnyOperator, isCentralAdmin } from "@/entities/member/model/identity"
 import { useAuthStore } from "@/entities/member/store/authStore"
 import UmcLogo from "@/shared/assets/icon/logo/UmcLogo"
 import { SETTINGS_ENTRY_PATH } from "@/shared/config/settingsNavigation"
@@ -38,7 +34,7 @@ export default function RecruitingHeader({
   const isAuthed = useAuthStore((s) => s.isAuthed)
 
   const showRecruiting = isAnyOperator(me)
-  const showSettings = isSuperAdmin(me) || isCentralStaff(me)
+  const showSettings = isCentralAdmin(me)
 
   const navItems = buildRecruitingNavItems({
     isAuthed,

--- a/src/widgets/navigation/sidebar/RecruitingSideBar.tsx
+++ b/src/widgets/navigation/sidebar/RecruitingSideBar.tsx
@@ -1,10 +1,7 @@
 import { useRouterState } from "@tanstack/react-router"
 import { useState } from "react"
 
-import {
-  RECRUITING_SIDEBAR_ITEMS,
-  resolveRecruitingSectionId,
-} from "@/shared/config/recruitingNavigation"
+import { resolveRecruitingSectionId } from "@/shared/config/recruitingNavigation"
 import { useActiveGeneration } from "@/shared/hooks/useActiveGisu"
 import { toUmcGisuLabel } from "@/shared/lib/gisuLabel"
 
@@ -12,6 +9,7 @@ import { BaseSideBar } from "./BaseSideBar"
 import { FlatSideBarItem } from "./FlatSideBarItem"
 import { SideBarMenu } from "./menu/SideBarMenu"
 import { SideBarMenuItem } from "./menu/SideBarMenuItem"
+import { useVisibleRecruitingSections } from "./useVisibleRecruitingSections"
 
 interface RecruitingSideBarProps {
   className?: string
@@ -26,8 +24,10 @@ export default function RecruitingSideBar({
   const pathname = activePathname ?? currentPathname
   const activeSectionId = resolveRecruitingSectionId(pathname)
 
+  const visibleSections = useVisibleRecruitingSections()
+
   const [manualOpenSectionId, setManualOpenSectionId] = useState<string>(() =>
-    activeSectionId ? "" : (RECRUITING_SIDEBAR_ITEMS[0]?.id ?? ""),
+    activeSectionId ? "" : (visibleSections[0]?.id ?? ""),
   )
   const { data: generation } = useActiveGeneration()
 
@@ -37,7 +37,7 @@ export default function RecruitingSideBar({
       label={toUmcGisuLabel(generation)}
       className={className}
     >
-      {RECRUITING_SIDEBAR_ITEMS.map(({ id, title, icon, to, menus }) =>
+      {visibleSections.map(({ id, title, icon, to, menus }) =>
         menus.length === 0 && to ? (
           <FlatSideBarItem
             key={id}

--- a/src/widgets/navigation/sidebar/useVisibleRecruitingSections.test.ts
+++ b/src/widgets/navigation/sidebar/useVisibleRecruitingSections.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+
+import { RECRUITING_SIDEBAR_ITEMS } from "@/shared/config/recruitingNavigation"
+
+import { filterRecruitingSections } from "./useVisibleRecruitingSections"
+
+function titlesFor(isCentral: boolean) {
+  return filterRecruitingSections(RECRUITING_SIDEBAR_ITEMS, {
+    isCentral,
+  }).map((section) => section.title)
+}
+
+describe("리크루팅 사이드바 역할 필터", () => {
+  // 디자인 권한표에 히스토리는 중앙 3종만 있고, 나머지는 서버가 403 을 준다
+  it("중앙이 아니면 히스토리가 숨는다", () => {
+    expect(titlesFor(false)).not.toContain("히스토리")
+  })
+
+  it("중앙은 히스토리까지 본다", () => {
+    expect(titlesFor(true)).toContain("히스토리")
+  })
+
+  // 디자인은 역할 변형 3종이 모두 같은 사이드바를 쓴다. 히스토리 외에는 감추지 않는다
+  it("히스토리 말고는 역할에 따라 사라지는 메뉴가 없다", () => {
+    const central = titlesFor(true)
+    const others = titlesFor(false)
+
+    expect(central.filter((t) => t !== "히스토리")).toEqual(others)
+    expect(others).toEqual(["대시보드", "모집 관리", "평가 관리"])
+  })
+
+  it("메뉴 순서는 정의 순서를 유지한다", () => {
+    expect(titlesFor(true)).toEqual([
+      "대시보드",
+      "모집 관리",
+      "평가 관리",
+      "히스토리",
+    ])
+  })
+})

--- a/src/widgets/navigation/sidebar/useVisibleRecruitingSections.ts
+++ b/src/widgets/navigation/sidebar/useVisibleRecruitingSections.ts
@@ -1,0 +1,34 @@
+import { useMemo } from "react"
+
+import { useMe } from "@/entities/member/hooks/useMe"
+import { isCentralStaff, isSuperAdmin } from "@/entities/member/model/identity"
+import { RECRUITING_SIDEBAR_ITEMS } from "@/shared/config/recruitingNavigation"
+
+import type { MemberInfoResponse } from "@/entities/member/api/me"
+import type { RecruitingSideBarSection } from "@/shared/config/recruitingNavigation"
+
+/** 평가 이력은 중앙 운영진만 조회할 수 있고 나머지는 서버가 403 을 준다. */
+const CENTRAL_ONLY_SECTION_IDS = new Set(["recruiting-history"])
+
+export function filterRecruitingSections(
+  sections: readonly RecruitingSideBarSection[],
+  { isCentral }: { isCentral: boolean },
+): RecruitingSideBarSection[] {
+  return sections.filter(
+    (section) => isCentral || !CENTRAL_ONLY_SECTION_IDS.has(section.id),
+  )
+}
+
+export function isCentralViewer(me: MemberInfoResponse | undefined): boolean {
+  return isSuperAdmin(me) || isCentralStaff(me)
+}
+
+export function useVisibleRecruitingSections() {
+  const { data: me } = useMe()
+  const isCentral = isCentralViewer(me)
+
+  return useMemo(
+    () => filterRecruitingSections(RECRUITING_SIDEBAR_ITEMS, { isCentral }),
+    [isCentral],
+  )
+}


### PR DESCRIPTION
> **PR #699 위에 쌓았습니다.** #699가 develop에 머지되면 이 PR의 diff가 정리됩니다. 먼저 #699를 봐주세요.

## 📸 작업 내용

리크루팅에 **역할 기반 진입 통제와 편집 잠금이 통째로 없던 문제**를 고칩니다.

- **진입 통제** — 로그인만 하면 아무 역할 없는 챌린저도 주소를 직접 쳐서 들어올 수 있었습니다. 하위 라우트를 통틀어 가드가 레이아웃의 `ensureMe` 하나뿐이었습니다
- **편집 잠금** — 입력 필드와 저장 버튼이 역할과 무관하게 열려 있어, 값을 고치고 저장을 눌러야 서버가 거부했습니다. 막지 않고 실패시키는 구조였습니다
- **루트 진입 목적지** — 데모데이 기준으로 전원이 매칭으로 향하고 있었습니다. 리크루팅 기간에 맞게 분기합니다

리소스 권한 분기(수정·합불 버튼, 평가자 게이팅)는 원래 잘 돌고 있었습니다. **없던 것은 역할 기반 통제**입니다.

## 🎞️ 주요 코드 설명

### 진입 통제는 역할, 편집 잠금은 서버 권한

둘을 섞지 않았습니다.

`beforeLoad`에서 서버 권한을 조회하는 선례는 있지만(`matching/projects/new.tsx`), 리크루팅 진입에는 맞지 않습니다. RECRUITMENT EDIT 권한을 조회하려면 seasonId 목록이 필요하고, 그러려면 차수 목록을 먼저 불러야 해서 **진입에 비동기 2회**가 붙습니다.

진입은 역할로 동기 판정하고, 편집 잠금은 이미 쓰고 있는 시즌별 EDIT 권한 조회를 그대로 씁니다. 권한이 시즌(학교×기수) 단위라 역할 타입으로 흉내 내면 서버가 허용하는 범위와 어긋납니다.

### 편집 잠금 적용 지점

| 화면 | 잠그는 것 |
|---|---|
| 모집 인원 설정 | **학교 행 단위로** 셀. 편집 가능한 시즌이 하나도 없으면 저장·자동 배정 버튼을 감춤 |
| 평가 담당자 배정 | 드래그 시작·종료, 저장, 전체 비우기, 칩 제거 |

`SchoolQuotaRow`에 `seasonId`가 있어 행 단위로 잠글 수 있었습니다. 지부 전체가 아니라 권한 있는 학교만 열립니다.

**권한 조회가 끝나기 전에도 잠가 뒀습니다.** 열어 두면 못 고칠 값을 고치게 되고 저장 시점에야 거부당합니다.

### 사이드바

디자인 권한표에는 챌린저 행이 없고, 역할 변형 3종(교내/지부장/중앙)이 **모두 같은 사이드바**를 씁니다. 그래서 히스토리 외에는 메뉴를 감추지 않습니다.

평가 이력은 권한표에 중앙 3종만 있고 서버도 나머지에 403을 주므로 사이드바에서 감춥니다.

### 루트 목적지

판정에 쓰던 `isOperator`가 학교 역할을 빼고 있어서, **교내 회장이 리크루팅을 쓰는데도 매칭으로 떨어지고** 있었습니다.

| 역할 | 이전 | 이후 |
|---|---|---|
| 비로그인 | `/intro` | `/projects` |
| 일반 챌린저 | `/matching` | `/projects` |
| 교내 운영진 | `/matching` | `/recruiting/dashboard/applications` |
| 지부장·중앙 | `/matching/projects` | 〃 |

시즌 성격에 따라 바뀌는 값이라 `landingPolicy` 상수로 모았습니다. 데모데이 기간이 오면 이 파일만 고칩니다. 챌린저 인증 전 계정을 인증 화면으로 보내는 분기는 그대로 뒀습니다.

**비로그인 → `/projects`는 프로젝트 목록·상세의 비인증 허용이 선행돼야 합니다.** 그 전에는 목록이 비어 보입니다.

### 검증

역할 5종 × 헤더·사이드바·진입을 대조했습니다.

| 역할 | 헤더 탭 | `/recruiting` | 리크루팅 사이드바 |
|---|---|---|---|
| 비로그인 | 소개 · 모집안내(비활성) · 프로젝트 | 차단 | — |
| 일반 챌린저 | + 데모데이 매칭 | 차단 | — |
| 교내 운영진 · 지부장 | + 리크루팅 | 가능 | 대시보드 · 모집 관리 · 평가 관리 |
| 중앙 3종 | + 설정 | 가능 | + 히스토리 |

`tsc -b` / `lint` 0 errors / 테스트 737개 / `build` 전부 통과합니다.

## 🔗 연결된 이슈

- Connected: #691, #698, #706, #707
- Closes #691
- Closes #698
- Closes #706
- Closes #707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 역할별 기본 랜딩 경로와 프로젝트 메뉴가 추가되었습니다.
  * 관리자·모집·매칭·설정 영역의 접근 권한 검사가 강화되었습니다.
  * 설정 사이드바와 중앙 운영진 전용 메뉴가 제공됩니다.
  * 시즌별 편집 권한에 따라 모집 정원과 평가 담당자 배정 기능이 제한됩니다.
  * 현재 기수에 맞는 헤더·사이드바 라벨이 표시됩니다.

* **버그 수정**
  * 권한이 없는 영역 접근 시 안내 후 적절한 화면으로 이동합니다.
  * 편집 권한이 없는 입력 항목이 읽기 전용으로 동작합니다.

* **테스트**
  * 역할별 랜딩, 메뉴 표시, 경로 활성화 및 기수 라벨 동작 검증이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
