### PR TITLE
Bug: 686 recruitment create error

### DIFF
--- a/src/features/recruiting/api/types.ts
+++ b/src/features/recruiting/api/types.ts
@@ -82,16 +82,16 @@ export type RawAdminRoundGroup = Omit<RecruitingRoundGroup, "rounds"> & {
   rounds?: RawAdminRound[]
 }
 
-// interviewRequired=true 는 아직 프론트에서 막아둔다. 지원자가 면접 가능 시간을
-// 제출하는 경로(RECRUITING-SCHEDULE-001)는 구현됐지만, 면접 있는 차수를 만들려면
-// 가능 일정 Form 과 그 안의 일정 문항 ID 를 함께 지정해야 한다. 아래 타입에
-// availabilityScheduleQuestionId 가 없어 지금 열면 차수 생성이 거부된다.
+// 백엔드(RecruitingRoundConfiguration.validateInterviewShape)는 interviewRequired=true일
+// 때 interviewStartAt/interviewEndAt만 필수로 본다. availabilityFormId는 생성 시점엔
+// 없어도 되고(OPEN 전환 전까지만 채우면 됨), 대신 availabilityFormId와
+// availabilityScheduleQuestionId는 둘 다 있거나 둘 다 없어야 한다.
 export type CreateRecruitingRoundInterviewFields =
   | {
       interviewRequired: true
       interviewStartAt: string
       interviewEndAt: string
-      availabilityFormId: string
+      availabilityFormId?: string
     }
   | {
       interviewRequired: false

--- a/src/features/recruiting/model/recruitingScope.ts
+++ b/src/features/recruiting/model/recruitingScope.ts
@@ -1,3 +1,5 @@
+import { formatSchoolName } from "@/shared/lib/formatSchoolName"
+
 import type { RecruitingRoundGroup } from "../api/types"
 
 export interface RecruitingScope {
@@ -73,7 +75,11 @@ export function applyScopeFilters(
   }
 
   if (showSchoolTabs && schoolTab !== "all") {
-    return scope.groups.filter((group) => group.schoolName === schoolTab)
+    // schoolTab은 SCHOOLS_BY_BRANCH 축약형("동국대")인데 group.schoolName은
+    // 백엔드 정식 명칭("동국대학교")이라 그대로 비교하면 항상 어긋난다.
+    return scope.groups.filter(
+      (group) => formatSchoolName(group.schoolName) === schoolTab,
+    )
   }
 
   return scope.groups

--- a/src/features/recruiting/model/recruitmentCreate.ts
+++ b/src/features/recruiting/model/recruitmentCreate.ts
@@ -1,3 +1,4 @@
+import type { RecruitingTrack } from "../api/types"
 import type { RecruitmentRoundType } from "./recruitmentList"
 
 export type PeriodFieldKey =
@@ -54,6 +55,52 @@ export function periodFieldToInstant(value: PeriodFieldValue): string {
 
 export function composeRecruitmentTitle(baseTitle: string, footer: string) {
   return footer ? `${baseTitle} ${footer}` : baseTitle
+}
+
+// Round 생성(POST)·수정(PUT) 요청 바디에서 공통되는 부분을 조립한다.
+// PUT은 부분 수정이 아니라 완전 교체라 title/recruitableTracks/기간 필드가 전부
+// 필수다(비면 400) — 호출부는 반드시 스토어의 최신 enabledParts·periodForm을
+// 통째로 넘겨야 하고, announcement 텍스트만 담아 보내면 안 된다.
+// 생성은 여기에 type/roundNo를 더해서, 수정은 그대로 보낸다.
+export function buildRoundConfigurationPayload({
+  title,
+  recruitableTracks,
+  secondChoiceEnabled,
+  periodForm,
+  interviewRequired,
+  announcement,
+  contactText,
+}: {
+  title: string
+  recruitableTracks: RecruitingTrack[]
+  secondChoiceEnabled: boolean
+  periodForm: Record<PeriodFieldKey, PeriodFieldValue>
+  interviewRequired: boolean
+  announcement?: string
+  contactText?: string
+}) {
+  return {
+    title,
+    recruitableTracks,
+    secondChoiceEnabled,
+    documentStartAt: periodFieldToInstant(periodForm.documentStartAt),
+    documentEndAt: periodFieldToInstant(periodForm.documentEndAt),
+    documentResultPublishedAt: periodFieldToInstant(
+      periodForm.documentResultPublishedAt,
+    ),
+    finalResultPublishedAt: periodFieldToInstant(
+      periodForm.finalResultPublishedAt,
+    ),
+    announcement,
+    contactText,
+    ...(interviewRequired
+      ? ({
+          interviewRequired: true as const,
+          interviewStartAt: periodFieldToInstant(periodForm.interviewStartAt),
+          interviewEndAt: periodFieldToInstant(periodForm.interviewEndAt),
+        } as const)
+      : ({ interviewRequired: false as const } as const)),
+  }
 }
 
 export const MAX_TITLE_LENGTH = 10000

--- a/src/features/recruiting/model/recruitmentList.ts
+++ b/src/features/recruiting/model/recruitmentList.ts
@@ -3,6 +3,7 @@ import dayjs from "dayjs"
 
 import { isChapter } from "@/entities/organization/model/chapters"
 import { SCHOOLS_BY_BRANCH } from "@/shared/config/schools"
+import { formatSchoolName } from "@/shared/lib/formatSchoolName"
 
 import type { Chapter } from "@/entities/organization/model/chapters"
 
@@ -14,11 +15,19 @@ import type {
 } from "../api/types"
 
 // 모집 생성(013)에 필요한 seasonId는 화면에서 새로 만드는 게 아니라, 이미
-// 존재하는 시즌 목록(공개 차수 목록 응답에 포함됨)에서 학교명으로 찾아 쓴다.
+// 존재하는 시즌 목록(관리자용 차수 목록 응답에 포함됨)에서 찾아 쓴다.
+// schoolId가 있으면 그걸 우선 쓴다 — schoolName은 조직 서비스(학교 드롭다운)와
+// 모집 서비스(시즌 목록)가 각자 따로 관리하는 문자열이라, 표기가 살짝만
+// 달라도(공백·축약 등) 일치 비교가 깨져 시즌이 있는데도 못 찾는 경우 대비
 export function findSeasonIdBySchool(
   groups: RecruitingRoundGroup[],
   school: string | null | undefined,
+  schoolId?: string | null,
 ): string | undefined {
+  if (schoolId) {
+    const bySchoolId = groups.find((group) => group.schoolId === schoolId)
+    if (bySchoolId) return bySchoolId.seasonId
+  }
   return groups.find((group) => group.schoolName === school)?.seasonId
 }
 
@@ -50,6 +59,7 @@ export interface RecruitmentPost {
 // 이 목록 자체를 받지 못한다(useAdminRecruitingRounds의 isForbidden 참고).
 export function mapRoundGroupsToPosts(
   groups: RecruitingRoundGroup[],
+  authorLabel?: string,
 ): RecruitmentPost[] {
   return groups.flatMap((group) => {
     if (!isChapter(group.chapterName)) return []
@@ -59,15 +69,15 @@ export function mapRoundGroupsToPosts(
         (round): round is RecruitingRound & { status: RecruitingRoundStatus } =>
           round.status != null,
       )
-      .map((round) => mapRoundToPost(group, chapter, round))
+      .map((round) => mapRoundToPost(group, chapter, round, authorLabel))
   })
 }
 
-// 백엔드 응답에 작성자 정보가 없어 authorLabel은 항상 비어 있다.
 function mapRoundToPost(
   group: RecruitingRoundGroup,
   chapter: Chapter,
   round: RecruitingRound & { status: RecruitingRoundStatus },
+  authorLabel?: string,
 ): RecruitmentPost {
   const start = round.documentStartAt ? dayjs(round.documentStartAt) : null
   const end = round.documentEndAt ? dayjs(round.documentEndAt) : null
@@ -76,7 +86,9 @@ function mapRoundToPost(
     postId: round.roundId,
     seasonId: group.seasonId,
     chapter,
-    school: group.schoolName,
+    // SCHOOLS_BY_BRANCH(SchoolTabs 등 세그먼트가 쓰는 축약형)와 비교 가능하도록
+    // 백엔드 정식 명칭("동국대학교")을 여기서 축약형("동국대")으로 통일한다.
+    school: formatSchoolName(group.schoolName),
     title: round.title,
     status: round.status,
     type: round.type,
@@ -90,6 +102,7 @@ function mapRoundToPost(
         )
       : undefined,
     dateLabel: start?.format("YYYY.MM.DD"),
+    authorLabel,
   }
 }
 

--- a/src/features/recruiting/ui/RecruitmentDraftArchiveCard.tsx
+++ b/src/features/recruiting/ui/RecruitmentDraftArchiveCard.tsx
@@ -58,7 +58,10 @@ function DraftPostRow({
           onPublish={() => onPublish(post.postId)}
           // 임시 보관함 안에서는 이미 DRAFT라 비공개 액션이 노출되지 않음
           onPrivatize={() => {}}
-          // TODO: 모집 공고 수정 페이지 라우트 연결
+          // TODO: DRAFT 수정은 생성 마법사 재사용 편집이 필요하다(문항 프리필용 조회
+          // API가 아직 없어 대기 중). /recruiting/recruitments/edit/$roundId는 OPEN
+          // 전용이라 DRAFT를 여기로 보내면 "공유 보관함에서 수정해달라"는 안내로
+          // 되돌아오는 순환이 생겨 연결하지 않는다.
           onEdit={() => console.info("TODO: 모집 공고 수정", post.postId)}
           onDuplicate={() => onDuplicate(post.postId)}
           onDelete={() => onDelete(post.postId)}

--- a/src/features/recruiting/ui/RecruitmentListPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentListPage.tsx
@@ -5,6 +5,7 @@ import { useMe } from "@/entities/member/hooks/useMe"
 import { CHAPTERS, isChapter } from "@/entities/organization/model/chapters"
 import DownChevronIcon from "@/shared/assets/icon/chevron/sidebar/DownChevronIcon"
 import { SCHOOLS_BY_BRANCH } from "@/shared/config/schools"
+import { formatSchoolName } from "@/shared/lib/formatSchoolName"
 import { IconButton } from "@/shared/ui/button/IconButton"
 import { FilterDropdown } from "@/shared/ui/FilterDropDown"
 import { PageLabel } from "@/shared/ui/page-label/PageLabel"
@@ -22,13 +23,21 @@ import {
   resolveViewerChapter,
   resolveViewerSchool,
 } from "../model/recruitingRole"
+import {
+  applyScopeFilters,
+  resolveRecruitingScope,
+} from "../model/recruitingScope"
 import { resolveAvailableTitle } from "../model/recruitmentCreate"
 import {
   groupPostsByChapter,
   mapRoundGroupsToPosts,
   RECRUITMENT_SORT_OPTIONS,
 } from "../model/recruitmentList"
-import { RECRUITMENT_LIST_MOCK } from "../model/recruitmentList.mock"
+import {
+  RECRUITING_MY_CHAPTER_MOCK,
+  RECRUITING_MY_SCHOOL_MOCK,
+  RECRUITMENT_LIST_MOCK,
+} from "../model/recruitmentList.mock"
 import { ChapterTabs } from "./ChapterTabs"
 import { RecruitmentCreateButton } from "./RecruitmentCreateButton"
 import { RecruitmentDraftArchiveCard } from "./RecruitmentDraftArchiveCard"
@@ -38,6 +47,7 @@ import { RecruitmentSchoolSearchDropdown } from "./RecruitmentSchoolSearchDropdo
 import { SchoolTabs } from "./SchoolTabs"
 
 import type { RecruitingListRole } from "../model/recruitingListRole"
+import type { RecruitingScope } from "../model/recruitingScope"
 import type { RecruitmentPost, RecruitmentSort } from "../model/recruitmentList"
 
 interface RecruitmentListPageProps {
@@ -47,16 +57,66 @@ interface RecruitmentListPageProps {
   useMockData?: boolean
 }
 
+// 테스트 라우트 전용: 실 데이터 없이 role만으로 조회 스코프를 흉내낸다.
+// 실 데이터 경로는 resolveRecruitingScope(권한 조회 결과)를 그대로 쓴다.
+function buildMockScope(role: RecruitingListRole): RecruitingScope {
+  if (role === "central") {
+    return {
+      groups: [],
+      chapters: [...CHAPTERS],
+      schools: [],
+      isFallback: false,
+    }
+  }
+  if (role === "chapterAdmin") {
+    return {
+      groups: [],
+      chapters: [RECRUITING_MY_CHAPTER_MOCK],
+      schools: [...SCHOOLS_BY_BRANCH[RECRUITING_MY_CHAPTER_MOCK]],
+      isFallback: false,
+    }
+  }
+  return {
+    groups: [],
+    chapters: [RECRUITING_MY_CHAPTER_MOCK],
+    schools: [RECRUITING_MY_SCHOOL_MOCK],
+    isFallback: true,
+  }
+}
+
+function filterMockPosts(
+  posts: RecruitmentPost[],
+  showChapterTabs: boolean,
+  showSchoolTabs: boolean,
+  chapterTab: string,
+  schoolTab: string,
+): RecruitmentPost[] {
+  if (showChapterTabs) {
+    return chapterTab === "all"
+      ? posts
+      : posts.filter((post) => post.chapter === chapterTab)
+  }
+  if (showSchoolTabs && schoolTab !== "all") {
+    return posts.filter((post) => post.school === schoolTab)
+  }
+  return posts
+}
+
 export function RecruitmentListPage({
   role: roleOverride,
   useMockData = false,
 }: RecruitmentListPageProps) {
   const navigate = useNavigate()
   const { data: me } = useMe()
+  // RecruitmentCreatePage(BasicInfoForm)가 진입 지점별 필드 잠금에 쓰는 값이라
+  // role 자체는 계속 넘긴다. 이 화면의 조회 범위는 더 이상 role로 가르지 않고
+  // resolveRecruitingScope의 실제 EDIT 권한 결과를 따른다.
   const role = roleOverride ?? resolveRecruitingListRole(me)
-  const viewerChapter = resolveViewerChapter(me)
   const viewerSchool = resolveViewerSchool(me)
-  const myChapter = isChapter(viewerChapter) ? viewerChapter : undefined
+  const viewerChapterName = resolveViewerChapter(me)
+  const viewerChapter = isChapter(viewerChapterName)
+    ? viewerChapterName
+    : undefined
 
   const [chapterTab, setChapterTab] = useState("all")
   const [schoolTab, setSchoolTab] = useState("all")
@@ -67,31 +127,73 @@ export function RecruitmentListPage({
   const [sort, setSort] = useState<RecruitmentSort>("NEWEST")
   const [sortOpen, setSortOpen] = useState(false)
 
-  // /admin/rounds는 학교 회장단 이상만 조회 가능하다(isForbidden). SCHOOL_STAFF는
-  // 현재 이 화면에서 공고 목록을 볼 수 없다 — 알려진 백엔드 권한 제약.
   const {
     groups,
     isLoading: isRoundsLoading,
     isError: isRoundsError,
     isForbidden,
   } = useAdminRecruitingRounds(sort)
-  const fetchedPosts = useMemo(() => mapRoundGroupsToPosts(groups), [groups])
+
+  // 편집 권한은 role이 아니라 시즌 단위 실제 EDIT 권한으로 판정한다(canEditRecruitmentPost 참고).
+  const seasonIds = useMemo(
+    () => [...new Set(groups.map((group) => group.seasonId))],
+    [groups],
+  )
+  const { permittedSeasonIds } = useRecruitingPermissions(seasonIds)
+
+  // EDIT 권한이 있는 시즌이 조회 범위. 권한이 하나도 없으면 내 학교로 좁혀 시도한다
+  // (resolveRecruitingScope 참고). 지부가 여럿이면 지부 탭, 한 지부에 학교가
+  // 여럿이면 학교 탭으로 가른다 — role 기반 3분기 렌더링을 대체한다.
+  const scope = useMemo(
+    () => resolveRecruitingScope(groups, permittedSeasonIds, viewerSchool),
+    [groups, permittedSeasonIds, viewerSchool],
+  )
+  const mockScope = useMemo(() => buildMockScope(role), [role])
+  const activeScope = useMockData ? mockScope : scope
+  // 세그먼트(지부/학교 탭) 노출은 현재 조회된 데이터 양이 아니라 역할 자체로 정한다.
+  // central=지부 세그먼트, chapterAdmin/schoolStaff=학교 세그먼트 — 게시글이
+  // 하나도 없어도(혹은 EDIT 권한 조회가 아직 비어도) 세그먼트는 항상 보여야 한다.
+  const showChapterTabs = role === "central"
+  const ownScopeChapter = useMockData
+    ? RECRUITING_MY_CHAPTER_MOCK
+    : viewerChapter
+  const showSchoolTabs =
+    (role === "chapterAdmin" || role === "schoolStaff") && !!ownScopeChapter
+
+  const authorLabel = me
+    ? `${me.nickname}/${me.name} · ${formatSchoolName(me.schoolName)}`
+    : undefined
+
+  const fetchedPosts = useMemo(() => {
+    const scopedGroups = applyScopeFilters(
+      scope,
+      chapterTab,
+      schoolTab,
+      scope.chapters,
+    )
+    return mapRoundGroupsToPosts(scopedGroups, authorLabel)
+  }, [scope, chapterTab, schoolTab, authorLabel])
 
   // mock 모드(테스트 라우트 전용)만 낙관적 업데이트를 위한 로컬 state가 필요하다.
   // 실제 모드는 mutation 성공 후 재조회된 fetchedPosts를 그대로 파생값으로 쓴다.
   const [mockPosts, setMockPosts] = useState<RecruitmentPost[]>(
     RECRUITMENT_LIST_MOCK,
   )
-  const posts = useMockData ? mockPosts : fetchedPosts
+  const viewPosts = useMockData
+    ? filterMockPosts(
+        mockPosts,
+        showChapterTabs,
+        showSchoolTabs,
+        chapterTab,
+        schoolTab,
+      )
+    : fetchedPosts
+  // 탭 필터와 무관하게 스코프 전체에서 postId로 찾아야 하는 액션(발행/삭제 등)에 쓴다.
+  const basePosts = useMockData
+    ? mockPosts
+    : mapRoundGroupsToPosts(scope.groups)
   const setPosts = setMockPosts
   const lastDeletedPostRef = useRef<RecruitmentPost | null>(null)
-
-  // 편집 권한은 role이 아니라 시즌 단위 실제 EDIT 권한으로 판정한다(canEditRecruitmentPost 참고).
-  const seasonIds = useMemo(
-    () => [...new Set(posts.map((post) => post.seasonId))],
-    [posts],
-  )
-  const { permittedSeasonIds } = useRecruitingPermissions(seasonIds)
 
   const updateRoundStatus = useUpdateRecruitingRoundStatus()
   const cloneRound = useCloneRecruitingRound()
@@ -106,7 +208,7 @@ export function RecruitmentListPage({
       )
       return
     }
-    const post = posts.find((item) => item.postId === postId)
+    const post = basePosts.find((item) => item.postId === postId)
     if (!post) return
     updateRoundStatus.mutate({
       seasonId: post.seasonId,
@@ -124,7 +226,7 @@ export function RecruitmentListPage({
       )
       return
     }
-    const post = posts.find((item) => item.postId === postId)
+    const post = basePosts.find((item) => item.postId === postId)
     if (!post) return
     updateRoundStatus.mutate({
       seasonId: post.seasonId,
@@ -136,11 +238,11 @@ export function RecruitmentListPage({
   const handleDelete = (postId: string) => {
     if (useMockData) {
       lastDeletedPostRef.current =
-        posts.find((post) => post.postId === postId) ?? null
+        basePosts.find((post) => post.postId === postId) ?? null
       setPosts((prev) => prev.filter((post) => post.postId !== postId))
       return
     }
-    const post = posts.find((item) => item.postId === postId)
+    const post = basePosts.find((item) => item.postId === postId)
     if (!post) return
     deleteRound.mutate({ seasonId: post.seasonId, roundId: postId })
   }
@@ -167,7 +269,7 @@ export function RecruitmentListPage({
       })
       return
     }
-    const post = posts.find((item) => item.postId === postId)
+    const post = basePosts.find((item) => item.postId === postId)
     if (!post) return
     // 같은 글을 여러 번 복제해도 제목이 겹치지 않도록 사용 가능한 제목을 먼저 찾는다.
     void resolveAvailableTitle(`${post.title} 복제본`, (title) =>
@@ -187,9 +289,10 @@ export function RecruitmentListPage({
     })
   }
 
-  // 공유 보관함이 보이는 뷰로 전환 (해당 학교가 속한 지부 탭 + 학교 드릴다운)
+  // 공유 보관함이 보이는 뷰로 전환 (지부 탭이 없는 스코프는 학교 탭만 바꾸고,
+  // 지부 탭이 있는 스코프는 해당 학교가 속한 지부 탭 + 학교 드릴다운으로 전환)
   const handleNavigateToArchive = (school: string) => {
-    if (role === "chapterAdmin" || role === "schoolStaff") {
+    if (!showChapterTabs) {
       setSchoolTab(school)
       return
     }
@@ -200,20 +303,23 @@ export function RecruitmentListPage({
     setSelectedSchool(school)
   }
 
-  const scopeChapters =
+  // central 세그먼트는 데이터 유무와 무관하게 조직의 전체 지부를 보여준다.
+  const centralChapters =
     chapterTab === "all"
       ? [...CHAPTERS]
       : isChapter(chapterTab)
         ? [chapterTab]
         : []
-  const chapterGroups = groupPostsByChapter(posts, scopeChapters)
-  const myChapterPosts = myChapter
-    ? posts.filter((post) => post.chapter === myChapter)
+  const chapterGroups = groupPostsByChapter(viewPosts, centralChapters)
+
+  const ownScopeSchools = ownScopeChapter
+    ? SCHOOLS_BY_BRANCH[ownScopeChapter]
     : []
-  const myScopedPosts =
-    schoolTab === "all"
-      ? myChapterPosts
-      : myChapterPosts.filter((post) => post.school === schoolTab)
+  // 학교 탭이 없는 단일 학교 스코프에서는 schoolTab이 항상 "all"로 머무르므로,
+  // 헤딩·보관함·생성 버튼 판단에는 실제 학교 이름을 대신 쓴다.
+  const ownScopeSchoolTab = showSchoolTabs
+    ? schoolTab
+    : ((useMockData ? RECRUITING_MY_SCHOOL_MOCK : viewerSchool) ?? schoolTab)
 
   return (
     <div className="flex w-full max-w-286.5 flex-col">
@@ -254,7 +360,7 @@ export function RecruitmentListPage({
         </div>
       ) : (
         <>
-          {role === "central" && (
+          {showChapterTabs && (
             <ChapterTabs
               value={chapterTab}
               onValueChange={(value) => {
@@ -264,9 +370,9 @@ export function RecruitmentListPage({
               className="mt-8"
             />
           )}
-          {(role === "chapterAdmin" || role === "schoolStaff") && myChapter && (
+          {!showChapterTabs && showSchoolTabs && (
             <SchoolTabs
-              schools={SCHOOLS_BY_BRANCH[myChapter]}
+              schools={ownScopeSchools}
               value={schoolTab}
               onValueChange={setSchoolTab}
               allLabel={role === "chapterAdmin" ? "지부 전체" : "학교 전체"}
@@ -274,7 +380,7 @@ export function RecruitmentListPage({
             />
           )}
 
-          {role === "central" && (
+          {showChapterTabs && (
             <div className="mt-8 flex flex-col gap-11">
               {chapterGroups.map(({ chapter, posts: chapterPosts }) => {
                 const scopedPosts = selectedSchool
@@ -360,11 +466,11 @@ export function RecruitmentListPage({
             </div>
           )}
 
-          {role === "chapterAdmin" && myChapter && (
+          {!showChapterTabs && ownScopeChapter && (
             <RecruitmentOwnScopeSection
-              chapter={myChapter}
-              posts={myScopedPosts}
-              schoolTab={schoolTab}
+              chapter={ownScopeChapter}
+              posts={viewPosts}
+              schoolTab={ownScopeSchoolTab}
               permittedSeasonIds={permittedSeasonIds}
               onPrivatize={handlePrivatize}
               onPublish={handlePublish}
@@ -373,33 +479,20 @@ export function RecruitmentListPage({
               onUndoDelete={handleUndoDelete}
               onNavigateToArchive={handleNavigateToArchive}
               archiveVisible
-              onCreate={() =>
-                navigate({
-                  to: "/recruiting/recruitments/new",
-                  search: {
-                    role,
-                    chapter: myChapter,
-                    school: schoolTab,
-                  },
-                })
+              archiveTitle={activeScope.isFallback ? "공유 보관함" : undefined}
+              onCreate={
+                activeScope.isFallback
+                  ? undefined
+                  : () =>
+                      navigate({
+                        to: "/recruiting/recruitments/new",
+                        search: {
+                          role,
+                          chapter: ownScopeChapter,
+                          school: ownScopeSchoolTab,
+                        },
+                      })
               }
-            />
-          )}
-
-          {role === "schoolStaff" && myChapter && (
-            <RecruitmentOwnScopeSection
-              chapter={myChapter}
-              posts={myScopedPosts}
-              schoolTab={schoolTab}
-              permittedSeasonIds={permittedSeasonIds}
-              onPrivatize={handlePrivatize}
-              onPublish={handlePublish}
-              onDuplicate={handleDuplicate}
-              onDelete={handleDelete}
-              onUndoDelete={handleUndoDelete}
-              onNavigateToArchive={handleNavigateToArchive}
-              archiveVisible={schoolTab === viewerSchool}
-              archiveTitle="공유 보관함"
             />
           )}
         </>

--- a/src/features/recruiting/ui/create/RecruitmentAnnouncementForm.tsx
+++ b/src/features/recruiting/ui/create/RecruitmentAnnouncementForm.tsx
@@ -14,8 +14,8 @@ import {
 import { getRecruitableTracks } from "../../model/parts"
 import {
   buildRecruitmentPreviewTitle,
+  buildRoundConfigurationPayload,
   composeRecruitmentTitle,
-  periodFieldToInstant,
 } from "../../model/recruitmentCreate"
 import { useRecruitmentCreateStore } from "../../model/useRecruitmentCreateStore"
 import { RecruitmentSectionHeader } from "../RecruitmentSectionHeader"
@@ -76,20 +76,48 @@ export function RecruitmentAnnouncementForm({
     !!seasonId &&
     !!roundId
   const hasUnsavedChanges = savedSnapshotRef.current !== announcement
-  const canTempSave = hasUnsavedChanges && !isSaving
+  const canTempSave = hasUnsavedChanges && !isSaving && !!seasonId && !!roundId
 
   useEffect(() => {
     onDirtyChange?.(hasUnsavedChanges)
   }, [hasUnsavedChanges, onDirtyChange])
 
-  const handleTempSave = () => {
+  // Round PUT은 완전 교체라 recruitableTracks/기간 등 필수 필드를 스토어의
+  // 최신 값으로 매번 전부 채워 보내야 한다(announcement만 담아 보내면 400).
+  // interviewRequired는 2단계 진입 시점에 이미 false로 고정된 상태로만 Round가
+  // 만들어졌으므로(면접 있는 모집은 그 전에 막힘) 여기서도 동일하게 false로 보낸다.
+  const buildRoundUpdatePayload = () =>
+    buildRoundConfigurationPayload({
+      title: composeRecruitmentTitle(previewTitle, basicInfo.footer),
+      recruitableTracks: getRecruitableTracks(enabledParts),
+      secondChoiceEnabled,
+      periodForm: basicInfo.periodForm,
+      interviewRequired: false,
+      announcement,
+      contactText,
+    })
+
+  const handleTempSave = async () => {
+    if (isSaving || !seasonId || !roundId) return
     setIsSaving(true)
-    // TODO: 실제 임시 저장 API 호출로 교체 (지금은 로딩 상태만 흉내)
-    setTimeout(() => {
+    try {
+      await updateRecruitingRound(seasonId, roundId, buildRoundUpdatePayload())
       savedSnapshotRef.current = announcement
-      setIsSaving(false)
       setShowTempSaveModal(true)
-    }, 600)
+    } catch (error) {
+      const message = isAxiosError(error)
+        ? (error.response?.data as { message?: string } | undefined)?.message
+        : undefined
+      addToast({
+        message: message ?? "임시 저장에 실패했습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } finally {
+      setIsSaving(false)
+    }
   }
 
   return (
@@ -146,7 +174,7 @@ export function RecruitmentAnnouncementForm({
             isLoading={isPublishing}
             onClick={() => setOpenModal("publishConfirm")}
           >
-            {isPublished ? "모집 공고 완료" : "모집 공고 올리기"}
+            {isPublished ? "모집 공고 완료" : "모집 공고 게시"}
           </Button>
         </div>
       </div>
@@ -172,32 +200,11 @@ export function RecruitmentAnnouncementForm({
           setOpenModal(null)
           setIsPublishing(true)
           try {
-            // interviewRequired는 2단계 진입 시점에 이미 false로 고정된 상태로만
-            // Round가 만들어졌으므로(면접 있는 모집은 그 전에 막힘) 여기서도 동일하게
-            // false로 보낸다 — Round 생성(createRecruitingRound)과 대칭.
-            await updateRecruitingRound(seasonId, roundId, {
-              title: composeRecruitmentTitle(
-                buildRecruitmentPreviewTitle({ ...basicInfo, gisuGeneration }),
-                basicInfo.footer,
-              ),
-              recruitableTracks: getRecruitableTracks(enabledParts),
-              secondChoiceEnabled,
-              documentStartAt: periodFieldToInstant(
-                basicInfo.periodForm.documentStartAt,
-              ),
-              documentEndAt: periodFieldToInstant(
-                basicInfo.periodForm.documentEndAt,
-              ),
-              documentResultPublishedAt: periodFieldToInstant(
-                basicInfo.periodForm.documentResultPublishedAt,
-              ),
-              finalResultPublishedAt: periodFieldToInstant(
-                basicInfo.periodForm.finalResultPublishedAt,
-              ),
-              interviewRequired: false,
-              announcement,
-              contactText,
-            })
+            await updateRecruitingRound(
+              seasonId,
+              roundId,
+              buildRoundUpdatePayload(),
+            )
             await updateRecruitingRoundStatus(seasonId, roundId, {
               status: "OPEN",
             })

--- a/src/features/recruiting/ui/create/RecruitmentBasicInfoForm.tsx
+++ b/src/features/recruiting/ui/create/RecruitmentBasicInfoForm.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
+import { isAxiosError } from "axios"
 import { useEffect, useRef, useState } from "react"
 
 import { useMe } from "@/entities/member/hooks/useMe"
@@ -25,8 +26,12 @@ import { OptionButtonGroup } from "@/shared/ui/option-button/OptionButtonGroup"
 import { useToastStore } from "@/shared/ui/toast/useToastStore"
 import { Tooltip } from "@/shared/ui/tooltip/Tooltip"
 
-import { checkRecruitingRoundTitleAvailability } from "../../api/recruitingApi"
+import {
+  checkRecruitingRoundTitleAvailability,
+  updateRecruitingRound,
+} from "../../api/recruitingApi"
 import { useAdminRecruitingRounds } from "../../hooks/useAdminRecruitingRounds"
+import { getRecruitableTracks } from "../../model/parts"
 import {
   resolveRecruitingListRole,
   resolveViewerChapter,
@@ -34,6 +39,7 @@ import {
 } from "../../model/recruitingRole"
 import {
   buildRecruitmentPreviewTitle,
+  buildRoundConfigurationPayload,
   composeRecruitmentTitle,
   dayCountInclusive,
   dayGap,
@@ -124,16 +130,29 @@ function formatMonthDay(dateStr: string): string {
 // 이미 완료된 일정(수정 불가) / 진행 중인 일정 / 예정된 일정
 type ScheduleItemStatus = "completed" | "active" | "upcoming"
 
+// 두 일정 사이의 선후 관계 검증(종료가 시작보다 앞서는지). 같은 구간의
+// 시작·종료뿐 아니라 서류 종료 ~ 면접 시작처럼 단계 간 순서를 볼 때도 재사용한다.
+function validateDateOrder(
+  start: Date | null,
+  end: Date | null,
+): string | null {
+  if (!start || !end) return null
+  if (end < start) {
+    return "종료 날짜는 시작 날짜 이후로 설정해 주세요."
+  }
+  return null
+}
+
 // 서류 접수 기간 검증. 필드 변경 시(handleDocumentEndAtChange)와 다음 단계 진입 시(handleNext) 공용으로 쓴다.
 function validateDocumentPeriod(
   recruitmentType: RecruitmentRoundType | undefined,
   start: Date | null,
   end: Date | null,
 ): string | null {
-  if (!recruitmentType || !start || !end) return null
-  if (end < start) {
-    return "종료 날짜는 시작 날짜 이후로 설정해 주세요."
-  }
+  if (!recruitmentType) return null
+  const orderError = validateDateOrder(start, end)
+  if (orderError) return orderError
+  if (!start || !end) return null
   const { min, max } = DOC_PERIOD_DAYS[recruitmentType]
   const days = dayCountInclusive(start, end)
   if (days < min || days > max) {
@@ -185,6 +204,8 @@ export function RecruitmentBasicInfoForm({
   const addToast = useToastStore((state) => state.addToast)
   const navigate = useNavigate()
   const [showTempSaveModal, setShowTempSaveModal] = useState(false)
+  const [tempSaveMessage, setTempSaveMessage] =
+    useState("임시저장이 완료되었습니다.")
   const [schoolSearchOpen, setSchoolSearchOpen] = useState(false)
   const chapter = useRecruitmentCreateStore((s) => s.basicInfo.chapter)
   const school = useRecruitmentCreateStore((s) => s.basicInfo.school)
@@ -204,6 +225,13 @@ export function RecruitmentBasicInfoForm({
   const setGisuGeneration = useRecruitmentCreateStore(
     (s) => s.setGisuGeneration,
   )
+  const roundId = useRecruitmentCreateStore((s) => s.roundId)
+  const enabledParts = useRecruitmentCreateStore((s) => s.enabledParts)
+  const secondChoiceEnabled = useRecruitmentCreateStore(
+    (s) => s.secondChoiceEnabled,
+  )
+  const announcement = useRecruitmentCreateStore((s) => s.announcement)
+  const contactText = useRecruitmentCreateStore((s) => s.contactText)
   const {
     groups: seasonGroups,
     isLoading: isSeasonGroupsLoading,
@@ -247,17 +275,23 @@ export function RecruitmentBasicInfoForm({
   const chapterOptions = chapterEntries
     .map((entry) => entry.chapterName)
     .filter(isChapter)
+  const selectedChapterEntry = chapterEntries.find(
+    (entry) => entry.chapterName === chapter,
+  )
   const schoolOptions =
-    chapterEntries
-      .find((entry) => entry.chapterName === chapter)
-      ?.schools.map((school) => school.schoolName) ?? []
+    selectedChapterEntry?.schools.map((school) => school.schoolName) ?? []
+  const selectedSchoolId = selectedChapterEntry?.schools.find(
+    (entry) => entry.schoolName === school,
+  )?.schoolId
 
   // seasonId는 URL param(목록 화면에서 넘어온 값)에 의존하지 않고, 학교가
   // 정해질 때마다 여기서 직접 조회해 스토어에 반영한다. 사이드바에서 이
   // 화면으로 바로 들어와 seasonId가 아예 없이 시작해도 동작하게 하기 위함.
   useEffect(() => {
-    setSeasonId(findSeasonIdBySchool(seasonGroups, school) ?? null)
-  }, [school, seasonGroups, setSeasonId])
+    setSeasonId(
+      findSeasonIdBySchool(seasonGroups, school, selectedSchoolId) ?? null,
+    )
+  }, [school, selectedSchoolId, seasonGroups, setSeasonId])
 
   // 모집 제목("UMC N기 ...")에 쓰는 기수 번호도 다른 단계(2·3단계)에서 재조회
   // 없이 쓸 수 있도록 여기서 한 번만 스토어에 반영해둔다.
@@ -460,6 +494,39 @@ export function RecruitmentBasicInfoForm({
     }
   }
 
+  // Round는 2단계(모집 문항)에서 트랙을 골라야 생성할 수 있어(백엔드가
+  // recruitableTracks를 필수로 검증), roundId가 아직 없으면 1단계 값을 보낼
+  // 서버 자원 자체가 없다 — 이 경우 클라이언트 상태로만 들고 있는다.
+  // roundId가 이미 있으면(2단계 이상 진행했다가 되돌아온 경우) 언제든 PUT으로
+  // 재수정할 수 있으므로 그때는 즉시 반영한다.
+  const persistBasicInfoIfRoundExists = async (
+    resolvedFooter: string,
+  ): Promise<boolean> => {
+    if (!roundId || !seasonId) return true
+    try {
+      await updateRecruitingRound(
+        seasonId,
+        roundId,
+        buildRoundConfigurationPayload({
+          title: composeRecruitmentTitle(previewTitle, resolvedFooter),
+          recruitableTracks: getRecruitableTracks(enabledParts),
+          secondChoiceEnabled,
+          periodForm,
+          interviewRequired,
+          announcement,
+          contactText,
+        }),
+      )
+      return true
+    } catch (error) {
+      const message = isAxiosError(error)
+        ? (error.response?.data as { message?: string } | undefined)?.message
+        : undefined
+      showPeriodErrorToast(message ?? "모집 정보 저장에 실패했습니다.")
+      return false
+    }
+  }
+
   const handleTempSave = async () => {
     if (isSaving) return
     setIsSaving(true)
@@ -472,12 +539,20 @@ export function RecruitmentBasicInfoForm({
       showTitleAdjustedToast()
     }
 
-    // TODO: 실제 임시 저장 API 호출로 교체 (지금은 로딩 상태만 흉내)
-    setTimeout(() => {
-      savedSnapshotRef.current = currentSnapshot
+    const persisted = await persistBasicInfoIfRoundExists(resolvedFooter)
+    if (!persisted) {
       setIsSaving(false)
-      setShowTempSaveModal(true)
-    }, 600)
+      return
+    }
+
+    savedSnapshotRef.current = currentSnapshot
+    setIsSaving(false)
+    setTempSaveMessage(
+      roundId
+        ? "임시저장이 완료되었습니다."
+        : "이 브라우저에 임시 저장되었습니다. 서버 저장은 다음 단계까지 진행해야 완료됩니다.",
+    )
+    setShowTempSaveModal(true)
   }
 
   const showPeriodErrorToast = (message: string) => {
@@ -504,7 +579,11 @@ export function RecruitmentBasicInfoForm({
 
   const handleDocumentEndAtChange = (date: string) => {
     updatePeriodField("documentEndAt", { date })
-    if (!periodForm.documentStartAt.date || !date) return
+    if (
+      !isCompleteDate(periodForm.documentStartAt.date) ||
+      !isCompleteDate(date)
+    )
+      return
 
     const start = parsePeriodDateTime(periodForm.documentStartAt)
     const end = parsePeriodDateTime({
@@ -515,9 +594,78 @@ export function RecruitmentBasicInfoForm({
     if (message) showPeriodErrorToast(message)
   }
 
+  const handleInterviewStartAtChange = (date: string) => {
+    updatePeriodField("interviewStartAt", { date })
+    if (!isCompleteDate(date)) return
+
+    const start = parsePeriodDateTime({
+      date,
+      time: periodForm.interviewStartAt.time,
+    })
+
+    // 서류 결과 발표보다 면접 시작이 앞서면(서류 > 면접 순서가 깨지면) 막는다.
+    // 결과 발표일이 아직 없으면 최소한 서류 모집 종료 기준으로라도 체크한다.
+    const documentGateField = isPeriodFieldComplete(
+      periodForm.documentResultPublishedAt,
+    )
+      ? periodForm.documentResultPublishedAt
+      : isCompleteDate(periodForm.documentEndAt.date)
+        ? periodForm.documentEndAt
+        : null
+    if (documentGateField) {
+      const documentGate = parsePeriodDateTime(documentGateField)
+      const crossStageError = validateDateOrder(documentGate, start)
+      if (crossStageError) {
+        showPeriodErrorToast(crossStageError)
+        return
+      }
+    }
+
+    if (isCompleteDate(periodForm.interviewEndAt.date)) {
+      const end = parsePeriodDateTime(periodForm.interviewEndAt)
+      const message = validateDateOrder(start, end)
+      if (message) showPeriodErrorToast(message)
+    }
+  }
+
+  const handleInterviewEndAtChange = (date: string) => {
+    updatePeriodField("interviewEndAt", { date })
+    if (
+      !isCompleteDate(periodForm.interviewStartAt.date) ||
+      !isCompleteDate(date)
+    )
+      return
+
+    const start = parsePeriodDateTime(periodForm.interviewStartAt)
+    const end = parsePeriodDateTime({
+      date,
+      time: periodForm.interviewEndAt.time,
+    })
+    const message = validateDateOrder(start, end)
+    if (message) showPeriodErrorToast(message)
+  }
+
+  const handleDocumentResultPublishedAtChange = (date: string) => {
+    updatePeriodField("documentResultPublishedAt", { date })
+    if (!isCompleteDate(periodForm.documentEndAt.date) || !isCompleteDate(date))
+      return
+
+    const documentEnd = parsePeriodDateTime(periodForm.documentEndAt)
+    const result = parsePeriodDateTime({
+      date,
+      time: periodForm.documentResultPublishedAt.time,
+    })
+    const message = validateDateOrder(documentEnd, result)
+    if (message) showPeriodErrorToast(message)
+  }
+
   const handleFinalResultPublishedAtChange = (date: string) => {
     updatePeriodField("finalResultPublishedAt", { date })
-    if (!periodForm.interviewEndAt.date || !date) return
+    if (
+      !isCompleteDate(periodForm.interviewEndAt.date) ||
+      !isCompleteDate(date)
+    )
+      return
 
     const interviewEnd = parsePeriodDate(periodForm.interviewEndAt)
     const result = parsePeriodDate({
@@ -568,6 +716,44 @@ export function RecruitmentBasicInfoForm({
       return
     }
 
+    // 서류 모집 종료보다 서류 결과 발표가 앞서면 막는다
+    const documentResultError = validateDateOrder(
+      documentEnd,
+      parsePeriodDateTime(periodForm.documentResultPublishedAt),
+    )
+    if (documentResultError) {
+      showPeriodErrorToast(documentResultError)
+      setIsAdvancing(false)
+      return
+    }
+
+    if (interviewRequired) {
+      const interviewStartDt = parsePeriodDateTime(periodForm.interviewStartAt)
+      const interviewEndDt = parsePeriodDateTime(periodForm.interviewEndAt)
+      const interviewOrderError = validateDateOrder(
+        interviewStartDt,
+        interviewEndDt,
+      )
+      if (interviewOrderError) {
+        showPeriodErrorToast(interviewOrderError)
+        setIsAdvancing(false)
+        return
+      }
+
+      // 서류 결과 발표보다 면접 시작이 앞서면(서류 > 면접 순서가 깨지면) 막는다
+      const documentGate = isPeriodFieldComplete(
+        periodForm.documentResultPublishedAt,
+      )
+        ? parsePeriodDateTime(periodForm.documentResultPublishedAt)
+        : documentEnd
+      const crossStageError = validateDateOrder(documentGate, interviewStartDt)
+      if (crossStageError) {
+        showPeriodErrorToast(crossStageError)
+        setIsAdvancing(false)
+        return
+      }
+    }
+
     const interviewEnd = parsePeriodDate(periodForm.interviewEndAt)
     const finalResult = parsePeriodDate(periodForm.finalResultPublishedAt)
     const interviewDelayError = interviewRequired
@@ -590,11 +776,16 @@ export function RecruitmentBasicInfoForm({
       }
     }
 
-    // TODO: 실제로는 1단계 데이터 저장 API 호출 후 다음 단계로 이동
-    setTimeout(() => {
+    // roundId가 아직 없으면(2단계 이전) 저장할 서버 자원이 없어 그냥 다음
+    // 단계로 넘어간다 — Round 생성은 2단계에서 트랙이 정해진 뒤 이루어진다.
+    const persisted = await persistBasicInfoIfRoundExists(resolvedFooter)
+    if (!persisted) {
       setIsAdvancing(false)
-      onNext()
-    }, 600)
+      return
+    }
+
+    setIsAdvancing(false)
+    onNext()
   }
 
   return (
@@ -766,9 +957,6 @@ export function RecruitmentBasicInfoForm({
                             },
                       })
                     }}
-                    disabled // TODO(면접 가능 시간대 Form 빌더 미구현): availabilityFormId를 세팅하는 화면이
-                    // 아직 없어서 interviewRequired=true로 OPEN 전환하면 RECRUITING_ROUND_INVALID_SCHEDULE로
-                    // 무조건 실패함. availability form 빌더 붙으면 이 disabled 제거.
                     variant="primary"
                     size="lg"
                     aria-label="면접 진행 여부"
@@ -794,8 +982,8 @@ export function RecruitmentBasicInfoForm({
                         : "2000-00-00 00:00"
                     }
                     endLabel={
-                      periodForm.documentEndAt.date
-                        ? `${periodForm.documentEndAt.date.slice(5)} ${periodForm.documentEndAt.time}`
+                      periodForm.finalResultPublishedAt.date
+                        ? `${periodForm.finalResultPublishedAt.date.slice(5)} ${periodForm.finalResultPublishedAt.time}`
                         : "00-00 23:59"
                     }
                     className="flex-1"
@@ -952,11 +1140,7 @@ export function RecruitmentBasicInfoForm({
                         <DateTextBox
                           label="시작"
                           value={periodForm.documentResultPublishedAt.date}
-                          onChange={(date) =>
-                            updatePeriodField("documentResultPublishedAt", {
-                              date,
-                            })
-                          }
+                          onChange={handleDocumentResultPublishedAtChange}
                         />
                         <TimeTextBox
                           value={periodForm.documentResultPublishedAt.time}
@@ -972,14 +1156,7 @@ export function RecruitmentBasicInfoForm({
 
                   <div className="flex flex-col gap-7">
                     <div className="flex flex-col gap-2">
-                      <span
-                        className={cn(
-                          "text-subtitle-3-semibold",
-                          interviewRequired
-                            ? "text-teal-600"
-                            : "text-teal-gray-300",
-                        )}
-                      >
+                      <span className="text-subtitle-3-semibold text-teal-600">
                         면접 진행 기간
                       </span>
                       <div className="flex items-center gap-2">
@@ -987,17 +1164,13 @@ export function RecruitmentBasicInfoForm({
                           <DateTextBox
                             label="시작"
                             value={periodForm.interviewStartAt.date}
-                            onChange={(date) =>
-                              updatePeriodField("interviewStartAt", { date })
-                            }
-                            disabled={!interviewRequired}
+                            onChange={handleInterviewStartAtChange}
                           />
                           <TimeTextBox
                             value={periodForm.interviewStartAt.time}
                             onChange={(time) =>
                               updatePeriodField("interviewStartAt", { time })
                             }
-                            disabled={!interviewRequired}
                           />
                         </div>
                         <span className="text-teal-gray-400">~</span>
@@ -1005,17 +1178,13 @@ export function RecruitmentBasicInfoForm({
                           <DateTextBox
                             label="종료"
                             value={periodForm.interviewEndAt.date}
-                            onChange={(date) =>
-                              updatePeriodField("interviewEndAt", { date })
-                            }
-                            disabled={!interviewRequired}
+                            onChange={handleInterviewEndAtChange}
                           />
                           <TimeTextBox
                             value={periodForm.interviewEndAt.time}
                             onChange={(time) =>
                               updatePeriodField("interviewEndAt", { time })
                             }
-                            disabled={!interviewRequired}
                           />
                         </div>
                       </div>
@@ -1101,7 +1270,7 @@ export function RecruitmentBasicInfoForm({
         onOpenChange={setShowTempSaveModal}
         variant="success"
         title="임시 저장 완료"
-        content="임시저장이 완료되었습니다."
+        content={tempSaveMessage}
         confirmText="확인"
         onConfirm={() => navigate({ to: "/recruiting/recruitments" })}
       />

--- a/src/features/recruiting/ui/create/RecruitmentBasicInfoForm.tsx
+++ b/src/features/recruiting/ui/create/RecruitmentBasicInfoForm.tsx
@@ -1165,12 +1165,14 @@ export function RecruitmentBasicInfoForm({
                             label="시작"
                             value={periodForm.interviewStartAt.date}
                             onChange={handleInterviewStartAtChange}
+                            disabled={!interviewRequired}
                           />
                           <TimeTextBox
                             value={periodForm.interviewStartAt.time}
                             onChange={(time) =>
                               updatePeriodField("interviewStartAt", { time })
                             }
+                            disabled={!interviewRequired}
                           />
                         </div>
                         <span className="text-teal-gray-400">~</span>
@@ -1179,12 +1181,14 @@ export function RecruitmentBasicInfoForm({
                             label="종료"
                             value={periodForm.interviewEndAt.date}
                             onChange={handleInterviewEndAtChange}
+                            disabled={!interviewRequired}
                           />
                           <TimeTextBox
                             value={periodForm.interviewEndAt.time}
                             onChange={(time) =>
                               updatePeriodField("interviewEndAt", { time })
                             }
+                            disabled={!interviewRequired}
                           />
                         </div>
                       </div>

--- a/src/features/recruiting/ui/create/RecruitmentQuestionForm.tsx
+++ b/src/features/recruiting/ui/create/RecruitmentQuestionForm.tsx
@@ -39,8 +39,8 @@ import {
 } from "../../model/parts"
 import {
   buildRecruitmentPreviewTitle,
+  buildRoundConfigurationPayload,
   composeRecruitmentTitle,
-  periodFieldToInstant,
 } from "../../model/recruitmentCreate"
 import {
   buildCommonSectionUpsertRequest,
@@ -650,16 +650,6 @@ export function RecruitmentQuestionForm({
     onBlankPartsChange?.(hasBlankEnabledPart)
   }, [hasBlankEnabledPart, onBlankPartsChange])
 
-  const handleTempSave = () => {
-    setIsSaving(true)
-    // TODO: 실제 임시 저장 API 호출로 교체 (지금은 로딩 상태만 흉내)
-    setTimeout(() => {
-      savedSnapshotRef.current = currentSnapshot
-      setIsSaving(false)
-      setShowTempSaveModal(true)
-    }, 600)
-  }
-
   const showErrorToast = (message: string) => {
     addToast({
       message,
@@ -670,102 +660,118 @@ export function RecruitmentQuestionForm({
     })
   }
 
-  const handleNext = async () => {
-    if (hasBlankEnabledPart) {
-      showErrorToast("사용 중인 섹션의 항목을 모두 적어주세요.")
-      return
-    }
+  // "임시 저장"과 "다음"이 공유하는 핵심 로직: roundId가 없으면 Round를 새로
+  // 만들고(있으면 재사용), Form 구조를 통째로 upsert한다. 실패 원인(Round 생성 vs
+  // Form 저장)에 따라 서로 다른 에러 메시지를 던진다.
+  const ensureRoundAndSaveForm = async (): Promise<string> => {
     const recruitableTracks = getRecruitableTracks(enabledParts)
-    if (recruitableTracks.length === 0) {
-      showErrorToast("모집할 트랙을 최소 1개 선택해 주세요.")
-      return
-    }
-    if (basicInfo.interviewRequired) {
-      // availabilityFormId 자체는 서버가 형식만 보고(> 0) 통과시키는 느슨한 참조라
-      // 프론트에서 채워 넣는 것만으로는 막힐 이유가 없다. 진짜 이유는 그 뒤 단계:
-      // 지원자가 면접 가능 시간대를 제출하는 백엔드 기능(RecruitingInterviewScheduleController
-      // .submitAvailability, RECRUITING-0419)이 Form 엔진 연동 전까지 501로 스텁 처리돼 있어
-      // 아직 개발되지 않았다. 즉 프론트가 뭘 만들든 지원자 쪽 제출 경로가 없어 면접
-      // 스케줄링이 end-to-end로 동작하지 않으므로, 그 기능이 나오기 전까지는 여기서 막는다.
-      showErrorToast(
-        "면접이 있는 모집은 아직 지원되지 않습니다. 1단계에서 면접 진행을 꺼주세요.",
-      )
-      return
-    }
-    if (!seasonId) {
-      showErrorToast("시즌 정보가 없어 모집 차수를 생성할 수 없습니다.")
-      return
-    }
-    if (!basicInfo.chapter || !basicInfo.school || !basicInfo.recruitmentType) {
-      showErrorToast("1단계 기본 정보를 먼저 입력해 주세요.")
-      return
-    }
 
-    setIsSubmitting(true)
+    let currentRoundId: string
     try {
       // roundId가 이미 있으면(직전 시도에서 Round 생성은 성공하고 Form 저장만
       // 실패한 경우) 재시도 시 Round를 또 만들지 않고 같은 roundId로 Form만 다시 저장한다.
-      const currentRoundId =
+      currentRoundId =
         roundId ??
-        (await createRecruitingRound(seasonId, {
-          title: composeRecruitmentTitle(
-            buildRecruitmentPreviewTitle({ ...basicInfo, gisuGeneration }),
-            basicInfo.footer,
-          ),
-          type: basicInfo.recruitmentType,
+        (await createRecruitingRound(seasonId!, {
+          ...buildRoundConfigurationPayload({
+            title: composeRecruitmentTitle(
+              buildRecruitmentPreviewTitle({ ...basicInfo, gisuGeneration }),
+              basicInfo.footer,
+            ),
+            recruitableTracks,
+            secondChoiceEnabled: questionToggleState["04"]?.enabled ?? true,
+            periodForm: basicInfo.periodForm,
+            interviewRequired: basicInfo.interviewRequired,
+          }),
+          type: basicInfo.recruitmentType!,
           roundNo:
             basicInfo.recruitmentType === "ADDITIONAL" && basicInfo.roundNo
               ? Number(basicInfo.roundNo)
               : undefined,
-          recruitableTracks,
-          secondChoiceEnabled: questionToggleState["04"]?.enabled ?? true,
-          documentStartAt: periodFieldToInstant(
-            basicInfo.periodForm.documentStartAt,
-          ),
-          documentEndAt: periodFieldToInstant(
-            basicInfo.periodForm.documentEndAt,
-          ),
-          documentResultPublishedAt: periodFieldToInstant(
-            basicInfo.periodForm.documentResultPublishedAt,
-          ),
-          finalResultPublishedAt: periodFieldToInstant(
-            basicInfo.periodForm.finalResultPublishedAt,
-          ),
-          interviewRequired: false,
         }))
-      if (!roundId) setRoundId(currentRoundId)
+    } catch (error) {
+      throw new Error(getRecruitingRoundCreateErrorMessage(error))
+    }
+    if (!roundId) setRoundId(currentRoundId)
 
-      try {
-        const trackSections = PARTS.filter(
-          (part) => enabledParts[part.key],
-        ).map((part) =>
+    try {
+      const trackSections = PARTS.filter((part) => enabledParts[part.key]).map(
+        (part) =>
           buildTrackSectionUpsertRequest(
             part.label,
             PART_KEY_TO_TRACK[part.key],
             partQuestionDrafts[part.key],
           ),
-        )
-        await upsertRecruitingApplicationForm(seasonId, currentRoundId, {
-          sections: [
-            buildCommonSectionUpsertRequest(
-              removedOptionsByQuestionIndex,
-              questionToggleState,
-            ),
-            ...trackSections,
-          ],
-        })
-      } catch (formError) {
-        const message = isAxiosError(formError)
-          ? (formError.response?.data as { message?: string } | undefined)
-              ?.message
-          : undefined
-        showErrorToast(message ?? "모집 문항 저장에 실패했습니다.")
-        return
-      }
+      )
+      await upsertRecruitingApplicationForm(seasonId!, currentRoundId, {
+        sections: [
+          buildCommonSectionUpsertRequest(
+            removedOptionsByQuestionIndex,
+            questionToggleState,
+          ),
+          ...trackSections,
+        ],
+      })
+    } catch (formError) {
+      const message = isAxiosError(formError)
+        ? (formError.response?.data as { message?: string } | undefined)
+            ?.message
+        : undefined
+      throw new Error(message ?? "모집 문항 저장에 실패했습니다.")
+    }
 
+    return currentRoundId
+  }
+
+  const validateBeforeSave = (): string | null => {
+    if (hasBlankEnabledPart) return "사용 중인 섹션의 항목을 모두 적어주세요."
+    if (getRecruitableTracks(enabledParts).length === 0)
+      return "모집할 트랙을 최소 1개 선택해 주세요."
+    if (!seasonId) return "시즌 정보가 없어 모집 차수를 생성할 수 없습니다."
+    if (!basicInfo.chapter || !basicInfo.school || !basicInfo.recruitmentType)
+      return "1단계 기본 정보를 먼저 입력해 주세요."
+    return null
+  }
+
+  const handleTempSave = async () => {
+    if (isSaving) return
+    const validationError = validateBeforeSave()
+    if (validationError) {
+      showErrorToast(validationError)
+      return
+    }
+
+    setIsSaving(true)
+    try {
+      await ensureRoundAndSaveForm()
+      savedSnapshotRef.current = currentSnapshot
+      setShowTempSaveModal(true)
+    } catch (error) {
+      showErrorToast(
+        error instanceof Error ? error.message : "임시 저장에 실패했습니다.",
+      )
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleNext = async () => {
+    const validationError = validateBeforeSave()
+    if (validationError) {
+      showErrorToast(validationError)
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      await ensureRoundAndSaveForm()
       onNext()
     } catch (error) {
-      showErrorToast(getRecruitingRoundCreateErrorMessage(error))
+      showErrorToast(
+        error instanceof Error
+          ? error.message
+          : "모집 차수 생성에 실패했습니다.",
+      )
     } finally {
       setIsSubmitting(false)
     }

--- a/src/shared/ui/date-text-box/DateTextBox.tsx
+++ b/src/shared/ui/date-text-box/DateTextBox.tsx
@@ -22,7 +22,7 @@ export function DateTextBox({
   return (
     <div
       className={cn(
-        "group flex h-11 w-[172px] items-center gap-2.5 rounded-[10px] border bg-white px-4",
+        "group flex h-11 w-[188px] items-center gap-2.5 rounded-[10px] border bg-white px-4",
         error
           ? "border-error-400"
           : disabled


### PR DESCRIPTION
## 📸 작업 내용

> 모집 목록 화면의 조회 범위를 role 게이팅 방식에서 `resolveRecruitingScope`(시즌별 실제 EDIT 권한) 기반으로 전환 

- 학교 축약명/정식명 불일치로 목록이 빈 화면으로 보이던 버그 대비 수정
- 모집 생성 화면에서 면접 미진행 시 면접 기간 입력을 비활성화했습니다.

## 🎞️ 주요 코드 설명

> 설명이 필요한 코드 위주로 작성해주세요


### "임시저장"이 서버 호출 없이 성공한 척만 하던 문제

```TypeScript
// Before
const handleTempSave = () => {
  setIsSaving(true)
  // TODO: 실제 임시 저장 API 호출로 교체 (지금은 로딩 상태만 흉내)
  setTimeout(() => {
    savedSnapshotRef.current = currentSnapshot
    setIsSaving(false)
    setShowTempSaveModal(true)
  }, 600)
}

// After
const persistBasicInfoIfRoundExists = async (resolvedFooter: string) => {
  if (!roundId || !seasonId) return true
  try {
    await updateRecruitingRound(
      seasonId,
      roundId,
      buildRoundConfigurationPayload({
        title: composeRecruitmentTitle(previewTitle, resolvedFooter),
        recruitableTracks: getRecruitableTracks(enabledParts),
        secondChoiceEnabled,
        periodForm,
        interviewRequired,
        announcement,
        contactText,
      }),
    )
    return true
  } catch (error) {
    // ...실패 토스트
    return false
  }
}
1·2단계(기본정보/모집문항)의 "임시저장" 버튼이 실제로는 setTimeout으로 로딩만 흉내 내고 서버에 아무것도 저장하지 않고 있었습니다. 그래서 1단계에서 값을 바꾸고 임시저장한 뒤 창을 나갔다 들어오면 변경 사항이 전부 날아가 있었습니다. 실제 updateRecruitingRound(PUT) 호출로 교체했습니다.
PUT은 부분 수정이 아니라 필드 전체를 다시 실어 보내야 하는 완전 교체 방식이라(비어 있으면 400), buildRoundConfigurationPayload로 요청 바디 조립을 한 곳으로 모아 생성(POST)·수정(PUT) 양쪽에서 필수 필드가 빠지지 않게 했습니다.
면접 진행 모집이 생성 자체가 막혀 있던 문제

// Before
if (basicInfo.interviewRequired) {
  showErrorToast(
    "면접이 있는 모집은 아직 지원되지 않습니다. 1단계에서 면접 진행을 꺼주세요.",
  )
  return
}
// ...createRecruitingRound 호출 시 interviewRequired: false 로 항상 고정

// After (api/types.ts)
export type CreateRecruitingRoundInterviewFields =
  | {
      interviewRequired: true
      interviewStartAt: string
      interviewEndAt: string
      availabilityFormId?: string // 필수였던 걸 optional로 정정
    }
  | { interviewRequired: false }
availabilityFormId가 생성 시점에 필수라고 잘못 알고 있어서(실제 백엔드 검증은 면접 시작·종료 시각만 필수) 면접 진행 모집은 프론트에서 아예 만들지 못하게 막아뒀던 코드였습니다. 백엔드 검증 로직(RecruitingRoundConfiguration.validateInterviewShape)을 다시 확인해 제약을 정정하고, 면접 진행 라운드도 정상적으로 생성/게시되도록 열었습니다.

### 모집 목록 조회 범위 — role 게이팅 → resolveRecruitingScope

```TypeScript
const scope = useMemo(
  () => resolveRecruitingScope(groups, permittedSeasonIds, viewerSchool),
  [groups, permittedSeasonIds, viewerSchool],
)
const showChapterTabs = role === "central"
const showSchoolTabs =
  (role === "chapterAdmin" || role === "schoolStaff") && !!ownScopeChapter
```

- 목록에 뜨는 데이터는 실제 EDIT 권한(resolveRecruitingScope) 기준으로 좁히되, 지부/학교 세그먼트(탭) 노출 여부는 역할로 판단하도록 분리

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #686 

## 💬 기타 더 이야기해볼 점

- 수정하기 화면의 경우, 2단계 조회 API가 없어서 임시 구현해두었습니다. 백엔드에 문의 예정입니다.
- 모집 생성 2단계 화면 기능의 경우, 동작 방식을 디자이너님께 문의드린 상황이며, 내일 중으로 회신 받는대로 반영 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 모집 공고 작성 및 임시 저장이 실제 서버에 저장되며, 저장 결과와 오류를 안내합니다.
  * 모집 단계별 날짜 순서와 필수 입력값을 검증합니다.
  * 학교별 권한과 검색 조건에 맞춰 목록, 탭, 보관함, 게시글 작업을 표시합니다.
  * 면접 일정 Form ID 없이도 면접 모집을 설정할 수 있습니다.
  * 학교명이 일관된 형식으로 표시됩니다.

* **개선 사항**
  * 게시 및 미리보기의 기간 정보가 최종 결과 발표일까지 정확히 반영됩니다.
  * 날짜 입력 영역의 너비가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->