### PR TITLE
fix: 빌드 타입 에러 수정 (AllocationStatus 및 테스트 타입 보완)

### DIFF
--- a/src/features/recruiting/ui/RecruitmentQuotaPage.test.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.test.tsx
@@ -73,7 +73,7 @@ describe("RecruitmentQuotaPage 저장 경로 분류", () => {
       isLoading: false,
       isError: false,
       isForbidden: false,
-    } as ReturnType<typeof useAdminRecruitingRounds>)
+    } as unknown as ReturnType<typeof useAdminRecruitingRounds>)
 
     // seasonConfigsMap에 unconfigured-season-123 설정이 없음
     vi.mocked(useRecruitingSeasonQuotas).mockReturnValue({
@@ -95,7 +95,11 @@ describe("RecruitmentQuotaPage 저장 경로 분류", () => {
     )
 
     // 수정 트리거 발생
-    fireEvent.click(screen.getAllByTestId("edit-school-btn")[0])
+    const editBtn = screen.getAllByTestId("edit-school-btn")[0]
+    expect(editBtn).toBeDefined()
+    if (editBtn) {
+      fireEvent.click(editBtn)
+    }
 
     const saveButton = screen.getByRole("button", { name: "저장" })
     expect(saveButton).not.toBeDisabled()

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -149,7 +149,7 @@ export function RecruitmentQuotaPage() {
           duration: 3000,
         })
       }
-      return "직접 수정 중"
+      return "임의 배정 중"
     })
     setIsDirty(true)
   }, [addToast])


### PR DESCRIPTION
## 📸 작업 내용

모집 인원 설정(`/recruiting/recruitments/quota`) 화면의 지부 전체 수정 기능 추가, 시즌 생성/수정 분기 처리 및 빌드 에러 수정 작업입니다.

- **"지부 전체" 행 직접 수정 기능 구현**:
  - 표 하단의 "지부 전체" 행에 `QuotaEditableCell`을 배치하여 PM, Design, Web PE, Mobile PE 파트별 지부 목표 인원을 직접 수정할 수 있도록 변경했습니다.
  - "지부 전체" 행 수정 시 개별 대학교 TO를 덮어쓰지 않고, 해당 지부의 파트별 목표 한도(`chapterTotals`)만 독립적으로 업데이트하도록 구현했습니다.
  - 부모 컴포넌트(`RecruitmentQuotaPage`) 리렌더링 시 "지부 전체" 수정 값이 초기화되지 않도록 `isTotalsEditedRef` 및 `prevSchoolsRef`로 상태 유지 보호를 적용했습니다.
- **모집 시즌 생성(`POST`) / 쿼터 수정(`PUT`) 분기 및 에러 처리**:
  - 모집 시즌 설정이 없는 행(`seasonId: undefined`)은 `POST /v1/recruiting/admin/seasons` (`createSeason`)를 호출하여 시즌 생성을 진행하고, 이미 존재하는 행은 `PUT /v1/recruiting/admin/seasons/{seasonId}/quotas` (`updateQuotas`)로 분기 처리했습니다.
  - `Promise.allSettled`를 적용하여 각 요청의 성공/실패를 개별 추적하고, 성공한 대학교만 `editedSchoolsMap`에서 제거하며 실패 건은 재시도할 수 있도록 유지합니다.
  - `RECRUITING-0103` (이미 존재하는 기수/학교 시즌) 에러 발생 시 명확한 새로고침 안내 토스트를 노출합니다.
- **develop 브랜치 머지 및 빌드 타입 에러 해결**:
  - `develop` 브랜치의 최신 변경 사항 머지 및 충돌 해결을 진행했습니다.
  - `AllocationStatus` 타입 정의 불일치 및 테스트 타입 에러를 보완하여 `pnpm build` (`tsc -b && vite build`) 100% 성공을 검증했습니다.

## 🎞️ 주요 코드 설명

### 주제 1: "지부 전체" 행 직접 수정 및 리렌더링 시 값 유지 보장 (`ChapterQuotaTableCard.tsx`)

```TypeScript
// 사용자가 지부 전체 수치를 수정한 경우 isTotalsEditedRef를 true로 설정하여
// 부모 컴포넌트 리렌더링 시 data.totals로 재초기화되는 현상을 방지합니다.
const isTotalsEditedRef = useRef(false)
const prevSchoolsRef = useRef(data.schools)

useEffect(() => {
  if (prevSchoolsRef.current !== data.schools) {
    prevSchoolsRef.current = data.schools
    isTotalsEditedRef.current = false
    setSchoolsData(data.schools)
    setLastValidSchoolsData(data.schools)
    setChapterTotals(data.totals)
  } else if (!isTotalsEditedRef.current) {
    setChapterTotals(data.totals)
  }
}, [data.schools, data.totals])

const handleChapterTotalChange = (
  partKey: "pm" | "design" | "webPe" | "mobilePe",
  newTotal: number,
) => {
  isTotalsEditedRef.current = true
  const updatedTotals = { ...chapterTotals, [partKey]: newTotal }
  updatedTotals.total =
    updatedTotals.pm +
    updatedTotals.design +
    updatedTotals.webPe +
    updatedTotals.mobilePe

  setChapterTotals(updatedTotals)
  onDirtyChange?.(true)
  onManualEdit?.()
  onSchoolsDataChange?.(schoolsData)
}
```

- 사용자가 "지부 전체" 수치를 수정하더라도 개별 학교의 TO를 강제로 자동 분할하지 않고, 지부 총 한도 수치만 독립적으로 수정됩니다.

### 주제 2: 시즌 미생성 대학교 생성(`createSeason`) / 기존 대학교 쿼터 수정(`updateQuotas`) 분기 처리 (`RecruitmentQuotaPage.tsx`)

```TypeScript
const existingSeasonRows = rawRows.filter(
  (row): row is SchoolQuotaRow & { seasonId: string } =>
    Boolean(row.seasonId) && canEditSeason(row.seasonId),
)
const newSeasonRows = rawRows.filter(
  (row): row is SchoolQuotaRow & { gisuId: string; schoolId: string } =>
    !row.seasonId && Boolean(row.gisuId) && Boolean(row.schoolId),
)

// newSeasonRows에 대해 Promise.allSettled 기반으로 createSeason(POST) 호출
if (newSeasonRows.length > 0) {
  const createResults = await Promise.allSettled(
    newSeasonRows.map(async (row) => {
      await createSeason({
        gisuId: row.gisuId,
        schoolId: row.schoolId,
        quotas: [
          { track: "PLAN", targetCount: row.pm },
          { track: "DESIGN", targetCount: row.design },
          { track: "WEB_PRODUCT_ENGINEER", targetCount: row.webPe },
          { track: "MOBILE_PRODUCT_ENGINEER", targetCount: row.mobilePe },
        ],
      })
      return row
    }),
  )
  ...
}
```

- 시즌이 아직 생성되지 않은 대학교(`seasonId` 없음)를 저장하면 `POST /v1/recruiting/admin/seasons`를 통해 새로운 시즌을 자동으로 생성합니다.

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #713 
