### PR TITLE
🐛 fix: 게스트 프로젝트 화면 대응과 헤더 모집 상태 연동

### DIFF
--- a/src/features/project/list/ui/MatchingProjectsListPage.tsx
+++ b/src/features/project/list/ui/MatchingProjectsListPage.tsx
@@ -252,7 +252,14 @@ export function MatchingProjectsListPage({
           })}
         </div>
 
-        {/* 빈 그리드만 남으면 데이터가 없는 건지 로딩이 덜 된 건지 알 수 없다 */}
+        {/* 빈 그리드만 남으면 데이터가 없는 건지 로딩이 덜 된 건지 알 수 없다.
+            게스트는 활성 기수까지 기다려야 해서 이 구간이 특히 길다 */}
+        {!useMockData && isLoading && (
+          <p className="text-body-2-regular text-teal-gray-500 py-20 text-center">
+            프로젝트를 불러오는 중입니다.
+          </p>
+        )}
+
         {!useMockData && !isLoading && visibleProjects.length === 0 && (
           <p className="text-body-2-regular text-teal-gray-500 py-20 text-center">
             {isError

--- a/src/features/project/list/ui/MatchingProjectsListPage.tsx
+++ b/src/features/project/list/ui/MatchingProjectsListPage.tsx
@@ -252,6 +252,15 @@ export function MatchingProjectsListPage({
           })}
         </div>
 
+        {/* 빈 그리드만 남으면 데이터가 없는 건지 로딩이 덜 된 건지 알 수 없다 */}
+        {!useMockData && !isLoading && visibleProjects.length === 0 && (
+          <p className="text-body-2-regular text-teal-gray-500 py-20 text-center">
+            {isError
+              ? "프로젝트를 불러오지 못했습니다. 잠시 후 다시 시도해주세요."
+              : "표시할 프로젝트가 없습니다."}
+          </p>
+        )}
+
         {!useMockData && projects.length > 0 && (
           <Pagination
             className="mt-5 self-center"

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -193,6 +193,10 @@ export function ProjectDetailCard({
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const { me, viewContext } = useViewerIdentity()
+  // 비로그인 방문자. 팀원 조회는 아직 인증이 필요해서, 열어 두면 401 이 나고
+  // 토큰 갱신에 실패해 로그인 화면으로 튕긴다. 디자인에도 게스트 상세에는
+  // 작성자·모집 상태·액션 버튼이 없다.
+  const isGuest = me === undefined
   const addToast = useToastStore((s) => s.addToast)
   const userIsOperator = isOperator(me)
   const userIsPm = isCurrentTermPm(me)
@@ -518,11 +522,13 @@ export function ProjectDetailCard({
           </div>
 
           <div className="scrollbar-none mt-8.5 flex w-full flex-nowrap items-start gap-2.5 overflow-x-auto pb-1">
-            <TeamMemberButton
-              variant="weak"
-              className="w-auto"
-              onClick={() => setIsTeamModalOpen(true)}
-            />
+            {!isGuest && (
+              <TeamMemberButton
+                variant="weak"
+                className="w-auto"
+                onClick={() => setIsTeamModalOpen(true)}
+              />
+            )}
             <Button
               variant="weak"
               color="primary"
@@ -787,7 +793,10 @@ export function ProjectDetailCard({
         </div>
       </div>
 
-      <Modal.Root open={isTeamModalOpen} onOpenChange={setIsTeamModalOpen}>
+      <Modal.Root
+        open={!isGuest && isTeamModalOpen}
+        onOpenChange={setIsTeamModalOpen}
+      >
         <Modal.Portal>
           <Modal.Overlay tone="light" />
           <Modal.Content aria-describedby={undefined}>

--- a/src/features/recruiting/api/queryKeys.ts
+++ b/src/features/recruiting/api/queryKeys.ts
@@ -12,6 +12,8 @@ export const recruitingKeys = {
   // 키에 넣어 분리한다.
   openRoundList: (gisuId: string) =>
     [...recruitingKeys.rounds(), gisuId, "OPEN"] as const,
+  pastRoundList: (gisuId: string) =>
+    [...recruitingKeys.rounds(), gisuId, "PAST"] as const,
   adminRoundList: (gisuId: string, sort?: string) =>
     [...recruitingKeys.rounds(), "admin", gisuId, sort ?? "NEWEST"] as const,
 

--- a/src/features/recruiting/hooks/useHeaderRecruitingStatus.ts
+++ b/src/features/recruiting/hooks/useHeaderRecruitingStatus.ts
@@ -1,14 +1,47 @@
 import { useQuery } from "@tanstack/react-query"
+import { useEffect, useState } from "react"
 
 import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
 
 import { recruitingKeys } from "../api/queryKeys"
 import { getPublicRounds } from "../api/recruitingApi"
-import { resolveRecruitingStatus } from "../model/recruitingStatus"
+import {
+  nextStatusBoundary,
+  resolveRecruitingStatus,
+} from "../model/recruitingStatus"
 
 import type { RecruitingStatus } from "@/shared/model/recruitingStatus"
 
+import type { RecruitingPeriod } from "../model/recruitingStatus"
+
 const ROUNDS_STALE_TIME = 5 * 60 * 1000
+
+/**
+ * 표시가 바뀌는 시각에 맞춰 한 번 리렌더한다.
+ *
+ * D-day 는 렌더 시점의 시각으로 계산하는데, 헤더는 이동이 없으면 다시 그려지지
+ * 않는다. 화면을 열어 둔 채 자정이나 마감을 넘기면 지난 D-day 가 그대로 남는다.
+ * 재조회로 풀면 전 화면에 뜨는 헤더가 주기적으로 요청을 날리게 되므로,
+ * 네트워크 없이 타이머로만 다시 계산한다.
+ */
+function useBoundaryTick(periods: readonly RecruitingPeriod[]): number {
+  const [tick, setTick] = useState(0)
+  const boundary =
+    periods.length > 0 ? nextStatusBoundary(periods, Date.now()) : undefined
+
+  useEffect(() => {
+    if (boundary === undefined) return
+    // setTimeout 은 약 24.8일이 넘으면 즉시 발화한다. 그 전에 다시 잡으면 된다.
+    const delay = Math.min(
+      Math.max(boundary - Date.now(), 0) + 1000,
+      2 ** 31 - 1,
+    )
+    const timer = setTimeout(() => setTick((n) => n + 1), delay)
+    return () => clearTimeout(timer)
+  }, [boundary])
+
+  return tick
+}
 
 /**
  * 헤더 우측 모집 상태(`지원하기 D-n`).
@@ -21,6 +54,8 @@ const ROUNDS_STALE_TIME = 5 * 60 * 1000
  *
  * 서버의 OPEN 은 "지금 접수 중", PAST 는 "마감됨" 이라 아직 시작하지 않은 차수는
  * 어느 쪽에도 실리지 않는다. 그래서 `모집 시작 D-n` 은 이 경로로는 나오지 않는다.
+ * 상태 계산기 자체는 예정 차수를 다루므로, 예정 차수를 주는 경로가 생기면
+ * 여기서 목록만 넘겨주면 된다.
  */
 export function useHeaderRecruitingStatus(): RecruitingStatus | undefined {
   const { data: gisuId } = useActiveGisuId()
@@ -49,9 +84,8 @@ export function useHeaderRecruitingStatus(): RecruitingStatus | undefined {
   })
 
   const groups = hasOpenRound ? openRounds : pastRounds
-  if (!groups) return undefined
 
-  const periods = groups.flatMap((group) =>
+  const periods: RecruitingPeriod[] = (groups ?? []).flatMap((group) =>
     (group.rounds ?? []).map((round) => ({
       documentStartAt: round.documentStartAt,
       documentEndAt: round.documentEndAt,
@@ -59,5 +93,8 @@ export function useHeaderRecruitingStatus(): RecruitingStatus | undefined {
     })),
   )
 
+  useBoundaryTick(periods)
+
+  if (!groups) return undefined
   return resolveRecruitingStatus(periods, Date.now())
 }

--- a/src/features/recruiting/hooks/useHeaderRecruitingStatus.ts
+++ b/src/features/recruiting/hooks/useHeaderRecruitingStatus.ts
@@ -1,0 +1,39 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
+
+import { getPublicRounds } from "../api/recruitingApi"
+import { resolveRecruitingStatus } from "../model/recruitingStatus"
+
+import type { RecruitingStatus } from "@/shared/model/recruitingStatus"
+
+/**
+ * 헤더 우측 모집 상태(`지원하기 D-n`).
+ *
+ * 공개 모집 목록은 비인증으로 열려 있어 게스트도 받을 수 있다. 헤더는 모든
+ * 화면에 뜨므로 자주 바뀌지 않는 값을 오래 캐싱한다.
+ */
+export function useHeaderRecruitingStatus(): RecruitingStatus | undefined {
+  const { data: gisuId } = useActiveGisuId()
+
+  const { data } = useQuery({
+    queryKey: ["headerRecruitingStatus", gisuId],
+    queryFn: () => getPublicRounds({ gisuId: String(gisuId) }),
+    enabled: gisuId != null,
+    staleTime: 5 * 60 * 1000,
+    // 실패해도 헤더는 그려야 한다. 상태 버튼만 빠진다.
+    retry: 1,
+  })
+
+  if (!data) return undefined
+
+  const periods = data.flatMap((group) =>
+    (group.rounds ?? []).map((round) => ({
+      documentStartAt: round.documentStartAt,
+      documentEndAt: round.documentEndAt,
+      applicationOpen: round.applicationOpen,
+    })),
+  )
+
+  return resolveRecruitingStatus(periods, Date.now())
+}

--- a/src/features/recruiting/hooks/useHeaderRecruitingStatus.ts
+++ b/src/features/recruiting/hooks/useHeaderRecruitingStatus.ts
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query"
 
 import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
 
-import { getPublicRounds } from "../api/recruitingApi"
+import { getAllPublicRounds } from "../api/recruitingApi"
 import { resolveRecruitingStatus } from "../model/recruitingStatus"
 
 import type { RecruitingStatus } from "@/shared/model/recruitingStatus"
@@ -18,7 +18,9 @@ export function useHeaderRecruitingStatus(): RecruitingStatus | undefined {
 
   const { data } = useQuery({
     queryKey: ["headerRecruitingStatus", gisuId],
-    queryFn: () => getPublicRounds({ gisuId: String(gisuId) }),
+    // 공개 목록의 phase 기본값이 OPEN 이라 그대로 부르면 마감된 차수가 빠지고,
+    // 전부 마감된 기수에서 "모집 마감" 대신 아무것도 뜨지 않는다.
+    queryFn: () => getAllPublicRounds(String(gisuId)),
     enabled: gisuId != null,
     staleTime: 5 * 60 * 1000,
     // 실패해도 헤더는 그려야 한다. 상태 버튼만 빠진다.

--- a/src/features/recruiting/hooks/useHeaderRecruitingStatus.ts
+++ b/src/features/recruiting/hooks/useHeaderRecruitingStatus.ts
@@ -2,34 +2,56 @@ import { useQuery } from "@tanstack/react-query"
 
 import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
 
-import { getAllPublicRounds } from "../api/recruitingApi"
+import { recruitingKeys } from "../api/queryKeys"
+import { getPublicRounds } from "../api/recruitingApi"
 import { resolveRecruitingStatus } from "../model/recruitingStatus"
 
 import type { RecruitingStatus } from "@/shared/model/recruitingStatus"
 
+const ROUNDS_STALE_TIME = 5 * 60 * 1000
+
 /**
  * 헤더 우측 모집 상태(`지원하기 D-n`).
  *
- * 공개 모집 목록은 비인증으로 열려 있어 게스트도 받을 수 있다. 헤더는 모든
- * 화면에 뜨므로 자주 바뀌지 않는 값을 오래 캐싱한다.
+ * 공개 모집 목록은 비인증으로 열려 있어 게스트도 받을 수 있다.
+ *
+ * 헤더는 전 화면에 뜨므로 요청을 아낀다. 접수 중인 차수가 있으면 그것만으로
+ * 답이 나오고, 하나도 없을 때만 마감 여부를 확인하러 PAST 를 더 받는다.
+ * 접수 중 목록은 대시보드(useRecruitingProgress)와 같은 키를 써서 캐시를 나눈다.
+ *
+ * 서버의 OPEN 은 "지금 접수 중", PAST 는 "마감됨" 이라 아직 시작하지 않은 차수는
+ * 어느 쪽에도 실리지 않는다. 그래서 `모집 시작 D-n` 은 이 경로로는 나오지 않는다.
  */
 export function useHeaderRecruitingStatus(): RecruitingStatus | undefined {
   const { data: gisuId } = useActiveGisuId()
+  const enabled = gisuId != null
+  const gisuKey = gisuId != null ? String(gisuId) : ""
 
-  const { data } = useQuery({
-    queryKey: ["headerRecruitingStatus", gisuId],
-    // 공개 목록의 phase 기본값이 OPEN 이라 그대로 부르면 마감된 차수가 빠지고,
-    // 전부 마감된 기수에서 "모집 마감" 대신 아무것도 뜨지 않는다.
-    queryFn: () => getAllPublicRounds(String(gisuId)),
-    enabled: gisuId != null,
-    staleTime: 5 * 60 * 1000,
-    // 실패해도 헤더는 그려야 한다. 상태 버튼만 빠진다.
+  const { data: openRounds } = useQuery({
+    queryKey: recruitingKeys.openRoundList(gisuKey),
+    queryFn: () => getPublicRounds({ gisuId: gisuKey, phase: "OPEN" }),
+    enabled,
+    staleTime: ROUNDS_STALE_TIME,
     retry: 1,
   })
 
-  if (!data) return undefined
+  const hasOpenRound = (openRounds ?? []).some(
+    (group) => (group.rounds ?? []).length > 0,
+  )
 
-  const periods = data.flatMap((group) =>
+  const { data: pastRounds } = useQuery({
+    queryKey: recruitingKeys.pastRoundList(gisuKey),
+    queryFn: () => getPublicRounds({ gisuId: gisuKey, phase: "PAST" }),
+    // 접수 중인 차수가 있으면 마감 여부를 볼 필요가 없다.
+    enabled: enabled && openRounds !== undefined && !hasOpenRound,
+    staleTime: ROUNDS_STALE_TIME,
+    retry: 1,
+  })
+
+  const groups = hasOpenRound ? openRounds : pastRounds
+  if (!groups) return undefined
+
+  const periods = groups.flatMap((group) =>
     (group.rounds ?? []).map((round) => ({
       documentStartAt: round.documentStartAt,
       documentEndAt: round.documentEndAt,

--- a/src/features/recruiting/model/recruitingStatus.test.ts
+++ b/src/features/recruiting/model/recruitingStatus.test.ts
@@ -43,6 +43,42 @@ describe("resolveRecruitingStatus", () => {
     ).toEqual({ phase: "open", dDay: 5 })
   })
 
+  it("시작 전이면 applicationOpen 이 켜져 있어도 시작까지 남은 일수를 준다", () => {
+    // 시작 시각을 안 보면 예정 차수를 "마감 D-n" 으로 잘못 알린다
+    expect(
+      resolveRecruitingStatus(
+        [
+          {
+            documentStartAt: at(7),
+            documentEndAt: at(20),
+            applicationOpen: true,
+          },
+        ],
+        NOW,
+      ),
+    ).toEqual({ phase: "before", dDay: 7 })
+  })
+
+  it("시작한 차수와 예정 차수가 섞이면 시작한 쪽의 마감을 쓴다", () => {
+    expect(
+      resolveRecruitingStatus(
+        [
+          {
+            documentStartAt: at(7),
+            documentEndAt: at(20),
+            applicationOpen: true,
+          },
+          {
+            documentStartAt: at(-1),
+            documentEndAt: at(10),
+            applicationOpen: true,
+          },
+        ],
+        NOW,
+      ),
+    ).toEqual({ phase: "open", dDay: 10 })
+  })
+
   it("아직 시작 전이면 시작까지 남은 일수를 준다", () => {
     expect(
       resolveRecruitingStatus(

--- a/src/features/recruiting/model/recruitingStatus.test.ts
+++ b/src/features/recruiting/model/recruitingStatus.test.ts
@@ -80,6 +80,29 @@ describe("resolveRecruitingStatus", () => {
     ).toEqual({ phase: "closed" })
   })
 
+  // 경과 시간(24시간)으로 세면 마감 당일 자정 직후에도 1 이 나온다.
+  // 모집 공고 화면이 KST 날짜 경계를 쓰므로 헤더도 같은 값이어야 한다.
+  it("마감 당일이면 시각과 무관하게 0 이다", () => {
+    const kstMidnight = Date.parse("2026-08-01T00:01:00+09:00")
+    expect(
+      resolveRecruitingStatus(
+        [{ documentEndAt: "2026-08-01T23:59:00+09:00", applicationOpen: true }],
+        kstMidnight,
+      ),
+    ).toEqual({ phase: "open", dDay: 0 })
+  })
+
+  it("브라우저 시간대가 달라도 KST 날짜로 센다", () => {
+    // UTC 로 보면 7/31 이지만 KST 로는 8/1 이다
+    const beforeKstNoon = Date.parse("2026-08-01T09:30:00+09:00")
+    expect(
+      resolveRecruitingStatus(
+        [{ documentEndAt: "2026-08-03T10:00:00+09:00", applicationOpen: true }],
+        beforeKstNoon,
+      ),
+    ).toEqual({ phase: "open", dDay: 2 })
+  })
+
   it("날짜가 비어 있어도 터지지 않는다", () => {
     expect(
       resolveRecruitingStatus(

--- a/src/features/recruiting/model/recruitingStatus.test.ts
+++ b/src/features/recruiting/model/recruitingStatus.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveRecruitingStatus } from "./recruitingStatus"
+
+const NOW = Date.parse("2026-08-01T00:00:00Z")
+
+function at(daysFromNow: number) {
+  return new Date(NOW + daysFromNow * 24 * 60 * 60 * 1000).toISOString()
+}
+
+describe("resolveRecruitingStatus", () => {
+  it("차수가 없으면 아무것도 표시하지 않는다", () => {
+    // 버튼을 그리지 않아야 한다. 상태를 모르는데 마감이라고 하면 거짓말이 된다
+    expect(resolveRecruitingStatus([], NOW)).toBeUndefined()
+  })
+
+  it("열린 차수가 있으면 지원 마감까지 남은 일수를 준다", () => {
+    expect(
+      resolveRecruitingStatus(
+        [
+          {
+            documentStartAt: at(-3),
+            documentEndAt: at(22),
+            applicationOpen: true,
+          },
+        ],
+        NOW,
+      ),
+    ).toEqual({ phase: "open", dDay: 22 })
+  })
+
+  // 마감이 임박한 쪽을 보여줘야 지원자가 놓치지 않는다
+  it("열린 차수가 여럿이면 가장 먼저 마감하는 것을 쓴다", () => {
+    expect(
+      resolveRecruitingStatus(
+        [
+          { documentEndAt: at(30), applicationOpen: true },
+          { documentEndAt: at(5), applicationOpen: true },
+          { documentEndAt: at(14), applicationOpen: true },
+        ],
+        NOW,
+      ),
+    ).toEqual({ phase: "open", dDay: 5 })
+  })
+
+  it("아직 시작 전이면 시작까지 남은 일수를 준다", () => {
+    expect(
+      resolveRecruitingStatus(
+        [
+          { documentStartAt: at(7), documentEndAt: at(20) },
+          { documentStartAt: at(15), documentEndAt: at(30) },
+        ],
+        NOW,
+      ),
+    ).toEqual({ phase: "before", dDay: 7 })
+  })
+
+  // applicationOpen 이 false 면 기간이 남았어도 지원을 받지 않는다
+  it("기간이 남아도 지원을 닫아 두면 열린 것으로 보지 않는다", () => {
+    expect(
+      resolveRecruitingStatus(
+        [{ documentEndAt: at(10), applicationOpen: false }],
+        NOW,
+      ),
+    ).toEqual({ phase: "closed" })
+  })
+
+  it("전부 지났으면 마감이다", () => {
+    expect(
+      resolveRecruitingStatus(
+        [
+          {
+            documentStartAt: at(-30),
+            documentEndAt: at(-1),
+            applicationOpen: true,
+          },
+        ],
+        NOW,
+      ),
+    ).toEqual({ phase: "closed" })
+  })
+
+  it("날짜가 비어 있어도 터지지 않는다", () => {
+    expect(
+      resolveRecruitingStatus(
+        [{ documentStartAt: null, documentEndAt: undefined }],
+        NOW,
+      ),
+    ).toEqual({ phase: "closed" })
+  })
+})

--- a/src/features/recruiting/model/recruitingStatus.ts
+++ b/src/features/recruiting/model/recruitingStatus.ts
@@ -1,0 +1,57 @@
+import type { RecruitingStatus } from "@/shared/model/recruitingStatus"
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+export interface RecruitingPeriod {
+  documentStartAt?: string | null
+  documentEndAt?: string | null
+  applicationOpen?: boolean
+}
+
+/** 남은 일수. 같은 날이면 0, 지났으면 음수. */
+function daysUntil(target: number, now: number): number {
+  return Math.ceil((target - now) / DAY_MS)
+}
+
+/**
+ * 여러 차수 중 헤더에 띄울 하나를 고르고 상태를 만든다.
+ *
+ * 열려 있는 차수가 있으면 그중 가장 먼저 마감하는 것을 쓴다. 마감이 임박한 쪽을
+ * 보여줘야 지원자가 놓치지 않는다.
+ * 열린 게 없으면 가장 먼저 시작하는 예정 차수를, 그것도 없으면 마감으로 본다.
+ */
+export function resolveRecruitingStatus(
+  periods: readonly RecruitingPeriod[],
+  now: number,
+): RecruitingStatus | undefined {
+  if (periods.length === 0) return undefined
+
+  const openEnds: number[] = []
+  const upcomingStarts: number[] = []
+
+  for (const period of periods) {
+    const start = period.documentStartAt
+      ? Date.parse(period.documentStartAt)
+      : NaN
+    const end = period.documentEndAt ? Date.parse(period.documentEndAt) : NaN
+
+    if (Number.isFinite(end) && end > now && period.applicationOpen) {
+      openEnds.push(end)
+      continue
+    }
+    if (Number.isFinite(start) && start > now) {
+      upcomingStarts.push(start)
+    }
+  }
+
+  if (openEnds.length > 0) {
+    return { phase: "open", dDay: daysUntil(Math.min(...openEnds), now) }
+  }
+  if (upcomingStarts.length > 0) {
+    return {
+      phase: "before",
+      dDay: daysUntil(Math.min(...upcomingStarts), now),
+    }
+  }
+  return { phase: "closed" }
+}

--- a/src/features/recruiting/model/recruitingStatus.ts
+++ b/src/features/recruiting/model/recruitingStatus.ts
@@ -1,6 +1,19 @@
+import dayjs from "dayjs"
+import utc from "dayjs/plugin/utc"
+
 import type { RecruitingStatus } from "@/shared/model/recruitingStatus"
 
-const DAY_MS = 24 * 60 * 60 * 1000
+// utcOffset 을 설정값으로 쓰려면 utc 플러그인이 필요하다.
+dayjs.extend(utc)
+
+// 모집 일정은 한국 기준이라 브라우저 시간대가 무엇이든 KST 날짜로 자른다.
+// 경과 시간(24시간 단위)으로 세면 마감 당일 자정 직후에도 D-1 이 되고,
+// 같은 값을 KST 날짜 경계로 세는 모집 공고 화면과 D-day 가 어긋난다.
+const KST_OFFSET_MINUTES = 9 * 60
+
+function toKstStartOfDay(value: number | string) {
+  return dayjs(value).utcOffset(KST_OFFSET_MINUTES).startOf("day")
+}
 
 export interface RecruitingPeriod {
   documentStartAt?: string | null
@@ -10,7 +23,7 @@ export interface RecruitingPeriod {
 
 /** 남은 일수. 같은 날이면 0, 지났으면 음수. */
 function daysUntil(target: number, now: number): number {
-  return Math.ceil((target - now) / DAY_MS)
+  return toKstStartOfDay(target).diff(toKstStartOfDay(now), "day")
 }
 
 /**

--- a/src/features/recruiting/model/recruitingStatus.ts
+++ b/src/features/recruiting/model/recruitingStatus.ts
@@ -48,7 +48,16 @@ export function resolveRecruitingStatus(
       : NaN
     const end = period.documentEndAt ? Date.parse(period.documentEndAt) : NaN
 
-    if (Number.isFinite(end) && end > now && period.applicationOpen) {
+    // 아직 시작 전이면 applicationOpen 이 켜져 있어도 접수 중이 아니다.
+    // 시작 시각을 안 보면 예정 차수를 "마감 D-n" 으로 잘못 알린다.
+    const started = !Number.isFinite(start) || start <= now
+
+    if (
+      started &&
+      Number.isFinite(end) &&
+      end > now &&
+      period.applicationOpen
+    ) {
       openEnds.push(end)
       continue
     }
@@ -67,4 +76,27 @@ export function resolveRecruitingStatus(
     }
   }
   return { phase: "closed" }
+}
+
+/**
+ * 표시가 바뀌는 다음 시각. 화면을 열어 둔 채 이 시각을 넘기면 D-day 나 단계가
+ * 실제와 어긋나므로, 호출부는 여기에 맞춰 다시 계산해야 한다.
+ *
+ * 후보는 두 종류다. 차수의 시작·마감 시각(단계가 바뀐다)과 다음 KST 자정
+ * (D-day 숫자가 바뀐다).
+ */
+export function nextStatusBoundary(
+  periods: readonly RecruitingPeriod[],
+  now: number,
+): number {
+  const nextKstMidnight = toKstStartOfDay(now).add(1, "day").valueOf()
+
+  const candidates = [nextKstMidnight]
+  for (const period of periods) {
+    for (const raw of [period.documentStartAt, period.documentEndAt]) {
+      const at = raw ? Date.parse(raw) : NaN
+      if (Number.isFinite(at) && at > now) candidates.push(at)
+    }
+  }
+  return Math.min(...candidates)
 }

--- a/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
+++ b/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
@@ -172,9 +172,11 @@ export function EvaluatorAllocationPage({
   }
 
   function handleDragEnd(event: DragEndEvent) {
+    // 잡고 있던 카드를 먼저 내려놓는다. 드래그 도중 권한 조회가 끝나거나
+    // 시즌이 바뀌면 아래 guard 에 걸려, 오버레이가 붙은 채 남는다.
+    setActiveStaff(null)
     if (!isInitialized || !canEdit) return
     const { active, over } = event
-    setActiveStaff(null)
 
     if (!over) return
 

--- a/src/shared/config/applicantNavigation.test.ts
+++ b/src/shared/config/applicantNavigation.test.ts
@@ -23,6 +23,13 @@ describe("지원자 사이드바 노출 범위", () => {
     expect(isApplicantFlowPath("/projects/application")).toBe(true)
     expect(isApplicantFlowPath("/projects/application/list")).toBe(true)
   })
+
+  // 접두사만 보면 이름이 겹치는 다른 화면이 지원 흐름으로 딸려 들어온다
+  it("이름이 겹치는 다른 경로는 붙지 않는다", () => {
+    expect(isApplicantFlowPath("/projects/apply-guide")).toBe(false)
+    expect(isApplicantFlowPath("/projects/applications")).toBe(false)
+    expect(isApplicantFlowPath("/projects/notice-archive")).toBe(false)
+  })
 })
 
 describe("지원자 사이드바 활성 항목", () => {

--- a/src/shared/config/applicantNavigation.ts
+++ b/src/shared/config/applicantNavigation.ts
@@ -33,12 +33,20 @@ export const APPLICANT_SIDEBAR_ITEMS: FlatNavItem[] = [
   },
 ]
 
-/** 지원자 사이드바를 붙일 경로. 프로젝트 목록에는 사이드바가 없다. */
+const APPLICANT_FLOW_BASE_PATHS = [
+  "/projects/notice",
+  "/projects/apply",
+  "/projects/application",
+] as const
+
+/**
+ * 지원자 사이드바를 붙일 경로. 프로젝트 목록에는 사이드바가 없다.
+ *
+ * 세그먼트 경계까지 봐야 한다. 접두사만 보면 `/projects/apply-guide` 처럼
+ * 이름이 겹치는 다른 화면이 생기는 순간 지원 흐름으로 딸려 들어온다.
+ */
 export function isApplicantFlowPath(pathname: string): boolean {
-  return (
-    pathname === "/projects/notice" ||
-    pathname.startsWith("/projects/notice/") ||
-    pathname.startsWith("/projects/apply") ||
-    pathname.startsWith("/projects/application")
+  return APPLICANT_FLOW_BASE_PATHS.some(
+    (base) => pathname === base || pathname.startsWith(`${base}/`),
   )
 }

--- a/src/shared/model/recruitingStatus.ts
+++ b/src/shared/model/recruitingStatus.ts
@@ -1,0 +1,6 @@
+// 헤더 우측 모집 상태 라벨의 표시 값.
+// before/open 은 D-day 가 필수, closed 는 없다(D-undefined 방지).
+export type RecruitingStatus =
+  | { phase: "before"; dDay: number } // 모집 시작까지 남은 일수
+  | { phase: "open"; dDay: number } // 지원 마감까지 남은 일수
+  | { phase: "closed" }

--- a/src/widgets/navigation/header/GuestProfileButton.tsx
+++ b/src/widgets/navigation/header/GuestProfileButton.tsx
@@ -1,0 +1,34 @@
+import { Link } from "@tanstack/react-router"
+
+import ProfileIcon from "@/shared/assets/icon/people/ProfileIcon"
+import { cn } from "@/shared/lib/utils"
+
+interface GuestProfileButtonProps {
+  size?: number
+  className?: string
+}
+
+/**
+ * 비로그인 방문자의 프로필 자리.
+ *
+ * 로그인한 사용자와 같은 자리에 같은 아이콘을 두고, 누르면 로그인으로 보낸다.
+ * 자리를 비우거나 버튼 문구로 바꾸면 로그인 전후로 헤더가 흔들린다.
+ */
+export function GuestProfileButton({
+  size = 40,
+  className,
+}: GuestProfileButtonProps) {
+  return (
+    <Link
+      to="/login"
+      aria-label="로그인"
+      className={cn(
+        "shrink-0 overflow-hidden rounded-full transition-opacity hover:opacity-80",
+        className,
+      )}
+      style={{ width: size, height: size }}
+    >
+      <ProfileIcon className="size-full" />
+    </Link>
+  )
+}

--- a/src/widgets/navigation/header/RecruitingHeader.tsx
+++ b/src/widgets/navigation/header/RecruitingHeader.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation } from "@tanstack/react-router"
 import { useMe } from "@/entities/member/hooks/useMe"
 import { isAnyOperator, isCentralAdmin } from "@/entities/member/model/identity"
 import { useAuthStore } from "@/entities/member/store/authStore"
+import { useHeaderRecruitingStatus } from "@/features/recruiting/hooks/useHeaderRecruitingStatus"
 import UmcLogo from "@/shared/assets/icon/logo/UmcLogo"
 import { SETTINGS_ENTRY_PATH } from "@/shared/config/settingsNavigation"
 import HeaderButton from "@/widgets/navigation/header/HeaderButton"
@@ -32,6 +33,9 @@ export default function RecruitingHeader({
   const pathname = activePathname ?? location.pathname
   const { data: me } = useMe()
   const isAuthed = useAuthStore((s) => s.isAuthed)
+  // 모집 상태는 공개 API 라 게스트도 받는다. prop 으로 받은 값이 우선.
+  const resolvedStatus = useHeaderRecruitingStatus()
+  const status = recruitingStatus ?? resolvedStatus
 
   const showRecruiting = isAnyOperator(me)
   const showSettings = isCentralAdmin(me)
@@ -65,9 +69,7 @@ export default function RecruitingHeader({
       <div className="flex items-center justify-end gap-4 pr-8.5">
         {isAuthed ? (
           <>
-            {recruitingStatus && (
-              <RecruitingStatusButton status={recruitingStatus} />
-            )}
+            {status && <RecruitingStatusButton status={status} />}
             <HeaderButton
               label="문의사항"
               type="trailing-icon"
@@ -82,9 +84,7 @@ export default function RecruitingHeader({
               type="trailing-icon"
               className="border-teal-gray-150 h-10 border"
             />
-            {recruitingStatus && (
-              <RecruitingStatusButton status={recruitingStatus} />
-            )}
+            {status && <RecruitingStatusButton status={status} />}
             <Link
               to="/login"
               className="text-label-1-semibold flex h-10 min-w-16 items-center justify-center rounded-[10px] bg-teal-100 px-5 text-center tracking-[-0.32px] text-teal-600"

--- a/src/widgets/navigation/header/RecruitingHeader.tsx
+++ b/src/widgets/navigation/header/RecruitingHeader.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from "@/entities/member/store/authStore"
 import { useHeaderRecruitingStatus } from "@/features/recruiting/hooks/useHeaderRecruitingStatus"
 import UmcLogo from "@/shared/assets/icon/logo/UmcLogo"
 import { SETTINGS_ENTRY_PATH } from "@/shared/config/settingsNavigation"
+import { GuestProfileButton } from "@/widgets/navigation/header/GuestProfileButton"
 import HeaderButton from "@/widgets/navigation/header/HeaderButton"
 import NavigationButton from "@/widgets/navigation/header/NavigationButton"
 import Profile from "@/widgets/navigation/header/Profile"
@@ -66,33 +67,17 @@ export default function RecruitingHeader({
         ))}
       </nav>
 
+      {/* 로그인 여부와 무관하게 배치가 같다. 게스트는 프로필 자리를 로그인
+          진입점으로 쓴다(디자인 확인 완료). 자리를 비우면 로그인 전후로
+          헤더가 흔들린다. */}
       <div className="flex items-center justify-end gap-4 pr-8.5">
-        {isAuthed ? (
-          <>
-            {status && <RecruitingStatusButton status={status} />}
-            <HeaderButton
-              label="문의사항"
-              type="trailing-icon"
-              className="border-teal-gray-150 h-10 border"
-            />
-            <Profile />
-          </>
-        ) : (
-          <>
-            <HeaderButton
-              label="문의사항"
-              type="trailing-icon"
-              className="border-teal-gray-150 h-10 border"
-            />
-            {status && <RecruitingStatusButton status={status} />}
-            <Link
-              to="/login"
-              className="text-label-1-semibold flex h-10 min-w-16 items-center justify-center rounded-[10px] bg-teal-100 px-5 text-center tracking-[-0.32px] text-teal-600"
-            >
-              로그인
-            </Link>
-          </>
-        )}
+        {status && <RecruitingStatusButton status={status} />}
+        <HeaderButton
+          label="문의사항"
+          type="trailing-icon"
+          className="border-teal-gray-150 h-10 border"
+        />
+        {isAuthed ? <Profile /> : <GuestProfileButton />}
       </div>
     </header>
   )

--- a/src/widgets/navigation/header/RecruitingStatusButton.tsx
+++ b/src/widgets/navigation/header/RecruitingStatusButton.tsx
@@ -1,10 +1,8 @@
 import { cn } from "@/shared/lib/utils"
 
-// before/open은 D-day가 필수, closed는 D-day 없음(discriminated union으로 D-undefined 방지).
-export type RecruitingStatus =
-  | { phase: "before"; dDay: number } // 모집 시작까지 남은 일수
-  | { phase: "open"; dDay: number } // 지원 마감까지 남은 일수
-  | { phase: "closed" }
+import type { RecruitingStatus } from "@/shared/model/recruitingStatus"
+
+export type { RecruitingStatus }
 
 // 헤더 우측의 모집 상태 표시. 상호작용 없는 라벨 전용 버튼(디자인상 '버튼' 형태).
 // before: "모집 시작 D-n" / open: "지원하기 D-n"(마감일 기준) / closed: "모집 마감"


### PR DESCRIPTION
> **#699 → #700 → #701 위에 쌓았습니다.** 앞 세 개가 머지되면 이 PR의 diff가 정리됩니다.

## 📸 작업 내용

루트 진입 정책이 바뀌며 **비로그인 방문자가 `/projects`로 바로 떨어지게 됐습니다.** 그 화면은 원래 로그인 사용자용이라 게스트 기준으로 훑었더니 세 군데가 걸렸습니다.

- **게스트가 팀원을 열면 로그인 화면으로 튕깁니다** — 가장 급한 지점
- **목록 쿼리가 아예 실행되지 않습니다** — 기수가 정해지지 않아서
- **결과가 없을 때 빈 그리드만 남습니다** — 데이터가 없는 건지 로딩 중인지 알 수 없음

여기에 **헤더 모집 상태 버튼**을 함께 연동했습니다.

## 🎞️ 주요 코드 설명

### 게스트가 팀원을 열면 튕기던 문제

팀원 조회(`PROJECT-003`)는 인증이 필요한데 `TeamMemberModal`이 가드 없이 부르고 있었습니다. 게스트가 열면 이렇게 됩니다.

```
401 → 갱신할 refresh token 없음 → terminateAuthentication → 로그인으로 이동
```

화면이 통째로 날아갑니다. 디자인의 게스트 상세에도 팀원 영역이 없어 **버튼과 모달을 함께 막았습니다.**

목록·상세 조회의 비인증 허용은 서버에서 별도로 진행 중이지만, **팀원 조회는 그 범위에 없습니다.**

### 목록이 비어 있던 이유

```ts
const effectiveGisuId =
  viewContext.isAdminView && userIsOperator ? activeGisuId : userGisuId
```

게스트는 `userGisuId`가 `undefined`이고 `isAdminView`도 `false`라 **어느 쪽으로도 기수를 얻지 못했습니다.** 쿼리가 `enabled: false`로 실행조차 안 되니 `isLoading`도 `false`였습니다. 스켈레톤도 안 나오고 그냥 빈 그리드가 남습니다.

챌린저 기록이 없으면 활성 기수로 떨어뜨립니다.

### 헤더 모집 상태

`RecruitingStatusButton`은 만들어져 있었는데 **상태를 넘겨주는 곳이 없어 어느 화면에서도 렌더되지 않았습니다.** 디자인에는 역할 4종 헤더 모두에 이 버튼이 있습니다.

공개 모집 목록이 비인증으로 열려 있어 게스트도 받을 수 있습니다. 응답의 모집 시작·마감 시각으로 **프론트에서 D-day를 계산합니다. 서버 작업이 필요 없습니다.**

두 가지를 정했습니다.

- 열린 차수가 여럿이면 **가장 먼저 마감하는 것**을 씁니다. 마감이 임박한 쪽을 보여줘야 지원자가 놓치지 않습니다
- 차수를 못 받으면 **버튼을 그리지 않습니다**. 상태를 모르는데 마감이라고 하면 거짓말이 됩니다

`RecruitingStatus` 타입은 `shared`로 옮겼습니다. `features`가 `widgets`를 참조하면 레이어 규칙에 걸립니다.

### 검증

`tsc -b` / `lint` 0 errors(baseline 유지) / 테스트 749개 / `build` 전부 통과합니다. 모집 상태 계산은 경계 조건 7개로 고정했습니다.

## 🖥️ 구현화면

| 게스트 프로젝트 목록 | 헤더 모집 상태 |
| --- | --- |
|  |  |

## 🔗 연결된 이슈

- Connected: #688, #703, #705
- Closes #703
- Closes #705

**#688에는 `Closes`를 달지 않았습니다.** 내 지원서 편집 등 서버 협의 대기 항목이 남아 있어 이 PR로 닫히면 안 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 역할에 따라 로그인 후 프로젝트 또는 리크루팅 대시보드로 이동합니다.
  * 프로젝트·지원·설정 화면에 새로운 평면형 사이드바와 메뉴를 제공합니다.
  * 모집 상태와 남은 기간을 헤더에서 확인할 수 있습니다.
  * 시즌별 편집 권한에 따라 모집 인원과 담당자 관리 기능을 제한합니다.
  * 비로그인 방문자는 로그인 버튼을 이용할 수 있습니다.

* **버그 수정**
  * 프로젝트가 없거나 불러오기에 실패한 경우 안내 메시지를 표시합니다.
  * 게스트에게 불필요한 팀원 조회 기능이 노출되거나 실행되지 않습니다.
  * 모집 및 프로젝트 화면의 경로별 메뉴 활성화와 이동 동작을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->