### PR TITLE
🐛 fix: 학교 운영진 모집 인원 조회 범위 정렬

### DIFF
--- a/docs/2026-07-25_리크루팅_시안_API_불일치.md
+++ b/docs/2026-07-25_리크루팅_시안_API_불일치.md
@@ -28,7 +28,7 @@ UI는 mock으로 다 만들어둔 상태인데, API를 붙이려고 보니 시�
 
 목록을 주는 오퍼레이션은 하나입니다.
 
-```
+```text
 RECRUITING-EVALUATION-003
 GET /api/v1/recruiting/rounds/{roundId}/applications
 
@@ -48,7 +48,7 @@ RecruitingApplicationSummaryResponse
 
 집계 API가 없는 건 아닙니다. `RECRUITING-ADMIN-081`(지원 현황 요약)이 있는데 주는 게 **지원서 상태 집계**입니다.
 
-```
+```text
 RECRUITING-ADMIN-081  GET /api/v1/recruiting/admin/summary?gisuId=
 RecruitingStatusSummaryResponse { totalCount, countByStatus, schools }
 SchoolSummaryResponse { schoolId, schoolName, chapterId, chapterName, totalCount, countByStatus, rounds }
@@ -84,7 +84,7 @@ RoundSummaryResponse { roundId, roundTitle, roundType, roundNo, totalCount, coun
 
 면접 질문 오퍼레이션 8개(`ADMIN-041~048`) 중 조회 응답이 둘 다 이렇습니다.
 
-```
+```text
 RECRUITING-ADMIN-044  GET /admin/rounds/{roundId}/questions              (공통 질문)
 RECRUITING-ADMIN-048  GET /admin/applications/{applicationId}/questions   (지원서별 질문)
 
@@ -95,7 +95,7 @@ RecruitingInterviewQuestionResponse { id, roundId, applicationId, content, order
 
 지원서 상세가 주는 `answers[]`도 확인했는데 이건 지원 폼 답변이라 면접과 별개입니다.
 
-```
+```text
 RECRUITING-EVALUATION-004  GET /rounds/{roundId}/applications/{applicationId}
 RecruitingApplicationDetailResponse { application, formResponseId, answers }
 answers[] = { questionId, textValue, selectedOptionIds, fileIds, times }
@@ -120,7 +120,7 @@ answers[] = { questionId, textValue, selectedOptionIds, fileIds, times }
 
 지원서 상태 enum 전체는 이렇습니다.
 
-```
+```text
 DRAFT | SUBMITTED | DOCUMENT_FAILED | INTERVIEW_ASSIGNED
 | INTERVIEW_SKIPPED | FINAL_PASSED | FINAL_FAILED | CANCELLED
 ```
@@ -129,7 +129,7 @@ DRAFT | SUBMITTED | DOCUMENT_FAILED | INTERVIEW_ASSIGNED
 
 합불 결정 오퍼레이션도 두 개뿐입니다.
 
-```
+```text
 RECRUITING-ADMIN-061  PATCH /admin/applications/{applicationId}/document-decision  { decision: PASS|FAIL, reason }
 RECRUITING-ADMIN-063  PATCH /admin/applications/{applicationId}/final-decision     { decision: PASS|FAIL, acceptedTrack, reason }
 ```
@@ -151,7 +151,7 @@ RECRUITING-ADMIN-063  PATCH /admin/applications/{applicationId}/final-decision  
 
 평가자 관련 경로를 전부 뽑으면 두 개입니다.
 
-```
+```text
 RECRUITING-ADMIN-031  POST   /admin/rounds/{roundId}/evaluators/{memberId}
 RECRUITING-ADMIN-032  DELETE /admin/rounds/{roundId}/evaluators/{memberId}
 RECRUITING-ADMIN-033  GET    /admin/rounds/{roundId}/evaluators
@@ -182,7 +182,7 @@ RecruitingRoundEvaluatorResponse { id, roundId, memberId }
 
 목록 응답(`RECRUITING-EVALUATION-003`)에 있는 날짜는 `submittedAt` 하나뿐입니다. 면접 일정은 별도 오퍼레이션에만 있고 지원서 단위 조회입니다.
 
-```
+```text
 RECRUITING-SCHEDULE-002  GET /api/v1/recruiting/applications/{applicationId}/interview-schedule
 RecruitingInterviewScheduleResponse { id, applicationId, status, startsAt, endsAt, location }
 ```
@@ -203,14 +203,14 @@ RecruitingInterviewScheduleResponse { id, applicationId, status, startsAt, endsA
 
 상태 변경은 세 값을 받습니다.
 
-```
+```text
 RECRUITING-ADMIN-015  PATCH /admin/seasons/{seasonId}/rounds/{roundId}/status
 UpdateRecruitingRoundStatusRequest { status: DRAFT | OPEN | CLOSED }
 ```
 
 그런데 차수 조회 응답에는 `status`가 없습니다.
 
-```
+```text
 RECRUITING-ADMIN-011  GET /admin/rounds?gisuId=
 RECRUITING-PUBLIC-001 GET /public/rounds?gisuId=
 
@@ -240,7 +240,7 @@ RoundResponse
 
 지원 폼 문항 타입에 `SCHEDULE`이 있습니다.
 
-```
+```text
 RECRUITING-PUBLIC-002  GET /public/forms/{applicationFormId}/structure
 QuestionResponse.type = SHORT_TEXT | LONG_TEXT | RADIO | CHECKBOX | DROPDOWN | SCHEDULE | FILE | PORTFOLIO
 ```
@@ -255,7 +255,7 @@ QuestionResponse.type = SHORT_TEXT | LONG_TEXT | RADIO | CHECKBOX | DROPDOWN | S
 
 철회(`CANCELLED`)와 면접 생략(`INTERVIEW_SKIPPED`)이 상태에 있는데 목록/상세에서 어떻게 보여야 하는지 정의가 없습니다.
 
-```
+```text
 RECRUITING-ADMIN-062        POST  /admin/applications/{applicationId}/interview/skip  { reason }
 RECRUITING-APPLICATION-004  PATCH /applications/{applicationId}/cancel                { reason }
 ```
@@ -296,7 +296,7 @@ RECRUITING-APPLICATION-004  PATCH /applications/{applicationId}/cancel          
 
 평가 등록 경로의 `stage`도 `DOCUMENT`, `INTERVIEW` 둘뿐이라 시안과 API가 이미 맞습니다.
 
-```
+```text
 RECRUITING-EVALUATION-001/002  .../evaluations/{stage}    stage enum = [ DOCUMENT, INTERVIEW ]
 ```
 
@@ -310,7 +310,7 @@ RECRUITING-EVALUATION-001/002  .../evaluations/{stage}    stage enum = [ DOCUMEN
 
 `RECRUITING-EVALUATION-002`가 `{ id, applicationId, evaluatorMemberId, stage, decision, comment, submittedAt }`로 `memberId`만 줘서 이름을 못 채우나 했는데, 멤버 프로필 조회에 다 있었습니다.
 
-```
+```text
 MEMBER-101  GET /api/v1/member/profile/{memberId}
   name, nickname, schoolName,
   roles[].roleType = CENTRAL_PRESIDENT | CHAPTER_PRESIDENT | SCHOOL_PRESIDENT | SCHOOL_PART_LEADER ...

--- a/docs/2026-07-25_리크루팅_시안_API_불일치.md
+++ b/docs/2026-07-25_리크루팅_시안_API_불일치.md
@@ -1,0 +1,363 @@
+# 리크루팅 시안 ↔ API 불일치 정리
+
+2026-07-25 기준.
+
+dev 서버 OpenAPI 스펙을 직접 받아(`GET /docs-json`, 경로 313개) 리크루팅 오퍼레이션 **50개를 전수로** 훑고, Figma 시안은 해당 프레임을 하나씩 열어서 대조했습니다.
+
+Figma 파일: `mgDK3eBgoDYfARQEmtcoxQ` (🍒 UMC Web)
+
+UI는 mock으로 다 만들어둔 상태인데, API를 붙이려고 보니 시안에 그려진 걸 채울 데이터가 없는 경우가 나왔습니다. 반대로 **시안에 없는 걸 제가 잘못 구현해둔 것도 두 건** 있어서 같이 적었습니다.
+
+각 항목에 어느 프레임의 어느 부분인지 링크와, 어느 오퍼레이션의 어떤 응답을 확인했는지 필드 원문을 붙였습니다. 해당 프레임에 항목별로 코멘트 남기겠습니다.
+
+맨 아래에 오퍼레이션 50개 전수 목록이 있습니다. 제가 놓친 게 있으면 짚어주세요.
+
+---
+
+## A. 시안대로 그릴 데이터가 없는 것
+
+### A-1. 지원자 목록 — 평가 상태 칩 (평가 전 / 평가 중 / 평가 완료)
+
+**문의: 서버 + 디자이너**
+
+- [교내 운영진 평가 플로우](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/%F0%9F%8D%92-UMC-Web?node-id=10646-58552) → `1. 서류 전형` 행의 첫 화면
+- [지부장·중앙운영진 평가 플로우](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/%F0%9F%8D%92-UMC-Web?node-id=10646-119330) → `1. 서류 전형` 행의 첫 화면
+- [서류 목록 디폴트](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/%F0%9F%8D%92-UMC-Web?node-id=10204-73507)
+
+시안의 "평가 상태" 컬럼은 **평가 전 / 평가 중 / 평가 완료** 3단계입니다. 카드 헤더에도 `총 127명 · ● 평가 진행 중` 태그가 있고, 필터 드롭다운에도 "평가 상태"가 있습니다.
+
+목록을 주는 오퍼레이션은 하나입니다.
+
+```
+RECRUITING-EVALUATION-003
+GET /api/v1/recruiting/rounds/{roundId}/applications
+
+RecruitingApplicationSummaryResponse
+  applicationId, applicantName, email, applicantMemberId,
+  firstChoice, secondChoice, acceptedTrack,
+  status, registrationStatus, submittedAt,
+  documentEvaluatedByMe, interviewEvaluatedByMe
+```
+
+평가 관련 필드가 `documentEvaluatedByMe` / `interviewEvaluatedByMe` 두 개뿐입니다. **내가 냈는지 여부만** 알 수 있습니다.
+
+문제는 "평가 중"입니다. 이 값은 정의상 "평가자 일부만 제출한 상태"인데, 그걸 알려면 그 지원자에 대한 평가자 전원의 제출 현황이 필요합니다.
+
+- **분모(전체 평가자 수)는 구할 수 있습니다.** `RECRUITING-ADMIN-033 GET /admin/rounds/{roundId}/evaluators`가 차수 평가자 목록을 줍니다.
+- **분자(제출한 사람 수)를 주는 곳이 없습니다.** 지원서마다 `RECRUITING-EVALUATION-002`를 호출해 세는 방법뿐인데, 지원자 수만큼 요청이 늘어나 목록에서는 못 씁니다.
+
+집계 API가 없는 건 아닙니다. `RECRUITING-ADMIN-081`(지원 현황 요약)이 있는데 주는 게 **지원서 상태 집계**입니다.
+
+```
+RECRUITING-ADMIN-081  GET /api/v1/recruiting/admin/summary?gisuId=
+RecruitingStatusSummaryResponse { totalCount, countByStatus, schools }
+SchoolSummaryResponse { schoolId, schoolName, chapterId, chapterName, totalCount, countByStatus, rounds }
+RoundSummaryResponse { roundId, roundTitle, roundType, roundNo, totalCount, countByStatus }
+```
+
+`countByStatus`는 `SUBMITTED` 몇 명, `DOCUMENT_FAILED` 몇 명 하는 식이라 평가 진행 상태와는 다른 값입니다. 공유해주신 API 문서에도 "평가 완료 인원을 집계하는 별도 통계는 아직 제공하지 않아요"라고 적혀 있어서 의도된 것으로 보입니다.
+
+- **디자이너**: "평가 완료"가 무엇을 뜻하나요? **합불 결정이 끝난 것**인가요, 아니면 **평가자 전원이 의견을 낸 것**인가요? 전자면 지원서 상태로 그릴 수 있어서 서버 변경 없이 해결됩니다.
+- **서버**: 후자라면 목록 응답에 제출 인원 수가 필요합니다. 분모는 이미 있으니 `evaluatedCount` 하나만 추가되면 됩니다.
+
+일단 지원서 `status` 기준으로 "결정 전 / 결정 완료" 2단계로 그려두고 진행합니다.
+
+> 참고로 제가 구현한 화면에는 행마다 `3/7` 카운터가 붙어 있는데, **시안을 다시 확인해보니 세 화면 어디에도 그런 카운터가 없습니다.** 제가 잘못 넣은 것이라 이번에 제거합니다. 문의 대상 아닙니다.
+
+---
+
+### A-2. 면접 평가 상세 — 면접자별 답변 기록
+
+**문의: 서버**
+
+[면접 평가 상세](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/%F0%9F%8D%92-UMC-Web?node-id=10659-155943)
+(프레임 이름이 `지원서 서류 평가/ 2-2. 평가 완료 엑티브`로 되어 있는데 내용은 면접 평가입니다. 이름이 잘못 붙은 것 같아 같이 알려드립니다.)
+
+시안 구조가 이렇습니다.
+
+- `공통 질문` 카드 — 질문 목록 + 편집 아이콘
+- 그 아래 `지원자 답변` — **면접자별로 텍스트 영역이 따로** 있습니다 (`면접자: 이방토/이예원`, `면접자: 벨라/황지원`)
+- `개별 질문` 카드 — 같은 구조
+- `운영진 평가` 카드 — 평가자 현황 테이블
+
+즉 답변은 지원자가 쓰는 게 아니라 **면접에 들어간 운영진이 각자 기록**하는 구조로 보입니다.
+
+면접 질문 오퍼레이션 8개(`ADMIN-041~048`) 중 조회 응답이 둘 다 이렇습니다.
+
+```
+RECRUITING-ADMIN-044  GET /admin/rounds/{roundId}/questions              (공통 질문)
+RECRUITING-ADMIN-048  GET /admin/applications/{applicationId}/questions   (지원서별 질문)
+
+RecruitingInterviewQuestionResponse { id, roundId, applicationId, content, orderNo, active }
+```
+
+질문 텍스트(`content`)만 있고 답변 필드가 없습니다. 생성/수정 요청도 `{ content, orderNo }`라 답변을 넣을 자리가 없습니다.
+
+지원서 상세가 주는 `answers[]`도 확인했는데 이건 지원 폼 답변이라 면접과 별개입니다.
+
+```
+RECRUITING-EVALUATION-004  GET /rounds/{roundId}/applications/{applicationId}
+RecruitingApplicationDetailResponse { application, formResponseId, answers }
+answers[] = { questionId, textValue, selectedOptionIds, fileIds, times }
+```
+
+- 면접 답변은 어디에 기록하나요? 평가 코멘트(`RECRUITING-EVALUATION-001`의 `comment`)에 합치는 구조인가요, 아니면 별도 API가 예정되어 있나요?
+- 시안대로 **면접자(운영진)별로 여러 벌**을 저장해야 하는데, 코멘트 하나로는 담기 어려워 보입니다.
+- 별도 API 예정이면 응답 형태만 미리 알려주시면 화면을 맞춰두겠습니다.
+
+이번 연동에서는 질문 목록만 붙이고 답변 영역은 비워둡니다.
+
+---
+
+### A-3. 면접 전형 — 평가 결과 컬럼
+
+**문의: 서버**
+
+[교내 운영진 평가 플로우](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/%F0%9F%8D%92-UMC-Web?node-id=10646-58552) → `2. 면접 전형` 행의 첫 화면
+[면접 전형 보드](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/%F0%9F%8D%92-UMC-Web?node-id=10639-463430)
+
+시안의 면접 목록에는 **"평가 결과" 컬럼**과 **"면접 평가 결과" 필터**가 있고, 값으로 `합격`과 `대기`가 그려져 있습니다.
+
+지원서 상태 enum 전체는 이렇습니다.
+
+```
+DRAFT | SUBMITTED | DOCUMENT_FAILED | INTERVIEW_ASSIGNED
+| INTERVIEW_SKIPPED | FINAL_PASSED | FINAL_FAILED | CANCELLED
+```
+
+서류는 `DOCUMENT_FAILED`로 탈락이 구분되는데 면접은 대응되는 값이 없습니다. 스펙 전체 enum에서 `INTERVIEW`가 들어간 값을 뽑으면 `INTERVIEW`, `INTERVIEW_ASSIGNED`, `INTERVIEW_SKIPPED` 셋뿐이고 `INTERVIEW_FAILED`는 없습니다.
+
+합불 결정 오퍼레이션도 두 개뿐입니다.
+
+```
+RECRUITING-ADMIN-061  PATCH /admin/applications/{applicationId}/document-decision  { decision: PASS|FAIL, reason }
+RECRUITING-ADMIN-063  PATCH /admin/applications/{applicationId}/final-decision     { decision: PASS|FAIL, acceptedTrack, reason }
+```
+
+면접 단독 합불이 없습니다. 지금 구조로는 면접 목록의 결과 컬럼이 결국 최종 결과를 보여주게 되고, 면접에서 떨어진 사람과 최종에서 떨어진 사람이 구분되지 않습니다.
+
+- 면접 합불을 따로 기록하나요? 아니면 설계상 최종 결정 하나로 끝나는 게 맞나요?
+- 후자라면 시안의 "면접 평가 결과" 필터와 결과 컬럼을 어떻게 처리할지 디자이너와 같이 정해야 합니다.
+
+---
+
+### A-4. 지원자 목록 — "내 담당 지원자" 토글
+
+**문의: 서버 + 디자이너**
+
+[교내 운영진 평가 플로우](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/%F0%9F%8D%92-UMC-Web?node-id=10646-58552) → `1. 서류 전형` 행의 첫 화면, 필터 영역
+
+시안에 `필터` 옆으로 **"내 담당 지원자" 토글**이 있습니다.
+
+평가자 관련 경로를 전부 뽑으면 두 개입니다.
+
+```
+RECRUITING-ADMIN-031  POST   /admin/rounds/{roundId}/evaluators/{memberId}
+RECRUITING-ADMIN-032  DELETE /admin/rounds/{roundId}/evaluators/{memberId}
+RECRUITING-ADMIN-033  GET    /admin/rounds/{roundId}/evaluators
+
+RecruitingRoundEvaluatorResponse { id, roundId, memberId }
+```
+
+배정 단위가 **모집 차수**입니다. `applicationId`가 들어가는 배정 경로는 없습니다. 즉 내가 어떤 차수의 평가자면 그 차수 지원자 전원이 내 담당입니다.
+
+화면이 학교(=차수) 단위 카드로 묶여 있어서, 토글을 켜도 결과가 전부 그대로거나 전부 사라지는 동작이 됩니다.
+
+- **서버**: 지원자별 평가 배정을 넣을 계획이 있나요?
+- **디자이너**: 계획이 없다면 이 토글은 빼는 게 맞아 보입니다. 같은 화면의 "내 담당 평가" 컬럼은 `documentEvaluatedByMe`로 채울 수 있어서 그대로 둘 수 있습니다.
+
+지금은 토글을 숨기고 컬럼만 남겨뒀습니다.
+
+---
+
+## B. 우회는 되는데 확인이 필요한 것
+
+### B-1. 면접 목록 — 첫 컬럼 "면접 일시"
+
+**문의: 디자이너**
+
+[교내 운영진 평가 플로우](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/%F0%9F%8D%92-UMC-Web?node-id=10646-58552) → `2. 면접 전형` 행의 첫 화면
+
+시안의 첫 컬럼이 **"면접 일시"**이고 값도 `04/22 03:33 면접`으로 표기됩니다. 정렬 드롭다운도 **"면접 날짜 순"**입니다.
+
+목록 응답(`RECRUITING-EVALUATION-003`)에 있는 날짜는 `submittedAt` 하나뿐입니다. 면접 일정은 별도 오퍼레이션에만 있고 지원서 단위 조회입니다.
+
+```
+RECRUITING-SCHEDULE-002  GET /api/v1/recruiting/applications/{applicationId}/interview-schedule
+RecruitingInterviewScheduleResponse { id, applicationId, status, startsAt, endsAt, location }
+```
+
+목록에서 채우려면 행마다 요청을 하나씩 더 보내야 합니다.
+
+일단 서류 전형과 동일하게 지원 일시를 쓰고 헤더 라벨도 "지원 일시"로 맞춰뒀습니다. 다만 이러면 **"면접 날짜 순" 정렬도 같이 의미가 깨집니다.** 면접 일시가 꼭 필요한지 알려주세요.
+
+---
+
+### B-2. 모집 목록 — DRAFT / OPEN / CLOSED 상태 칩
+
+**문의: 서버 + 모집 관리 담당(주디)**
+
+[모집 관리](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/%F0%9F%8D%92-UMC-Web?node-id=9519-130499)
+
+제 담당은 아닌데 대조하다 같이 발견해서 공유드립니다.
+
+상태 변경은 세 값을 받습니다.
+
+```
+RECRUITING-ADMIN-015  PATCH /admin/seasons/{seasonId}/rounds/{roundId}/status
+UpdateRecruitingRoundStatusRequest { status: DRAFT | OPEN | CLOSED }
+```
+
+그런데 차수 조회 응답에는 `status`가 없습니다.
+
+```
+RECRUITING-ADMIN-011  GET /admin/rounds?gisuId=
+RECRUITING-PUBLIC-001 GET /public/rounds?gisuId=
+
+RoundResponse
+  roundId, title, type, roundNo, recruitableTracks, secondChoiceEnabled,
+  documentStartAt, documentEndAt, documentResultPublishedAt,
+  interviewRequired, interviewStartAt, interviewEndAt, finalResultPublishedAt,
+  announcement, applicationFormId, formId, applicationOpen
+```
+
+`applicationOpen: boolean` 하나뿐이라 DRAFT와 CLOSED가 둘 다 `false`로 나올 것 같습니다. 그러면 시안의 3상태 칩을 구분해서 그릴 수 없습니다.
+
+- **서버**: 목록 응답에서 DRAFT와 CLOSED를 어떻게 구분하나요? `status`를 내려주실 수 있을까요?
+
+덧붙여 차수 생성/수정 요청에는 `availabilityFormId`(면접 가능 일정 폼)가 있는데 `RoundResponse`에는 없습니다. 쓰기만 되고 읽기가 안 되는 것 같은데 의도인지도 확인 부탁드립니다.
+
+---
+
+## C. 반대로 API에는 있는데 시안에 없는 것
+
+화면 처리 방침이 없어서 물어보는 쪽입니다.
+
+### C-1. 일정 선택 문항 타입 (`SCHEDULE`)
+
+**문의: 디자이너 + 서버**
+[지원 폼](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/%F0%9F%8D%92-UMC-Web?node-id=10399-456810)
+
+지원 폼 문항 타입에 `SCHEDULE`이 있습니다.
+
+```
+RECRUITING-PUBLIC-002  GET /public/forms/{applicationFormId}/structure
+QuestionResponse.type = SHORT_TEXT | LONG_TEXT | RADIO | CHECKBOX | DROPDOWN | SCHEDULE | FILE | PORTFOLIO
+```
+
+시안에 해당 UI가 없습니다. 다만 차수 설정에 `availabilityFormId`(면접 가능 일정 폼)가 따로 있고 `RECRUITING-SCHEDULE-001`(면접 가능 일정 제출)이 스펙에 **"미구현"으로 명시**돼 있는 걸 보면, `SCHEDULE`은 지원 폼이 아니라 면접 일정 폼 전용일 가능성이 있습니다.
+
+- 지원 폼에도 `SCHEDULE`이 나올 수 있나요? 안 나온다면 폴백만 넣고 넘어가겠습니다.
+
+### C-2. 지원서 상태 `CANCELLED`, `INTERVIEW_SKIPPED` / 면접 생략 액션
+
+**문의: 디자이너**
+
+철회(`CANCELLED`)와 면접 생략(`INTERVIEW_SKIPPED`)이 상태에 있는데 목록/상세에서 어떻게 보여야 하는지 정의가 없습니다.
+
+```
+RECRUITING-ADMIN-062        POST  /admin/applications/{applicationId}/interview/skip  { reason }
+RECRUITING-APPLICATION-004  PATCH /applications/{applicationId}/cancel                { reason }
+```
+
+면접 생략은 운영진이 의도적으로 거는 상태라 실제로 나올 겁니다. **면접 생략 액션 버튼 자체도 시안에서 못 찾았습니다.** 지원자 목록이나 평가 상세에 필요한 것 아닌지 확인 부탁드립니다.
+
+### C-3. 2지망을 받지 않는 모집
+
+**문의: 디자이너**
+
+`RoundResponse.secondChoiceEnabled: boolean`이 있습니다. 2지망 없이 모집하는 경우가 가능한데 지원 폼 시안이 이 경우를 다루지 않습니다. 꺼져 있으면 2지망 문항을 숨기면 될지 확인 부탁드립니다.
+
+---
+
+## 문의 대상 요약
+
+| 항목               | 서버 | 디자이너 | 기타                                              |
+| ------------------ | :--: | :------: | ------------------------------------------------- |
+| A-1 평가 상태 칩   |  O   |    O     | 디자이너 답변에 따라 서버 변경이 불필요할 수 있음 |
+| A-2 면접자별 답변  |  O   |          | 제일 급함                                         |
+| A-3 면접 합불      |  O   |    △     |                                                   |
+| A-4 내 담당 토글   |  O   |    O     |                                                   |
+| B-1 면접 일시      |      |    O     |                                                   |
+| B-2 모집 상태      |  O   |          | 주디                                              |
+| C-1 SCHEDULE 문항  |  O   |    O     |                                                   |
+| C-2 철회·면접 생략 |      |    O     |                                                   |
+| C-3 2지망 비활성   |      |    O     |                                                   |
+
+---
+
+## 시안·API는 맞는데 제 구현이 틀린 것 (문의 불필요, 제가 수정)
+
+대조하면서 발견한 제 실수입니다. 참고만 해주세요.
+
+**1. 지원자 목록의 `3/7` 카운터** — 세 시안(교내 운영진 / 지부장·중앙운영진 / 서류 목록 디폴트) 어디에도 없습니다. 제거합니다.
+
+**2. 최종 평가 화면의 "내 평가 등록" 패널** — [최종 평가 상세 시안](https://www.figma.com/design/mgDK3eBgoDYfARQEmtcoxQ/%F0%9F%8D%92-UMC-Web?node-id=11067-151769)을 보면 오른쪽 `운영진 평가` 카드는 **과거 전형(서류/면접) 평가 이력을 읽기 전용으로** 보여주고, 하단은 `지원자 최종 평가` + `최종 합격 / 최종 불합격` 토글뿐입니다. 평가 등록 폼이 없습니다.
+
+평가 등록 경로의 `stage`도 `DOCUMENT`, `INTERVIEW` 둘뿐이라 시안과 API가 이미 맞습니다.
+
+```
+RECRUITING-EVALUATION-001/002  .../evaluations/{stage}    stage enum = [ DOCUMENT, INTERVIEW ]
+```
+
+제가 최종 화면에 등록 패널을 넣어둔 게 잘못입니다. 제거합니다.
+
+---
+
+## 해결된 건 (문의 불필요)
+
+운영진 평가 목록의 평가자 이름·직책 표시는 문제없습니다.
+
+`RECRUITING-EVALUATION-002`가 `{ id, applicationId, evaluatorMemberId, stage, decision, comment, submittedAt }`로 `memberId`만 줘서 이름을 못 채우나 했는데, 멤버 프로필 조회에 다 있었습니다.
+
+```
+MEMBER-101  GET /api/v1/member/profile/{memberId}
+  name, nickname, schoolName,
+  roles[].roleType = CENTRAL_PRESIDENT | CHAPTER_PRESIDENT | SCHOOL_PRESIDENT | SCHOOL_PART_LEADER ...
+  challengerRecords[].chapterName
+```
+
+시안대로 표시 가능합니다.
+
+---
+
+## 부록: 리크루팅 오퍼레이션 50개 전수
+
+제가 놓친 게 있으면 이 표에서 짚어주세요.
+
+### 이번에 쓰는 것 (제 담당 3화면)
+
+| ID                  | 경로                                                 | 용도                                 |
+| ------------------- | ---------------------------------------------------- | ------------------------------------ |
+| ADMIN-011           | `GET /admin/rounds`                                  | 차수·지부·학교 인벤토리              |
+| ADMIN-033           | `GET /admin/rounds/{roundId}/evaluators`             | 평가자 목록                          |
+| ADMIN-041~048       | `.../questions`                                      | 면접 질문 CRUD (시안에 편집 UI 있음) |
+| ADMIN-061 / 063     | `PATCH .../document-decision`, `.../final-decision`  | 서류·최종 합불                       |
+| EVALUATION-001~004  | `/rounds/{roundId}/applications...`                  | 평가 등록·조회, 목록·상세            |
+| PUBLIC-001 / 002    | `GET /public/rounds`, `/public/forms/{id}/structure` | 공개 모집, 문항 구조                 |
+| APPLICATION-001~004 | `/applications...`                                   | 초안·수정·제출·철회                  |
+
+### 이번에 안 쓰는 것과 이유
+
+| ID                 | 경로                                  | 안 쓰는 이유                                                                                   |
+| ------------------ | ------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| ADMIN-001~004      | 시즌 설정·목표 인원                   | 모집 인원 설정 화면 (준오 담당)                                                                |
+| ADMIN-012~017, 021 | 차수 생성·수정·복제·삭제, Form Upsert | 모집 관리·생성 화면 (주디 담당)                                                                |
+| ADMIN-031 / 032    | 평가자 추가·제거                      | 평가 인원 배정 화면 (별도 이슈)                                                                |
+| ADMIN-051 / 052    | 면접 일정 요청·확정                   | 면접 일정 화면 미착수                                                                          |
+| ADMIN-062          | 면접 생략                             | 시안에 액션 없음 → C-2로 문의                                                                  |
+| ADMIN-071~073      | 등록 준비·취소·확정                   | 최종 등록 화면 (범위 밖)                                                                       |
+| ADMIN-081          | 지원 현황 요약                        | 대시보드 (헤일리 담당). 목록 카드 카운트에 쓸 여지는 있음                                      |
+| ADMIN-082          | 비식별 CSV 다운로드                   | 현재 평가 이력 화면이 클라이언트에서 CSV를 만들고 있음. **서버 CSV로 바꿔야 하는지 확인 필요** |
+| PUBLIC-003~007     | 익명 지원                             | 로그인 경로 먼저, 이후 착수                                                                    |
+| SCHEDULE-001 / 002 | 면접 일정 제출·조회                   | 001은 스펙에 미구현 표기. 002는 B-1 참고                                                       |
+
+`ADMIN-082`(서버 CSV)만 확실치 않습니다. 평가 이력 다운로드를 서버 것으로 바꿔야 하면 알려주세요.
+
+---
+
+## 진행 상황
+
+A-1, A-3, A-4, B-1은 우회한 상태로 지원자 목록 연동을 먼저 진행합니다. 되돌리는 비용이 크지 않도록 변환 로직 한 곳과 컬럼 정의에만 몰아뒀습니다.
+
+**A-2가 제일 급합니다.** 면접 평가 화면을 마무리하려면 답변 저장 방식이 정해져야 합니다.

--- a/docs/2026-07-25_리크루팅_시안_API_불일치.md
+++ b/docs/2026-07-25_리크루팅_시안_API_불일치.md
@@ -208,24 +208,30 @@ RECRUITING-ADMIN-015  PATCH /admin/seasons/{seasonId}/rounds/{roundId}/status
 UpdateRecruitingRoundStatusRequest { status: DRAFT | OPEN | CLOSED }
 ```
 
-그런데 차수 조회 응답에는 `status`가 없습니다.
+공개 목록과 관리자 목록은 같은 `RoundResponse` 이름을 사용하지만 응답 필드가 다릅니다. 공개 목록에는 `applicationOpen`이 있고, 관리자 목록에는 모집 관리에 필요한 `status`와 `availabilityFormId`가 포함됩니다.
 
 ```text
 RECRUITING-ADMIN-011  GET /admin/rounds?gisuId=
 RECRUITING-PUBLIC-001 GET /public/rounds?gisuId=
 
-RoundResponse
+PublicRoundResponse
   roundId, title, type, roundNo, recruitableTracks, secondChoiceEnabled,
   documentStartAt, documentEndAt, documentResultPublishedAt,
   interviewRequired, interviewStartAt, interviewEndAt, finalResultPublishedAt,
   announcement, applicationFormId, formId, applicationOpen
 ```
 
-`applicationOpen: boolean` 하나뿐이라 DRAFT와 CLOSED가 둘 다 `false`로 나올 것 같습니다. 그러면 시안의 3상태 칩을 구분해서 그릴 수 없습니다.
+관리자 목록은 다음 필드를 기준으로 상태와 면접 가능 일정 폼을 표시할 수 있습니다.
 
-- **서버**: 목록 응답에서 DRAFT와 CLOSED를 어떻게 구분하나요? `status`를 내려주실 수 있을까요?
+```text
+AdminRoundResponse
+  id, title, type, roundNo, recruitableTracks, secondChoiceEnabled,
+  status, documentStartAt, documentEndAt, documentResultPublishedAt,
+  interviewRequired, interviewStartAt, interviewEndAt, finalResultPublishedAt,
+  announcement, availabilityFormId, contactText
+```
 
-덧붙여 차수 생성/수정 요청에는 `availabilityFormId`(면접 가능 일정 폼)가 있는데 `RoundResponse`에는 없습니다. 쓰기만 되고 읽기가 안 되는 것 같은데 의도인지도 확인 부탁드립니다.
+따라서 `DRAFT`·`OPEN`·`CLOSED` 상태와 `availabilityFormId`는 관리자 화면에서 관리자 목록 응답으로 처리해야 하며, 공개 목록 응답과 혼용하지 않습니다.
 
 ---
 

--- a/docs/2026-08-08_dev-도메인-SPA-라우팅-404.md
+++ b/docs/2026-08-08_dev-도메인-SPA-라우팅-404.md
@@ -1,0 +1,102 @@
+# dev 도메인 리크루팅 quota 라우트 404 대응
+
+2026-08-08 기준으로 `dongguk_10_centralpresident@example.com` 계정으로 리크루팅 모집 인원 설정 페이지 접근 시 확인된 dev 호스팅 오류를 정리한다.
+
+## 증상
+
+다음 경로로 직접 접근하거나 새로고침하면 브라우저 콘솔에 문서 요청 404가 표시된다.
+
+```text
+GET https://dev.university.neordinary.com/recruiting/recruitments/quota/ 404
+```
+
+이 요청은 API 요청이 아니라 브라우저가 프론트엔드 진입 문서(`index.html`)를 가져오는 요청이다. 따라서 로그인 권한, 모집 권한, quota API 응답과 무관하게 발생할 수 있다.
+
+## 라우트 구현 확인
+
+프론트 라우트는 정상적으로 선언되어 있다.
+
+```tsx
+createFileRoute("/recruiting/recruitments/quota")
+```
+
+- 라우트 파일: `src/routes/recruiting/recruitments/quota.tsx`
+- 생성 라우트 트리: `src/routeTree.gen.ts`
+- 로컬 Vite: `/recruiting/recruitments/quota`와 `/recruiting/recruitments/quota/` 모두 200
+
+라우트 선언에 trailing slash가 없는 것은 원인이 아니다. SPA 애플리케이션은 서버가 모든 클라이언트 라우트를 `index.html`로 전달해야 한다.
+
+## dev 도메인 응답 확인
+
+```bash
+for path in \
+  / \
+  /recruiting \
+  /recruiting/recruitments \
+  /recruiting/recruitments/quota \
+  /recruiting/recruitments/quota/; do
+  curl -k -s -o /dev/null -w "%{http_code} %{content_type}\n" \
+    "https://dev.university.neordinary.com${path}"
+done
+```
+
+확인 결과:
+
+| 요청 경로                         | 응답 | 의미                                |
+| --------------------------------- | ---: | ----------------------------------- |
+| `/`                               |  200 | 루트 문서 제공 정상                 |
+| `/recruiting/recruitments/quota`  |  301 | S3가 trailing slash로 리다이렉트    |
+| `/recruiting/recruitments/quota/` |  404 | S3에 해당 디렉터리 문서가 없어 실패 |
+
+trailing slash 404 응답의 주요 헤더는 다음과 같다.
+
+```text
+server: AmazonS3
+x-cache: Error from cloudfront
+```
+
+따라서 현재 dev 도메인에서는 SPA rewrite가 적용되지 않았거나, CloudFront가 rewrite가 적용되지 않은 설정을 캐시하고 있다.
+
+## 저장소 설정
+
+`amplify.yml`에는 다음 SPA fallback 설정이 이미 존재한다.
+
+```yaml
+customRules:
+  - source: /<*>
+    target: /index.html
+    status: "200"
+```
+
+코드 저장소 설정과 실제 dev 도메인의 응답이 다르므로, 프론트 라우트 코드가 아닌 AWS Amplify 배포 설정의 적용 상태를 확인해야 한다.
+
+## 조치 절차
+
+1. dev AWS Amplify 앱의 Rewrites and redirects에서 다음 규칙을 확인한다.
+
+   ```text
+   Source: /<*>
+   Target address: /index.html
+   Type: Rewrite (200)
+   ```
+
+2. 해당 규칙이 없거나 다르면 `amplify.yml` 기준으로 설정을 반영한다.
+3. 설정 반영 후 dev 브랜치를 재배포한다.
+4. CloudFront 캐시가 남아 있으면 invalidation을 수행한다.
+5. 아래 두 경로가 모두 200이고 응답 본문이 프론트 `index.html`인지 확인한다.
+
+   ```text
+   https://dev.university.neordinary.com/recruiting/recruitments/quota
+   https://dev.university.neordinary.com/recruiting/recruitments/quota/
+   ```
+
+6. 브라우저에서 직접 접근, 새로고침, 로그인 후 접근을 각각 확인한다.
+
+## 판단 기준
+
+- 로컬 404: Vite 개발 서버 또는 라우트 생성 문제를 확인한다.
+- dev 도메인에서만 404: Amplify/CloudFront rewrite 적용 문제다.
+- `index.html` 로드 후 API 401/403: 그때부터 인증·역할·서버 권한 문제를 확인한다.
+- `/api/...` 요청 404: API base URL 또는 백엔드 엔드포인트 문제를 별도로 확인한다.
+
+이번 증상은 프론트 라우트와 quota API를 실행하기 전의 문서 요청 단계에서 발생하므로, 테스트 계정 권한 문제로 분류하지 않는다.

--- a/docs/2026-08-08_dev-도메인-SPA-라우팅-404.md
+++ b/docs/2026-08-08_dev-도메인-SPA-라우팅-404.md
@@ -35,7 +35,7 @@ for path in \
   /recruiting/recruitments \
   /recruiting/recruitments/quota \
   /recruiting/recruitments/quota/; do
-  curl -k -s -o /dev/null -w "%{http_code} %{content_type}\n" \
+  curl -sS --max-time 15 -o /dev/null -w "%{http_code} %{content_type}\n" \
     "https://dev.university.neordinary.com${path}"
 done
 ```

--- a/docs/superpowers/plans/2026-08-08-recruiting-role-header-alignment.md
+++ b/docs/superpowers/plans/2026-08-08-recruiting-role-header-alignment.md
@@ -698,7 +698,7 @@ git commit -m "test: 서버 역할별 헤더 시나리오 확장"
 
 - Create: `src/routes/test/route.tsx`
 - Modify: `src/routeTree.gen.ts`
-- Test: `pnpm build` production bundle
+- Test: `pnpm build` 및 production preview 런타임 접근 차단
 
 - [ ] **Step 1: 테스트 디렉터리 공통 부모 라우트를 추가한다.**
 
@@ -722,11 +722,11 @@ pnpm build
 rg -n "TestRouteRoute|Test.*Route.*getParentRoute.*TestRouteRoute" src/routeTree.gen.ts
 ```
 
-Expected: `TestRouteRoute`가 생성되고 테스트 하위 라우트의 `getParentRoute`가 공통 테스트 부모를 가리키며 production build가 PASS한다.
+Expected: `TestRouteRoute`가 생성되고 테스트 하위 라우트의 `getParentRoute`가 공통 테스트 부모를 가리키며 production build가 PASS한다. 테스트 라우트 모듈의 번들 포함 여부가 아니라 production에서의 런타임 접근 차단을 완료 기준으로 삼는다.
 
 - [ ] **Step 3: production 빌드 가드와 개발 빌드 접근을 확인한다.**
 
-개발 서버에서는 `/test/recruiting-header`와 기존 `/test/*` 페이지가 렌더링되어야 한다. production preview에서는 동일한 경로가 `/`로 이동해야 한다.
+개발 서버에서는 `/test/recruiting-header`와 기존 `/test/*` 페이지가 렌더링되어야 한다. production preview에서는 동일한 경로가 `/`로 이동해야 한다. 별도 빌드 제외 설정은 추가하지 않고 공통 부모 라우트의 `beforeLoad` 리다이렉트를 운영 접근 제한의 단일 기준으로 사용한다.
 
 ```bash
 pnpm build

--- a/docs/superpowers/plans/2026-08-08-recruiting-role-header-alignment.md
+++ b/docs/superpowers/plans/2026-08-08-recruiting-role-header-alignment.md
@@ -1,0 +1,818 @@
+# 리크루팅 역할·헤더 권한 정렬 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `/recruiting/*`, `/projects/*`, `/manage/*`의 로그인·비로그인 분기와 역할별 헤더·라우팅 가드를 UMC 서버 권한 계약 및 피그마 헤더 스펙에 맞춘다.
+
+**Architecture:** 서버 권한의 단일 기준을 프런트 capability 함수로 표현하고, 루트 리다이렉트·라우트 `beforeLoad`·헤더 탭 노출이 같은 함수를 사용하도록 정렬한다. 지원 작성은 로그인 사용자의 `/v1/recruiting/applications`와 게스트의 `/v1/recruiting/public/applications`를 분리하고, 익명 초안 식별자와 약관 응답 타입을 서버 계약에 맞춘다. 헤더는 네비게이션 활성 정책, 모집 상태 CTA, 프로필 아바타를 독립 책임으로 나눈다.
+
+**Tech Stack:** React, TypeScript, TanStack Router, TanStack Query, Axios, Tailwind CSS, Vitest, Vite, UMC `/umc-api` 검증 절차
+
+---
+
+## 작업 범위와 권한 기준
+
+브랜치는 현재 `feat/#688-header-role-branching` 하나를 유지하고 PR도 하나만 유지한다. 아래 작업은 같은 브랜치에서 논리적 커밋 여러 개로 진행한다. 새로운 브랜치·PR은 만들지 않는다.
+
+서버 기준은 UMC 서버 저장소의 `origin/develop` 최신 커밋을 사용한다.
+
+- `src/main/java/com/umc/product/recruiting/application/service/evaluator/RecruitingPermissionEvaluator.java`
+- `src/main/java/com/umc/product/authorization/domain/AuthoritySnapshot.java`
+- `src/main/java/com/umc/product/common/domain/enums/ChallengerRoleType.java`
+- `src/main/java/com/umc/product/organization/application/service/evaluator/SchoolPermissionEvaluator.java`
+- `src/main/java/com/umc/product/organization/application/service/evaluator/ChapterPermissionEvaluator.java`
+
+리크루팅의 리소스 ID가 없는 진입 권한은 `SUPER_ADMIN`, 중앙 회장, 중앙 부회장, 학교 회장, 학교 부회장으로 제한한다. 특정 차수·폼·학교 리소스에서는 서버가 기수·학교 범위를 추가 검증하므로 프런트 가드는 진입 메뉴를 제어하고 최종 권한은 서버에 맡긴다.
+
+| 역할                                                             | 리크루팅 헤더/라우트 | 설정 헤더/라우트 | 서버 기준           |
+| ---------------------------------------------------------------- | -------------------- | ---------------- | ------------------- |
+| `SUPER_ADMIN`                                                    | 허용                 | 허용             | 중앙 핵심           |
+| `CENTRAL_PRESIDENT`, `CENTRAL_VICE_PRESIDENT`                    | 허용                 | 허용             | 중앙 핵심           |
+| `SCHOOL_PRESIDENT`, `SCHOOL_VICE_PRESIDENT`                      | 허용                 | 불허             | 학교 운영 핵심      |
+| `CENTRAL_OPERATING_TEAM_MEMBER`, `CENTRAL_EDUCATION_TEAM_MEMBER` | 불허                 | 불허             | 중앙 핵심 아님      |
+| `CHAPTER_PRESIDENT`                                              | 불허                 | 불허             | 리크루팅 권한 없음  |
+| 학교 파트장·기타 운영진                                          | 불허                 | 불허             | 리크루팅 권한 없음  |
+| 일반 챌린저·게스트                                               | 불허                 | 불허             | 인증 또는 권한 없음 |
+
+## 파일 책임 지도
+
+### 역할·라우팅 정책
+
+- Modify: `src/entities/member/model/identity.ts` — 서버 기준 capability 함수
+- Test: `src/entities/member/model/identity.test.ts` — 역할별 허용·거부 행렬
+- Modify: `src/routes/index.tsx` — 로그인 사용자의 기본 랜딩 분기
+- Modify: `src/routes/recruiting/route.tsx` — 리크루팅 진입 가드
+- Modify: `src/routes/manage/route.tsx` — 설정 진입 가드
+
+### 게스트·로그인 지원 흐름
+
+- Modify: `src/features/recruiting/ui/apply/RecruitingApplyPage.tsx` — 초안 식별자 사용
+- Verify: `src/features/recruiting/hooks/useApplyMutations.ts` — 로그인·익명 mutation 분기 유지
+- Verify: `src/features/recruiting/api/recruitingApi.ts` — 공개·인증 API 엔드포인트 계약 테스트 대상
+- Modify: `src/shared/api/terms.ts` — 서버의 문자열 int64 약관 ID 정규화
+- Test: `src/features/recruiting/api/recruitingApi.test.ts`
+- Test: `src/features/recruiting/model/applyDraftStorage.test.ts`
+
+### 헤더·프로필 UI
+
+- Modify: `src/widgets/navigation/header/RecruitingHeader.tsx` — 인증 상태에 따른 CTA와 탭 조합
+- Modify: `src/widgets/navigation/header/RecruitingStatusButton.tsx` — 모집 상태별 렌더링
+- Modify: `src/widgets/navigation/header/GuestProfileButton.tsx` — 게스트 오픈·마감 로그인 색상
+- Modify: `src/widgets/navigation/header/recruitingHeaderNav.ts` — 모집 안내 활성 경로와 프로젝트 경로 충돌 해결
+- Test: `src/widgets/navigation/header/recruitingHeaderNav.test.ts`
+- Create: `src/shared/ui/profile/ProfileAvatar.tsx` — 피그마 공용 프로필 표현 컴포넌트
+- Test: `src/shared/ui/profile/ProfileAvatar.test.tsx`
+- Modify: `src/widgets/navigation/header/Profile.tsx`
+- Modify: `src/widgets/navigation/header/ProfileDropdown.tsx`
+
+### 검증용 코드와 생성 파일
+
+- Modify: `src/routes/test/recruiting-header.tsx` — 개발 중 역할·모집 상태 시나리오 확장
+- Create: `src/routes/test/route.tsx` — `/test/*` 개발 환경 공통 가드
+- Modify: `src/routeTree.gen.ts` — 테스트 부모 라우트 생성 후 갱신
+
+## Task 1: 서버 권한 행렬을 프런트 capability 함수에 반영
+
+**Files:**
+
+- Modify: `src/entities/member/model/identity.ts:59-114`
+- Test: `src/entities/member/model/identity.test.ts:80-125`
+
+- [ ] **Step 1: 서버와 다른 역할을 실패 조건으로 추가한다.**
+
+중앙 운영팀원, 중앙 교육팀원, 지부장은 리크루팅 capability가 false여야 한다. 중앙 핵심과 학교 회장단은 true로 유지한다. 설정은 중앙 핵심만 true여야 한다.
+
+```ts
+it("서버가 리크루팅을 허용하지 않는 중앙 실무·지부 역할은 false", () => {
+  expect(isRecruitingOperator(makeMe(["CENTRAL_OPERATING_TEAM_MEMBER"]))).toBe(
+    false,
+  )
+  expect(isRecruitingOperator(makeMe(["CENTRAL_EDUCATION_TEAM_MEMBER"]))).toBe(
+    false,
+  )
+  expect(isRecruitingOperator(makeMe(["CHAPTER_PRESIDENT"]))).toBe(false)
+})
+
+it("설정은 중앙 핵심만 true", () => {
+  expect(isCentralAdmin(makeMe(["SUPER_ADMIN"]))).toBe(true)
+  expect(isCentralAdmin(makeMe(["CENTRAL_PRESIDENT"]))).toBe(true)
+  expect(isCentralAdmin(makeMe(["CENTRAL_OPERATING_TEAM_MEMBER"]))).toBe(false)
+})
+```
+
+- [ ] **Step 2: 역할 테스트만 실행해 수정 전 실패를 확인한다.**
+
+```bash
+pnpm exec vitest run src/entities/member/model/identity.test.ts
+```
+
+Expected: 새 중앙 실무·교육·지부장 및 설정 중앙 실무 테스트가 FAIL한다.
+
+- [ ] **Step 3: 서버와 동일한 최소 capability 판정으로 변경한다.**
+
+```ts
+export function isCentralAdmin(me: MemberInfoResponse | undefined): boolean {
+  return isCentralCore(me)
+}
+
+export function isRecruitingOperator(
+  me: MemberInfoResponse | undefined,
+): boolean {
+  return isCentralCore(me) || isSchoolLeadership(me)
+}
+```
+
+기존 `isOperator`, `isAnyOperator`, `isCentralStaff`는 프로젝트·사이드바 등 다른 영역의 의미가 있으므로 전역 의미를 바꾸지 않는다.
+
+- [ ] **Step 4: 역할 테스트가 통과하는지 확인한다.**
+
+```bash
+pnpm exec vitest run src/entities/member/model/identity.test.ts
+```
+
+Expected: 중앙 실무·교육팀원과 지부장은 false이고 중앙 핵심·학교 회장단만 true다.
+
+- [ ] **Step 5: 같은 브랜치에 논리적 커밋을 만든다.**
+
+```bash
+git add src/entities/member/model/identity.ts src/entities/member/model/identity.test.ts
+git commit -m "fix: 서버 권한 기준 역할 capability 정렬"
+```
+
+## Task 2: 루트·리크루팅·설정 라우트가 같은 capability를 사용하도록 정렬
+
+**Files:**
+
+- Modify: `src/routes/index.tsx:24-28`
+- Modify: `src/routes/recruiting/route.tsx:14-24`
+- Modify: `src/routes/manage/route.tsx:18-27`
+
+- [ ] **Step 1: 세 라우트의 권한 조건을 확인한다.**
+
+```bash
+rg -n "isAnyOperator|isOperator|isCentralStaff|isCentralAdmin|isRecruitingOperator" src/routes/index.tsx src/routes/recruiting/route.tsx src/routes/manage/route.tsx
+```
+
+Expected:
+
+- `/` 운영자 랜딩은 `isRecruitingOperator`를 사용한다.
+- `/recruiting`의 `beforeLoad`는 `ensureMe` 후 `isRecruitingOperator`를 사용한다.
+- `/manage`의 `beforeLoad`는 `ensureMe` 후 `isCentralAdmin`을 사용한다.
+
+- [ ] **Step 2: 인증 실패와 역할 실패 흐름을 유지한다.**
+
+```ts
+const me = await ensureMe(context.queryClient, location.href)
+if (!isRecruitingOperator(me)) {
+  notifyAccessDenied()
+  throw redirect({ to: "/" })
+}
+```
+
+비로그인은 `ensureMe`의 `/login` 및 `returnTo` 처리를 사용하고, 로그인했지만 역할이 없으면 접근 거부 후 `/`로 이동한다. 설정 라우트는 같은 구조에서 조건만 `isCentralAdmin(me)`을 사용한다.
+
+- [ ] **Step 3: 정적 검사 후 커밋한다.**
+
+```bash
+pnpm exec eslint src/routes/index.tsx src/routes/recruiting/route.tsx src/routes/manage/route.tsx
+pnpm exec tsc --noEmit
+git add src/routes/index.tsx src/routes/recruiting/route.tsx src/routes/manage/route.tsx
+git commit -m "fix: 역할별 리크루팅과 설정 라우트 가드 정렬"
+```
+
+Expected: ESLint와 TypeScript가 PASS한다.
+
+## Task 3: 게스트·로그인 지원 API 계약을 테스트로 고정하고 약관 ID를 정규화
+
+**Files:**
+
+- Modify: `src/features/recruiting/api/recruitingApi.test.ts`
+- Modify: `src/shared/api/terms.ts`
+- Create: `src/shared/api/terms.test.ts`
+
+- [ ] **Step 1: 공개·인증 엔드포인트 테스트를 추가한다.**
+
+공개 mutation은 다음 경로를 사용해야 한다.
+
+```ts
+expect(api.post).toHaveBeenCalledWith(
+  "/v1/recruiting/public/applications",
+  expect.any(Object),
+)
+expect(api.put).toHaveBeenCalledWith(
+  "/v1/recruiting/public/applications",
+  expect.any(Object),
+)
+expect(api.post).toHaveBeenCalledWith(
+  "/v1/recruiting/public/applications/submit",
+  expect.any(Object),
+)
+```
+
+인증 mutation은 `/v1/recruiting/applications` 및 해당 ID 하위 경로를 사용해야 한다.
+
+```ts
+expect(api.post).toHaveBeenCalledWith(
+  "/v1/recruiting/applications",
+  expect.any(Object),
+)
+expect(api.put).toHaveBeenCalledWith(
+  "/v1/recruiting/applications/application-1",
+  expect.any(Object),
+)
+expect(api.post).toHaveBeenCalledWith(
+  "/v1/recruiting/applications/application-1/submit",
+  {},
+)
+```
+
+- [ ] **Step 2: 테스트를 실행해 현재 공개·인증 분기를 확인한다.**
+
+```bash
+pnpm exec vitest run src/features/recruiting/api/recruitingApi.test.ts
+```
+
+Expected: 공개 및 인증 API 매핑 테스트가 PASS한다.
+
+- [ ] **Step 3: 문자열 약관 ID를 API 경계에서 숫자로 정규화한다.**
+
+실제 개발 서버가 `result.id`를 문자열로 반환할 수 있으므로 화면과 mutation context에는 숫자만 전달한다.
+
+```ts
+interface RawPublicTermResponse {
+  id: number | string
+  link: string
+  isMandatory: boolean
+}
+
+export interface PublicTermResponse {
+  id: number
+  link: string
+  isMandatory: boolean
+}
+
+export async function getPublicTermByType(
+  termType: TermType,
+): Promise<PublicTermResponse> {
+  const { data } = await api.get<ApiResponse<RawPublicTermResponse>>(
+    `/v1/terms/type/\${termType}`,
+  )
+  const id = Number(data.result.id)
+  if (!Number.isFinite(id)) throw new Error("invalid public term id")
+  return { ...data.result, id }
+}
+```
+
+- [ ] **Step 4: 문자열 응답 테스트와 API 테스트를 통과시킨다.**
+
+```bash
+pnpm exec vitest run src/features/recruiting/api/recruitingApi.test.ts src/shared/api/terms.test.ts
+pnpm exec tsc --noEmit
+```
+
+Expected: `id: "1"` 응답이 숫자 `1`로 정규화되고 모든 테스트가 PASS한다.
+
+- [ ] **Step 5: API 계약 커밋을 만든다.**
+
+```bash
+git add src/features/recruiting/api/recruitingApi.test.ts src/shared/api/terms.ts src/shared/api/terms.test.ts
+git commit -m "test: 게스트와 로그인 지원 API 계약 고정"
+```
+
+## Task 4: 게스트 초안의 “새로 시작”이 익명 세션 키를 삭제하도록 수정
+
+**Files:**
+
+- Modify: `src/features/recruiting/ui/apply/RecruitingApplyPage.tsx:67-75,266-271`
+- Test: `src/features/recruiting/model/applyDraftStorage.test.ts`
+
+- [ ] **Step 1: 익명 세션 식별자 삭제 테스트를 추가한다.**
+
+```ts
+it("익명 세션 초안은 익명 세션 식별자로 삭제한다", () => {
+  writeApplyDraft("7", "anonymous-session-1", DRAFT)
+  clearApplyDraft("7", "anonymous-session-1")
+
+  expect(readApplyDraft("7", "anonymous-session-1")).toBeNull()
+  expect(readApplyDraft("7", "")).toBeNull()
+})
+```
+
+- [ ] **Step 2: 화면의 모든 초안 참조를 `storageIdentity` 기준으로 통일한다.**
+
+페이지에서 이미 읽기·저장·제출 오류 정리에 `storageIdentity`를 사용하므로 “새로 시작”도 같은 값을 사용한다.
+
+```tsx
+const storageIdentity = isAnonymous ? anonymousSessionId : memberId
+
+onClick={() => {
+  clearApplyDraft(roundId, storageIdentity)
+  setResumeDecided(true)
+}}
+```
+
+- [ ] **Step 3: 초안 테스트·타입 검사를 실행하고 커밋한다.**
+
+```bash
+pnpm exec vitest run src/features/recruiting/model/applyDraftStorage.test.ts
+pnpm exec eslint src/features/recruiting/ui/apply/RecruitingApplyPage.tsx
+pnpm exec tsc --noEmit
+git add src/features/recruiting/ui/apply/RecruitingApplyPage.tsx src/features/recruiting/model/applyDraftStorage.test.ts
+git commit -m "fix: 게스트 지원서 새로 시작 시 익명 초안 초기화"
+```
+
+Expected: 게스트에서 기존 익명 초안이 삭제되고 새 입력으로 다시 저장된다.
+
+## Task 5: 모집 안내·프로젝트 네비게이션 활성 상태를 라우트와 일치
+
+**Files:**
+
+- Modify: `src/widgets/navigation/header/recruitingHeaderNav.ts`
+- Modify: `src/widgets/navigation/header/recruitingHeaderNav.test.ts`
+
+- [ ] **Step 1: 공개 경로별 활성 상태 실패 테스트를 추가한다.**
+
+```ts
+it("모집 공고와 지원 화면에서는 모집 안내가 활성이다", () => {
+  expect(activeLabels("/projects/notice", GUEST)).toEqual(["모집 안내"])
+  expect(activeLabels("/projects/apply/7", GUEST)).toEqual(["모집 안내"])
+})
+
+it("프로젝트 목록과 상세 화면에서는 프로젝트가 활성이다", () => {
+  expect(activeLabels("/projects", GUEST)).toEqual(["프로젝트"])
+  expect(activeLabels("/projects/49", GUEST)).toEqual(["프로젝트"])
+})
+```
+
+- [ ] **Step 2: 공통 `/projects` prefix 충돌을 해결한다.**
+
+```ts
+export type NavItem = {
+  label: string
+  to: string
+  disabled?: boolean
+  activeBasePath?: string
+  activeBasePaths?: string[]
+  inactiveBasePaths?: string[]
+}
+
+function matchesBasePath(pathname: string, basePath: string): boolean {
+  return pathname === basePath || pathname.startsWith(basePath + "/")
+}
+
+export function isNavActive(pathname: string, item: NavItem): boolean {
+  if (item.disabled) return false
+  if (item.inactiveBasePaths?.some((base) => matchesBasePath(pathname, base))) {
+    return false
+  }
+
+  const activeBasePaths = item.activeBasePaths ?? [
+    item.activeBasePath ?? item.to,
+  ]
+  return activeBasePaths.some((base) => matchesBasePath(pathname, base))
+}
+```
+
+항목은 다음처럼 구성한다.
+
+```ts
+{
+  label: "모집 안내",
+  to: "/projects/notice",
+  activeBasePaths: ["/projects/notice", "/projects/apply"],
+},
+{
+  label: "프로젝트",
+  to: "/projects",
+  inactiveBasePaths: ["/projects/notice", "/projects/apply"],
+},
+```
+
+기존 루트 `/` placeholder와 비활성 모집 안내 항목을 제거한다.
+
+- [ ] **Step 3: 네비게이션 테스트와 커밋을 실행한다.**
+
+```bash
+pnpm exec vitest run src/widgets/navigation/header/recruitingHeaderNav.test.ts
+git add src/widgets/navigation/header/recruitingHeaderNav.ts src/widgets/navigation/header/recruitingHeaderNav.test.ts
+git commit -m "fix: 모집 안내 네비게이션 활성 경로 정렬"
+```
+
+Expected: 모집 공고·지원 경로에서는 모집 안내만 활성이고 프로젝트 목록·상세에서는 프로젝트만 활성이다.
+
+## Task 6: 모집 상태 CTA를 인증 상태와 피그마 상태에 맞게 분기
+
+**Files:**
+
+- Modify: `src/widgets/navigation/header/RecruitingHeader.tsx:42-83`
+- Modify: `src/widgets/navigation/header/RecruitingStatusButton.tsx`
+- Modify: `src/widgets/navigation/header/GuestProfileButton.tsx`
+
+- [ ] **Step 1: 헤더 상태 행렬을 코드 기준으로 고정한다.**
+
+| 인증   | 모집 상태 | 상태 CTA         | 우측 프로필 영역           |
+| ------ | --------- | ---------------- | -------------------------- |
+| 게스트 | open      | `지원하기` 링크  | 연한 청록 `로그인`         |
+| 게스트 | closed    | 회색 `모집 마감` | 진한 청록/흰 글자 `로그인` |
+| 로그인 | open      | `지원하기` 링크  | 프로필                     |
+| 로그인 | closed    | 상태 CTA 숨김    | 프로필                     |
+
+- [ ] **Step 2: 상태 버튼에 인증 여부를 전달하고 로그인 사용자의 마감 CTA를 숨긴다.**
+
+```tsx
+interface RecruitingStatusButtonProps {
+  status: RecruitingStatus
+  isAuthed: boolean
+}
+
+export function RecruitingStatusButton({
+  status,
+  isAuthed,
+}: RecruitingStatusButtonProps) {
+  if (status.phase === "closed") {
+    if (isAuthed) return null
+    return <span className={cn(BASE_CLASS, IDLE_CLASS)}>모집 마감</span>
+  }
+
+  return (
+    <Link
+      to="/projects/notice"
+      className={cn(
+        BASE_CLASS,
+        "text-label-1-semibold bg-teal-600 text-white transition-colors hover:bg-teal-700",
+      )}
+    >
+      지원하기
+    </Link>
+  )
+}
+```
+
+헤더 호출부는 `<RecruitingStatusButton status={status} isAuthed={isAuthed} />`로 변경한다.
+
+- [ ] **Step 3: 게스트 로그인 버튼의 마감 색상을 분기한다.**
+
+```tsx
+interface GuestProfileButtonProps {
+  recruitingStatus?: RecruitingStatus
+  className?: string
+}
+
+export function GuestProfileButton({
+  recruitingStatus,
+  className,
+}: GuestProfileButtonProps) {
+  const isClosed = recruitingStatus?.phase === "closed"
+
+  return (
+    <Link
+      to="/login"
+      className={cn(
+        "text-label-1-semibold flex h-10 min-w-16 shrink-0 items-center justify-center rounded-[10px] px-5 text-center tracking-[-0.32px] transition-colors",
+        isClosed
+          ? "bg-teal-600 text-white hover:bg-teal-700"
+          : "bg-teal-100 text-teal-600 hover:bg-teal-200",
+        className,
+      )}
+    >
+      로그인
+    </Link>
+  )
+}
+```
+
+호출부는 `<GuestProfileButton recruitingStatus={status} />`로 변경한다.
+
+- [ ] **Step 4: 상태 테스트와 브라우저 검증을 실행한다.**
+
+```bash
+pnpm exec vitest run src/features/recruiting/model/recruitingStatus.test.ts src/widgets/navigation/header/recruitingHeaderNav.test.ts
+pnpm exec tsc --noEmit
+```
+
+개발 헤더 시나리오에서 게스트·중앙 핵심·학교 회장단·챌린저 각각의 open/closed를 확인한다. 피그마 헤더 node `3280:110402` 기준으로 상태 CTA 텍스트, 마감 로그인 색상, 로그인 사용자 마감 CTA 미노출을 확인한다.
+
+- [ ] **Step 5: 헤더 상태 커밋을 만든다.**
+
+```bash
+git add src/widgets/navigation/header/RecruitingHeader.tsx src/widgets/navigation/header/RecruitingStatusButton.tsx src/widgets/navigation/header/GuestProfileButton.tsx
+git commit -m "fix: 모집 상태와 인증별 헤더 CTA 정렬"
+```
+
+## Task 7: 프로필 아이콘을 공용 `ProfileAvatar`로 추출
+
+**Files:**
+
+- Create: `src/shared/ui/profile/ProfileAvatar.tsx`
+- Test: `src/shared/ui/profile/ProfileAvatar.test.tsx`
+- Modify: `src/widgets/navigation/header/Profile.tsx`
+- Modify: `src/widgets/navigation/header/ProfileDropdown.tsx`
+
+- [ ] **Step 1: 피그마 변형을 표현하는 컴포넌트 타입과 테스트를 정의한다.**
+
+공용 컴포넌트의 API는 크기 `40 | 46 | 100`, 상태 `default | filled | hover-upload`, 이미지 fallback을 표현한다. 테스트는 세 크기의 width/height, 이미지 유무에 따른 fallback, hover-upload 아이콘 레이어를 확인한다.
+
+```ts
+type ProfileAvatarSize = 40 | 46 | 100
+type ProfileAvatarState = "default" | "filled" | "hover-upload"
+```
+
+```tsx
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { ProfileAvatar } from "./ProfileAvatar"
+
+describe("ProfileAvatar", () => {
+  it("피그마 크기 변형을 적용한다", () => {
+    const { container } = render(<ProfileAvatar size={46} />)
+    expect(container.firstChild).toHaveStyle({
+      width: "46px",
+      height: "46px",
+    })
+  })
+
+  it("이미지가 없으면 기본 프로필 아이콘을 표시한다", () => {
+    const { container } = render(<ProfileAvatar />)
+    expect(container.querySelector("svg")).toBeTruthy()
+  })
+
+  it("이미지가 있으면 이미지와 업로드 상태 레이어를 표시한다", () => {
+    render(
+      <ProfileAvatar
+        src="https://example.com/profile.png"
+        alt="사용자 프로필"
+        state="hover-upload"
+      />,
+    )
+    expect(screen.getByAltText("사용자 프로필")).toBeInTheDocument()
+    expect(screen.getByTestId("profile-avatar-upload")).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: 최소 공용 표현 컴포넌트를 구현한다.**
+
+```tsx
+import CloudUploadIcon from "@/shared/assets/icon/upload/CloudUploadIcon"
+import ProfileIcon from "@/shared/assets/icon/people/ProfileIcon"
+import { cn } from "@/shared/lib/utils"
+
+export type ProfileAvatarSize = 40 | 46 | 100
+export type ProfileAvatarState = "default" | "filled" | "hover-upload"
+
+interface ProfileAvatarProps {
+  size?: ProfileAvatarSize
+  src?: string | null
+  alt?: string
+  state?: ProfileAvatarState
+  className?: string
+}
+
+export function ProfileAvatar({
+  size = 40,
+  src,
+  alt = "프로필 이미지",
+  state = src ? "filled" : "default",
+  className,
+}: ProfileAvatarProps) {
+  return (
+    <span
+      className={cn(
+        "relative inline-flex shrink-0 overflow-hidden rounded-full",
+        className,
+      )}
+      style={{ width: size, height: size }}
+    >
+      {src ? (
+        <img src={src} alt={alt} className="size-full object-cover" />
+      ) : (
+        <ProfileIcon className="size-full" aria-hidden="true" />
+      )}
+      {state === "hover-upload" && (
+        <span
+          data-testid="profile-avatar-upload"
+          className="absolute inset-0 flex items-center justify-center bg-black/40 text-white"
+        >
+          <CloudUploadIcon className="size-5" aria-hidden="true" />
+        </span>
+      )}
+    </span>
+  )
+}
+```
+
+- [ ] **Step 3: 헤더 프로필과 드롭다운의 중복 렌더링을 교체한다.**
+
+`Profile.tsx`의 직접 `img/ProfileIcon` 분기를 `ProfileAvatar size={size}`로 바꾼다. `ProfileDropdown.tsx`의 46px 프로필 버튼 내부도 `ProfileAvatar size={46}`으로 바꾼다. 드롭다운의 이동·기수·로그아웃 책임은 기존 컴포넌트에 남긴다.
+
+```tsx
+<ProfileAvatar size={size} src={profileSrc} alt={me?.name ?? "프로필 이미지"} />
+```
+
+- [ ] **Step 4: 프로필 테스트와 타입 검사를 실행한다.**
+
+```bash
+pnpm exec vitest run src/shared/ui/profile/ProfileAvatar.test.tsx
+pnpm exec eslint src/shared/ui/profile/ProfileAvatar.tsx src/widgets/navigation/header/Profile.tsx src/widgets/navigation/header/ProfileDropdown.tsx
+pnpm exec tsc --noEmit
+```
+
+Expected: 피그마 profile node `3427:121347`의 기본·filled·upload와 40/46/100 크기 검증이 PASS한다.
+
+- [ ] **Step 5: 프로필 공용화 커밋을 만든다.**
+
+```bash
+git add src/shared/ui/profile/ProfileAvatar.tsx src/shared/ui/profile/ProfileAvatar.test.tsx src/widgets/navigation/header/Profile.tsx src/widgets/navigation/header/ProfileDropdown.tsx
+git commit -m "refactor: 프로필 아바타 공용 컴포넌트 추출"
+```
+
+## Task 8: 개발 전용 헤더 시나리오를 서버 역할 행렬로 확장
+
+**Files:**
+
+- Modify: `src/routes/test/recruiting-header.tsx`
+
+- [ ] **Step 1: 테스트 시나리오의 잘못된 역할 매핑을 수정한다.**
+
+현재 `admin`이 중앙 운영팀원, `operator`가 지부장으로 매핑되어 서버 권한과 반대되는 상태를 대표한다. 다음 시나리오를 사용한다.
+
+```ts
+type RoleScenario =
+  | "centralCore"
+  | "schoolLeadership"
+  | "centralStaff"
+  | "chapterPresident"
+  | "challenger"
+  | "guest"
+
+const SCENARIO_ROLE_TYPE: Record<Exclude<RoleScenario, "guest">, RoleType> = {
+  centralCore: "CENTRAL_PRESIDENT",
+  schoolLeadership: "SCHOOL_PRESIDENT",
+  centralStaff: "CENTRAL_OPERATING_TEAM_MEMBER",
+  chapterPresident: "CHAPTER_PRESIDENT",
+  challenger: "CHALLENGER",
+}
+```
+
+- [ ] **Step 2: 역할별 기대 헤더를 확인한다.**
+
+- 중앙 핵심: `리크루팅`, `설정` 노출
+- 학교 회장단: `리크루팅`만 노출
+- 중앙 운영팀원·지부장: 운영 탭 미노출
+- 챌린저: 모집 종료 시 `데모데이 매칭` 노출
+- 게스트: `지원하기` 또는 `모집 마감`, `로그인`
+
+- [ ] **Step 3: 브라우저에서 피그마 주요 화면을 대조한다.**
+
+```bash
+pnpm dev --host 127.0.0.1 --port 5173
+```
+
+다음 경로를 확인한다.
+
+- `/test/recruiting-header`: 6개 역할 × open/closed
+- `/projects`: 게스트 프로젝트 탭 활성
+- `/projects/notice`: 게스트 모집 안내 탭 활성
+- `/projects/apply/7`: 모집 안내 탭 활성 및 익명 지원 UI
+- `/recruiting/dashboard/applications`: 비로그인 리다이렉트, 허용 역할 진입
+- `/manage/school`: 비로그인·비허용 역할 차단, 중앙 핵심 진입
+
+피그마는 다음 노드를 읽기 전용으로 대조한다.
+
+- 헤더 `3280:110402`
+- 헤더 버튼 `3256:122480`
+- 네비게이션 버튼 `3248:119501`
+- 프로필 `3427:121347`
+
+- [ ] **Step 4: 개발 시나리오 커밋을 만든다.**
+
+```bash
+git add src/routes/test/recruiting-header.tsx
+git commit -m "test: 서버 역할별 헤더 시나리오 확장"
+```
+
+## Task 9: `/test/*` 개발 환경 전용 공통 가드 적용
+
+**Files:**
+
+- Create: `src/routes/test/route.tsx`
+- Modify: `src/routeTree.gen.ts`
+- Test: `pnpm build` production bundle
+
+- [ ] **Step 1: 테스트 디렉터리 공통 부모 라우트를 추가한다.**
+
+기존 테스트 페이지는 개발 환경에서 계속 사용하되, `src/routes/test/route.tsx`에서 모든 하위 경로를 감싼다. `import.meta.env.DEV`가 false인 production build에서는 `/`로 리다이렉트한다.
+
+```tsx
+import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/test")({
+  beforeLoad: () => {
+    if (!import.meta.env.DEV) throw redirect({ to: "/" })
+  },
+  component: () => <Outlet />,
+})
+```
+
+- [ ] **Step 2: 모든 `/test/*` 하위 경로가 공통 부모를 사용하는지 확인한다.**
+
+```bash
+pnpm build
+rg -n "TestRouteRoute|Test.*Route.*getParentRoute.*TestRouteRoute" src/routeTree.gen.ts
+```
+
+Expected: `TestRouteRoute`가 생성되고 테스트 하위 라우트의 `getParentRoute`가 공통 테스트 부모를 가리키며 production build가 PASS한다.
+
+- [ ] **Step 3: production 빌드 가드와 개발 빌드 접근을 확인한다.**
+
+개발 서버에서는 `/test/recruiting-header`와 기존 `/test/*` 페이지가 렌더링되어야 한다. production preview에서는 동일한 경로가 `/`로 이동해야 한다.
+
+```bash
+pnpm build
+pnpm preview --host 127.0.0.1 --port 4173
+```
+
+Expected: production preview에서 `/test/recruiting-header` 접근 시 주소가 `/`로 바뀐다.
+
+- [ ] **Step 4: 남은 데드 경로·미사용 export를 정적 검사한다.**
+
+```bash
+rg -n "disabled: true|activeBasePath|isRecruitingOperator|isCentralAdmin|ProfileAvatar" src
+pnpm exec eslint src
+pnpm exec tsc --noEmit
+```
+
+확인할 사항:
+
+- 모집 안내가 루트 `/` placeholder를 사용하지 않는다.
+- 역할 capability가 실제 라우트·헤더·테스트에서 사용된다.
+- `ProfileAvatar`가 헤더와 드롭다운에서 사용된다.
+- `/test/*`의 공통 개발 전용 가드가 `src/routes/test/route.tsx`에만 존재한다.
+
+- [ ] **Step 5: 개발 전용 가드 커밋을 만든다.**
+
+```bash
+git add src/routes/test/route.tsx src/routeTree.gen.ts
+git commit -m "fix: 테스트 라우트를 개발 환경으로 제한"
+```
+
+## Task 10: 단일 PR 최종 검증·푸시
+
+**Files:**
+
+- Verify: 현재 브랜치 전체 변경
+- Do not stage automatically: `.claude/`, `.playwright-mcp/`, 기존 조사 문서 등 의도하지 않은 파일
+
+- [ ] **Step 1: 서버 계약을 최신 develop 기준으로 재확인한다.**
+
+```bash
+git -C /Users/2sac/Documents/github/umc-product-server fetch origin develop
+git -C /Users/2sac/Documents/github/umc-product-server rev-parse origin/develop
+```
+
+`/umc-api` 절차로 공개 모집·약관 API는 인증 없이 200, 관리자 모집 API는 인증 없이 401인지 확인한다. 서버 역할은 중앙 핵심·학교 회장단만 리크루팅, 중앙 핵심만 설정 쓰기로 기록한다.
+
+- [ ] **Step 2: 전체 검증 명령을 실행한다.**
+
+```bash
+pnpm exec vitest run src/entities/member/model/identity.test.ts src/features/recruiting/api/recruitingApi.test.ts src/features/recruiting/model/applyDraftStorage.test.ts src/widgets/navigation/header/recruitingHeaderNav.test.ts src/shared/ui/profile/ProfileAvatar.test.tsx
+pnpm test:run
+pnpm exec eslint src
+pnpm exec tsc --noEmit
+pnpm build
+git diff --check
+```
+
+Expected: 대상 테스트, 전체 테스트, ESLint, TypeScript, production build, whitespace 검사가 모두 PASS한다.
+
+- [ ] **Step 3: PR에 포함할 파일만 확인한다.**
+
+```bash
+git status --short
+git diff --stat origin/develop...HEAD
+git diff --stat
+```
+
+`git add -A`를 사용하지 않고 작업 목록의 소스·테스트·생성 파일만 stage한다. 피그마 캡처, `.claude/`, 기존 문서 등 검증 산출물은 PR에 넣지 않는다.
+
+- [ ] **Step 4: 현재 PR 브랜치에 push한다.**
+
+```bash
+git push origin feat/#688-header-role-branching
+```
+
+새 브랜치나 새 PR은 만들지 않는다. 기존 PR에 이번 커밋들이 포함되는지만 확인한다.
+
+## 완료 기준
+
+- 중앙 운영/교육팀원과 지부장이 `/recruiting` 및 `/manage` 메뉴·라우트에 진입하지 못한다.
+- 중앙 핵심과 학교 회장단만 서버와 일치하는 리크루팅 메뉴를 본다.
+- 중앙 핵심만 설정 메뉴를 본다.
+- 게스트는 공개 지원 API와 공개 개인정보 약관 API를 사용하고, 로그인 사용자는 인증 API를 사용한다.
+- 게스트의 “새로 시작”이 익명 세션 초안을 실제로 삭제한다.
+- `/projects/notice`와 `/projects/apply/:roundId`에서 모집 안내가 활성이고 프로젝트와 동시에 활성화되지 않는다.
+- 마감 헤더의 게스트 로그인 색상과 로그인 사용자 CTA가 피그마와 일치한다.
+- 헤더 프로필과 드롭다운이 `ProfileAvatar`를 공유하고 40/46/100 크기와 상태를 표현한다.
+- 테스트 라우트와 비활성 placeholder 경로가 운영 번들에 남지 않는다.
+- 전체 테스트·린트·타입 검사·빌드가 통과한다.

--- a/docs/superpowers/plans/2026-08-08-recruiting-role-header-alignment.md
+++ b/docs/superpowers/plans/2026-08-08-recruiting-role-header-alignment.md
@@ -255,7 +255,7 @@ export async function getPublicTermByType(
   termType: TermType,
 ): Promise<PublicTermResponse> {
   const { data } = await api.get<ApiResponse<RawPublicTermResponse>>(
-    `/v1/terms/type/\${termType}`,
+    `/v1/terms/type/${termType}`,
   )
   const id = Number(data.result.id)
   if (!Number.isFinite(id)) throw new Error("invalid public term id")

--- a/src/entities/organization/hooks/useSchoolChapterMap.ts
+++ b/src/entities/organization/hooks/useSchoolChapterMap.ts
@@ -4,7 +4,11 @@ import { useCallback, useMemo } from "react"
 import { getChaptersWithSchools } from "@/entities/organization/api/organization"
 import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
 
-export function useSchoolChapterMap() {
+export interface SchoolChapterMapOptions {
+  refetchInterval?: number | false
+}
+
+export function useSchoolChapterMap(options: SchoolChapterMapOptions = {}) {
   const { data: gisuData } = useActiveGisu()
 
   const activeGisuId = gisuData?.gisuId ? Number(gisuData.gisuId) : undefined
@@ -14,6 +18,7 @@ export function useSchoolChapterMap() {
     queryFn: () => getChaptersWithSchools(String(activeGisuId!)),
     enabled: activeGisuId != null,
     staleTime: 5 * 60 * 1000,
+    refetchInterval: options.refetchInterval ?? false,
   })
 
   const chapters = useMemo(() => chaptersData?.chapters ?? [], [chaptersData])

--- a/src/features/recruiting/api/queryKeys.ts
+++ b/src/features/recruiting/api/queryKeys.ts
@@ -14,8 +14,14 @@ export const recruitingKeys = {
     [...recruitingKeys.rounds(), gisuId, "OPEN"] as const,
   pastRoundList: (gisuId: string) =>
     [...recruitingKeys.rounds(), gisuId, "PAST"] as const,
-  adminRoundList: (gisuId: string, sort?: string) =>
-    [...recruitingKeys.rounds(), "admin", gisuId, sort ?? "NEWEST"] as const,
+  adminRoundList: (gisuId: string, sort?: string, chapterId?: string) =>
+    [
+      ...recruitingKeys.rounds(),
+      "admin",
+      gisuId,
+      sort ?? "NEWEST",
+      chapterId ?? "all",
+    ] as const,
 
   round: (gisuId: string, roundId: string) =>
     [...recruitingKeys.rounds(), gisuId, roundId] as const,

--- a/src/features/recruiting/hooks/useAdminRecruitingRounds.ts
+++ b/src/features/recruiting/hooks/useAdminRecruitingRounds.ts
@@ -8,11 +8,20 @@ import { getAdminRounds, getAllPublicRounds } from "../api/recruitingApi"
 
 import type { AdminRoundsQuery } from "../api/types"
 
+export interface AdminRecruitingRoundsOptions {
+  fresh?: boolean
+  refetchInterval?: number | false
+}
+
 // 모집 생성 화면에서 seasonId를 찾는 용도 전용. 공개 목록(useRecruitingRounds)은
 // OPEN/CLOSED 차수만 내려줘서 차수가 하나도 없는 시즌은 빠지므로, 관리자용
 // 목록(GET /admin/rounds)에서 시즌 자체를 조회해야 한다.
 // 평가자 권한만 있는 운영진 등 권한 부족으로 403을 받는 경우 공개 목록으로 폴백한다.
-export function useAdminRecruitingRounds(sort?: AdminRoundsQuery["sort"]) {
+export function useAdminRecruitingRounds(
+  sort?: AdminRoundsQuery["sort"],
+  options: AdminRecruitingRoundsOptions = {},
+) {
+  const shouldRefresh = options.fresh ?? false
   const gisuQuery = useActiveGisu()
   const gisuId =
     gisuQuery.data?.gisuId != null ? String(gisuQuery.data.gisuId) : null
@@ -33,7 +42,10 @@ export function useAdminRecruitingRounds(sort?: AdminRoundsQuery["sort"]) {
     retry: (failureCount, error) =>
       !(isAxiosError(error) && error.response?.status === 403) &&
       failureCount < 2,
-    staleTime: 5 * 60 * 1000,
+    staleTime: shouldRefresh ? 0 : 5 * 60 * 1000,
+    refetchOnMount: shouldRefresh ? "always" : true,
+    refetchOnWindowFocus: shouldRefresh,
+    refetchInterval: options.refetchInterval ?? false,
   })
 
   const isForbidden =

--- a/src/features/recruiting/hooks/useAdminRecruitingRounds.ts
+++ b/src/features/recruiting/hooks/useAdminRecruitingRounds.ts
@@ -11,6 +11,8 @@ import type { AdminRoundsQuery } from "../api/types"
 export interface AdminRecruitingRoundsOptions {
   fresh?: boolean
   refetchInterval?: number | false
+  chapterId?: string
+  enabled?: boolean
 }
 
 // 모집 생성 화면에서 seasonId를 찾는 용도 전용. 공개 목록(useRecruitingRounds)은
@@ -22,23 +24,30 @@ export function useAdminRecruitingRounds(
   options: AdminRecruitingRoundsOptions = {},
 ) {
   const shouldRefresh = options.fresh ?? false
+  const isEnabled = options.enabled ?? true
   const gisuQuery = useActiveGisu()
   const gisuId =
     gisuQuery.data?.gisuId != null ? String(gisuQuery.data.gisuId) : null
+  const chapterId = options.chapterId
 
   const roundsQuery = useQuery({
-    queryKey: recruitingKeys.adminRoundList(gisuId ?? "", sort),
+    queryKey: recruitingKeys.adminRoundList(gisuId ?? "", sort, chapterId),
     queryFn: async () => {
       try {
-        return await getAdminRounds({ gisuId: gisuId!, sort })
+        return await getAdminRounds({ gisuId: gisuId!, chapterId, sort })
       } catch (error) {
         if (isAxiosError(error) && error.response?.status === 403) {
-          return await getAllPublicRounds(gisuId!)
+          const publicGroups = await getAllPublicRounds(gisuId!)
+          return chapterId
+            ? publicGroups.filter(
+                (group) => String(group.chapterId) === String(chapterId),
+              )
+            : publicGroups
         }
         throw error
       }
     },
-    enabled: gisuId != null,
+    enabled: isEnabled && gisuId != null,
     retry: (failureCount, error) =>
       !(isAxiosError(error) && error.response?.status === 403) &&
       failureCount < 2,

--- a/src/features/recruiting/hooks/useRecruitingSeasonQuotas.test.tsx
+++ b/src/features/recruiting/hooks/useRecruitingSeasonQuotas.test.tsx
@@ -1,0 +1,97 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { createElement } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  getRecruitingSeasonConfiguration,
+  updateRecruitingSeasonQuotas,
+} from "../api/recruitingApi"
+import { useRecruitingSeasonQuotas } from "./useRecruitingSeasonQuotas"
+
+import type { ReactNode } from "react"
+
+import type { RecruitingSeasonConfigurationResponse } from "../api/types"
+
+vi.mock("../api/recruitingApi", () => ({
+  createRecruitingSeason: vi.fn(),
+  getRecruitingSeasonConfiguration: vi.fn(),
+  updateRecruitingSeason: vi.fn(),
+  updateRecruitingSeasonQuotas: vi.fn(),
+}))
+
+function createConfiguration(
+  id: string,
+): RecruitingSeasonConfigurationResponse {
+  return {
+    id,
+    gisuId: "15",
+    schoolId: id,
+    memo: null,
+    quotas: [],
+    rounds: [],
+  }
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children)
+  }
+}
+
+describe("useRecruitingSeasonQuotas 요청 페이싱", () => {
+  const seasonConfigurationRequests: string[] = []
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    seasonConfigurationRequests.length = 0
+    vi.mocked(getRecruitingSeasonConfiguration).mockImplementation(
+      async (seasonId) => {
+        seasonConfigurationRequests.push(seasonId)
+        return createConfiguration(seasonId)
+      },
+    )
+    vi.mocked(updateRecruitingSeasonQuotas).mockResolvedValue(undefined)
+  })
+
+  it("시즌 설정을 중복 없이 순차 조회하고 저장 후 변경된 시즌만 재조회한다", async () => {
+    const { result } = renderHook(
+      () =>
+        useRecruitingSeasonQuotas(["2", "1", "2"], {
+          fresh: true,
+          refetchInterval: 30_000,
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(seasonConfigurationRequests).toEqual(["1", "2"])
+
+    const requestCountBeforeSave = seasonConfigurationRequests.length
+
+    await act(async () => {
+      await result.current.updateQuotas([
+        {
+          seasonId: "1",
+          schoolName: "서울대학교",
+          payload: { quotas: [] },
+        },
+      ])
+    })
+
+    await waitFor(() => {
+      expect(seasonConfigurationRequests).toHaveLength(
+        requestCountBeforeSave + 1,
+      )
+    })
+    expect(seasonConfigurationRequests.at(-1)).toBe("1")
+  })
+})

--- a/src/features/recruiting/hooks/useRecruitingSeasonQuotas.ts
+++ b/src/features/recruiting/hooks/useRecruitingSeasonQuotas.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueries, useQueryClient } from "@tanstack/react-query"
-import { useMemo } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import { useToastStore } from "@/shared/ui/toast/useToastStore"
 
@@ -31,21 +31,49 @@ export interface UpdateSeasonQuotasResult {
   failedCount: number
 }
 
-export function useRecruitingSeasonQuotas(seasonIds: string[]) {
+export interface RecruitingSeasonQuotasOptions {
+  fresh?: boolean
+  refetchInterval?: number | false
+}
+
+const SEASON_CONFIGURATION_REQUEST_GAP = 100
+
+const wait = (milliseconds: number) =>
+  new Promise<void>((resolve) => {
+    window.setTimeout(resolve, milliseconds)
+  })
+
+export function useRecruitingSeasonQuotas(
+  seasonIds: string[],
+  options: RecruitingSeasonQuotasOptions = {},
+) {
+  const shouldRefresh = options.fresh ?? false
+  const refetchInterval = options.refetchInterval ?? false
+  const shouldUseSequentialRefetch =
+    typeof refetchInterval === "number" && refetchInterval > 0
   const queryClient = useQueryClient()
   const addToast = useToastStore((state) => state.addToast)
+  const [isSequentialLoading, setIsSequentialLoading] = useState(false)
+  const seasonIdsKey = seasonIds.join("|")
 
   const uniqueSeasonIds = useMemo(
-    () => [...new Set(seasonIds.filter(Boolean))].sort(),
-    [seasonIds],
+    () => [...new Set(seasonIdsKey.split("|").filter(Boolean))].sort(),
+    [seasonIdsKey],
   )
 
   const { seasonConfigsMap, isLoading, isError } = useQueries({
     queries: uniqueSeasonIds.map((seasonId) => ({
       queryKey: recruitingKeys.seasonConfiguration(seasonId),
       queryFn: () => getRecruitingSeasonConfiguration(seasonId),
-      enabled: Boolean(seasonId),
-      staleTime: 5 * 60 * 1000,
+      enabled: !shouldUseSequentialRefetch && Boolean(seasonId),
+      staleTime: shouldRefresh ? 0 : 5 * 60 * 1000,
+      refetchOnMount: shouldUseSequentialRefetch
+        ? false
+        : shouldRefresh
+          ? "always"
+          : true,
+      refetchOnWindowFocus: shouldUseSequentialRefetch ? false : shouldRefresh,
+      refetchInterval: false,
     })),
     combine: (results) => {
       const map = new Map<string, RecruitingSeasonConfigurationResponse>()
@@ -63,13 +91,62 @@ export function useRecruitingSeasonQuotas(seasonIds: string[]) {
     },
   })
 
+  useEffect(() => {
+    if (!shouldUseSequentialRefetch || uniqueSeasonIds.length === 0) {
+      setIsSequentialLoading(false)
+      return
+    }
+
+    let cancelled = false
+    let isFetching = false
+
+    const fetchSeasonConfigurations = async (initialFetch: boolean) => {
+      if (cancelled || isFetching) return
+
+      isFetching = true
+      if (initialFetch) setIsSequentialLoading(true)
+
+      for (const [index, seasonId] of uniqueSeasonIds.entries()) {
+        if (cancelled) break
+
+        await queryClient
+          .fetchQuery({
+            queryKey: recruitingKeys.seasonConfiguration(seasonId),
+            queryFn: () => getRecruitingSeasonConfiguration(seasonId),
+            staleTime: 0,
+            retry: false,
+          })
+          .catch(() => undefined)
+
+        if (!cancelled && index < uniqueSeasonIds.length - 1) {
+          await wait(SEASON_CONFIGURATION_REQUEST_GAP)
+        }
+      }
+
+      if (initialFetch && !cancelled) setIsSequentialLoading(false)
+      isFetching = false
+    }
+
+    void fetchSeasonConfigurations(true)
+    const intervalId = window.setInterval(() => {
+      void fetchSeasonConfigurations(false)
+    }, refetchInterval)
+
+    return () => {
+      cancelled = true
+      window.clearInterval(intervalId)
+    }
+  }, [
+    queryClient,
+    refetchInterval,
+    shouldUseSequentialRefetch,
+    uniqueSeasonIds,
+  ])
+
   const createSeasonMutation = useMutation({
     mutationFn: (payload: CreateRecruitingSeasonRequest) =>
       createRecruitingSeason(payload),
     onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: recruitingKeys.seasons(),
-      })
       void queryClient.invalidateQueries({
         queryKey: recruitingKeys.rounds(),
       })
@@ -84,9 +161,12 @@ export function useRecruitingSeasonQuotas(seasonIds: string[]) {
       seasonId: string
       payload: UpdateRecruitingSeasonRequest
     }) => updateRecruitingSeason(seasonId, payload),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({
-        queryKey: recruitingKeys.seasons(),
+    onSuccess: (_data, variables) => {
+      void queryClient.fetchQuery({
+        queryKey: recruitingKeys.seasonConfiguration(variables.seasonId),
+        queryFn: () => getRecruitingSeasonConfiguration(variables.seasonId),
+        staleTime: 0,
+        retry: false,
       })
     },
   })
@@ -127,8 +207,17 @@ export function useRecruitingSeasonQuotas(seasonIds: string[]) {
       if (!data) return
 
       if (data.fulfilledCount > 0) {
-        void queryClient.invalidateQueries({
-          queryKey: recruitingKeys.seasons(),
+        const successfulSeasonIds = new Set(
+          data.successfulVariables.map(({ seasonId }) => seasonId),
+        )
+
+        successfulSeasonIds.forEach((seasonId) => {
+          void queryClient.fetchQuery({
+            queryKey: recruitingKeys.seasonConfiguration(seasonId),
+            queryFn: () => getRecruitingSeasonConfiguration(seasonId),
+            staleTime: 0,
+            retry: false,
+          })
         })
       }
 
@@ -163,7 +252,7 @@ export function useRecruitingSeasonQuotas(seasonIds: string[]) {
 
   return {
     seasonConfigsMap,
-    isLoading,
+    isLoading: shouldUseSequentialRefetch ? isSequentialLoading : isLoading,
     isError,
     updateQuotas: updateQuotasMutation.mutateAsync,
     createSeason: createSeasonMutation.mutateAsync,

--- a/src/features/recruiting/model/recruitmentQuota.test.ts
+++ b/src/features/recruiting/model/recruitmentQuota.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  findMatchingSchoolQuotaRow,
+  getChangedSchoolQuotaRows,
+  getConflictedSchoolQuotaRows,
+  getSchoolQuotaIdentity,
+  mergeSchoolQuotaRows,
+  type SchoolQuotaEdits,
+  type SchoolQuotaRow,
+} from "./recruitmentQuota"
+
+const createRow = (
+  overrides: Partial<SchoolQuotaRow> = {},
+): SchoolQuotaRow => ({
+  seasonId: "1",
+  gisuId: "5",
+  schoolId: "10",
+  schoolName: "서울대학교",
+  pm: 1,
+  design: 2,
+  webPe: 3,
+  mobilePe: 4,
+  total: 10,
+  ...overrides,
+})
+
+describe("getChangedSchoolQuotaRows", () => {
+  it("변경된 학교 row만 반환한다", () => {
+    const originalRows = [
+      createRow(),
+      createRow({
+        seasonId: "2",
+        schoolId: "11",
+        schoolName: "연세대학교",
+        pm: 5,
+        total: 14,
+      }),
+    ]
+    const currentRows = [createRow({ pm: 4, total: 13 }), originalRows[1]!]
+
+    expect(getChangedSchoolQuotaRows(originalRows, currentRows)).toEqual([
+      currentRows[0],
+    ])
+  })
+
+  it("시즌이 없는 새 학교 row의 quota 변경을 반환한다", () => {
+    const originalRows = [
+      createRow({ seasonId: undefined, schoolId: "10", pm: 0, total: 0 }),
+    ]
+    const currentRows = [
+      createRow({ seasonId: undefined, schoolId: "10", pm: 2, total: 2 }),
+    ]
+
+    expect(getChangedSchoolQuotaRows(originalRows, currentRows)).toEqual(
+      currentRows,
+    )
+  })
+})
+
+describe("편집 중인 모집 인원 동기화", () => {
+  it("식별자 표현이 달라도 같은 시즌 row로 매칭한다", () => {
+    const serverRow = createRow({ gisuId: "5", schoolId: "10" })
+    const editedRow = {
+      ...serverRow,
+      gisuId: undefined,
+      pm: 4,
+      total: 13,
+    }
+
+    expect(findMatchingSchoolQuotaRow([serverRow], editedRow)).toEqual(
+      serverRow,
+    )
+    expect(getChangedSchoolQuotaRows([serverRow], [editedRow])).toEqual([
+      editedRow,
+    ])
+  })
+
+  it("편집한 row만 유지하고 편집하지 않은 row는 최신 서버값을 반영한다", () => {
+    const originalRows = [
+      createRow(),
+      createRow({
+        seasonId: "2",
+        schoolId: "11",
+        schoolName: "연세대학교",
+        pm: 5,
+      }),
+    ]
+    const originalRow = originalRows[0]!
+    const secondOriginalRow = originalRows[1]!
+    const editedRow = { ...originalRow, pm: 4, total: 13 }
+    const edits: SchoolQuotaEdits = new Map([
+      [getSchoolQuotaIdentity(originalRow), { row: editedRow, originalRow }],
+    ])
+    const latestServerRows = [
+      originalRow,
+      { ...secondOriginalRow, pm: 7, total: 16 },
+    ]
+
+    expect(mergeSchoolQuotaRows(latestServerRows, edits)).toEqual([
+      editedRow,
+      latestServerRows[1],
+    ])
+  })
+
+  it("최초 입력 이후 서버값이 바뀐 row를 충돌로 반환한다", () => {
+    const originalRow = createRow()
+    const editedRow = { ...originalRow, pm: 4, total: 13 }
+    const edits: SchoolQuotaEdits = new Map([
+      [getSchoolQuotaIdentity(editedRow), { row: editedRow, originalRow }],
+    ])
+
+    expect(
+      getConflictedSchoolQuotaRows(
+        [{ ...originalRow, pm: 3, total: 12 }],
+        edits,
+      ),
+    ).toEqual([editedRow])
+  })
+
+  it("서버값이 편집 시작 시점과 같으면 충돌로 표시하지 않는다", () => {
+    const originalRow = createRow()
+    const editedRow = { ...originalRow, pm: 4, total: 13 }
+    const edits: SchoolQuotaEdits = new Map([
+      [getSchoolQuotaIdentity(editedRow), { row: editedRow, originalRow }],
+    ])
+
+    expect(getConflictedSchoolQuotaRows([originalRow], edits)).toEqual([])
+  })
+})

--- a/src/features/recruiting/model/recruitmentQuota.ts
+++ b/src/features/recruiting/model/recruitmentQuota.ts
@@ -10,6 +10,124 @@ export interface SchoolQuotaRow {
   total: number
 }
 
+export interface SchoolQuotaEdit {
+  row: SchoolQuotaRow
+  originalRow?: SchoolQuotaRow
+}
+
+export type SchoolQuotaEdits = Map<string, SchoolQuotaEdit>
+
+const QUOTA_FIELDS = ["pm", "design", "webPe", "mobilePe"] as const
+
+export function getSchoolQuotaIdentity(row: SchoolQuotaRow): string {
+  if (row.gisuId && row.schoolId) {
+    return `school:${row.gisuId}:${row.schoolId}`
+  }
+  if (row.seasonId) return `season:${row.seasonId}`
+  return `school:${row.gisuId ?? ""}:${row.schoolId ?? row.schoolName}`
+}
+
+function isSameSchoolQuotaRow(
+  left: SchoolQuotaRow,
+  right: SchoolQuotaRow,
+): boolean {
+  if (left.seasonId && right.seasonId) {
+    return String(left.seasonId) === String(right.seasonId)
+  }
+
+  if (left.gisuId && left.schoolId && right.gisuId && right.schoolId) {
+    return (
+      String(left.gisuId) === String(right.gisuId) &&
+      String(left.schoolId) === String(right.schoolId)
+    )
+  }
+
+  if (left.schoolId && right.schoolId) {
+    return (
+      String(left.schoolId) === String(right.schoolId) &&
+      left.schoolName === right.schoolName
+    )
+  }
+
+  return left.schoolName === right.schoolName
+}
+
+export function findMatchingSchoolQuotaRow(
+  rows: SchoolQuotaRow[],
+  targetRow: SchoolQuotaRow,
+): SchoolQuotaRow | undefined {
+  return rows.find((row) => isSameSchoolQuotaRow(row, targetRow))
+}
+
+function hasQuotaChanged(
+  originalRow: SchoolQuotaRow,
+  currentRow: SchoolQuotaRow,
+): boolean {
+  return QUOTA_FIELDS.some((field) => currentRow[field] !== originalRow[field])
+}
+
+export function mergeSchoolQuotaRows(
+  serverRows: SchoolQuotaRow[],
+  edits: SchoolQuotaEdits,
+): SchoolQuotaRow[] {
+  const serverIdentities = new Set(
+    serverRows.map((row) => getSchoolQuotaIdentity(row)),
+  )
+  const mergedRows = serverRows.map((serverRow) => {
+    const edit =
+      edits.get(getSchoolQuotaIdentity(serverRow)) ??
+      [...edits.values()].find((item) =>
+        isSameSchoolQuotaRow(item.row, serverRow),
+      )
+    return edit?.row ?? serverRow
+  })
+
+  edits.forEach((edit, identity) => {
+    if (
+      !serverIdentities.has(identity) &&
+      !findMatchingSchoolQuotaRow(serverRows, edit.row)
+    ) {
+      mergedRows.push(edit.row)
+    }
+  })
+
+  return mergedRows
+}
+
+export function getConflictedSchoolQuotaRows(
+  serverRows: SchoolQuotaRow[],
+  edits: SchoolQuotaEdits,
+): SchoolQuotaRow[] {
+  const serverRowsByIdentity = new Map(
+    serverRows.map((row) => [getSchoolQuotaIdentity(row), row]),
+  )
+
+  return [...edits.values()]
+    .filter((edit) => {
+      const serverRow =
+        serverRowsByIdentity.get(getSchoolQuotaIdentity(edit.row)) ??
+        findMatchingSchoolQuotaRow(serverRows, edit.row)
+
+      if (!serverRow) return Boolean(edit.originalRow)
+      if (!edit.originalRow) return true
+
+      return hasQuotaChanged(edit.originalRow, serverRow)
+    })
+    .map((edit) => edit.row)
+}
+
+export function getChangedSchoolQuotaRows(
+  originalRows: SchoolQuotaRow[],
+  currentRows: SchoolQuotaRow[],
+): SchoolQuotaRow[] {
+  return currentRows.filter((currentRow) => {
+    const originalRow = findMatchingSchoolQuotaRow(originalRows, currentRow)
+    if (!originalRow) return true
+
+    return hasQuotaChanged(originalRow, currentRow)
+  })
+}
+
 export interface PartCounts {
   pm: number
   design: number

--- a/src/features/recruiting/ui/ChapterQuotaTableCard.tsx
+++ b/src/features/recruiting/ui/ChapterQuotaTableCard.tsx
@@ -18,10 +18,12 @@ interface ChapterQuotaTableCardProps {
   onManualEdit?: () => void
   onErrorExceeded?: (partName: string, maxAllowed: number) => void
   onSchoolsDataChange?: (schools: SchoolQuotaRow[]) => void
+  onSchoolDataChange?: (school: SchoolQuotaRow) => void
   /** 자동 배정 요청. 대상 지부가 자기 자신일 때만 한 번 실행한다. */
   autoAllocateRequest?: { id: number; chapter: string } | null
   /** 시즌별 편집 가능 여부. 없으면 전부 편집 가능으로 본다. */
   canEditSeason?: (seasonId: string | undefined) => boolean
+  conflictedSchoolNames?: ReadonlySet<string>
   className?: string
 }
 
@@ -32,8 +34,10 @@ export function ChapterQuotaTableCard({
   onManualEdit,
   onErrorExceeded,
   onSchoolsDataChange,
+  onSchoolDataChange,
   autoAllocateRequest,
   canEditSeason,
+  conflictedSchoolNames,
   className,
 }: ChapterQuotaTableCardProps) {
   const [schoolsData, setSchoolsData] = useState<SchoolQuotaRow[]>(data.schools)
@@ -167,6 +171,9 @@ export function ChapterQuotaTableCard({
         updated.pm + updated.design + updated.webPe + updated.mobilePe
       return { ...updated, total }
     })
+    const updatedSchool = nextSchoolsData.find(
+      (school) => school.schoolName === schoolName,
+    )
 
     prevSchoolsRef.current = nextSchoolsData
     setSchoolsData(nextSchoolsData)
@@ -186,7 +193,7 @@ export function ChapterQuotaTableCard({
 
     onDirtyChange?.(true)
     onManualEdit?.()
-    onSchoolsDataChange?.(nextSchoolsData)
+    if (updatedSchool) onSchoolDataChange?.(updatedSchool)
   }
 
   const currentPMTotal = schoolsData.reduce((acc, s) => acc + s.pm, 0)
@@ -297,14 +304,25 @@ export function ChapterQuotaTableCard({
           const readOnly = canEditSeason
             ? !canEditSeason(school.seasonId)
             : false
+          const isConflicted = conflictedSchoolNames?.has(school.schoolName)
           return (
             <div
               key={school.schoolName}
               className="divide-teal-gray-300 flex h-14 w-full divide-x"
             >
-              <div className="bg-teal-gray-50 flex w-42.5 items-center justify-center">
+              <div
+                className={cn(
+                  "bg-teal-gray-50 flex w-42.5 items-center justify-center",
+                  isConflicted && "bg-warning-50",
+                )}
+              >
                 <p className="text-heading-7-semibold text-teal-gray-700">
                   {school.schoolName}
+                  {isConflicted && (
+                    <span className="text-label-2-medium text-warning-500 pl-1">
+                      충돌
+                    </span>
+                  )}
                 </p>
               </div>
               <QuotaEditableCell

--- a/src/features/recruiting/ui/QuotaEditableCell.test.tsx
+++ b/src/features/recruiting/ui/QuotaEditableCell.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { normalizeQuotaInput, QuotaEditableCell } from "./QuotaEditableCell"
+
+describe("normalizeQuotaInput", () => {
+  it("기존 0에 숫자를 입력하면 앞뒤에 0이 남지 않는다", () => {
+    expect(normalizeQuotaInput("0", "10")).toBe("1")
+    expect(normalizeQuotaInput("0", "01")).toBe("1")
+  })
+
+  it("일반적인 숫자와 빈 입력은 유지한다", () => {
+    expect(normalizeQuotaInput("1", "10")).toBe("10")
+    expect(normalizeQuotaInput("10", "")).toBe("")
+  })
+})
+
+describe("QuotaEditableCell", () => {
+  it("0 앞에 숫자를 입력해도 10이 아닌 1로 반영한다", () => {
+    const onChange = vi.fn()
+
+    render(<QuotaEditableCell partName="PM" value={0} onChange={onChange} />)
+
+    const input = screen.getByRole("textbox", { name: "PM TO" })
+    fireEvent.change(input, { target: { value: "10" } })
+
+    expect(onChange).toHaveBeenCalledWith(1)
+    expect(input).toHaveValue("1")
+  })
+})

--- a/src/features/recruiting/ui/QuotaEditableCell.tsx
+++ b/src/features/recruiting/ui/QuotaEditableCell.tsx
@@ -12,6 +12,20 @@ interface QuotaEditableCellProps {
   className?: string
 }
 
+export function normalizeQuotaInput(
+  previousValue: string,
+  nextValue: string,
+): string {
+  const digitsOnly = nextValue.replace(/[^0-9]/g, "").slice(0, 4)
+
+  if (previousValue === "0" && digitsOnly.length === 2) {
+    const withoutExistingZero = digitsOnly.replace("0", "")
+    if (withoutExistingZero.length === 1) return withoutExistingZero
+  }
+
+  return digitsOnly.replace(/^0+(?=\d)/, "")
+}
+
 export function QuotaEditableCell({
   partName,
   value,
@@ -42,10 +56,10 @@ export function QuotaEditableCell({
   }, [isError, partName, maxAllowed, onErrorExceeded])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const digitsOnly = e.target.value.replace(/[^0-9]/g, "").slice(0, 4)
-    setInputValue(digitsOnly)
+    const normalizedValue = normalizeQuotaInput(inputValue, e.target.value)
+    setInputValue(normalizedValue)
 
-    const parsed = digitsOnly === "" ? 0 : Number(digitsOnly)
+    const parsed = normalizedValue === "" ? 0 : Number(normalizedValue)
     onChange(parsed)
   }
 

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.test.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.test.tsx
@@ -1,15 +1,20 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useMe } from "@/entities/member/hooks/useMe"
 
 import { useAdminRecruitingRounds } from "../hooks/useAdminRecruitingRounds"
 import { useRecruitingSeasonQuotas } from "../hooks/useRecruitingSeasonQuotas"
 import { RecruitmentQuotaPage } from "./RecruitmentQuotaPage"
 
+import type { MemberInfoResponse } from "@/entities/member/api/me"
+
 import type { RecruitingSeasonConfigurationResponse } from "../api/types"
 
 vi.mock("../hooks/useAdminRecruitingRounds")
 vi.mock("../hooks/useRecruitingSeasonQuotas")
+vi.mock("@/entities/member/hooks/useMe", () => ({ useMe: vi.fn() }))
 vi.mock("../hooks/useRecruitingPermissions", () => ({
   useRecruitingPermissions: () => ({
     permittedSeasonIds: new Set(["unconfigured-season-123"]),
@@ -22,8 +27,16 @@ vi.mock("@/shared/ui/toast/useToastStore", () => ({
 
 vi.mock("./ChapterQuotaTableCard", () => ({
   ChapterQuotaTableCard: vi.fn(
-    ({ onSchoolDataChange, onDirtyChange, conflictedSchoolNames }) => (
+    ({ data, onSchoolDataChange, onDirtyChange, conflictedSchoolNames }) => (
       <div>
+        <div data-testid="quota-schools">
+          {data.schools
+            .map(
+              (school: { schoolName: string; total: number }) =>
+                `${school.schoolName} ${school.total}명`,
+            )
+            .join(",")}
+        </div>
         <div data-testid="conflict-names">
           {[...(conflictedSchoolNames ?? [])].join(",")}
         </div>
@@ -51,6 +64,17 @@ vi.mock("./ChapterQuotaTableCard", () => ({
     ),
   ),
 }))
+vi.mock("./ChapterTabs", () => ({
+  ChapterTabs: () => <div data-testid="chapter-tabs" />,
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(useMe).mockReturnValue({
+    data: undefined,
+    isLoading: false,
+  } as unknown as ReturnType<typeof useMe>)
+})
 
 describe("RecruitmentQuotaPage 저장 경로 분류", () => {
   it("시즌 설정이 없는 행(seasonId가 없는 행)을 저장하면 updateQuotas 대신 createSeason(POST)을 호출한다", async () => {
@@ -223,5 +247,157 @@ describe("RecruitmentQuotaPage 저장 경로 분류", () => {
     expect(screen.getByRole("alert")).toHaveTextContent(
       "현재 입력값은 유지하고 있습니다",
     )
+  })
+
+  it("학교 회장단은 본인 지부만 조회하고 지부 세그먼트를 숨긴다", () => {
+    const schoolPresident: MemberInfoResponse = {
+      id: "member-1",
+      name: "가천대 회장",
+      nickname: "가천대 회장",
+      email: "gacheon_10_schoolpresident@umc.dev",
+      schoolId: "10",
+      schoolName: "가천대학교",
+      profileImageLink: null,
+      status: "ACTIVE",
+      hasLocalCredential: true,
+      roles: [
+        {
+          challengerRoleId: "role-1",
+          challengerId: "challenger-1",
+          roleType: "SCHOOL_PRESIDENT",
+          organizationType: "SCHOOL",
+          organizationId: "10",
+          gisuId: "15",
+          gisu: "10",
+        },
+      ],
+      currentGisuMemberInfo: {
+        gisuId: "15",
+        generation: "10",
+        challenger: {
+          challengerId: "challenger-1",
+          part: "PLAN",
+          challengerStatus: "ACTIVE",
+        },
+        isAdmin: true,
+        roleTypes: ["SCHOOL_PRESIDENT"],
+      },
+      challengerRecords: [
+        {
+          challengerId: "challenger-1",
+          memberId: "member-1",
+          gisuId: "15",
+          gisu: "10",
+          chapterId: "29",
+          chapterName: "Chromium",
+          part: "PLAN",
+          challengerStatus: "ACTIVE",
+          name: "가천대 회장",
+          nickname: "가천대 회장",
+          email: "gacheon_10_schoolpresident@umc.dev",
+          schoolId: "10",
+          schoolName: "가천대학교",
+        },
+      ],
+    }
+
+    vi.mocked(useMe).mockReturnValue({
+      data: schoolPresident,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useMe>)
+    vi.mocked(useAdminRecruitingRounds).mockReturnValue({
+      groups: [
+        {
+          seasonId: "chromium-season",
+          gisuId: "15",
+          chapterId: "29",
+          chapterName: "Chromium",
+          schoolId: "10",
+          schoolName: "가천대학교",
+          rounds: [],
+        },
+        {
+          seasonId: "chromium-dongguk-season",
+          gisuId: "15",
+          chapterId: "29",
+          chapterName: "Chromium",
+          schoolId: "20",
+          schoolName: "동국대학교",
+          rounds: [],
+        },
+        {
+          seasonId: "ferrum-season",
+          gisuId: "15",
+          chapterId: "30",
+          chapterName: "Ferrum",
+          schoolId: "11",
+          schoolName: "연세대학교",
+          rounds: [],
+        },
+      ],
+      generation: 10,
+      isLoading: false,
+      isError: false,
+      isForbidden: false,
+    } as unknown as ReturnType<typeof useAdminRecruitingRounds>)
+    vi.mocked(useRecruitingSeasonQuotas).mockReturnValue({
+      seasonConfigsMap: new Map([
+        [
+          "chromium-season",
+          {
+            id: "chromium-season",
+            gisuId: "15",
+            schoolId: "10",
+            memo: null,
+            quotas: [
+              { track: "PLAN", targetCount: 1 },
+              { track: "DESIGN", targetCount: 1 },
+              { track: "WEB_PRODUCT_ENGINEER", targetCount: 5 },
+              { track: "MOBILE_PRODUCT_ENGINEER", targetCount: 5 },
+            ],
+            rounds: [],
+          },
+        ],
+        [
+          "chromium-dongguk-season",
+          {
+            id: "chromium-dongguk-season",
+            gisuId: "15",
+            schoolId: "20",
+            memo: null,
+            quotas: [
+              { track: "PLAN", targetCount: 2 },
+              { track: "DESIGN", targetCount: 2 },
+              { track: "WEB_PRODUCT_ENGINEER", targetCount: 4 },
+              { track: "MOBILE_PRODUCT_ENGINEER", targetCount: 4 },
+            ],
+            rounds: [],
+          },
+        ],
+      ]),
+      updateQuotas: vi.fn(),
+      createSeason: vi.fn(),
+      updateSeason: vi.fn(),
+      isSaving: false,
+      isLoading: false,
+      isError: false,
+    })
+
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <RecruitmentQuotaPage />
+      </QueryClientProvider>,
+    )
+
+    expect(useAdminRecruitingRounds).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ chapterId: "29", enabled: true }),
+    )
+    expect(screen.queryByTestId("chapter-tabs")).not.toBeInTheDocument()
+    expect(screen.getByText("Chromium")).toBeInTheDocument()
+    expect(screen.getByTestId("quota-schools")).toHaveTextContent(
+      "가천대학교 12명,동국대학교 12명",
+    )
+    expect(screen.queryByText("Ferrum")).not.toBeInTheDocument()
   })
 })

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.test.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.test.tsx
@@ -400,4 +400,100 @@ describe("RecruitmentQuotaPage 저장 경로 분류", () => {
     )
     expect(screen.queryByText("Ferrum")).not.toBeInTheDocument()
   })
+
+  it("학교 운영진의 지부명이 없으면 모집 데이터를 조회하지 않는다", () => {
+    const schoolPresidentWithoutChapterName: MemberInfoResponse = {
+      id: "member-1",
+      name: "가천대 회장",
+      nickname: "가천대 회장",
+      email: "gacheon_10_schoolpresident@umc.dev",
+      schoolId: "10",
+      schoolName: "가천대학교",
+      profileImageLink: null,
+      status: "ACTIVE",
+      hasLocalCredential: true,
+      roles: [
+        {
+          challengerRoleId: "role-1",
+          challengerId: "challenger-1",
+          roleType: "SCHOOL_PRESIDENT",
+          organizationType: "SCHOOL",
+          organizationId: "10",
+          gisuId: "15",
+          gisu: "10",
+        },
+      ],
+      currentGisuMemberInfo: {
+        gisuId: "15",
+        generation: "10",
+        challenger: {
+          challengerId: "challenger-1",
+          part: "PLAN",
+          challengerStatus: "ACTIVE",
+        },
+        isAdmin: true,
+        roleTypes: ["SCHOOL_PRESIDENT"],
+      },
+      challengerRecords: [
+        {
+          challengerId: "challenger-1",
+          memberId: "member-1",
+          gisuId: "15",
+          gisu: "10",
+          chapterId: "29",
+          chapterName: "",
+          part: "PLAN",
+          challengerStatus: "ACTIVE",
+          name: "가천대 회장",
+          nickname: "가천대 회장",
+          email: "gacheon_10_schoolpresident@umc.dev",
+          schoolId: "10",
+          schoolName: "가천대학교",
+        },
+      ],
+    }
+
+    vi.mocked(useMe).mockReturnValue({
+      data: schoolPresidentWithoutChapterName,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useMe>)
+    vi.mocked(useAdminRecruitingRounds).mockReturnValue({
+      groups: [
+        {
+          seasonId: "chromium-season",
+          gisuId: "15",
+          chapterId: "29",
+          chapterName: "Chromium",
+          schoolId: "10",
+          schoolName: "가천대학교",
+          rounds: [],
+        },
+      ],
+      generation: 10,
+      isLoading: false,
+      isError: false,
+      isForbidden: false,
+    } as unknown as ReturnType<typeof useAdminRecruitingRounds>)
+    vi.mocked(useRecruitingSeasonQuotas).mockReturnValue({
+      seasonConfigsMap: new Map(),
+      updateQuotas: vi.fn(),
+      createSeason: vi.fn(),
+      updateSeason: vi.fn(),
+      isSaving: false,
+      isLoading: false,
+      isError: false,
+    })
+
+    render(
+      <QueryClientProvider client={new QueryClient()}>
+        <RecruitmentQuotaPage />
+      </QueryClientProvider>,
+    )
+
+    expect(useAdminRecruitingRounds).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ chapterId: "29", enabled: false }),
+    )
+    expect(screen.getByTestId("quota-schools")).toHaveTextContent(/^$/)
+  })
 })

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.test.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.test.tsx
@@ -6,6 +6,8 @@ import { useAdminRecruitingRounds } from "../hooks/useAdminRecruitingRounds"
 import { useRecruitingSeasonQuotas } from "../hooks/useRecruitingSeasonQuotas"
 import { RecruitmentQuotaPage } from "./RecruitmentQuotaPage"
 
+import type { RecruitingSeasonConfigurationResponse } from "../api/types"
+
 vi.mock("../hooks/useAdminRecruitingRounds")
 vi.mock("../hooks/useRecruitingSeasonQuotas")
 vi.mock("../hooks/useRecruitingPermissions", () => ({
@@ -19,15 +21,18 @@ vi.mock("@/shared/ui/toast/useToastStore", () => ({
 }))
 
 vi.mock("./ChapterQuotaTableCard", () => ({
-  ChapterQuotaTableCard: vi.fn(({ onSchoolsDataChange, onDirtyChange }) => (
-    <div>
-      <button
-        type="button"
-        data-testid="edit-school-btn"
-        onClick={() => {
-          onDirtyChange()
-          onSchoolsDataChange([
-            {
+  ChapterQuotaTableCard: vi.fn(
+    ({ onSchoolDataChange, onDirtyChange, conflictedSchoolNames }) => (
+      <div>
+        <div data-testid="conflict-names">
+          {[...(conflictedSchoolNames ?? [])].join(",")}
+        </div>
+        <button
+          type="button"
+          data-testid="edit-school-btn"
+          onClick={() => {
+            onDirtyChange()
+            onSchoolDataChange?.({
               seasonId: undefined,
               gisuId: "15",
               schoolId: "10",
@@ -37,14 +42,14 @@ vi.mock("./ChapterQuotaTableCard", () => ({
               webPe: 5,
               mobilePe: 5,
               total: 14,
-            },
-          ])
-        }}
-      >
-        Trigger Edit
-      </button>
-    </div>
-  )),
+            })
+          }}
+        >
+          Trigger Edit
+        </button>
+      </div>
+    ),
+  ),
 }))
 
 describe("RecruitmentQuotaPage 저장 경로 분류", () => {
@@ -119,5 +124,104 @@ describe("RecruitmentQuotaPage 저장 경로 분류", () => {
       })
       expect(mockUpdateQuotas).not.toHaveBeenCalled()
     })
+  })
+
+  it("편집 중인 row는 서버 갱신으로 덮어쓰지 않고 충돌을 표시한다", async () => {
+    const seasonConfigsMap = new Map<
+      string,
+      RecruitingSeasonConfigurationResponse
+    >([
+      [
+        "unconfigured-season-123",
+        {
+          id: "unconfigured-season-123",
+          gisuId: "15",
+          schoolId: "10",
+          memo: null,
+          quotas: [
+            { track: "PLAN", targetCount: 1 },
+            { track: "DESIGN", targetCount: 1 },
+            { track: "WEB_PRODUCT_ENGINEER", targetCount: 1 },
+            { track: "MOBILE_PRODUCT_ENGINEER", targetCount: 1 },
+          ],
+          rounds: [],
+        },
+      ],
+    ])
+
+    vi.mocked(useAdminRecruitingRounds).mockReturnValue({
+      groups: [
+        {
+          seasonId: "unconfigured-season-123",
+          gisuId: "15",
+          chapterId: "1",
+          chapterName: "Chromium",
+          schoolId: "10",
+          schoolName: "서울대학교",
+          rounds: [],
+        },
+      ],
+      generation: 15,
+      isLoading: false,
+      isError: false,
+      isForbidden: false,
+    } as unknown as ReturnType<typeof useAdminRecruitingRounds>)
+
+    vi.mocked(useRecruitingSeasonQuotas).mockReturnValue({
+      seasonConfigsMap,
+      updateQuotas: vi.fn(),
+      createSeason: vi.fn(),
+      updateSeason: vi.fn(),
+      isSaving: false,
+      isLoading: false,
+      isError: false,
+    })
+
+    const queryClient = new QueryClient()
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <RecruitmentQuotaPage />
+      </QueryClientProvider>,
+    )
+
+    fireEvent.click(screen.getAllByTestId("edit-school-btn")[0]!)
+
+    seasonConfigsMap.set("unconfigured-season-123", {
+      id: "unconfigured-season-123",
+      gisuId: "15",
+      schoolId: "10",
+      memo: null,
+      quotas: [
+        { track: "PLAN", targetCount: 3 },
+        { track: "DESIGN", targetCount: 1 },
+        { track: "WEB_PRODUCT_ENGINEER", targetCount: 1 },
+        { track: "MOBILE_PRODUCT_ENGINEER", targetCount: 1 },
+      ],
+      rounds: [],
+    })
+    vi.mocked(useRecruitingSeasonQuotas).mockReturnValue({
+      seasonConfigsMap: new Map(seasonConfigsMap),
+      updateQuotas: vi.fn(),
+      createSeason: vi.fn(),
+      updateSeason: vi.fn(),
+      isSaving: false,
+      isLoading: false,
+      isError: false,
+    })
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <RecruitmentQuotaPage />
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("conflict-names")[0]).toHaveTextContent(
+        "서울대학교",
+      )
+    })
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "현재 입력값은 유지하고 있습니다",
+    )
   })
 })

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -63,7 +63,9 @@ export function RecruitmentQuotaPage() {
   const viewerChapterName = viewerChapterRecord?.chapterName
   const isSchoolScoped = isSchoolLeadership(me) && !isCentralCore(me)
   const canLoadRounds =
-    !isMeLoading && (!isSchoolScoped || Boolean(viewerChapterId))
+    !isMeLoading &&
+    (!isSchoolScoped ||
+      (Boolean(viewerChapterId) && Boolean(viewerChapterName)))
   const isAll = !isSchoolScoped && chapterTab === "all"
   const activeChapter = isSchoolScoped ? viewerChapterName : chapterTab
 
@@ -134,7 +136,8 @@ export function RecruitmentQuotaPage() {
       activeGisuId,
     )
 
-    if (!isSchoolScoped || !viewerChapterName) return mapped
+    if (!isSchoolScoped) return mapped
+    if (!viewerChapterName) return []
     return mapped.filter(
       (chapterData) => chapterData.chapter === viewerChapterName,
     )

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import ResetIcon from "@/shared/assets/icon/reset/ResetIcon"
@@ -12,6 +12,15 @@ import { useAdminRecruitingRounds } from "../hooks/useAdminRecruitingRounds"
 import { useRecruitingPermissions } from "../hooks/useRecruitingPermissions"
 import { useRecruitingSeasonQuotas } from "../hooks/useRecruitingSeasonQuotas"
 import { hasAnyEditableSeason } from "../model/recruitingEditLock"
+import {
+  findMatchingSchoolQuotaRow,
+  getChangedSchoolQuotaRows,
+  getConflictedSchoolQuotaRows,
+  getSchoolQuotaIdentity,
+  mergeSchoolQuotaRows,
+  type SchoolQuotaEdits,
+  type SchoolQuotaRow,
+} from "../model/recruitmentQuota"
 import { mapGroupsToChapterQuotaData } from "../model/recruitmentQuotaMapper"
 import {
   type AllocationStatus,
@@ -20,7 +29,7 @@ import {
 import { ChapterTabs } from "./ChapterTabs"
 import { QuotaApplicantStatusCard } from "./QuotaApplicantStatusCard"
 
-import type { SchoolQuotaRow } from "../model/recruitmentQuota"
+const QUOTA_PAGE_REFETCH_INTERVAL = 30_000
 
 export function RecruitmentQuotaPage() {
   const [chapterTab, setChapterTab] = useState("all")
@@ -34,13 +43,18 @@ export function RecruitmentQuotaPage() {
   } | null>(null)
 
   const [editedSchoolsMap, setEditedSchoolsMap] = useState<
-    Map<string, SchoolQuotaRow[]>
+    Map<string, SchoolQuotaEdits>
   >(new Map())
 
   const addToast = useToastStore((state) => state.addToast)
 
-  const { groups } = useAdminRecruitingRounds()
-  const { chapters: serverChapters } = useSchoolChapterMap()
+  const { groups } = useAdminRecruitingRounds(undefined, {
+    fresh: true,
+    refetchInterval: QUOTA_PAGE_REFETCH_INTERVAL,
+  })
+  const { chapters: serverChapters } = useSchoolChapterMap({
+    refetchInterval: QUOTA_PAGE_REFETCH_INTERVAL,
+  })
   const { data: activeGisuData } = useActiveGisu()
   const activeGisuId = activeGisuData?.gisuId
     ? String(activeGisuData.gisuId)
@@ -58,14 +72,11 @@ export function RecruitmentQuotaPage() {
     [activeTabGroups],
   )
   const { seasonConfigsMap, updateQuotas, createSeason, isSaving } =
-    useRecruitingSeasonQuotas(seasonIds)
+    useRecruitingSeasonQuotas(seasonIds, {
+      fresh: true,
+      refetchInterval: QUOTA_PAGE_REFETCH_INTERVAL,
+    })
 
-  // 편집 권한은 시즌 단위라 서버 조회 결과를 그대로 쓴다. 권한을 확인하기
-  // 전에는 잠가 둔다. 열어 두면 못 고칠 값을 고치고 저장에서야 거부당한다.
-  //
-  // 조회 범위는 현재 탭이 아니라 지부 전체다. 저장은 탭을 옮겨 다니며 쌓인
-  // editedSchoolsMap 을 통째로 보내는데, 현재 탭 시즌만 조회하면 다른 지부에서
-  // 고친 값이 권한 없음으로 판정돼 조용히 빠진다.
   const allSeasonIds = useMemo(
     () => [...new Set(groups.map((g) => g.seasonId))],
     [groups],
@@ -105,10 +116,70 @@ export function RecruitmentQuotaPage() {
       if (!editedSchools) return chapterData
       return {
         ...chapterData,
-        schools: editedSchools,
+        schools: mergeSchoolQuotaRows(chapterData.schools, editedSchools),
       }
     })
   }, [allChaptersData, editedSchoolsMap])
+
+  const conflictedSchoolNamesByChapter = useMemo(() => {
+    const conflicts = new Map<string, Set<string>>()
+
+    allChaptersData.forEach((chapterData) => {
+      const edits = editedSchoolsMap.get(chapterData.chapter)
+      if (!edits) return
+
+      const conflictedRows = getConflictedSchoolQuotaRows(
+        chapterData.schools,
+        edits,
+      )
+      if (conflictedRows.length === 0) return
+
+      conflicts.set(
+        chapterData.chapter,
+        new Set(conflictedRows.map((row) => row.schoolName)),
+      )
+    })
+
+    return conflicts
+  }, [allChaptersData, editedSchoolsMap])
+
+  const conflictSummary = useMemo(
+    () =>
+      [...conflictedSchoolNamesByChapter.entries()].flatMap(
+        ([chapter, schoolNames]) =>
+          [...schoolNames].map((schoolName) => `${chapter} ${schoolName}`),
+      ),
+    [conflictedSchoolNamesByChapter],
+  )
+
+  useEffect(() => {
+    if (isDirty || editedSchoolsMap.size === 0) return
+
+    const isSynced = [...editedSchoolsMap.entries()].every(
+      ([chapter, edits]) => {
+        const serverRows = allChaptersData.find(
+          (chapterData) => chapterData.chapter === chapter,
+        )?.schools
+        if (!serverRows) return false
+
+        const serverRowsByIdentity = new Map(
+          serverRows.map((row) => [getSchoolQuotaIdentity(row), row]),
+        )
+
+        return [...edits.values()].every((edit) => {
+          const serverRow = serverRowsByIdentity.get(
+            getSchoolQuotaIdentity(edit.row),
+          )
+          return (
+            serverRow != null &&
+            getChangedSchoolQuotaRows([serverRow], [edit.row]).length === 0
+          )
+        })
+      },
+    )
+
+    if (isSynced) setEditedSchoolsMap(new Map())
+  }, [allChaptersData, editedSchoolsMap, isDirty])
 
   const isAll = chapterTab === "all"
 
@@ -172,27 +243,104 @@ export function RecruitmentQuotaPage() {
     (chapter: string, schools: SchoolQuotaRow[]) => {
       setEditedSchoolsMap((prev) => {
         const next = new Map(prev)
-        next.set(chapter, schools)
+
+        const serverRows =
+          allChaptersData.find((chapterData) => chapterData.chapter === chapter)
+            ?.schools ?? []
+        const chapterEdits = new Map(next.get(chapter) ?? [])
+
+        schools.forEach((row) => {
+          const existingEntry = [...chapterEdits.entries()].find(([, edit]) =>
+            findMatchingSchoolQuotaRow([edit.row], row),
+          )
+          const serverRow = findMatchingSchoolQuotaRow(serverRows, row)
+          const identity =
+            existingEntry?.[0] ?? getSchoolQuotaIdentity(serverRow ?? row)
+          const originalRow = existingEntry?.[1].originalRow ?? serverRow
+          const isChanged =
+            serverRow == null ||
+            getChangedSchoolQuotaRows([serverRow], [row]).length > 0
+
+          if (!isChanged) {
+            chapterEdits.delete(identity)
+            return
+          }
+
+          if (existingEntry && existingEntry[0] !== identity) {
+            chapterEdits.delete(existingEntry[0])
+          }
+          chapterEdits.set(identity, { row, originalRow })
+        })
+
+        if (chapterEdits.size === 0) {
+          next.delete(chapter)
+        } else {
+          next.set(chapter, chapterEdits)
+        }
+
         return next
       })
     },
-    [],
+    [allChaptersData],
+  )
+
+  const handleSchoolDataChange = useCallback(
+    (chapter: string, school: SchoolQuotaRow) => {
+      setEditedSchoolsMap((prev) => {
+        const next = new Map(prev)
+        const serverRows =
+          allChaptersData.find((chapterData) => chapterData.chapter === chapter)
+            ?.schools ?? []
+        const chapterEdits = new Map(next.get(chapter) ?? [])
+        const existingEntry = [...chapterEdits.entries()].find(([, edit]) =>
+          findMatchingSchoolQuotaRow([edit.row], school),
+        )
+        const serverRow = findMatchingSchoolQuotaRow(serverRows, school)
+        const identity =
+          existingEntry?.[0] ?? getSchoolQuotaIdentity(serverRow ?? school)
+        const originalRow = existingEntry?.[1].originalRow ?? serverRow
+        const isChanged =
+          serverRow == null ||
+          getChangedSchoolQuotaRows([serverRow], [school]).length > 0
+
+        if (!isChanged) {
+          chapterEdits.delete(identity)
+        } else {
+          chapterEdits.set(identity, { row: school, originalRow })
+        }
+
+        if (chapterEdits.size === 0) {
+          next.delete(chapter)
+        } else {
+          next.set(chapter, chapterEdits)
+        }
+
+        return next
+      })
+    },
+    [allChaptersData],
   )
 
   const handleSave = async () => {
     const targetChapters = isAll
-      ? chaptersDataWithEdits
-      : chaptersDataWithEdits.filter((c) => c.chapter === chapterTab)
+      ? allChaptersData
+      : allChaptersData.filter((c) => c.chapter === chapterTab)
 
-    const rawRows = targetChapters.flatMap(
-      (c) => editedSchoolsMap.get(c.chapter) ?? [],
-    )
+    const changedRows = targetChapters.flatMap((chapterData) => {
+      const edits = editedSchoolsMap.get(chapterData.chapter)
+      if (!edits) return []
 
-    const existingSeasonRows = rawRows.filter(
+      return getChangedSchoolQuotaRows(
+        chapterData.schools,
+        [...edits.values()].map((edit) => edit.row),
+      )
+    })
+
+    const existingSeasonRows = changedRows.filter(
       (row): row is SchoolQuotaRow & { seasonId: string } =>
         Boolean(row.seasonId) && canEditSeason(row.seasonId),
     )
-    const newSeasonRows = rawRows.filter(
+    const newSeasonRows = changedRows.filter(
       (row): row is SchoolQuotaRow & { gisuId: string; schoolId: string } => {
         if (!row.seasonId && Boolean(row.gisuId) && Boolean(row.schoolId)) {
           const targetGroup = groups.find(
@@ -222,10 +370,14 @@ export function RecruitmentQuotaPage() {
       },
     }))
 
-    if (payloadList.length === 0 && newSeasonRows.length === 0) return
+    if (payloadList.length === 0 && newSeasonRows.length === 0) {
+      setIsDirty(false)
+      return
+    }
 
     try {
-      const successfulSchoolNames = new Set<string>()
+      let hasSuccessfulWrite = false
+      let hasWriteFailure = false
 
       if (newSeasonRows.length > 0) {
         const createResults = await Promise.allSettled(
@@ -252,8 +404,9 @@ export function RecruitmentQuotaPage() {
           if (!row) return
 
           if (result.status === "fulfilled") {
-            successfulSchoolNames.add(row.schoolName)
+            hasSuccessfulWrite = true
           } else {
+            hasWriteFailure = true
             failedCreateSchoolNames.push(row.schoolName)
             const err = result.reason as {
               code?: string
@@ -290,44 +443,12 @@ export function RecruitmentQuotaPage() {
       if (payloadList.length > 0) {
         const updateResult = await updateQuotas(payloadList)
 
-        updateResult.successfulVariables.forEach((v) => {
-          if (v.schoolName) {
-            successfulSchoolNames.add(v.schoolName)
-          }
-        })
+        hasSuccessfulWrite ||= updateResult.fulfilledCount > 0
+        hasWriteFailure ||= updateResult.failedCount > 0
       }
 
-      if (successfulSchoolNames.size > 0) {
-        let remainingCount = 0
-        const nextMap = new Map<string, SchoolQuotaRow[]>()
-
-        editedSchoolsMap.forEach((rows, chapter) => {
-          const remainingRows = rows.filter((r) => {
-            const seasonIdToCheck =
-              r.seasonId ??
-              groups.find(
-                (g) =>
-                  String(g.schoolId) === String(r.schoolId) &&
-                  String(g.gisuId) === String(r.gisuId),
-              )?.seasonId
-            const isPermitted =
-              canEditEverySeason || canEditSeason(seasonIdToCheck)
-            const isSuccessfullySaved =
-              successfulSchoolNames.has(r.schoolName) && isPermitted
-            return !isSuccessfullySaved
-          })
-          if (remainingRows.length > 0) {
-            nextMap.set(chapter, remainingRows)
-            remainingCount += remainingRows.length
-          }
-        })
-
-        if (remainingCount === 0) {
-          setIsDirty(false)
-          setEditedSchoolsMap(new Map())
-        } else {
-          setEditedSchoolsMap(nextMap)
-        }
+      if (hasSuccessfulWrite && !hasWriteFailure) {
+        setIsDirty(false)
       }
     } catch {
       addToast({
@@ -388,6 +509,21 @@ export function RecruitmentQuotaPage() {
         </p>
 
         <div className="flex w-full flex-col gap-4">
+          {conflictSummary.length > 0 && (
+            <div
+              role="alert"
+              className="border-warning-200 bg-warning-50 text-warning-600 rounded-[8px] border px-4 py-3"
+            >
+              <p className="text-body-2-semibold">
+                서버에서 모집 인원이 변경되었습니다.
+              </p>
+              <p className="text-body-2-medium mt-1">
+                {conflictSummary.join(", ")}의 현재 입력값은 유지하고 있습니다.
+                저장하면 서버의 최신 값을 덮어쓸 수 있습니다.
+              </p>
+            </div>
+          )}
+
           {/* 지원자 현황 */}
           <QuotaApplicantStatusCard
             title={statusCardTitle}
@@ -461,9 +597,15 @@ export function RecruitmentQuotaPage() {
                     onManualEdit={handleManualEdit}
                     onErrorExceeded={handleErrorExceeded}
                     canEditSeason={canEditSeason}
+                    onSchoolDataChange={(school) =>
+                      handleSchoolDataChange(chapterData.chapter, school)
+                    }
                     onSchoolsDataChange={(schools) =>
                       handleSchoolsDataChange(chapterData.chapter, schools)
                     }
+                    conflictedSchoolNames={conflictedSchoolNamesByChapter.get(
+                      chapterData.chapter,
+                    )}
                     autoAllocateRequest={autoAllocateRequest}
                   />
                 ))
@@ -475,12 +617,18 @@ export function RecruitmentQuotaPage() {
                   onManualEdit={handleManualEdit}
                   onErrorExceeded={handleErrorExceeded}
                   canEditSeason={canEditSeason}
+                  onSchoolDataChange={(school) =>
+                    handleSchoolDataChange(selectedChapterData.chapter, school)
+                  }
                   onSchoolsDataChange={(schools) =>
                     handleSchoolsDataChange(
                       selectedChapterData.chapter,
                       schools,
                     )
                   }
+                  conflictedSchoolNames={conflictedSchoolNamesByChapter.get(
+                    selectedChapterData.chapter,
+                  )}
                   autoAllocateRequest={autoAllocateRequest}
                 />
               )}

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 
+import { useMe } from "@/entities/member/hooks/useMe"
+import {
+  isCentralCore,
+  isSchoolLeadership,
+} from "@/entities/member/model/identity"
+import { getCurrentGisuChallengerRecords } from "@/entities/member/view-mode/currentGisuRecords"
 import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import ResetIcon from "@/shared/assets/icon/reset/ResetIcon"
 import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
@@ -32,6 +38,7 @@ import { QuotaApplicantStatusCard } from "./QuotaApplicantStatusCard"
 const QUOTA_PAGE_REFETCH_INTERVAL = 30_000
 
 export function RecruitmentQuotaPage() {
+  const { data: me, isLoading: isMeLoading } = useMe()
   const [chapterTab, setChapterTab] = useState("all")
   const [isDirty, setIsDirty] = useState(false)
   const [allocationStatus, setAllocationStatus] =
@@ -48,13 +55,33 @@ export function RecruitmentQuotaPage() {
 
   const addToast = useToastStore((state) => state.addToast)
 
+  const viewerChapterRecord = useMemo(
+    () => getCurrentGisuChallengerRecords(me)[0],
+    [me],
+  )
+  const viewerChapterId = viewerChapterRecord?.chapterId
+  const viewerChapterName = viewerChapterRecord?.chapterName
+  const isSchoolScoped = isSchoolLeadership(me) && !isCentralCore(me)
+  const canLoadRounds =
+    !isMeLoading && (!isSchoolScoped || Boolean(viewerChapterId))
+  const isAll = !isSchoolScoped && chapterTab === "all"
+  const activeChapter = isSchoolScoped ? viewerChapterName : chapterTab
+
   const { groups } = useAdminRecruitingRounds(undefined, {
     fresh: true,
     refetchInterval: QUOTA_PAGE_REFETCH_INTERVAL,
+    chapterId: isSchoolScoped ? viewerChapterId : undefined,
+    enabled: canLoadRounds,
   })
   const { chapters: serverChapters } = useSchoolChapterMap({
     refetchInterval: QUOTA_PAGE_REFETCH_INTERVAL,
   })
+  const visibleGroups = useMemo(() => {
+    if (!isSchoolScoped || !viewerChapterId) return groups
+    return groups.filter(
+      (group) => String(group.chapterId) === String(viewerChapterId),
+    )
+  }, [groups, isSchoolScoped, viewerChapterId])
   const { data: activeGisuData } = useActiveGisu()
   const activeGisuId = activeGisuData?.gisuId
     ? String(activeGisuData.gisuId)
@@ -62,10 +89,10 @@ export function RecruitmentQuotaPage() {
 
   const activeTabGroups = useMemo(
     () =>
-      chapterTab === "all"
-        ? groups
-        : groups.filter((g) => g.chapterName === chapterTab),
-    [groups, chapterTab],
+      isAll
+        ? visibleGroups
+        : visibleGroups.filter((g) => g.chapterName === activeChapter),
+    [activeChapter, isAll, visibleGroups],
   )
   const seasonIds = useMemo(
     () => [...new Set(activeTabGroups.map((g) => g.seasonId))],
@@ -78,8 +105,8 @@ export function RecruitmentQuotaPage() {
     })
 
   const allSeasonIds = useMemo(
-    () => [...new Set(groups.map((g) => g.seasonId))],
-    [groups],
+    () => [...new Set(visibleGroups.map((g) => g.seasonId))],
+    [visibleGroups],
   )
   const { permittedSeasonIds, isLoading: isPermissionLoading } =
     useRecruitingPermissions(allSeasonIds)
@@ -99,16 +126,26 @@ export function RecruitmentQuotaPage() {
     seasonIds.length > 0 &&
     seasonIds.every((id) => permittedSeasonIds.has(String(id)))
 
-  const allChaptersData = useMemo(
-    () =>
-      mapGroupsToChapterQuotaData(
-        groups,
-        seasonConfigsMap,
-        serverChapters,
-        activeGisuId,
-      ),
-    [groups, seasonConfigsMap, serverChapters, activeGisuId],
-  )
+  const allChaptersData = useMemo(() => {
+    const mapped = mapGroupsToChapterQuotaData(
+      visibleGroups,
+      seasonConfigsMap,
+      serverChapters,
+      activeGisuId,
+    )
+
+    if (!isSchoolScoped || !viewerChapterName) return mapped
+    return mapped.filter(
+      (chapterData) => chapterData.chapter === viewerChapterName,
+    )
+  }, [
+    activeGisuId,
+    visibleGroups,
+    isSchoolScoped,
+    seasonConfigsMap,
+    serverChapters,
+    viewerChapterName,
+  ])
 
   const chaptersDataWithEdits = useMemo(() => {
     return allChaptersData.map((chapterData) => {
@@ -180,8 +217,6 @@ export function RecruitmentQuotaPage() {
 
     if (isSynced) setEditedSchoolsMap(new Map())
   }, [allChaptersData, editedSchoolsMap, isDirty])
-
-  const isAll = chapterTab === "all"
 
   const handleTabChange = (nextValue: string) => {
     setChapterTab(nextValue)
@@ -324,7 +359,7 @@ export function RecruitmentQuotaPage() {
   const handleSave = async () => {
     const targetChapters = isAll
       ? allChaptersData
-      : allChaptersData.filter((c) => c.chapter === chapterTab)
+      : allChaptersData.filter((c) => c.chapter === activeChapter)
 
     const changedRows = targetChapters.flatMap((chapterData) => {
       const edits = editedSchoolsMap.get(chapterData.chapter)
@@ -343,7 +378,7 @@ export function RecruitmentQuotaPage() {
     const newSeasonRows = changedRows.filter(
       (row): row is SchoolQuotaRow & { gisuId: string; schoolId: string } => {
         if (!row.seasonId && Boolean(row.gisuId) && Boolean(row.schoolId)) {
-          const targetGroup = groups.find(
+          const targetGroup = visibleGroups.find(
             (g) =>
               String(g.schoolId) === String(row.schoolId) &&
               String(g.gisuId) === String(row.gisuId),
@@ -462,9 +497,9 @@ export function RecruitmentQuotaPage() {
   }
 
   const selectedChapterData = chaptersDataWithEdits.find(
-    (item) => item.chapter === chapterTab,
+    (item) => item.chapter === activeChapter,
   ) ?? {
-    chapter: chapterTab,
+    chapter: activeChapter ?? "",
     schoolCount: 0,
     schools: [],
     totals: { pm: 0, design: 0, webPe: 0, mobilePe: 0, total: 0 },
@@ -485,7 +520,7 @@ export function RecruitmentQuotaPage() {
   const showAutoAllocateButton = !isAll && canEditEverySeason
   const showSaveButton = canEditAny
 
-  const pageTitle = isAll ? "UMC 11th" : chapterTab
+  const pageTitle = isAll ? "UMC 11th" : (activeChapter ?? "")
   const statusCardTitle = isAll ? "전체 지원자 현황" : "지부 지원자 현황"
 
   return (
@@ -501,7 +536,9 @@ export function RecruitmentQuotaPage() {
         className="pl-3"
       />
 
-      <ChapterTabs value={chapterTab} onValueChange={handleTabChange} />
+      {!isSchoolScoped && !isMeLoading && (
+        <ChapterTabs value={chapterTab} onValueChange={handleTabChange} />
+      )}
 
       <div className="flex w-full flex-col gap-6">
         <p className="text-heading-3-semibold px-3 text-teal-700">


### PR DESCRIPTION
## 📸 작업 내용

- 학교 회장·부회장의 모집 인원 설정 조회를 현재 기수의 소속 지부로 제한했습니다.
- 학교 운영진 화면에서 전체·지부 세그먼트 선택 UI를 숨겼습니다.
- 관리자 모집 목록 API 요청에 `chapterId`를 전달하고 지부별 query cache를 분리했습니다.
- 동일 지부 타 학교의 조회 결과가 API 계약에 따라 반환되면 TO 행을 표시하고, 편집 권한이 없는 행은 읽기 전용으로 유지합니다.
- 현재 기수 소속 지부를 확인하지 못한 경우 범위가 넓은 조회를 실행하지 않습니다.

## 🎞️ 주요 코드 설명

- `RecruitmentQuotaPage`가 현재 기수의 소속 지부 ID·이름을 기준으로 데이터와 화면을 필터링합니다.
- `useAdminRecruitingRounds`가 `chapterId`와 `enabled` 옵션을 지원하고, query key에도 지부 범위를 포함합니다.
- 학교 운영진과 동일 지부 타 학교 TO가 함께 표시되는 회귀 테스트를 추가했습니다.

## 🔗 연결된 이슈

- Connected: #727
- Closes #727

## ✅ 검증

- `pnpm exec vitest run src/features/recruiting/api/recruitingApi.test.ts src/features/recruiting/ui/RecruitmentQuotaPage.test.tsx`
- `pnpm exec eslint src/features/recruiting/ui/RecruitmentQuotaPage.test.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 모집 상태와 로그인 여부에 따라 랜딩 헤더의 지원·로그인·마감 안내를 표시합니다.
  * 권한과 지부 범위에 맞춰 모집 정원 데이터를 조회·편집합니다.
  * 정원 편집 중 서버 변경 충돌을 감지하고 해당 학교를 표시합니다.
  * 비활성 메뉴 선택 시 안내 토스트를 제공합니다.
* **버그 수정**
  * 정원 입력값을 올바르게 정리하고, 직접 경로 접근 시 발생하는 배포 404 원인과 해결 절차를 문서화했습니다.
* **문서**
  * 모집 화면과 API 간 불일치 및 권한·라우팅 개선 계획을 정리했습니다.
* **테스트**
  * 정원 편집, 충돌 감지, 권한별 화면, 입력값 처리를 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

