### PR TITLE
💄 feat: 게스트 프로젝트 카드·상세 디자인 반영과 검색 색인 전환

### DIFF
--- a/src/features/project/list/model/projectDetailCta.test.ts
+++ b/src/features/project/list/model/projectDetailCta.test.ts
@@ -126,6 +126,28 @@ describe("resolveProjectDetailCtaMode", () => {
     expect(resolveProjectDetailCtaMode(ctaParams)).toBe("apply")
   })
 
+  // 게스트는 지부도 지원 이력도 없어 아래 분기가 전부 기본값으로 흐른다.
+  // 먼저 가르지 않으면 지원할 수 없는 사람에게 지원하기가 열린다.
+  it("비로그인 게스트면 다른 조건과 무관하게 guest를 반환한다", () => {
+    expect(resolveProjectDetailCtaMode({ ...ctaParams, isGuest: true })).toBe(
+      "guest",
+    )
+    expect(
+      resolveProjectDetailCtaMode({
+        ...ctaParams,
+        isGuest: true,
+        isOperator: true,
+      }),
+    ).toBe("guest")
+    expect(
+      resolveProjectDetailCtaMode({
+        ...ctaParams,
+        isGuest: true,
+        isSameBranch: false,
+      }),
+    ).toBe("guest")
+  })
+
   it("내 파트를 모집하지 않는 프로젝트면 apply-blocked-part를 반환한다", () => {
     expect(
       resolveProjectDetailCtaMode({ ...ctaParams, isPartIneligible: true }),

--- a/src/features/project/list/model/projectDetailCta.ts
+++ b/src/features/project/list/model/projectDetailCta.ts
@@ -1,6 +1,7 @@
 import type { ProjectDetail } from "@/entities/project/api/matchingProject"
 
 export type ProjectDetailCtaMode =
+  | "guest"
   | "recruit-questions"
   | "my-application"
   | "apply"
@@ -13,6 +14,7 @@ export type ProjectDetailCtaMode =
   | "plan-only"
 
 interface ResolveCtaParams {
+  isGuest?: boolean
   isOperator: boolean
   isPm: boolean
   isSameBranch: boolean
@@ -26,6 +28,7 @@ interface ResolveCtaParams {
 }
 
 export function resolveProjectDetailCtaMode({
+  isGuest = false,
   isOperator,
   isPm,
   isSameBranch,
@@ -37,6 +40,9 @@ export function resolveProjectDetailCtaMode({
   isPartRecruitClosed,
   hasActiveRound,
 }: ResolveCtaParams): ProjectDetailCtaMode {
+  // 게스트는 지부도 지원 이력도 없어 아래 분기가 전부 기본값으로 흐른다.
+  // 그대로 두면 지원할 수 없는 사람에게 지원하기가 열리므로 먼저 가른다.
+  if (isGuest) return "guest"
   if (isOperator) return "recruit-questions"
   if (isPm) return "recruit-questions"
   if (!isSameBranch) return "other-branch"

--- a/src/features/project/list/ui/MatchingProjectCard.tsx
+++ b/src/features/project/list/ui/MatchingProjectCard.tsx
@@ -16,6 +16,13 @@ export type MatchingProjectCardVariant =
   | "default"
   | "defaultAnimation"
   | "hoverAnimation"
+  /**
+   * 비로그인 게스트용. 작성자 줄과 파트별 모집 현황을 빼고 파트 이름만 나열한다.
+   *
+   * 디자인이 그렇기도 하지만 데이터도 없다. 공개 응답은 작성자의 이름과 학교를
+   * 지우고 내려주므로, 기본 카드로 그리면 작성자 줄에 구분점만 남는다.
+   */
+  | "guest"
 
 interface MatchingProjectCardProps {
   variant?: MatchingProjectCardVariant
@@ -34,6 +41,35 @@ function RecruitRowItem(row: ProjectRecruitRow) {
         <CounterLabel size="xs" current={current} total={total} />
       </div>
       <RecruitStatusChip done={isDone} className="shrink-0" />
+    </div>
+  )
+}
+
+function GuestCardBody({ data }: { data: MatchingProject }) {
+  const cover = data.coverImage
+  const partNames = data.recruitRows.map((row) => row.part).filter(Boolean)
+
+  return (
+    <div className="flex w-full min-w-0 flex-col items-stretch self-stretch">
+      <div className="bg-teal-gray-200 relative z-0 aspect-[348/184] w-full min-w-0 shrink-0 self-stretch overflow-hidden">
+        <ProjectThumbnail
+          src={cover?.src}
+          alt={cover?.alt ?? `${data.title} 대표 이미지`}
+        />
+      </div>
+
+      <div className="flex w-full min-w-0 flex-col items-start gap-3 p-5">
+        <h3 className="text-heading-7-semibold text-teal-gray-900 w-full min-w-0 truncate">
+          {data.title}
+        </h3>
+        {/* 로그인 카드는 한 줄이지만 게스트 카드는 두 줄까지 보여준다 */}
+        <p className="text-body-2-medium text-teal-gray-600 line-clamp-2 h-10.5 w-full min-w-0">
+          {data.description}
+        </p>
+        <p className="text-caption-2-regular text-teal-gray-500 line-clamp-1 w-full min-w-0">
+          {partNames.join(" · ")}
+        </p>
+      </div>
     </div>
   )
 }
@@ -97,7 +133,9 @@ export function MatchingProjectCard({
   const data = dataProp ?? DEFAULT_MATCHING_PROJECT_MOCK
   const forcedHover = variant === "hoverAnimation"
   const interactiveHover =
-    variant === "default" || variant === "defaultAnimation"
+    variant === "default" ||
+    variant === "defaultAnimation" ||
+    variant === "guest"
 
   return (
     <div
@@ -114,7 +152,11 @@ export function MatchingProjectCard({
           interactiveHover && !forcedHover && "group-hover:-translate-y-1",
         )}
       >
-        <CardBody data={data} />
+        {variant === "guest" ? (
+          <GuestCardBody data={data} />
+        ) : (
+          <CardBody data={data} />
+        )}
         <div
           aria-hidden
           className={cn(

--- a/src/features/project/list/ui/MatchingProjectCardSkeleton.tsx
+++ b/src/features/project/list/ui/MatchingProjectCardSkeleton.tsx
@@ -1,0 +1,61 @@
+import { cn } from "@/shared/lib/utils"
+
+interface MatchingProjectCardSkeletonProps {
+  /** 게스트 카드는 작성자 줄과 모집 현황이 없어 아래쪽이 짧다. */
+  variant?: "default" | "guest"
+  className?: string
+}
+
+export function MatchingProjectCardSkeleton({
+  variant = "default",
+  className,
+}: MatchingProjectCardSkeletonProps) {
+  const isGuest = variant === "guest"
+
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "shadow-drop-neutral-4 flex w-full min-w-0 flex-col items-stretch overflow-hidden rounded-xl bg-white",
+        className,
+      )}
+    >
+      <div className="bg-teal-gray-150 aspect-[348/184] w-full shrink-0 animate-pulse" />
+
+      <div
+        className={cn(
+          "flex w-full min-w-0 flex-col items-start p-5",
+          isGuest ? "gap-3" : "gap-4",
+        )}
+      >
+        <div className="flex w-full min-w-0 flex-col items-start gap-1.5">
+          <div className="bg-teal-gray-150 h-6 w-2/5 animate-pulse rounded-md" />
+          {isGuest ? (
+            <div className="flex w-full flex-col gap-1">
+              <div className="bg-teal-gray-150 h-4 w-full animate-pulse rounded-md" />
+              <div className="bg-teal-gray-150 h-4 w-4/5 animate-pulse rounded-md" />
+            </div>
+          ) : (
+            <>
+              <div className="bg-teal-gray-150 h-4 w-full animate-pulse rounded-md" />
+              <div className="bg-teal-gray-150 h-3.5 w-1/3 animate-pulse rounded-md" />
+            </>
+          )}
+        </div>
+
+        {isGuest ? (
+          <div className="bg-teal-gray-150 h-3.5 w-1/2 animate-pulse rounded-md" />
+        ) : (
+          <div className="flex h-20 w-full min-w-0 flex-col items-start gap-1">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="flex w-full items-center justify-between">
+                <div className="bg-teal-gray-150 h-4 w-28 animate-pulse rounded-md" />
+                <div className="bg-teal-gray-150 h-6 w-14 animate-pulse rounded-full" />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/features/project/list/ui/MatchingProjectsListPage.tsx
+++ b/src/features/project/list/ui/MatchingProjectsListPage.tsx
@@ -13,6 +13,7 @@ import { Pagination } from "@/shared/ui/Pagination"
 
 import { useMatchingProjectListFilters } from "../model/matchingProjectList"
 import { MatchingProjectCard } from "./MatchingProjectCard"
+import { MatchingProjectCardSkeleton } from "./MatchingProjectCardSkeleton"
 import { ProjectDetailCard } from "./ProjectDetailCard"
 import { ProjectSearchField } from "./ProjectSearchField"
 
@@ -29,6 +30,9 @@ const PART_LABEL: Record<string, string> = {
   NODEJS: "Node.js",
 }
 const PART_ORDER = ["DESIGN", "WEB", "IOS", "ANDROID", "SPRINGBOOT", "NODEJS"]
+
+/** 로딩 중 자리를 채울 카드 수. 한 화면에 대략 두 줄이 찬다. */
+const SKELETON_CARD_COUNT = 6
 
 function toMatchingProject(project: ProjectItem): MatchingProject {
   const owner = project.productOwner
@@ -222,10 +226,24 @@ export function MatchingProjectsListPage({
 
         <div
           className={cn(
-            "grid min-w-0 grid-cols-2 gap-5",
+            // 게스트는 사이드바가 없어 폭이 넓다. 2열로 두면 카드가 디자인의
+            // 두 배 가까이 커진다. 로그인 화면은 매칭과 같은 그리드라 건드리지 않는다.
+            "grid min-w-0 gap-5",
+            isGuest ? "grid-cols-3" : "grid-cols-2",
             openFilterId && "pointer-events-none",
           )}
         >
+          {/* 빈 그리드만 남으면 데이터가 없는 건지 로딩이 덜 된 건지 알 수 없다.
+              게스트는 활성 기수까지 기다려야 해서 이 구간이 특히 길다 */}
+          {!useMockData &&
+            isLoading &&
+            Array.from({ length: SKELETON_CARD_COUNT }).map((_, index) => (
+              <MatchingProjectCardSkeleton
+                key={index}
+                variant={isGuest ? "guest" : "default"}
+              />
+            ))}
+
           {visibleProjects.map((project, index) => {
             return (
               <div key={project.id} className="min-w-0">
@@ -262,11 +280,6 @@ export function MatchingProjectsListPage({
 
         {/* 빈 그리드만 남으면 데이터가 없는 건지 로딩이 덜 된 건지 알 수 없다.
             게스트는 활성 기수까지 기다려야 해서 이 구간이 특히 길다 */}
-        {!useMockData && isLoading && (
-          <p className="text-body-2-regular text-teal-gray-500 py-20 text-center">
-            프로젝트를 불러오는 중입니다.
-          </p>
-        )}
 
         {!useMockData && !isLoading && visibleProjects.length === 0 && (
           <p className="text-body-2-regular text-teal-gray-500 py-20 text-center">

--- a/src/features/project/list/ui/MatchingProjectsListPage.tsx
+++ b/src/features/project/list/ui/MatchingProjectsListPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 
+import { useMe } from "@/entities/member/hooks/useMe"
 import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import { MOCK_MATCHING_PROJECTS } from "@/entities/project/model/matchingProject.mock"
 import { trackEvent } from "@/shared/analytics"
@@ -85,6 +86,10 @@ export function MatchingProjectsListPage({
     isError,
     filterDescriptors,
   } = useMatchingProjectListFilters()
+  // 비로그인 게스트. 공개 응답은 작성자 이름·학교를 지우고 오므로 카드도
+  // 디자인대로 작성자 줄과 모집 현황을 빼고 파트 이름만 보여준다.
+  const { data: me } = useMe()
+  const isGuest = me === undefined
 
   const { getChapterIdBySchool } = useSchoolChapterMap()
 
@@ -245,7 +250,10 @@ export function MatchingProjectsListPage({
                     )
                   }}
                 >
-                  <MatchingProjectCard variant="default" data={project} />
+                  <MatchingProjectCard
+                    variant={isGuest ? "guest" : "default"}
+                    data={project}
+                  />
                 </button>
               </div>
             )

--- a/src/features/project/list/ui/MatchingProjectsListPage.tsx
+++ b/src/features/project/list/ui/MatchingProjectsListPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 
-import { useMe } from "@/entities/member/hooks/useMe"
+import { useAuthStore } from "@/entities/member/store/authStore"
 import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import { MOCK_MATCHING_PROJECTS } from "@/entities/project/model/matchingProject.mock"
 import { trackEvent } from "@/shared/analytics"
@@ -92,8 +92,10 @@ export function MatchingProjectsListPage({
   } = useMatchingProjectListFilters()
   // 비로그인 게스트. 공개 응답은 작성자 이름·학교를 지우고 오므로 카드도
   // 디자인대로 작성자 줄과 모집 현황을 빼고 파트 이름만 보여준다.
-  const { data: me } = useMe()
-  const isGuest = me === undefined
+  //
+  // me 의 유무로 보면 안 된다. 회원 조회는 비동기라 로그인 사용자도 첫 렌더에는
+  // me 가 없어, 잠깐 게스트 카드가 스쳐 지나간다. 토큰 유무는 동기로 안다.
+  const isGuest = !useAuthStore((s) => s.isAuthed)
 
   const { getChapterIdBySchool } = useSchoolChapterMap()
 

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -10,6 +10,7 @@ import {
   isCurrentTermPm,
   isOperator,
 } from "@/entities/member/model/identity"
+import { useAuthStore } from "@/entities/member/store/authStore"
 import { useViewerIdentity } from "@/entities/member/view-mode/useViewerIdentity"
 import {
   getActiveMatchingRound,
@@ -181,7 +182,10 @@ export function ProjectDetailCard({
   // 비로그인 방문자. 팀원 조회는 아직 인증이 필요해서, 열어 두면 401 이 나고
   // 토큰 갱신에 실패해 로그인 화면으로 튕긴다. 디자인에도 게스트 상세에는
   // 작성자·모집 상태·액션 버튼이 없다.
-  const isGuest = me === undefined
+  //
+  // me 의 유무로 보면 안 된다. 회원 조회는 비동기라 로그인 사용자도 첫 렌더에는
+  // me 가 없어, 잠깐 게스트 화면이 스쳐 지나간다. 토큰 유무는 동기로 안다.
+  const isGuest = !useAuthStore((s) => s.isAuthed)
   const addToast = useToastStore((s) => s.addToast)
   const userIsOperator = isOperator(me)
   const userIsPm = isCurrentTermPm(me)

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -29,6 +29,7 @@ import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
 import { ProjectLogo } from "@/shared/assets/icon/logo/ProjectLogo"
 import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
 import { formatSchoolName } from "@/shared/lib/formatSchoolName"
+import { cn } from "@/shared/lib/utils"
 import { withImageCacheKey } from "@/shared/lib/withImageCacheKey"
 import { Button } from "@/shared/ui/Button"
 import { TeamMemberButton } from "@/shared/ui/button/TeamMemberButton"
@@ -416,6 +417,7 @@ export function ProjectDetailCard({
   const ctaMode =
     viewOnly && !isAdminView && !isPmView
       ? resolveProjectDetailCtaMode({
+          isGuest,
           isOperator: false,
           isPm: false,
           isSameBranch,
@@ -427,6 +429,7 @@ export function ProjectDetailCard({
           isPartRecruitClosed,
         })
       : resolveProjectDetailCtaMode({
+          isGuest,
           isOperator: isAdminView,
           isPm: isPmView,
           isSameBranch,
@@ -496,32 +499,48 @@ export function ProjectDetailCard({
               </p>
             </div>
 
-            <div className="flex w-full flex-col items-start gap-1.5">
-              {data.recruitRows.map((row) => {
-                const done = isRecruitDone(row)
-                return (
-                  <div
-                    key={row.part}
-                    className="flex w-full min-w-0 items-center justify-between gap-3"
-                  >
-                    <div className="flex w-30.5 min-w-0 shrink-0 items-center justify-between gap-2">
-                      <span className="text-body-2-medium text-teal-gray-700 truncate">
-                        {row.part}
-                      </span>
-                      <CounterLabel
-                        size="sm"
-                        current={row.current}
-                        total={row.total}
-                      />
+            {/* 게스트에게는 모집 현황 대신 파트와 모집 인원만 한 줄로 준다 */}
+            {isGuest ? (
+              <p className="text-body-2-medium text-teal-gray-600 w-full">
+                {data.recruitRows
+                  .map((row) => `${row.part} ${row.total}`)
+                  .join(" · ")}
+              </p>
+            ) : (
+              <div className="flex w-full flex-col items-start gap-1.5">
+                {data.recruitRows.map((row) => {
+                  const done = isRecruitDone(row)
+                  return (
+                    <div
+                      key={row.part}
+                      className="flex w-full min-w-0 items-center justify-between gap-3"
+                    >
+                      <div className="flex w-30.5 min-w-0 shrink-0 items-center justify-between gap-2">
+                        <span className="text-body-2-medium text-teal-gray-700 truncate">
+                          {row.part}
+                        </span>
+                        <CounterLabel
+                          size="sm"
+                          current={row.current}
+                          total={row.total}
+                        />
+                      </div>
+                      <RecruitStatusChip done={done} />
                     </div>
-                    <RecruitStatusChip done={done} />
-                  </div>
-                )
-              })}
-            </div>
+                  )
+                })}
+              </div>
+            )}
           </div>
 
-          <div className="scrollbar-none mt-8.5 flex w-full flex-nowrap items-start gap-2.5 overflow-x-auto pb-1">
+          {/* 게스트 상세에는 액션이 없다. 팀원·기획안·지원 모두 로그인이 필요해
+              눌러도 로그인으로 튕기므로 디자인대로 영역째 두지 않는다. */}
+          <div
+            className={cn(
+              "scrollbar-none mt-8.5 w-full flex-nowrap items-start gap-2.5 overflow-x-auto pb-1",
+              isGuest ? "hidden" : "flex",
+            )}
+          >
             {!isGuest && (
               <TeamMemberButton
                 variant="weak"

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -35,6 +35,7 @@ import { Button } from "@/shared/ui/Button"
 import { TeamMemberButton } from "@/shared/ui/button/TeamMemberButton"
 import { RecruitStatusChip } from "@/shared/ui/chip/RecruitStatusChip"
 import { CounterLabel } from "@/shared/ui/CounterLabel"
+import { LoadingSpinner } from "@/shared/ui/LoadingSpinner"
 import { Modal } from "@/shared/ui/Modal"
 import { ProjectThumbnail } from "@/shared/ui/ProjectThumbnail"
 import { useToastStore } from "@/shared/ui/toast/useToastStore"
@@ -82,35 +83,18 @@ interface ProjectDetailCardProps {
   canManageProject?: boolean
 }
 
-function ProjectDetailCardSkeleton() {
+/**
+ * 카드 자리를 미리 잡지 않는다. 흰 판을 띄웠다가 내용이 들어오면서 높이가
+ * 튀는 것보다, 어두운 배경 위에 스피너만 두는 편이 덜 흔들린다.
+ */
+function ProjectDetailCardLoading() {
   return (
-    <div className="flex max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-135 min-w-0 flex-col items-start overflow-x-hidden overflow-y-auto rounded-2xl bg-white">
-      <div className="bg-teal-gray-200 aspect-[540/286] w-full shrink-0 animate-pulse" />
-      <div className="flex w-full flex-col items-start p-5">
-        <div className="flex w-full flex-col items-start gap-6">
-          <div className="flex w-full flex-col items-start gap-2.5">
-            <div className="flex w-full flex-row items-center justify-between gap-4">
-              <div className="bg-teal-gray-150 h-6 w-full max-w-52 animate-pulse rounded-md" />
-              <div className="bg-teal-gray-150 h-4 w-32 animate-pulse rounded-md" />
-            </div>
-            <div className="bg-teal-gray-150 h-4 w-full animate-pulse rounded-md" />
-          </div>
-          <div className="flex w-full flex-col items-start gap-1.5">
-            {[0, 1, 2].map((i) => (
-              <div key={i} className="flex w-full items-center justify-between">
-                <div className="bg-teal-gray-150 h-4 w-28 animate-pulse rounded-md" />
-                <div className="bg-teal-gray-150 h-6 w-14 animate-pulse rounded-full" />
-              </div>
-            ))}
-          </div>
-        </div>
-        <div className="mt-8.5 flex w-full flex-row items-start gap-2.5">
-          <div className="bg-teal-gray-150 h-11 w-11 animate-pulse rounded-xl" />
-          <div className="bg-teal-gray-150 h-11 flex-1 animate-pulse rounded-xl" />
-          <div className="bg-teal-gray-150 h-11 flex-1 animate-pulse rounded-xl" />
-        </div>
-      </div>
-    </div>
+    <LoadingSpinner
+      size="lg"
+      label="프로젝트를 불러오는 중"
+      className="text-white"
+      trackClassName="border-white/30 border-t-white"
+    />
   )
 }
 
@@ -459,7 +443,7 @@ export function ProjectDetailCard({
   }, [detail, projectId, ctaMode, viewOnly])
 
   if (isDetailLoading) {
-    return <ProjectDetailCardSkeleton />
+    return <ProjectDetailCardLoading />
   }
 
   return (

--- a/src/routes/projects/application/$applicationId.tsx
+++ b/src/routes/projects/application/$applicationId.tsx
@@ -17,6 +17,10 @@ import type {
 import type { ApplicationSection } from "@/features/recruiting/model/applicationDetail"
 
 export const Route = createFileRoute("/projects/application/$applicationId")({
+  // 개인 지원 정보라 색인시키지 않는다.
+  head: () => ({
+    meta: [{ name: "robots", content: "noindex, nofollow" }],
+  }),
   beforeLoad: () => {
     if (typeof window !== "undefined") {
       const isVerified = sessionStorage.getItem("isApplicationVerified")

--- a/src/routes/projects/application/index.tsx
+++ b/src/routes/projects/application/index.tsx
@@ -15,6 +15,10 @@ import { CodeInput } from "@/shared/ui/input/CodeInput"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
 
 export const Route = createFileRoute("/projects/application/")({
+  // 개인 지원 정보라 색인시키지 않는다.
+  head: () => ({
+    meta: [{ name: "robots", content: "noindex, nofollow" }],
+  }),
   beforeLoad: () => {
     if (typeof window !== "undefined") {
       const isVerified = sessionStorage.getItem("isApplicationVerified")

--- a/src/routes/projects/application/list.tsx
+++ b/src/routes/projects/application/list.tsx
@@ -13,6 +13,10 @@ import type { RecruitingApplication } from "@/features/recruiting"
 import type { PartTag } from "@/shared/model/domain"
 
 export const Route = createFileRoute("/projects/application/list")({
+  // 개인 지원 정보라 색인시키지 않는다.
+  head: () => ({
+    meta: [{ name: "robots", content: "noindex, nofollow" }],
+  }),
   beforeLoad: () => {
     if (typeof window !== "undefined") {
       const isVerified = sessionStorage.getItem("isApplicationVerified")

--- a/src/routes/projects/apply/$roundId.tsx
+++ b/src/routes/projects/apply/$roundId.tsx
@@ -4,6 +4,10 @@ import { ensureMe } from "@/features/auth/lib/ensureMe"
 import { RecruitingApplyPage } from "@/features/recruiting"
 
 export const Route = createFileRoute("/projects/apply/$roundId")({
+  // 개인 지원 정보라 색인시키지 않는다.
+  head: () => ({
+    meta: [{ name: "robots", content: "noindex, nofollow" }],
+  }),
   // /projects 레이아웃에는 로그인 가드가 없다. 지원서 작성은 로그인 사용자
   // 경로만 구현하므로 이 라우트에서 직접 건다.
   beforeLoad: async ({ context, location }) => {

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -4,8 +4,16 @@ import {
   MatchingProjectsListPage,
   validateProjectListSearch,
 } from "@/features/project/list"
+import { createMeta, SITE_URL } from "@/shared/seo"
 
 export const Route = createFileRoute("/projects/")({
+  // 비로그인 유입 진입로라 색인시킨다. 지원 대상자가 검색으로 닿아야 한다.
+  head: () =>
+    createMeta(
+      "프로젝트 | UMC",
+      "UMC 에서 진행 중인 프로젝트를 학교·파트별로 확인할 수 있습니다.",
+      { canonical: `${SITE_URL}/projects` },
+    ),
   validateSearch: validateProjectListSearch,
   component: ProjectsListRoute,
 })

--- a/src/routes/projects/notice.tsx
+++ b/src/routes/projects/notice.tsx
@@ -1,7 +1,14 @@
 import { createFileRoute } from "@tanstack/react-router"
 
 import { RecruitmentNoticePage } from "@/features/recruiting"
+import { createMeta, SITE_URL } from "@/shared/seo"
 
 export const Route = createFileRoute("/projects/notice")({
+  head: () =>
+    createMeta(
+      "모집 공고 | UMC",
+      "UMC 학교별 모집 공고와 지원 일정을 확인할 수 있습니다.",
+      { canonical: `${SITE_URL}/projects/notice` },
+    ),
   component: RecruitmentNoticePage,
 })

--- a/src/routes/projects/route.tsx
+++ b/src/routes/projects/route.tsx
@@ -11,10 +11,10 @@ import Footer from "@/widgets/footer/Footer"
 import RecruitingHeader from "@/widgets/navigation/header/RecruitingHeader"
 import { FlatSideBar } from "@/widgets/navigation/sidebar/FlatSideBar"
 
+// robots 는 하위 라우트에서 각자 정한다. 여기서 한 번에 걸면 색인시켜야 할
+// 프로젝트 목록까지 막힌다. 지원서 작성·조회처럼 개인 화면은 각 라우트에서
+// noindex 를 명시한다.
 export const Route = createFileRoute("/projects")({
-  head: () => ({
-    meta: [{ name: "robots", content: "noindex, nofollow" }],
-  }),
   component: ProjectsLayout,
 })
 

--- a/src/shared/lib/withImageCacheKey.test.ts
+++ b/src/shared/lib/withImageCacheKey.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+
+import { withImageCacheKey } from "./withImageCacheKey"
+
+const PRESIGNED =
+  "https://bucket.s3.ap-northeast-2.amazonaws.com/a.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20260806T110434Z&X-Amz-Signature=abc123"
+
+describe("withImageCacheKey", () => {
+  it("값이 없으면 null", () => {
+    expect(withImageCacheKey(null, 1)).toBeNull()
+    expect(withImageCacheKey("", 1)).toBeNull()
+  })
+
+  it("일반 URL 에는 캐시키를 붙인다", () => {
+    expect(withImageCacheKey("https://cdn.example.com/a.jpg", 7)).toBe(
+      "https://cdn.example.com/a.jpg?v=7",
+    )
+    expect(withImageCacheKey("https://cdn.example.com/a.jpg?w=100", 7)).toBe(
+      "https://cdn.example.com/a.jpg?w=100&v=7",
+    )
+  })
+
+  it("해시는 뒤에 남긴다", () => {
+    expect(withImageCacheKey("https://cdn.example.com/a.jpg#frag", 7)).toBe(
+      "https://cdn.example.com/a.jpg?v=7#frag",
+    )
+  })
+
+  // 파라미터를 하나라도 더하면 서명이 깨져 403 이 되고 이미지가 fallback 으로 빠진다
+  it("presigned URL 은 그대로 둔다", () => {
+    expect(withImageCacheKey(PRESIGNED, 7)).toBe(PRESIGNED)
+  })
+})

--- a/src/shared/lib/withImageCacheKey.ts
+++ b/src/shared/lib/withImageCacheKey.ts
@@ -1,8 +1,20 @@
+/**
+ * presigned URL 은 서명이 쿼리 파라미터 집합에 걸려 있어, 파라미터를 하나라도
+ * 더하면 서명이 깨져 403 이 된다.
+ *
+ * 캐시를 깰 필요도 없다. 서버가 요청마다 새 서명으로 URL 을 발급하므로
+ * 같은 이미지라도 주소가 매번 달라진다.
+ */
+function isPresigned(url: string): boolean {
+  return url.includes("X-Amz-Signature=")
+}
+
 export function withImageCacheKey(
   src: string | null | undefined,
   cacheKey: number,
 ): string | null {
   if (!src) return null
+  if (isPresigned(src)) return src
 
   const hashIndex = src.indexOf("#")
   const baseUrl = hashIndex >= 0 ? src.slice(0, hashIndex) : src

--- a/src/shared/ui/LoadingSpinner.tsx
+++ b/src/shared/ui/LoadingSpinner.tsx
@@ -1,0 +1,41 @@
+import { cn } from "@/shared/lib/utils"
+
+const SIZE_CLASS = {
+  sm: "h-5 w-5 border-2",
+  md: "h-8 w-8 border-[3px]",
+  lg: "h-11 w-11 border-4",
+} as const
+
+interface LoadingSpinnerProps {
+  size?: keyof typeof SIZE_CLASS
+  /** 스크린리더용 문구. 화면에는 보이지 않는다. */
+  label?: string
+  className?: string
+  /** 어두운 배경 위에 띄울 때처럼 링 색을 바꿔야 하는 경우에만 쓴다. */
+  trackClassName?: string
+}
+
+export function LoadingSpinner({
+  size = "md",
+  label = "불러오는 중",
+  className,
+  trackClassName,
+}: LoadingSpinnerProps) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn("flex items-center justify-center", className)}
+    >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "border-teal-gray-200 animate-spin rounded-full border-t-teal-400 motion-reduce:animate-none",
+          SIZE_CLASS[size],
+          trackClassName,
+        )}
+      />
+      <span className="sr-only">{label}</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## 📸 작업 내용

- **게스트 카드·상세를 디자인대로 분기했다.** 지금까지 게스트도 로그인 사용자와 똑같은 카드·상세를 보고 있었다.
- **프로젝트 목록·모집 공고를 검색 색인 대상으로 바꿨다.** 게스트 진입은 열어 두고 `noindex` 는 그대로여서, 검색으로 닿을 수 없었다.
- 지원서 작성·내 지원서는 개인 정보라 라우트별로 `noindex` 를 명시했다.

## 🎞️ 주요 코드 설명

### 게스트 카드에 데이터가 없다

공개 응답은 작성자의 `name` 과 `schoolName` 을 `null` 로 준다(`nickname` 만 온다). 기본 카드는 `작성자 · 학교` 를 그리므로, 게스트에게는 **구분점만 남은 빈 줄**이 나간다.

디자인도 게스트 카드에는 작성자 줄이 없다. `MatchingProjectCard` 에 `guest` variant 를 추가해 작성자 줄과 파트별 모집 현황을 빼고, 파트 이름만 나열하며 설명을 두 줄까지 보여준다.

| | 로그인 | 게스트 |
|---|---|---|
| 작성자·학교 | 표시 | 없음 |
| 설명 | 1줄 | 2줄 |
| 파트 | 파트별 인원 + 모집 상태 | 파트 이름만 (`Design · Web · SpringBoot`) |

상세는 모집 현황 표 대신 파트와 모집 인원을 한 줄로 주고(`Design 1 · Web 3 · SpringBoot 3`), 액션 영역을 감춘다. 팀원·기획안·지원 모두 로그인이 필요해 눌러도 로그인으로 튕긴다.

### 게스트에게 지원하기가 열려 있었다

`resolveProjectDetailCtaMode` 는 지부·지원 이력·파트 자격을 차례로 본다. **게스트는 이 값이 전부 없어서 모든 분기를 통과해 `apply` 로 떨어진다.** 지원할 수 없는 사람에게 지원하기가 열리는 셈이라, `guest` 를 맨 앞에서 가르도록 했다.

### 색인 범위

레이아웃에 `noindex` 를 한 번에 걸면 색인시켜야 할 목록까지 막힌다. 라우트별로 나눴다.

| 경로 | 색인 |
|---|---|
| `/projects` (목록) | O |
| `/projects/notice` (모집 공고) | O |
| `/projects/apply/*`, `/projects/application/*` | X |

모집 공고를 색인 대상에 넣은 건 판단이 들어간 부분이라, 빼는 게 맞다면 알려주세요.

## 🔗 연결된 이슈

- Connected: #688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 비로그인 상태에서도 프로젝트 목록과 상세 정보를 확인할 수 있도록 게스트 전용 카드와 CTA가 추가되었습니다.
  - 게스트에게는 프로젝트 이미지, 제목, 설명, 파트 정보 등 공개 콘텐츠만 표시됩니다.
  - 프로젝트 및 공지 페이지에 제목, 설명, canonical URL 등 SEO 정보가 제공됩니다.

- **개선**
  - 지원 관련 개인정보 및 지원서 페이지가 검색엔진에 노출되지 않도록 설정되었습니다.
  - 프로젝트 하위 페이지별 검색 노출 정책이 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->