### PR TITLE
✨ feat: 소개 랜딩 헤더 진입 경로 연결과 프로젝트 목록 3열 고정

### DIFF
--- a/src/features/intro/ui/IntroPage.tsx
+++ b/src/features/intro/ui/IntroPage.tsx
@@ -12,6 +12,8 @@ import { ProductTeamIntroSection } from "./sections/ProductTeamIntroSection"
 import { ProductTeamMembersSection } from "./sections/ProductTeamMembersSection"
 import { SolutionSection } from "./sections/SolutionSection"
 
+import type { RecruitingStatus } from "@/shared/model/recruitingStatus"
+
 const LANDING_BACKGROUND_FADE_LEFT = 40
 const LANDING_BACKGROUND_FADE_RIGHT = 120
 const LANDING_BACKGROUND_MASK = `linear-gradient(to right, transparent, #000 ${LANDING_BACKGROUND_FADE_LEFT}px, #000 calc(100% - ${LANDING_BACKGROUND_FADE_RIGHT}px), transparent)`
@@ -47,7 +49,12 @@ function StaticGlow({
   )
 }
 
-export function IntroPage() {
+interface IntroPageProps {
+  /** 헤더 우측 모집 상태. 조회는 라우트가 하고 여기는 받아서 넘기기만 한다. */
+  recruitingStatus?: RecruitingStatus
+}
+
+export function IntroPage({ recruitingStatus }: IntroPageProps) {
   return (
     <main
       className="flex w-full justify-center"
@@ -56,7 +63,7 @@ export function IntroPage() {
         overflowX: "clip",
       }}
     >
-      <LandingHeader />
+      <LandingHeader recruitingStatus={recruitingStatus} />
       <div className="relative w-[1440px]">
         <div className="pointer-events-none absolute inset-0 overflow-hidden">
           <div

--- a/src/features/intro/ui/components/LandingHeader.tsx
+++ b/src/features/intro/ui/components/LandingHeader.tsx
@@ -1,6 +1,7 @@
-import { useLocation, useNavigate } from "@tanstack/react-router"
+import { Link, useLocation, useNavigate } from "@tanstack/react-router"
 import { useEffect, useRef, useState } from "react"
 
+import { useAuthStore } from "@/entities/member/store/authStore"
 import UmcLogo from "@/shared/assets/icon/logo/UmcLogo"
 import {
   getDisabledNavMessage,
@@ -8,12 +9,33 @@ import {
   type HeaderNavItem,
   isHeaderNavItemActive,
 } from "@/shared/config/headerNavPolicy"
+import {
+  buildLoginRedirectSearch,
+  getCurrentReturnTo,
+} from "@/shared/lib/loginRedirect"
 import { cn } from "@/shared/lib/utils"
 import { useToastStore } from "@/shared/ui/toast/useToastStore"
 
-export function LandingHeader() {
+import type { RecruitingStatus } from "@/shared/model/recruitingStatus"
+
+/** 어두운 히어로 위에 얹히는 헤더라 우측 버튼도 밝은 배경을 쓸 수 없다. */
+const SLOT_BUTTON_CLASS =
+  "flex h-10 min-w-16 items-center justify-center rounded-[10px] px-5 text-center text-[16px] font-semibold tracking-[-0.32px] whitespace-nowrap transition-colors"
+
+interface LandingHeaderProps {
+  /**
+   * 모집 상태. 라우트에서 넣어 준다.
+   *
+   * 여기서 직접 조회하지 않는 이유는 조회 훅이 리크루팅 기능에 있어서다.
+   * 소개 화면이 그 훅을 바로 부르면 기능끼리 가로로 엮여 경계 검사에 걸린다.
+   */
+  recruitingStatus?: RecruitingStatus
+}
+
+export function LandingHeader({ recruitingStatus }: LandingHeaderProps) {
   const { pathname } = useLocation()
   const navigate = useNavigate()
+  const isAuthed = useAuthStore((s) => s.isAuthed)
   const [isVisible, setIsVisible] = useState(true)
   const lastScrollY = useRef(0)
   const visibleRef = useRef(true)
@@ -142,7 +164,40 @@ export function LandingHeader() {
           })}
         </nav>
 
-        <div className="h-full w-55" />
+        {/* 랜딩에서 지원 흐름으로 들어가는 유일한 진입로다. 비로그인 방문자가
+            대부분이라 로그인 자리도 함께 둔다. */}
+        <div className="flex h-full w-55 items-center justify-end gap-4 pr-12.5">
+          {recruitingStatus?.phase === "open" && (
+            <Link
+              to="/projects/notice"
+              className={cn(
+                SLOT_BUTTON_CLASS,
+                "border border-white/20 bg-white/15 text-white hover:bg-white/25",
+              )}
+            >
+              지원하기
+            </Link>
+          )}
+          {recruitingStatus?.phase === "closed" && !isAuthed && (
+            <span
+              className={cn(
+                SLOT_BUTTON_CLASS,
+                "border border-white/10 bg-white/5 font-medium text-white/50",
+              )}
+            >
+              모집 마감
+            </span>
+          )}
+          {!isAuthed && (
+            <Link
+              to="/login"
+              search={buildLoginRedirectSearch(getCurrentReturnTo())}
+              className="text-[16px] font-semibold tracking-[-0.32px] whitespace-nowrap text-white transition-colors hover:text-white/70"
+            >
+              로그인
+            </Link>
+          )}
+        </div>
       </div>
     </header>
   )

--- a/src/features/project/list/ui/MatchingProjectsListPage.tsx
+++ b/src/features/project/list/ui/MatchingProjectsListPage.tsx
@@ -72,10 +72,19 @@ function toMatchingProject(project: ProjectItem): MatchingProject {
 
 interface MatchingProjectsListPageProps {
   useMockData?: boolean
+  /**
+   * 카드 그리드 열 수.
+   *
+   * 로그인 여부가 아니라 화면 폭이 정한다. 이 목록은 사이드바가 있는
+   * `/matching/projects` 와 사이드바가 없는 `/projects` 가 함께 쓰는데,
+   * 같은 열 수를 주면 한쪽 카드가 디자인보다 커진다.
+   */
+  columns?: 2 | 3
 }
 
 export function MatchingProjectsListPage({
   useMockData = false,
+  columns = 2,
 }: MatchingProjectsListPageProps) {
   const {
     openFilterId,
@@ -228,10 +237,8 @@ export function MatchingProjectsListPage({
 
         <div
           className={cn(
-            // 게스트는 사이드바가 없어 폭이 넓다. 2열로 두면 카드가 디자인의
-            // 두 배 가까이 커진다. 로그인 화면은 매칭과 같은 그리드라 건드리지 않는다.
             "grid min-w-0 gap-5",
-            isGuest ? "grid-cols-3" : "grid-cols-2",
+            columns === 3 ? "grid-cols-3" : "grid-cols-2",
             openFilterId && "pointer-events-none",
           )}
         >

--- a/src/routes/intro.tsx
+++ b/src/routes/intro.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router"
 
 import { IntroPage } from "@/features/intro/ui/IntroPage"
+import { useHeaderRecruitingStatus } from "@/features/recruiting/hooks/useHeaderRecruitingStatus"
 import { createMeta, SITE_URL } from "@/shared/seo"
 
 export const Route = createFileRoute("/intro")({
@@ -10,5 +11,11 @@ export const Route = createFileRoute("/intro")({
       "프로젝트 등록·조회부터 지원 폼 제출, 실시간 매칭 결과 확인까지. UMC 데모데이 팀 매칭 시스템 사용 가이드.",
       { canonical: `${SITE_URL}/intro` },
     ),
-  component: IntroPage,
+  component: IntroRoute,
 })
+
+// 모집 상태 조회는 라우트가 맡는다. 소개 화면이 리크루팅 훅을 직접 부르면
+// 기능끼리 가로로 엮인다.
+function IntroRoute() {
+  return <IntroPage recruitingStatus={useHeaderRecruitingStatus()} />
+}

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -19,5 +19,6 @@ export const Route = createFileRoute("/projects/")({
 })
 
 function ProjectsListRoute() {
-  return <MatchingProjectsListPage />
+  // 이 화면은 사이드바 없이 전폭이라 로그인 여부와 상관없이 3열이다.
+  return <MatchingProjectsListPage columns={3} />
 }

--- a/src/routes/test/recruiting-header.tsx
+++ b/src/routes/test/recruiting-header.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react"
 
 import { authKeys } from "@/entities/member/hooks/useMe"
 import { useAuthStore } from "@/entities/member/store/authStore"
+import { LandingHeader } from "@/features/intro/ui/components/LandingHeader"
 import { cn } from "@/shared/lib/utils"
 import RecruitingHeader from "@/widgets/navigation/header/RecruitingHeader"
 
@@ -89,10 +90,18 @@ const PHASE_OPTIONS: { label: string; value: RecruitingStatus }[] = [
   { label: "마감", value: { phase: "closed" } },
 ]
 
+type HeaderKind = "app" | "landing"
+
+const HEADER_OPTIONS: { label: string; value: HeaderKind }[] = [
+  { label: "앱 안쪽 (Dark=False)", value: "app" },
+  { label: "랜딩 소개 (Dark=True)", value: "landing" },
+]
+
 function RecruitingHeaderTestPage() {
   const queryClient = useQueryClient()
   const [role, setRole] = useState<RoleScenario>("centralCore")
   const [phaseIndex, setPhaseIndex] = useState(0)
+  const [headerKind, setHeaderKind] = useState<HeaderKind>("app")
 
   // 선택한 역할 시나리오에 맞춰 auth/me를 목킹. 언마운트 시 원복.
   useEffect(() => {
@@ -115,9 +124,47 @@ function RecruitingHeaderTestPage() {
 
   return (
     <main className="min-h-screen w-full">
-      <RecruitingHeader recruitingStatus={PHASE_OPTIONS[phaseIndex]!.value} />
+      {headerKind === "app" ? (
+        <RecruitingHeader recruitingStatus={PHASE_OPTIONS[phaseIndex]!.value} />
+      ) : (
+        // 랜딩 헤더는 fixed 라 그대로 두면 화면 맨 위에 붙는다. transform 을 준
+        // 상자가 fixed 의 기준이 되므로 이 자리에 갇혀서 그려진다.
+        <div
+          className="relative h-20 w-full bg-[#101f1e]"
+          style={{ transform: "translateZ(0)" }}
+        >
+          <LandingHeader recruitingStatus={PHASE_OPTIONS[phaseIndex]!.value} />
+        </div>
+      )}
 
       <div className="flex flex-col gap-6 p-8">
+        <div className="flex flex-col gap-2">
+          <span className="text-label-1-medium text-teal-gray-600">헤더</span>
+          <div className="flex flex-wrap gap-2">
+            {HEADER_OPTIONS.map(({ label, value }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setHeaderKind(value)}
+                className={cn(
+                  "text-body-3-medium rounded-full border px-3 py-1.5",
+                  headerKind === value
+                    ? "border-teal-600 bg-teal-600 text-white"
+                    : "border-teal-gray-200 text-teal-gray-500 bg-white",
+                )}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          {headerKind === "landing" && (
+            <p className="text-body-3-regular text-teal-gray-500">
+              랜딩 헤더는 탭이 소개·모집 안내·프로젝트 셋뿐이고 역할에 따라
+              늘어나지 않는다. 역할 선택은 앱 안쪽 헤더에만 영향을 준다.
+            </p>
+          )}
+        </div>
+
         <div className="flex flex-col gap-2">
           <span className="text-label-1-medium text-teal-gray-600">역할</span>
           <div className="flex flex-wrap gap-2">

--- a/src/shared/config/headerNavPolicy.ts
+++ b/src/shared/config/headerNavPolicy.ts
@@ -1,33 +1,40 @@
-export const RECRUITING_DISABLED_MESSAGE =
-  "리크루팅 서비스는 11기 모집 때 공개됩니다. 많은 관심 부탁드립니다!"
-
 export type HeaderNavItem = {
   label: string
   to: string
   activeBasePath?: string
+  activeBasePaths?: string[]
+  inactiveBasePaths?: string[]
   disabled?: boolean
   disabledMessage?: string
 }
 
+/**
+ * 랜딩(소개) 헤더의 탭.
+ *
+ * 앱 안쪽 헤더와 목록이 다르다. 랜딩은 아직 로그인하지 않은 방문자가 먼저 닿는
+ * 화면이라 공개된 곳만 연다. 권한이 있어야 들어가는 리크루팅·설정과 로그인이
+ * 필요한 데모데이 매칭은 여기 두지 않는다. 눌러서 로그인이나 권한 없음으로
+ * 튕기는 탭은 진입로가 아니라 막다른 길이다.
+ *
+ * 앱 안쪽 헤더는 권한과 모집 시점에 따라 탭이 늘어난다. `buildRecruitingNavItems`
+ * 가 따로 만든다.
+ */
 export const HEADER_NAV_ITEMS: HeaderNavItem[] = [
   {
     label: "소개",
     to: "/intro",
   },
   {
+    label: "모집 안내",
+    to: "/projects/notice",
+    // 지원 폼도 모집 안내에서 이어지는 화면이라 같은 탭이 켜져야 한다.
+    activeBasePaths: ["/projects/notice", "/projects/apply"],
+  },
+  {
     label: "프로젝트",
     to: "/projects",
-  },
-  {
-    label: "데모데이 매칭",
-    to: "/matching/projects",
-    activeBasePath: "/matching",
-  },
-  {
-    label: "리크루팅",
-    to: "/recruiting",
-    disabled: true,
-    disabledMessage: RECRUITING_DISABLED_MESSAGE,
+    // `/projects` 로 시작하는 모집 흐름까지 삼키면 두 탭이 같이 켜진다.
+    inactiveBasePaths: ["/projects/notice", "/projects/apply"],
   },
 ]
 
@@ -38,8 +45,23 @@ export function getDisabledNavMessage(item: HeaderNavItem) {
   )
 }
 
-export function isHeaderNavItemActive(pathname: string, item: HeaderNavItem) {
-  const basePath = item.activeBasePath ?? item.to
-
+function matchesBasePath(pathname: string, basePath: string): boolean {
+  if (basePath === "/") return pathname === "/"
   return pathname === basePath || pathname.startsWith(basePath + "/")
+}
+
+export function isHeaderNavItemActive(pathname: string, item: HeaderNavItem) {
+  if (item.disabled) return false
+  if (
+    item.inactiveBasePaths?.some((basePath) =>
+      matchesBasePath(pathname, basePath),
+    )
+  ) {
+    return false
+  }
+
+  const activeBasePaths = item.activeBasePaths ?? [
+    item.activeBasePath ?? item.to,
+  ]
+  return activeBasePaths.some((basePath) => matchesBasePath(pathname, basePath))
 }

--- a/src/widgets/navigation/header/RecruitingHeader.tsx
+++ b/src/widgets/navigation/header/RecruitingHeader.tsx
@@ -8,7 +8,9 @@ import {
 import { useAuthStore } from "@/entities/member/store/authStore"
 import { useHeaderRecruitingStatus } from "@/features/recruiting/hooks/useHeaderRecruitingStatus"
 import UmcLogo from "@/shared/assets/icon/logo/UmcLogo"
+import { getDisabledNavMessage } from "@/shared/config/headerNavPolicy"
 import { SETTINGS_ENTRY_PATH } from "@/shared/config/settingsNavigation"
+import { useToastStore } from "@/shared/ui/toast/useToastStore"
 import { GuestProfileButton } from "@/widgets/navigation/header/GuestProfileButton"
 import HeaderButton from "@/widgets/navigation/header/HeaderButton"
 import NavigationButton from "@/widgets/navigation/header/NavigationButton"
@@ -16,6 +18,7 @@ import Profile from "@/widgets/navigation/header/Profile"
 import {
   buildRecruitingNavItems,
   isNavActive,
+  type NavItem,
 } from "@/widgets/navigation/header/recruitingHeaderNav"
 import {
   type RecruitingStatus,
@@ -47,6 +50,21 @@ export default function RecruitingHeader({
   // 잠깐 더 보이는 편이 덜 어색하다.
   const isRecruitingPeriod = status?.phase === "open"
 
+  const addToast = useToastStore((s) => s.addToast)
+
+  // 비활성 탭은 Link 가 아니라 버튼으로 그려진다. 핸들러를 안 주면 눌러도
+  // 아무 일도 일어나지 않아 고장 난 것처럼 보인다. 아직 없는 화면이라는 안내는
+  // 실패가 아니므로 에러(red)가 아닌 공지(notice)로 띄운다.
+  const notifyComingSoon = (item: NavItem) => {
+    addToast({
+      message: getDisabledNavMessage(item),
+      color: "primary",
+      variant: "deep",
+      type: "notice",
+      duration: 3000,
+    })
+  }
+
   const navItems = buildRecruitingNavItems({
     isAuthed,
     showRecruiting,
@@ -69,6 +87,7 @@ export default function RecruitingHeader({
             to={item.to}
             selected={isNavActive(pathname, item)}
             disabled={item.disabled}
+            onClick={item.disabled ? () => notifyComingSoon(item) : undefined}
             className="min-w-18 px-4.5"
           />
         ))}


### PR DESCRIPTION
## 📸 작업 내용

- 소개 랜딩(`/intro`) 헤더 우측에 진입 버튼을 채웠다. 모집 진행 중이면 `지원하기`(→ `/projects/notice`), 마감이면 `모집 마감`, 비로그인 방문자에게는 `로그인`(→ `/login?returnTo=<현재 경로>`)을 노출한다.
- 헤더 GNB 의 `모집 안내` 탭이 자리표시자 경로(`/`)라 눌리지 않던 문제를 `/projects/notice` 로 연결해 풀었다.
- 경로 접두가 겹쳐 `모집 안내` 와 `프로젝트` 가 동시에 활성으로 보이던 문제를 활성/비활성 기준 경로를 나눠 해결했다.
- 아직 화면이 없는 비활성 탭을 눌러도 아무 반응이 없던 문제를 안내 토스트로 채웠다. 실패가 아니므로 에러가 아닌 공지 색으로 띄운다.
- `/projects` 프로젝트 목록이 로그인하면 2열로 좁아지던 문제를 3열 고정으로 바로잡았다.
- `/test/recruiting-header` 미리보기에 랜딩(Dark) 헤더 토글을 더해 앱 안쪽 헤더와 나란히 비교할 수 있게 했다.

## 🎞️ 주요 코드 설명

### 탭 활성 판정: 접두가 겹치는 경로 분리

`모집 안내`(`/projects/notice`)와 `프로젝트`(`/projects`)는 접두가 겹친다. 기존처럼 `startsWith` 하나로 판정하면 모집 안내에 들어갔을 때 두 탭이 같이 켜진다. 활성으로 볼 경로와 양보할 경로를 나눠 뒀다.

```TypeScript
{
  label: "모집 안내",
  to: "/projects/notice",
  // 지원 폼도 모집 안내에서 이어지는 화면이라 같은 탭이 켜져야 한다.
  activeBasePaths: ["/projects/notice", "/projects/apply"],
},
{
  label: "프로젝트",
  to: "/projects",
  // `/projects` 로 시작하는 모집 흐름까지 삼키면 두 탭이 같이 켜진다.
  inactiveBasePaths: ["/projects/notice", "/projects/apply"],
},
```

### 모집 상태는 라우트가 넣어 준다

랜딩 헤더가 모집 상태 조회 훅을 직접 부르면 소개 기능이 리크루팅 기능에 가로로 의존하게 되어 `lint:boundaries` 기준선을 넘긴다. 조회는 라우트가 맡고 화면에는 값만 내려 준다.

```TypeScript
function IntroRoute() {
  return <IntroPage recruitingStatus={useHeaderRecruitingStatus()} />
}
```

### 목록 열 수는 로그인 여부가 아니라 화면 폭이 정한다

`MatchingProjectsListPage` 는 사이드바가 있는 `/matching/projects` 와 사이드바가 없는 `/projects` 가 함께 쓴다. 열 수를 로그인 여부로 가르면 전폭 화면이 2열로 좁아진다. 쓰는 쪽에서 열 수를 정하도록 바꿨다.

```TypeScript
// /projects: 사이드바 없이 전폭이라 로그인 여부와 상관없이 3열이다.
<MatchingProjectsListPage columns={3} />
```

## 🔗 연결된 이슈

- Connected: #710, #724, #725
- Closes #710
- Closes #724
- Closes #725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 랜딩 페이지 헤더에서 로그인, 지원하기, 모집 마감 상태를 확인할 수 있습니다.
  * 로그인 후 원래 보고 있던 위치로 돌아올 수 있습니다.
  * 프로젝트 목록을 3열 카드 그리드로 제공합니다.
  * 비활성 내비게이션 항목 선택 시 안내 토스트를 표시합니다.

* **개선 사항**
  * 페이지별 내비게이션 활성 상태가 경로에 맞게 표시됩니다.
  * 모집 상태에 따라 랜딩 헤더의 액션과 안내가 동적으로 변경됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->