### PR TITLE
✨ feat: 지부장 리크루팅 접근 허용

### DIFF
--- a/src/entities/member/model/identity.test.ts
+++ b/src/entities/member/model/identity.test.ts
@@ -113,14 +113,14 @@ describe("isRecruitingOperator", () => {
     expect(isRecruitingOperator(makeMe(["SCHOOL_VICE_PRESIDENT"]))).toBe(true)
   })
 
-  it("중앙 실무·교육팀원과 지부장은 false", () => {
+  it("중앙 실무·교육팀원은 false, 지부장은 true", () => {
     expect(
       isRecruitingOperator(makeMe(["CENTRAL_OPERATING_TEAM_MEMBER"])),
     ).toBe(false)
     expect(
       isRecruitingOperator(makeMe(["CENTRAL_EDUCATION_TEAM_MEMBER"])),
     ).toBe(false)
-    expect(isRecruitingOperator(makeMe(["CHAPTER_PRESIDENT"]))).toBe(false)
+    expect(isRecruitingOperator(makeMe(["CHAPTER_PRESIDENT"]))).toBe(true)
   })
 
   it("학교 파트장·기타운영진은 false", () => {

--- a/src/entities/member/model/identity.ts
+++ b/src/entities/member/model/identity.ts
@@ -98,20 +98,10 @@ export function isAnyOperator(me: MemberInfoResponse | undefined): boolean {
   return isOperator(me) || isSchoolStaff(me)
 }
 
-/**
- * 리크루팅을 다룰 수 있는 역할.
- *
- * 서버가 모집 시즌·차수·폼·평가자·합불을 허용하는 범위에 맞춘다. 학교 쪽은
- * 회장단만 통과하고 파트장·기타 운영진은 거부되므로, 메뉴를 열어 주면 들어가서
- * 막히기만 한다.
- *
- * `isAnyOperator` 와 따로 두는 이유는 그 함수가 사이드바·뷰 모드·프로젝트 관리 등
- * 열 곳에서 학교 역할 4종을 포함하는 의미로 쓰이고 있어서다.
- */
 export function isRecruitingOperator(
   me: MemberInfoResponse | undefined,
 ): boolean {
-  return isCentralCore(me) || isSchoolLeadership(me)
+  return isCentralCore(me) || isChapterPresident(me) || isSchoolLeadership(me)
 }
 
 export function canAccessProjectSettings(


### PR DESCRIPTION
## 📸 작업 내용

- 지부장 역할을 리크루팅 공통 capability에 포함했습니다.
- 지부장의 `/recruiting` 직접 접근과 리크루팅 헤더 메뉴 노출을 허용했습니다.
- 기존 리소스별 편집 권한 분기는 유지합니다.

## 🎞️ 주요 코드 설명

- `isRecruitingOperator`가 중앙 핵심, 지부장, 학교 회장단을 리크루팅 운영 역할로 판정합니다.
- `/recruiting` 라우트 가드와 `RecruitingHeader`가 동일 capability를 사용합니다.
- 역할 판정 테스트에서 지부장은 허용하고 중앙 실무·교육팀원과 학교 기타 운영진은 계속 제한합니다.

## 🔗 연결된 이슈

- Connected: #730
- Closes #730

## ✅ 검증

- `pnpm exec vitest run src/entities/member/model/identity.test.ts`
- `pnpm exec eslint src/entities/member/model/identity.ts src/entities/member/model/identity.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기능 개선**
  * 지부장 역할을 가진 사용자가 모집 운영 권한을 사용할 수 있도록 변경했습니다.

* **버그 수정**
  * 모집 운영 권한 판정이 실제 역할 기준과 일치하도록 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->