### PR TITLE
🐛 fix: 헤더 지원하기 CTA 가 눌리지 않던 문제

### DIFF
--- a/src/features/recruiting/api/recruitingApi.ts
+++ b/src/features/recruiting/api/recruitingApi.ts
@@ -7,6 +7,7 @@ import type {
   ApiEvaluationStage,
   CloneRecruitingRoundRequest,
   ConfirmInterviewSchedulesRequest,
+  CreateAnonymousApplicationDraftBody,
   CreateApplicationDraftBody,
   CreateRecruitingRoundRequest,
   CreateRecruitingSeasonRequest,
@@ -432,6 +433,16 @@ export async function createApplicationDraft(
 ): Promise<RecruitingApplicationCreated> {
   const { data } = await api.post<ApiResponse<RecruitingApplicationCreated>>(
     "/v1/recruiting/applications",
+    body,
+  )
+  return data.result
+}
+
+export async function createAnonymousApplicationDraft(
+  body: CreateAnonymousApplicationDraftBody,
+): Promise<RecruitingApplicationCreated> {
+  const { data } = await api.post<ApiResponse<RecruitingApplicationCreated>>(
+    "/v1/recruiting/public/applications",
     body,
   )
   return data.result

--- a/src/features/recruiting/api/types.ts
+++ b/src/features/recruiting/api/types.ts
@@ -624,6 +624,16 @@ export interface CreateApplicationDraftBody {
   secondChoice?: RecruitingTrack
 }
 
+export interface CreateAnonymousApplicationDraftBody {
+  applicationFormId: number
+  applicantName: string
+  applicantEmail: string
+  firstChoice: RecruitingTrack
+  secondChoice?: RecruitingTrack
+  privacyTermId: number
+  privacyAgreed: boolean
+}
+
 export interface UpdateApplicationDraftBody {
   applicantName: string
   applicantEmail: string

--- a/src/features/recruiting/hooks/useApplyMutations.ts
+++ b/src/features/recruiting/hooks/useApplyMutations.ts
@@ -2,9 +2,12 @@ import { useMutation } from "@tanstack/react-query"
 import { isAxiosError } from "axios"
 
 import {
+  createAnonymousApplicationDraft,
   createApplicationDraft,
   saveApplicationDraft,
+  submitAnonymousApplication,
   submitApplication,
+  updateAnonymousApplication,
 } from "../api/recruitingApi"
 import {
   clearApplyDraft,
@@ -27,6 +30,14 @@ interface ApplySaveContext {
   roundId: string
   memberId: string
   applicationFormId: string
+  isAnonymous: boolean
+  privacyTermId?: number
+  privacyAgreed: boolean
+}
+
+function getAnonymousCredentialEmail() {
+  if (typeof window === "undefined") return null
+  return sessionStorage.getItem("anonymousEmail")
 }
 
 // 브라우저에 남은 초안을 버려도 되는 경우만 고른다. 4xx 전체로 넓히면 세션
@@ -55,13 +66,23 @@ async function createAndRemember(
   context: ApplySaveContext,
   input: ApplySaveInput,
 ): Promise<ApplyDraftRef> {
-  const created = await createApplicationDraft({
-    applicationFormId: Number(context.applicationFormId),
-    applicantName: input.applicantName,
-    applicantEmail: input.applicantEmail,
-    firstChoice: input.firstChoice,
-    secondChoice: input.secondChoice,
-  })
+  const created = context.isAnonymous
+    ? await createAnonymousApplicationDraft({
+        applicationFormId: Number(context.applicationFormId),
+        applicantName: input.applicantName,
+        applicantEmail: input.applicantEmail,
+        firstChoice: input.firstChoice,
+        secondChoice: input.secondChoice,
+        privacyTermId: context.privacyTermId ?? 0,
+        privacyAgreed: context.privacyAgreed,
+      })
+    : await createApplicationDraft({
+        applicationFormId: Number(context.applicationFormId),
+        applicantName: input.applicantName,
+        applicantEmail: input.applicantEmail,
+        firstChoice: input.firstChoice,
+        secondChoice: input.secondChoice,
+      })
   const draft: ApplyDraftRef = {
     applicationId: String(created.applicationId),
     applicationKey: created.applicationKey,
@@ -86,13 +107,32 @@ export function useSaveApplicationDraft(context: ApplySaveContext) {
       }
 
       try {
-        await saveApplicationDraft(draft.applicationId, body)
+        if (context.isAnonymous) {
+          const credentialEmail =
+            (existing ? getAnonymousCredentialEmail() : null) ??
+            input.applicantEmail
+          await updateAnonymousApplication({
+            credentialEmail,
+            applicationKey: draft.applicationKey,
+            ...body,
+          })
+        } else {
+          await saveApplicationDraft(draft.applicationId, body)
+        }
         return draft
       } catch (error) {
         if (!existing || !isStaleDraft(error)) throw error
         clearApplyDraft(context.roundId, context.memberId)
         const recreated = await createAndRemember(context, input)
-        await saveApplicationDraft(recreated.applicationId, body)
+        if (context.isAnonymous) {
+          await updateAnonymousApplication({
+            credentialEmail: input.applicantEmail,
+            applicationKey: recreated.applicationKey,
+            ...body,
+          })
+        } else {
+          await saveApplicationDraft(recreated.applicationId, body)
+        }
         return recreated
       }
     },
@@ -101,11 +141,26 @@ export function useSaveApplicationDraft(context: ApplySaveContext) {
 
 export function useSubmitApplication(context: ApplySaveContext) {
   return useMutation({
-    mutationFn: (applicationId: string) => submitApplication(applicationId),
+    mutationFn: ({ applicationId, applicationKey }: ApplySubmitInput) => {
+      if (context.isAnonymous) {
+        const email = getAnonymousCredentialEmail()
+        if (!email) throw new Error("anonymous credential missing")
+        return submitAnonymousApplication({
+          email,
+          applicationKey,
+        })
+      }
+      return submitApplication(applicationId)
+    },
     onSuccess: () => {
       // 제출하면 더 이상 이어쓸 초안이 아니다. 남겨 두면 다음 진입에서
       // 제출된 지원서를 초안으로 오인해 덮어쓰기를 시도한다.
       clearApplyDraft(context.roundId, context.memberId)
     },
   })
+}
+
+interface ApplySubmitInput {
+  applicationId: string
+  applicationKey: string
 }

--- a/src/features/recruiting/ui/apply/AnonymousPrivacyConsent.tsx
+++ b/src/features/recruiting/ui/apply/AnonymousPrivacyConsent.tsx
@@ -1,0 +1,44 @@
+import { Checkbox } from "@/shared/ui/input/checkbox/Checkbox"
+
+import type { PublicTermResponse } from "@/shared/api/terms"
+
+interface AnonymousPrivacyConsentProps {
+  term: PublicTermResponse | undefined
+  checked: boolean
+  disabled?: boolean
+  onChange: (checked: boolean) => void
+}
+
+export function AnonymousPrivacyConsent({
+  term,
+  checked,
+  disabled = false,
+  onChange,
+}: AnonymousPrivacyConsentProps) {
+  return (
+    <div className="border-teal-gray-100 flex items-start gap-3 rounded-[12px] border bg-white px-7 py-5">
+      <Checkbox
+        checked={checked}
+        disabled={disabled || !term}
+        variant="primary"
+        aria-label="개인정보 처리방침 동의"
+        onChange={onChange}
+      />
+      <div className="flex min-w-0 flex-col gap-1">
+        <button
+          type="button"
+          disabled={!term}
+          onClick={() => {
+            if (term) window.open(term.link, "_blank", "noopener,noreferrer")
+          }}
+          className="text-body-2-medium text-teal-gray-700 text-left underline underline-offset-2 disabled:no-underline"
+        >
+          개인정보 처리방침에 동의합니다 (필수)
+        </button>
+        <p className="text-label-1-medium text-teal-gray-400">
+          익명 지원서 작성과 지원 결과 안내를 위해 필요합니다.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/features/recruiting/ui/apply/RecruitingApplyPage.tsx
+++ b/src/features/recruiting/ui/apply/RecruitingApplyPage.tsx
@@ -1,8 +1,11 @@
+import { useQuery } from "@tanstack/react-query"
 import { useNavigate } from "@tanstack/react-router"
 import { isAxiosError } from "axios"
 import { useEffect, useMemo, useRef, useState } from "react"
 
 import { useMe } from "@/entities/member/hooks/useMe"
+import { useAuthStore } from "@/entities/member/store/authStore"
+import { getPublicTermByType } from "@/shared/api/terms"
 import { Button } from "@/shared/ui/Button"
 import { useToastStore } from "@/shared/ui/toast/useToastStore"
 
@@ -14,6 +17,7 @@ import {
 } from "../../hooks/useApplyMutations"
 import { clearApplyDraft, readApplyDraft } from "../../model/applyDraftStorage"
 import { buildApplyAnswerPayload } from "../../model/applyPayload"
+import { AnonymousPrivacyConsent } from "./AnonymousPrivacyConsent"
 import { ApplicantInfoFields } from "./ApplicantInfoFields"
 import { RecruitingApplyForm } from "./RecruitingApplyForm"
 
@@ -59,8 +63,21 @@ function Notice({ children }: { children: React.ReactNode }) {
 export function RecruitingApplyPage({ roundId }: RecruitingApplyPageProps) {
   const navigate = useNavigate()
   const addToast = useToastStore((state) => state.addToast)
-  const { data: me } = useMe()
+  const isAuthed = useAuthStore((state) => state.isAuthed)
+  const isAnonymous = !isAuthed
+  const { data: me, isLoading: isMeLoading } = useMe()
   const memberId = me?.id ?? ""
+  const anonymousSessionId = useMemo(
+    () => (isAnonymous ? getOrCreateAnonymousSessionId() : ""),
+    [isAnonymous],
+  )
+  const storageIdentity = isAnonymous ? anonymousSessionId : memberId
+  const privacyTermQuery = useQuery({
+    queryKey: ["terms", "PRIVACY"],
+    queryFn: () => getPublicTermByType("PRIVACY"),
+    enabled: isAnonymous,
+    staleTime: 5 * 60 * 1000,
+  })
 
   const [applicant, setApplicant] = useState<ApplicantInfo>({
     applicantName: "",
@@ -70,6 +87,7 @@ export function RecruitingApplyPage({ roundId }: RecruitingApplyPageProps) {
   })
   const [applicationKey, setApplicationKey] = useState<string | undefined>()
   const [resumeDecided, setResumeDecided] = useState(false)
+  const [privacyAgreed, setPrivacyAgreed] = useState(false)
 
   // 로그인 정보로 한 번만 채운다. me 가 다시 조회될 때마다 채우면 사용자가
   // 일부러 비운 칸이 되살아난다(빈 문자열은 falsy 라 폴백에 걸린다).
@@ -85,8 +103,8 @@ export function RecruitingApplyPage({ roundId }: RecruitingApplyPageProps) {
   }, [me])
 
   const savedDraft = useMemo(
-    () => (memberId ? readApplyDraft(roundId, memberId) : null),
-    [roundId, memberId],
+    () => (storageIdentity ? readApplyDraft(roundId, storageIdentity) : null),
+    [roundId, storageIdentity],
   )
 
   const { round, config, isLoading, isStructureFetching, isError, isNotFound } =
@@ -94,8 +112,11 @@ export function RecruitingApplyPage({ roundId }: RecruitingApplyPageProps) {
 
   const context = {
     roundId,
-    memberId,
+    memberId: storageIdentity,
     applicationFormId: round?.applicationFormId ?? "",
+    isAnonymous,
+    privacyTermId: privacyTermQuery.data?.id,
+    privacyAgreed,
   }
   const saveDraft = useSaveApplicationDraft(context)
   const submit = useSubmitApplication(context)
@@ -114,12 +135,22 @@ export function RecruitingApplyPage({ roundId }: RecruitingApplyPageProps) {
   // 이름·이메일은 문항이 아니라 지원서 필드라 폼 검증에 걸리지 않는다.
   // 보내기 직전에 확인한다 — 없다고 폼을 감추면 작성 중인 답변이 사라진다.
   const missingApplicantInfo = () => {
+    if (isAuthed && !memberId) return "로그인 정보를 불러오는 중입니다."
     if (awaitingResumeChoice) {
       return "이어서 작성할지 새로 시작할지 먼저 선택해 주세요."
     }
     if (!applicant.applicantName.trim()) return "이름을 입력해 주세요."
     if (!applicant.applicantEmail.trim()) return "이메일을 입력해 주세요."
     if (!applicant.firstChoice) return "1지망 파트를 선택해 주세요."
+    if (isAnonymous && privacyTermQuery.isError) {
+      return "개인정보 처리방침을 불러오지 못했습니다. 잠시 후 다시 시도해주세요."
+    }
+    if (isAnonymous && !privacyTermQuery.data) {
+      return "개인정보 처리방침을 불러오는 중입니다."
+    }
+    if (isAnonymous && !privacyAgreed) {
+      return "개인정보 처리방침에 동의해 주세요."
+    }
     return null
   }
 
@@ -179,13 +210,16 @@ export function RecruitingApplyPage({ roundId }: RecruitingApplyPageProps) {
     try {
       // 제출은 저장된 내용을 확정하는 동작이라 마지막 저장을 먼저 보낸다.
       const draft = await persist(values)
-      await submit.mutateAsync(draft.applicationId)
+      await submit.mutateAsync({
+        applicationId: draft.applicationId,
+        applicationKey: draft.applicationKey,
+      })
     } catch (error) {
       // 서버는 이미 제출된 지원서에도 저장은 받아 주고 제출만 거부한다. 응답이
       // 유실돼 제출된 줄 모르고 다시 누르면 이 경로로 영원히 돌게 되므로,
       // 상태가 어긋났다는 답을 받으면 초안 참조를 정리하고 내 지원서로 보낸다.
       if (isFinalizedApplication(error)) {
-        clearApplyDraft(roundId, memberId)
+        clearApplyDraft(roundId, storageIdentity)
         showError("이미 제출된 지원서입니다. 내 지원서에서 확인해주세요.")
         void navigate({ to: LIST_PATH })
         throw new Error("already finalized")
@@ -252,8 +286,19 @@ export function RecruitingApplyPage({ roundId }: RecruitingApplyPageProps) {
         }
         recruitableTracks={round.recruitableTracks}
         secondChoiceEnabled={round.secondChoiceEnabled}
-        disabled={saveDraft.isPending || submit.isPending}
+        disabled={
+          saveDraft.isPending || submit.isPending || (isAuthed && isMeLoading)
+        }
       />
+
+      {isAnonymous && (
+        <AnonymousPrivacyConsent
+          term={privacyTermQuery.data}
+          checked={privacyAgreed}
+          disabled={saveDraft.isPending || submit.isPending}
+          onChange={setPrivacyAgreed}
+        />
+      )}
 
       <p className="text-label-1-medium text-teal-gray-400 px-1">
         임시저장한 지원서는 이 브라우저에서만 이어서 작성할 수 있습니다.

--- a/src/routes/projects/apply/$roundId.tsx
+++ b/src/routes/projects/apply/$roundId.tsx
@@ -1,6 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
 
-import { ensureMe } from "@/features/auth/lib/ensureMe"
 import { RecruitingApplyPage } from "@/features/recruiting"
 
 export const Route = createFileRoute("/projects/apply/$roundId")({
@@ -8,11 +7,6 @@ export const Route = createFileRoute("/projects/apply/$roundId")({
   head: () => ({
     meta: [{ name: "robots", content: "noindex, nofollow" }],
   }),
-  // /projects 레이아웃에는 로그인 가드가 없다. 지원서 작성은 로그인 사용자
-  // 경로만 구현하므로 이 라우트에서 직접 건다.
-  beforeLoad: async ({ context, location }) => {
-    await ensureMe(context.queryClient, location.href)
-  },
   component: RecruitingApplyRoute,
 })
 

--- a/src/shared/api/terms.ts
+++ b/src/shared/api/terms.ts
@@ -1,0 +1,19 @@
+import { api } from "@/shared/lib/axios"
+
+import type { ApiResponse } from "@/shared/lib/apiResponse"
+import type { TermType } from "@/shared/model/domain"
+
+export interface PublicTermResponse {
+  id: number
+  link: string
+  isMandatory: boolean
+}
+
+export async function getPublicTermByType(
+  termType: TermType,
+): Promise<PublicTermResponse> {
+  const { data } = await api.get<ApiResponse<PublicTermResponse>>(
+    `/v1/terms/type/${termType}`,
+  )
+  return data.result
+}

--- a/src/widgets/navigation/header/RecruitingStatusButton.tsx
+++ b/src/widgets/navigation/header/RecruitingStatusButton.tsx
@@ -1,37 +1,52 @@
+import { Link } from "@tanstack/react-router"
+
 import { cn } from "@/shared/lib/utils"
 
 import type { RecruitingStatus } from "@/shared/model/recruitingStatus"
 
 export type { RecruitingStatus }
 
-// 헤더 우측의 모집 상태 표시. 상호작용 없는 라벨 전용 버튼(디자인상 '버튼' 형태).
-// before: "모집 시작 D-n" / open: "지원하기 D-n"(마감일 기준) / closed: "모집 마감"
+const BASE_CLASS =
+  "flex h-10 min-w-16 items-center justify-center rounded-[10px] px-5 py-1 text-center whitespace-nowrap tracking-[-0.32px]"
+
+const IDLE_CLASS =
+  "text-label-1-medium border-teal-gray-150 text-teal-gray-400 shadow-inner-neutral-1 border bg-white"
+
+/**
+ * 헤더 우측의 모집 상태.
+ *
+ * 접수 중일 때만 누를 수 있다. `지원하기` 는 행동을 시키는 문구인데 눌리지 않으면
+ * 막다른 길이 된다. 헤더 `모집 안내` 탭이 아직 비활성이라(#710) 게스트에게는
+ * 이게 모집 흐름으로 들어가는 유일한 경로다.
+ *
+ * 시작 전과 마감은 알리기만 하면 되므로 라벨 그대로 둔다.
+ */
 export function RecruitingStatusButton({
   status,
 }: {
   status: RecruitingStatus
 }) {
-  const base =
-    "flex h-10 min-w-16 items-center justify-center rounded-[10px] px-5 py-1 text-center whitespace-nowrap tracking-[-0.32px]"
-
   if (status.phase === "open") {
     return (
-      <span
-        className={cn(base, "text-label-1-semibold bg-teal-600 text-white")}
+      <Link
+        to="/projects/notice"
+        className={cn(
+          BASE_CLASS,
+          "text-label-1-semibold bg-teal-600 text-white transition-colors hover:bg-teal-700",
+        )}
       >
         지원하기 D-{status.dDay}
+      </Link>
+    )
+  }
+
+  if (status.phase === "before") {
+    return (
+      <span className={cn(BASE_CLASS, IDLE_CLASS)}>
+        모집 시작 D-{status.dDay}
       </span>
     )
   }
 
-  const grayClassName = cn(
-    base,
-    "text-label-1-medium border-teal-gray-150 text-teal-gray-400 shadow-inner-neutral-1 border bg-white",
-  )
-
-  if (status.phase === "before") {
-    return <span className={grayClassName}>모집 시작 D-{status.dDay}</span>
-  }
-
-  return <span className={grayClassName}>모집 마감</span>
+  return <span className={cn(BASE_CLASS, IDLE_CLASS)}>모집 마감</span>
 }


### PR DESCRIPTION
## 📸 작업 내용

- 헤더 우측 모집 상태를 `span` 으로 그리고 있어서 **접수 중일 때도 클릭이 되지 않았다.** 접수 중일 때만 모집 공고로 연결했다.
- 시작 전(`모집 시작 D-n`)과 마감(`모집 마감`)은 알리기만 하면 되므로 라벨 그대로 뒀다.

## 🎞️ 주요 코드 설명

QA 중에 발견했다. `지원하기 D-n` 은 행동을 시키는 문구인데 눌리지 않으면 막다른 길이 된다.

확인해 보니 그 자리가 더 넓은 구멍이었다. **게스트가 헤더에서 모집 흐름으로 갈 경로가 하나도 없었다.**

| 헤더 항목 | 상태 |
|---|---|
| 모집 안내 | 비활성 (#710 랜딩 경로 확정 대기) |
| 지원하기 D-n | 클릭 불가 |

목적지는 모집 공고(`/projects/notice`)로 잡았다. 비인증으로 열려 있어 게스트가 그대로 들어갈 수 있고, 거기서 지원하기를 누르면 지원 폼 라우트의 로그인 가드가 받는다.

## 🖥️ 구현화면

비로그인 상태로 확인했다.

- 헤더에 `지원하기 D-2` 가 링크로 렌더된다 (`<a href="/projects/notice">`)
- 클릭 시 모집 공고로 이동하고, 진행 중인 차수(`동국대학교 UMC 10기 정규 모집 테스트1`, `모집 마감 D-2`)가 보인다

## 🔗 연결된 이슈

- Connected: #688

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 모집 중 상태의 버튼을 클릭하면 모집 안내 페이지로 이동할 수 있습니다.
  * 모집 중 버튼에 마우스를 올리면 상호작용 가능한 스타일이 표시됩니다.

* **버그 수정**
  * 모집 시작 전 및 마감 상태에서는 기존처럼 비활성 상태가 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->