### PR TITLE
✨ feat: 지원하기 흐름 지원자 전용 사이드바

### DIFF
--- a/src/routes/projects/route.tsx
+++ b/src/routes/projects/route.tsx
@@ -1,9 +1,15 @@
 import { createFileRoute, Outlet, useRouterState } from "@tanstack/react-router"
 
 import RightChevronIconFilled from "@/shared/assets/icon/chevron/filled/RightChevronIconFilled"
+import {
+  APPLICANT_SIDEBAR_ITEMS,
+  isApplicantFlowPath,
+} from "@/shared/config/applicantNavigation"
+import { useActiveGeneration } from "@/shared/hooks/useActiveGisu"
+import { toUmcGisuLabel } from "@/shared/lib/gisuLabel"
 import Footer from "@/widgets/footer/Footer"
 import RecruitingHeader from "@/widgets/navigation/header/RecruitingHeader"
-import SideBar from "@/widgets/navigation/sidebar/SideBar"
+import { FlatSideBar } from "@/widgets/navigation/sidebar/FlatSideBar"
 
 export const Route = createFileRoute("/projects")({
   head: () => ({
@@ -15,6 +21,9 @@ export const Route = createFileRoute("/projects")({
 function ProjectsLayout() {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const normalizedPathname = pathname.replace(/\/$/, "") || "/projects"
+  const { data: generation } = useActiveGeneration()
+  // 프로젝트 목록은 사이드바 없이 전폭으로 보여준다
+  const showApplicantSideBar = isApplicantFlowPath(normalizedPathname)
 
   // 프로젝트 목록은 지원하기 흐름이 아니라 독립 화면이라 상위 경로가 다르다.
   let trail: string[] = []
@@ -22,7 +31,7 @@ function ProjectsLayout() {
   let description: string | undefined = undefined
 
   if (normalizedPathname === "/projects") {
-    trail = ["프로젝트"]
+    trail = ["홈", "프로젝트"]
     title = "프로젝트"
     description = "UMC 에서 진행 중인 프로젝트를 확인할 수 있습니다."
   } else if (normalizedPathname === "/projects/notice") {
@@ -30,9 +39,10 @@ function ProjectsLayout() {
     title = "모집 공고"
     description = "학교별 모집 공고를 확인하고 지원할 수 있습니다."
   } else if (normalizedPathname.startsWith("/projects/apply")) {
-    trail = ["리크루팅", "지원하기", "지원서 작성"]
-    title = "지원서 작성"
-    description = "모집 문항에 답해 지원서를 제출합니다."
+    // 지원 폼은 모집 공고 위에 카드로 올라오는 구조라 타이틀이 공고 그대로다
+    trail = ["리크루팅", "지원하기", "지원 방법"]
+    title = "모집 공고"
+    description = "학교별 모집 공고를 확인하고 지원할 수 있습니다."
   } else if (normalizedPathname.startsWith("/projects/application")) {
     trail = ["리크루팅", "지원하기", "내 지원서"]
     title = "내 지원서"
@@ -47,7 +57,13 @@ function ProjectsLayout() {
     <main className="flex h-full min-h-screen w-full flex-col">
       <RecruitingHeader />
       <div className="flex w-full flex-1">
-        <SideBar />
+        {showApplicantSideBar && (
+          <FlatSideBar
+            ariaLabel="지원하기 사이드 메뉴"
+            label={toUmcGisuLabel(generation)}
+            items={APPLICANT_SIDEBAR_ITEMS}
+          />
+        )}
         <div className="flex min-w-0 flex-1 flex-col">
           <div className="min-h-200 px-8 pt-10">
             <div className="flex flex-col gap-6.5 pl-3">

--- a/src/shared/config/applicantNavigation.test.ts
+++ b/src/shared/config/applicantNavigation.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveFlatNavItemId } from "@/shared/config/navigationResolve"
+
+import {
+  APPLICANT_SIDEBAR_ITEMS,
+  isApplicantFlowPath,
+} from "./applicantNavigation"
+
+function activeAt(pathname: string) {
+  return resolveFlatNavItemId(pathname, APPLICANT_SIDEBAR_ITEMS)
+}
+
+describe("지원자 사이드바 노출 범위", () => {
+  // 프로젝트 목록은 디자인상 사이드바 없이 전폭이다
+  it("프로젝트 목록에는 붙지 않는다", () => {
+    expect(isApplicantFlowPath("/projects")).toBe(false)
+  })
+
+  it("지원하기 흐름에는 붙는다", () => {
+    expect(isApplicantFlowPath("/projects/notice")).toBe(true)
+    expect(isApplicantFlowPath("/projects/apply/12")).toBe(true)
+    expect(isApplicantFlowPath("/projects/application")).toBe(true)
+    expect(isApplicantFlowPath("/projects/application/list")).toBe(true)
+  })
+})
+
+describe("지원자 사이드바 활성 항목", () => {
+  it("화면마다 해당 항목이 켜진다", () => {
+    expect(activeAt("/projects/notice")).toBe("applicant-notice")
+    expect(activeAt("/projects/apply/12")).toBe("applicant-guide")
+    expect(activeAt("/projects/application")).toBe("applicant-application")
+    expect(activeAt("/projects/application/list")).toBe("applicant-application")
+  })
+
+  // 라우트가 없어 이동은 막지만 활성 표시는 되어야 한다
+  it("지원 방법은 이동이 막혀 있다", () => {
+    const guide = APPLICANT_SIDEBAR_ITEMS.find(
+      (i) => i.id === "applicant-guide",
+    )
+    expect(guide?.disabled).toBe(true)
+  })
+
+  it("항목 순서는 디자인대로 셋이다", () => {
+    expect(APPLICANT_SIDEBAR_ITEMS.map((i) => i.title)).toEqual([
+      "지원 방법",
+      "모집 공고",
+      "내 지원서",
+    ])
+  })
+})

--- a/src/shared/config/applicantNavigation.ts
+++ b/src/shared/config/applicantNavigation.ts
@@ -1,0 +1,44 @@
+import DocumentIcon from "@/shared/assets/icon/document/DocumentIcon"
+import EditIcon from "@/shared/assets/icon/edit/EditIcon"
+import TeamIcon from "@/shared/assets/icon/people/TeamIcon"
+
+import type { FlatNavItem } from "@/shared/config/navigation"
+
+/**
+ * 지원자(게스트 포함)가 쓰는 평면 3항목.
+ *
+ * `지원 방법` 은 아직 단독 라우트가 없다. 지원 폼(`/projects/apply/{roundId}`)
+ * 에서 활성으로 표시되어야 하므로 매칭 경로만 두고 이동은 막아 둔다.
+ * 안내 페이지가 정해지면 disabled 를 떼고 to 를 그 경로로 바꾼다.
+ */
+export const APPLICANT_SIDEBAR_ITEMS: FlatNavItem[] = [
+  {
+    id: "applicant-guide",
+    title: "지원 방법",
+    to: "/projects/apply",
+    icon: EditIcon,
+    disabled: true,
+  },
+  {
+    id: "applicant-notice",
+    title: "모집 공고",
+    to: "/projects/notice",
+    icon: TeamIcon,
+  },
+  {
+    id: "applicant-application",
+    title: "내 지원서",
+    to: "/projects/application",
+    icon: DocumentIcon,
+  },
+]
+
+/** 지원자 사이드바를 붙일 경로. 프로젝트 목록에는 사이드바가 없다. */
+export function isApplicantFlowPath(pathname: string): boolean {
+  return (
+    pathname === "/projects/notice" ||
+    pathname.startsWith("/projects/notice/") ||
+    pathname.startsWith("/projects/apply") ||
+    pathname.startsWith("/projects/application")
+  )
+}

--- a/src/shared/config/navigation.ts
+++ b/src/shared/config/navigation.ts
@@ -19,6 +19,8 @@ export interface SideBarSection {
 /** 대분류 없이 링크만 나열하는 사이드바(지원자용·설정용)의 항목 */
 export interface FlatNavItem extends SideBarMenu {
   icon: ComponentType<SVGProps<SVGSVGElement>>
+  /** 대응 라우트가 아직 없는 항목. 활성 표시는 하되 이동은 막는다 */
+  disabled?: boolean
 }
 
 export const SIDEBAR_ITEMS: SideBarSection[] = [

--- a/src/widgets/navigation/header/RecruitingHeader.tsx
+++ b/src/widgets/navigation/header/RecruitingHeader.tsx
@@ -70,7 +70,7 @@ export default function RecruitingHeader({
             )}
             <HeaderButton
               label="문의사항"
-              type="text"
+              type="trailing-icon"
               className="border-teal-gray-150 h-10 border"
             />
             <Profile />
@@ -79,7 +79,7 @@ export default function RecruitingHeader({
           <>
             <HeaderButton
               label="문의사항"
-              type="text"
+              type="trailing-icon"
               className="border-teal-gray-150 h-10 border"
             />
             {recruitingStatus && (

--- a/src/widgets/navigation/sidebar/FlatSideBar.tsx
+++ b/src/widgets/navigation/sidebar/FlatSideBar.tsx
@@ -35,6 +35,7 @@ export function FlatSideBar({
           to={item.to}
           icon={item.icon}
           isActive={activeItemId === item.id}
+          disabled={item.disabled}
         />
       ))}
     </BaseSideBar>

--- a/src/widgets/navigation/sidebar/FlatSideBarItem.tsx
+++ b/src/widgets/navigation/sidebar/FlatSideBarItem.tsx
@@ -9,6 +9,7 @@ interface FlatSideBarItemProps {
   to: string
   icon: ComponentType<SVGProps<SVGSVGElement>>
   isActive: boolean
+  disabled?: boolean
 }
 
 export function FlatSideBarItem({
@@ -16,35 +17,54 @@ export function FlatSideBarItem({
   to,
   icon: Icon,
   isActive,
+  disabled = false,
 }: FlatSideBarItemProps) {
+  const body = (
+    <span
+      className={cn(
+        "flex h-12 w-39 items-center gap-2 rounded-[12px] pl-3 transition-all duration-200 ease-in-out",
+        !disabled && "hover:bg-teal-gray-100",
+        isActive && "shadow-inner-primary-1 bg-teal-100 hover:bg-teal-100",
+      )}
+    >
+      <Icon
+        aria-hidden="true"
+        className={cn(
+          "h-5 w-5",
+          isActive ? "text-teal-600" : "text-teal-gray-400",
+        )}
+      />
+      <span
+        className={cn(
+          "text-subtitle-3-semibold",
+          isActive ? "text-teal-600" : "text-teal-gray-600",
+        )}
+      >
+        {title}
+      </span>
+    </span>
+  )
+
+  // 대응 라우트가 아직 없는 항목은 링크로 만들면 눌렀을 때 갈 곳이 없다.
+  if (disabled) {
+    return (
+      <span
+        aria-current={isActive ? "page" : undefined}
+        aria-disabled="true"
+        className="flex h-12 w-42 items-center"
+      >
+        {body}
+      </span>
+    )
+  }
+
   return (
     <Link
       to={to}
       aria-current={isActive ? "page" : undefined}
       className="flex h-12 w-42 items-center"
     >
-      <span
-        className={cn(
-          "hover:bg-teal-gray-100 flex h-12 w-39 items-center gap-2 rounded-[12px] pl-3 transition-all duration-200 ease-in-out",
-          isActive && "shadow-inner-primary-1 bg-teal-100 hover:bg-teal-100",
-        )}
-      >
-        <Icon
-          aria-hidden="true"
-          className={cn(
-            "h-5 w-5",
-            isActive ? "text-teal-600" : "text-teal-gray-400",
-          )}
-        />
-        <span
-          className={cn(
-            "text-subtitle-3-semibold",
-            isActive ? "text-teal-600" : "text-teal-gray-600",
-          )}
-        >
-          {title}
-        </span>
-      </span>
+      {body}
     </Link>
   )
 }


### PR DESCRIPTION
> **PR #699 → #700 위에 쌓았습니다.** 앞 두 개가 develop에 머지되면 이 PR의 diff가 정리됩니다. #699 → #700 → 이 PR 순서로 봐주세요.

## 📸 작업 내용

`/projects` 하위가 **매칭 사이드바를 쓰고 있던 문제**를 고칩니다.

비로그인 방문자에게 `팀 매칭 { 공지, 프로젝트 목록, 내 지원 현황, 매칭 현황 }`이 보이는데 링크는 전부 `/matching/*`이라 **누르면 로그인으로 튕깁니다.** 게스트 유입 흐름과 정면으로 어긋났습니다.

- 프로젝트 목록은 사이드바 없이 전폭으로 (디자인 기준)
- 모집 공고·지원 폼·내 지원서에는 **지원자 전용 3항목**
- 지원 폼 브레드크럼·타이틀, 프로젝트 목록 브레드크럼, `문의사항` 캐럿 아이콘

## 🎞️ 주요 코드 설명

### 사이드바를 경로별로 갈아끼움

```
/projects                → 없음
/projects/notice         → 모집 공고 활성
/projects/apply/{id}     → 지원 방법 활성
/projects/application*   → 내 지원서 활성
```

PR #699에서 만든 `FlatSideBar`를 그대로 씁니다. **설정 영역과 같은 컴포넌트에 items만 다르게** 넣었습니다.

### `지원 방법`에 대응 라우트가 없습니다

디자인에는 3항목이 있는데 `지원 방법`은 단독 화면이 없습니다. 지원 폼에서 활성으로 표시되어야 하므로 **매칭 경로만 두고 이동은 막았습니다.**

```ts
{ id: "applicant-guide", title: "지원 방법", to: "/projects/apply", disabled: true }
```

`FlatSideBarItem`이 `disabled`면 `Link` 대신 `span`으로 렌더해 갈 곳 없는 링크를 만들지 않습니다. **안내 페이지가 정해지면 `disabled`를 떼고 `to`만 바꾸면 됩니다.**

### 브레드크럼

| 화면 | 이전 | 이후 |
|---|---|---|
| 지원 폼 3단 | `지원서 작성` | `지원 방법` |
| 지원 폼 타이틀 | `지원서 작성` | `모집 공고` |
| 프로젝트 목록 | `프로젝트` | `홈 > 프로젝트` |

디자인은 지원 폼이 모집 공고 화면 위에 카드로 올라오는 구조라 타이틀이 공고 그대로 유지됩니다. `/projects/notice`와 `/projects/application*`은 원래 디자인과 일치해 손대지 않았습니다.

### 검증

`tsc -b` / `lint` 0 errors / 테스트 742개 / `build` 전부 통과합니다. 사이드바 노출 범위와 활성 항목을 테스트 5개로 고정했습니다.

## 🖥️ 구현화면

| 프로젝트 목록 (사이드바 없음) | 지원하기 흐름 |
| --- | --- |
|  |  |

## 🔗 연결된 이슈

- Connected: #688
- Closes #708

**#688 은 `Closes` 로 걸지 않았습니다.** 내 지원서 편집과 게스트 진입이 서버 협의 대기라 아직 닫히면 안 됩니다. 이 PR 몫은 #708 로 분리했습니다.

`/test/*` 정리(#695)는 이 PR 이후에 진행합니다. `test/recruiting-apply.tsx`가 지원자 사이드바의 참고 자료였습니다.
