### PR TITLE
task: 718 recruitment create qa

### DIFF
--- a/src/features/recruiting/api/queryKeys.ts
+++ b/src/features/recruiting/api/queryKeys.ts
@@ -53,6 +53,9 @@ export const recruitingKeys = {
 
   forms: () => [...recruitingKeys.all, "forms"] as const,
 
+  adminFormStructure: (seasonId: string, roundId: string) =>
+    [...recruitingKeys.forms(), "admin", seasonId, roundId] as const,
+
   formStructure: (
     applicationFormId: string,
     firstChoice: string,

--- a/src/features/recruiting/api/recruitingApi.ts
+++ b/src/features/recruiting/api/recruitingApi.ts
@@ -28,6 +28,7 @@ import type {
   RawStatusCounts,
   RawStatusSummary,
   RawTrackCount,
+  RecruitingAdminFormStructureResponse,
   RecruitingApplicationCreated,
   RecruitingApplicationCredentialRequest,
   RecruitingApplicationDetail,
@@ -612,6 +613,16 @@ export async function updateRecruitingRound(
     `/v1/recruiting/admin/seasons/${seasonId}/rounds/${roundId}`,
     payload,
   )
+}
+
+export async function getRecruitingApplicationForm(
+  seasonId: string,
+  roundId: string,
+): Promise<RecruitingAdminFormStructureResponse> {
+  const { data } = await api.get<
+    ApiResponse<RecruitingAdminFormStructureResponse>
+  >(`/v1/recruiting/admin/seasons/${seasonId}/rounds/${roundId}/form`)
+  return data.result
 }
 
 // Round가 DRAFT일 때만 지원 Form 구조를 통째로 Upsert할 수 있다. Round 생성

--- a/src/features/recruiting/api/types.ts
+++ b/src/features/recruiting/api/types.ts
@@ -83,21 +83,18 @@ export type RawAdminRoundGroup = Omit<RecruitingRoundGroup, "rounds"> & {
 }
 
 // 백엔드(RecruitingRoundConfiguration.validateInterviewShape)는 interviewRequired=true일
-// 때 interviewStartAt/interviewEndAt만 필수로 본다. availabilityFormId는 생성 시점엔
-// 없어도 되고(OPEN 전환 전까지만 채우면 됨), 대신 availabilityFormId와
-// availabilityScheduleQuestionId는 둘 다 있거나 둘 다 없어야 한다.
+// 때 interviewStartAt/interviewEndAt만 필수로 본다. 면접 일정 Form(availabilityFormId,
+// availabilityScheduleQuestionId)은 서버가 자동으로 만들어 주므로 클라이언트가 보낼 필요가 없다.
 export type CreateRecruitingRoundInterviewFields =
   | {
       interviewRequired: true
       interviewStartAt: string
       interviewEndAt: string
-      availabilityFormId?: string
     }
   | {
       interviewRequired: false
       interviewStartAt?: never
       interviewEndAt?: never
-      availabilityFormId?: never
     }
 
 export type CreateRecruitingRoundRequest = {
@@ -536,6 +533,43 @@ export interface UpsertRecruitingSectionRequest {
 export interface UpsertRecruitingApplicationFormRequest {
   description?: string
   sections: UpsertRecruitingSectionRequest[]
+}
+
+// Form 전체 구조 조회(GET .../rounds/{roundId}/form, RECRUITING-ADMIN-022) 응답.
+// Form 상태·지망 트랙과 무관하게 전체 섹션/문항/옵션 트리를 반환하며, Upsert
+// 요청과 대칭되는 clientKey/nextSectionKey를 그대로 포함해 조회 결과를 편집
+// 화면 state로 로드했다가 그대로 PUT하는 왕복이 가능하다. 아직 Form이 없는
+// Round는 exists: false와 함께 빈 sections를 반환한다.
+export interface RecruitingAdminFormOptionResponse {
+  optionId?: number
+  content: string
+  other: boolean
+  nextSectionKey?: string | null
+}
+
+export interface RecruitingAdminFormQuestionResponse {
+  questionId?: number
+  type: RecruitingQuestionType
+  title: string
+  description?: string | null
+  required: boolean
+  options?: RecruitingAdminFormOptionResponse[]
+}
+
+export interface RecruitingAdminFormSectionResponse {
+  sectionId?: number
+  clientKey: string
+  title: string
+  description?: string | null
+  type: RecruitingSectionType
+  track?: RecruitingTrack
+  questions: RecruitingAdminFormQuestionResponse[]
+}
+
+export interface RecruitingAdminFormStructureResponse {
+  exists: boolean
+  description?: string | null
+  sections: RecruitingAdminFormSectionResponse[]
 }
 
 export interface RecruitingSelectedOption {

--- a/src/features/recruiting/model/recruitmentQuestion.ts
+++ b/src/features/recruiting/model/recruitmentQuestion.ts
@@ -1,6 +1,9 @@
-import { type PartKey, PARTS } from "./parts"
+import { PART_KEY_TO_TRACK, type PartKey, PARTS } from "./parts"
 
 import type {
+  RecruitingAdminFormQuestionResponse,
+  RecruitingAdminFormStructureResponse,
+  RecruitingQuestionType,
   RecruitingTrack,
   UpsertRecruitingSectionRequest,
 } from "../api/types"
@@ -197,24 +200,16 @@ function toRecruitingQuestionType(
   return type === "radio" ? "RADIO" : "SHORT_TEXT"
 }
 
-// 공통 문항(01~05) 섹션을 Form Upsert 요청 payload로 직렬화한다.
-// 파트별(TRACK) 섹션 직렬화는 buildTrackSectionUpsertRequest가 별도로 담당한다.
+// 공통 문항(01~05 고정 문항 + 운영진이 추가한 자유 문항) 섹션을 Form Upsert 요청
+// payload로 직렬화한다. 파트별(TRACK) 섹션 직렬화는 buildTrackSectionUpsertRequest가
+// 별도로 담당한다.
 export function buildCommonSectionUpsertRequest(
   removedOptionsByQuestionIndex: Record<string, string[]>,
   questionToggleState: Record<string, { enabled: boolean; required: boolean }>,
-): {
-  clientKey: string
-  title: string
-  type: "COMMON"
-  questions: {
-    type: "RADIO" | "SHORT_TEXT"
-    title: string
-    description?: string
-    required: boolean
-    options?: { content: string; other: boolean }[]
-  }[]
-} {
-  const questions = RECRUITMENT_DEFAULT_QUESTIONS.filter(
+  additionalQuestions: RecruitmentQuestion[] = [],
+  sectionId?: number,
+): UpsertRecruitingSectionRequest {
+  const defaultQuestions = RECRUITMENT_DEFAULT_QUESTIONS.filter(
     (question) => questionToggleState[question.index]?.enabled ?? true,
   ).map((question) => {
     const removed = removedOptionsByQuestionIndex[question.index] ?? []
@@ -230,11 +225,28 @@ export function buildCommonSectionUpsertRequest(
     }
   })
 
+  const extraQuestions = additionalQuestions.map((question) => ({
+    questionId: question.questionId,
+    type: toRecruitingQuestionTypeFromField(question.fieldType),
+    title: question.title,
+    description: question.caption || undefined,
+    required: question.required,
+    options:
+      question.fieldType === "radio" || question.fieldType === "checkbox"
+        ? question.options.map((option) => ({
+            optionId: option.optionId,
+            content: option.content,
+            other: false,
+          }))
+        : undefined,
+  }))
+
   return {
+    sectionId,
     clientKey: "common",
     title: "기본 문항",
     type: "COMMON",
-    questions,
+    questions: [...defaultQuestions, ...extraQuestions],
   }
 }
 
@@ -261,13 +273,16 @@ export function buildTrackSectionUpsertRequest(
   partLabel: string,
   track: RecruitingTrack,
   questions: RecruitmentQuestion[],
+  sectionId?: number,
 ): UpsertRecruitingSectionRequest {
   return {
+    sectionId,
     clientKey: `track-${track}`,
     title: partLabel,
     type: "TRACK",
     track,
     questions: questions.map((question) => ({
+      questionId: question.questionId,
       type: toRecruitingQuestionTypeFromField(question.fieldType),
       title: question.title,
       description: question.caption || undefined,
@@ -275,10 +290,160 @@ export function buildTrackSectionUpsertRequest(
       options:
         question.fieldType === "radio" || question.fieldType === "checkbox"
           ? question.options.map((option) => ({
+              optionId: option.optionId,
               content: option.content,
               other: false,
             }))
           : undefined,
     })),
+  }
+}
+
+const TRACK_TO_PART_KEY: Record<RecruitingTrack, PartKey | undefined> =
+  Object.fromEntries(
+    Object.entries(PART_KEY_TO_TRACK).map(([partKey, track]) => [
+      track,
+      partKey as PartKey,
+    ]),
+  ) as Record<RecruitingTrack, PartKey | undefined>
+
+// 생성 마법사가 다루는 문항 유형(text/radio/checkbox/file/portfolio) 밖의
+// 응답 타입(LONG_TEXT/DROPDOWN/SCHEDULE 등)은 아직 편집 UI가 없어 "text"로
+// 안전하게 내려서 최소한 값이 사라지진 않게 한다.
+function toRecruitmentFieldType(
+  type: RecruitingQuestionType,
+): RecruitmentFieldType {
+  switch (type) {
+    case "RADIO":
+      return "radio"
+    case "CHECKBOX":
+      return "checkbox"
+    case "FILE":
+      return "file"
+    case "PORTFOLIO":
+      return "portfolio"
+    default:
+      return "text"
+  }
+}
+
+function mapAdminQuestionResponseToRecruitmentQuestion(
+  question: RecruitingAdminFormQuestionResponse,
+): RecruitmentQuestion {
+  const fieldType = toRecruitmentFieldType(question.type)
+  return makeRecruitmentQuestion({
+    questionId: question.questionId,
+    title: fieldType === "portfolio" ? "" : question.title,
+    caption: question.description ?? "",
+    fieldType,
+    required: question.required,
+    options: (question.options ?? []).map((option) => ({
+      optionId: option.optionId,
+      content: option.content,
+    })),
+  })
+}
+
+export interface RecruitmentQuestionDraftState {
+  questionToggleState: Record<string, { enabled: boolean; required: boolean }>
+  removedOptionsByQuestionIndex: Record<string, string[]>
+  commonQuestionDrafts: RecruitmentQuestion[]
+  partQuestionDrafts: Partial<Record<PartKey, RecruitmentQuestion[]>>
+  enabledParts: Partial<Record<PartKey, boolean>>
+  secondChoiceEnabled: boolean
+  // 저장 시 기존 섹션을 새 섹션처럼 보내 백엔드가 지우고 다시 만들지 않도록,
+  // GET 응답의 sectionId를 그대로 들고 있다가 Upsert 요청에 되돌려 보낸다.
+  commonSectionId?: number
+  sectionIdByPart: Partial<Record<PartKey, number>>
+}
+
+// GET .../rounds/{roundId}/form(RecruitingAdminFormStructureResponse) 응답을
+// 생성 마법사 Step2(RecruitmentQuestionForm)가 쓰는 내부 draft 모델로 되돌린다.
+// 고정 문항(01~05)은 제목을 못 바꾸므로 title로 매칭하고, 나머지 COMMON 문항은
+// 운영진이 추가한 자유 문항으로 취급한다. Form이 아직 없으면(exists: false)
+// undefined를 반환해 호출부가 생성 모드와 동일한 빈 draft로 폴백하게 한다.
+export function mapAdminFormToQuestionDraft(
+  structure: RecruitingAdminFormStructureResponse | undefined,
+): RecruitmentQuestionDraftState | undefined {
+  if (!structure || !structure.exists) return undefined
+
+  const commonSection = structure.sections.find((s) => s.type === "COMMON")
+  const trackSections = structure.sections.filter((s) => s.type === "TRACK")
+
+  const questionToggleState: Record<
+    string,
+    { enabled: boolean; required: boolean }
+  > = {}
+  const removedOptionsByQuestionIndex: Record<string, string[]> = {}
+  const commonQuestionDrafts: RecruitmentQuestion[] = []
+
+  const responseQuestions = commonSection?.questions ?? []
+  const matchedResponseQuestions =
+    new Set<RecruitingAdminFormQuestionResponse>()
+
+  for (const defaultQuestion of RECRUITMENT_DEFAULT_QUESTIONS) {
+    const matched = responseQuestions.find(
+      (q) => q.title === defaultQuestion.title,
+    )
+    if (["03", "04"].includes(defaultQuestion.index)) {
+      if (matched) {
+        const responseOptionContents = new Set(
+          (matched.options ?? []).map((o) => o.content),
+        )
+        const removed = (defaultQuestion.options ?? []).filter(
+          (option) => !responseOptionContents.has(option),
+        )
+        questionToggleState[defaultQuestion.index] = {
+          enabled: true,
+          required: matched.required,
+        }
+        if (removed.length > 0) {
+          removedOptionsByQuestionIndex[defaultQuestion.index] = removed
+        }
+      } else {
+        // 2지망(04)만 통째로 끌 수 있다. 1지망(03)이 응답에 없는 건
+        // 비정상 상태라 기본값(활성)으로 둔다.
+        questionToggleState[defaultQuestion.index] = {
+          enabled: defaultQuestion.index !== "04",
+          required: true,
+        }
+      }
+    }
+    if (matched) matchedResponseQuestions.add(matched)
+  }
+
+  for (const question of responseQuestions) {
+    if (matchedResponseQuestions.has(question)) continue
+    commonQuestionDrafts.push(
+      mapAdminQuestionResponseToRecruitmentQuestion(question),
+    )
+  }
+
+  const partQuestionDrafts: Partial<Record<PartKey, RecruitmentQuestion[]>> = {}
+  const enabledParts: Partial<Record<PartKey, boolean>> = {}
+  const sectionIdByPart: Partial<Record<PartKey, number>> = {}
+
+  for (const section of trackSections) {
+    const partKey = section.track && TRACK_TO_PART_KEY[section.track]
+    if (!partKey) continue
+    enabledParts[partKey] = true
+    partQuestionDrafts[partKey] = section.questions.map((question) =>
+      mapAdminQuestionResponseToRecruitmentQuestion(question),
+    )
+    if (section.sectionId != null) sectionIdByPart[partKey] = section.sectionId
+  }
+
+  return {
+    questionToggleState,
+    removedOptionsByQuestionIndex,
+    commonQuestionDrafts:
+      commonQuestionDrafts.length > 0
+        ? commonQuestionDrafts
+        : [makeRecruitmentQuestion()],
+    partQuestionDrafts,
+    enabledParts,
+    secondChoiceEnabled: questionToggleState["04"]?.enabled ?? true,
+    commonSectionId: commonSection?.sectionId,
+    sectionIdByPart,
   }
 }

--- a/src/features/recruiting/model/useRecruitmentCreateStore.tsx
+++ b/src/features/recruiting/model/useRecruitmentCreateStore.tsx
@@ -30,7 +30,6 @@ const DEFAULT_BASIC_INFO: RecruitmentBasicInfo = {
   // 공통 디폴트: 정규 모집·1차가 항상 기본 선택되어 있어야 한다.
   recruitmentType: "REGULAR",
   roundNo: "1",
-  // availability form 빌더 미구현이라 체크박스 자체를 disabled로 막아둠
   interviewRequired: false,
   footer: "",
   periodForm: INITIAL_PERIOD_FORM,

--- a/src/features/recruiting/ui/RecruitmentDraftArchiveCard.tsx
+++ b/src/features/recruiting/ui/RecruitmentDraftArchiveCard.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "@tanstack/react-router"
 import { useState } from "react"
 
 import { cn } from "@/shared/lib/utils"
@@ -13,10 +14,12 @@ import { RecruitmentSchoolSection } from "./RecruitmentSchoolSection"
 
 import type { Chapter } from "@/entities/organization/model/chapters"
 
+import type { RecruitingListRole } from "../model/recruitingListRole"
 import type { RecruitmentPost } from "../model/recruitmentList"
 
 interface RecruitmentDraftArchiveCardProps {
   chapter: Chapter
+  role: RecruitingListRole
   posts: RecruitmentPost[]
   permittedSeasonIds: ReadonlySet<string>
   onPublish: (postId: string) => void
@@ -30,6 +33,8 @@ interface RecruitmentDraftArchiveCardProps {
 
 function DraftPostRow({
   post,
+  role,
+  chapter,
   permittedSeasonIds,
   onPublish,
   onDuplicate,
@@ -37,12 +42,16 @@ function DraftPostRow({
   onUndoDelete,
 }: {
   post: RecruitmentPost
+  role: RecruitingListRole
+  chapter: Chapter
   permittedSeasonIds: ReadonlySet<string>
   onPublish: (postId: string) => void
   onDuplicate: (postId: string) => void
   onDelete: (postId: string) => void
   onUndoDelete: () => void
 }) {
+  const navigate = useNavigate()
+
   return (
     <RecruitmentPostRow
       title={post.title}
@@ -55,14 +64,21 @@ function DraftPostRow({
       rightAction={
         <RecruitmentPostMoreMenu
           status={post.status}
+          role={role}
+          ownChapter={chapter}
           onPublish={() => onPublish(post.postId)}
           // 임시 보관함 안에서는 이미 DRAFT라 비공개 액션이 노출되지 않음
           onPrivatize={() => {}}
-          // TODO: DRAFT 수정은 생성 마법사 재사용 편집이 필요하다(문항 프리필용 조회
-          // API가 아직 없어 대기 중). /recruiting/recruitments/edit/$roundId는 OPEN
-          // 전용이라 DRAFT를 여기로 보내면 "공유 보관함에서 수정해달라"는 안내로
-          // 되돌아오는 순환이 생겨 연결하지 않는다.
-          onEdit={() => console.info("TODO: 모집 공고 수정", post.postId)}
+          // DRAFT는 문항 프리필용 조회 API가 아직 없어 생성 마법사 재사용 편집은
+          // 못 만든다. 우선 OPEN과 같은 수정 화면으로 보내고, 그 화면이 DRAFT
+          // 상태를 보고 "아직 지원하지 않음" 안내를 보여주도록 한다.
+          onEdit={() =>
+            navigate({
+              to: "/recruiting/recruitments/edit/$roundId",
+              params: { roundId: post.postId },
+              search: { seasonId: post.seasonId },
+            })
+          }
           onDuplicate={() => onDuplicate(post.postId)}
           onDelete={() => onDelete(post.postId)}
           onUndoDelete={onUndoDelete}
@@ -74,6 +90,7 @@ function DraftPostRow({
 
 export function RecruitmentDraftArchiveCard({
   chapter,
+  role,
   posts,
   permittedSeasonIds,
   onPublish,
@@ -130,6 +147,8 @@ export function RecruitmentDraftArchiveCard({
                 <DraftPostRow
                   key={post.postId}
                   post={post}
+                  role={role}
+                  chapter={chapter}
                   permittedSeasonIds={permittedSeasonIds}
                   onPublish={onPublish}
                   onDuplicate={onDuplicate}
@@ -154,6 +173,8 @@ export function RecruitmentDraftArchiveCard({
                     <DraftPostRow
                       key={post.postId}
                       post={post}
+                      role={role}
+                      chapter={chapter}
                       permittedSeasonIds={permittedSeasonIds}
                       onPublish={onPublish}
                       onDuplicate={onDuplicate}

--- a/src/features/recruiting/ui/RecruitmentDuplicateModal.tsx
+++ b/src/features/recruiting/ui/RecruitmentDuplicateModal.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useMemo, useState } from "react"
+
+import { CHAPTERS } from "@/entities/organization/model/chapters"
+import CloseThinIcon from "@/shared/assets/icon/close/CloseThinIcon"
+import ResetIcon from "@/shared/assets/icon/reset/ResetIcon"
+import { SCHOOLS_BY_BRANCH } from "@/shared/config/schools"
+import { cn } from "@/shared/lib/utils"
+import { Button } from "@/shared/ui/Button"
+import { CheckboxList } from "@/shared/ui/input/checkbox/CheckboxList"
+import { Modal } from "@/shared/ui/Modal"
+
+import type { Chapter } from "@/entities/organization/model/chapters"
+
+// SUPER_ADMIN/HQ_LEAD/HQ_ADMIN → "central": 전 지부를 넘나들며 학교를 고른다.
+// CHAPTER_ADMIN → "chapterAdmin": 본인 지부 하나로 고정, 학교는 기본 전체 선택.
+// SCHOOL_ADMIN/SCHOOL_STAFF는 이 모달을 아예 띄우지 않고 즉시 복제한다.
+type DuplicateModalRole = "central" | "chapterAdmin"
+
+interface RecruitmentDuplicateModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  role: DuplicateModalRole
+  ownChapter?: Chapter
+  onCancel: () => void
+  onConfirm: (selectedSchools: string[]) => void
+}
+
+export function RecruitmentDuplicateModal({
+  open,
+  onOpenChange,
+  role,
+  ownChapter,
+  onCancel,
+  onConfirm,
+}: RecruitmentDuplicateModalProps) {
+  const chapters = useMemo(
+    () => (role === "central" ? [...CHAPTERS] : ownChapter ? [ownChapter] : []),
+    [role, ownChapter],
+  )
+  const [activeChapter, setActiveChapter] = useState<Chapter | undefined>(
+    chapters[0],
+  )
+  const [selectedSchools, setSelectedSchools] = useState<Set<string>>(new Set())
+
+  // 모달을 다시 열 때마다 role에 맞는 기본 선택 상태로 되돌린다.
+  // chapterAdmin은 본인 지부 학교 전체가 기본 선택, central은 빈 선택으로 시작.
+  useEffect(() => {
+    if (!open) return
+    setActiveChapter(chapters[0])
+    setSelectedSchools(
+      role === "chapterAdmin" && ownChapter
+        ? new Set(SCHOOLS_BY_BRANCH[ownChapter])
+        : new Set(),
+    )
+  }, [open, role, ownChapter, chapters])
+
+  const currentSchools = activeChapter ? SCHOOLS_BY_BRANCH[activeChapter] : []
+  const selectedList = useMemo(() => [...selectedSchools], [selectedSchools])
+  const hasSelection = selectedList.length > 0
+
+  const toggleSchool = (school: string, checked: boolean) => {
+    setSelectedSchools((prev) => {
+      const next = new Set(prev)
+      if (checked) next.add(school)
+      else next.delete(school)
+      return next
+    })
+  }
+
+  const removeSchool = (school: string) => {
+    setSelectedSchools((prev) => {
+      const next = new Set(prev)
+      next.delete(school)
+      return next
+    })
+  }
+
+  return (
+    <Modal.Root
+      open={open}
+      onOpenChange={(nextOpen) => {
+        onOpenChange(nextOpen)
+        if (!nextOpen) onCancel()
+      }}
+    >
+      <Modal.Portal>
+        <Modal.Overlay tone="light" />
+        <Modal.Content className="shadow-drop-neutral-1 flex max-h-[calc(100vh-4rem)] w-[46.75rem] max-w-[calc(100vw-2rem)] flex-col rounded-[0.625rem] border border-neutral-200 bg-white focus:outline-none">
+          <div className="flex flex-col items-start gap-4 px-8 pt-8">
+            <div className="flex flex-col items-start gap-2 px-1">
+              <Modal.Title className="text-teal-gray-900 text-[1.625rem] leading-[130%] font-semibold">
+                모집 공고 복제하기
+              </Modal.Title>
+              <Modal.Description className="text-teal-gray-500 w-[27.5rem] max-w-full leading-[145%]">
+                선택한 학교의 공유 보관함에 추가됩니다.
+              </Modal.Description>
+            </div>
+
+            <div className="flex w-full items-start justify-between">
+              <div className="flex flex-col items-start gap-1.5 py-2 pr-4">
+                {chapters.map((chapter) => {
+                  const active = chapter === activeChapter
+                  return (
+                    <button
+                      key={chapter}
+                      type="button"
+                      disabled={role === "chapterAdmin"}
+                      onClick={() => setActiveChapter(chapter)}
+                      className={cn(
+                        "flex h-11 w-[8.875rem] items-center gap-2.5 rounded-xl px-4 text-lg leading-[140%]",
+                        active
+                          ? "bg-teal-50 font-semibold text-teal-700"
+                          : "text-teal-gray-500 font-medium",
+                        role === "chapterAdmin" && "cursor-default",
+                      )}
+                    >
+                      {chapter}
+                    </button>
+                  )
+                })}
+              </div>
+
+              <div className="border-teal-gray-200 bg-teal-gray-50 flex max-h-100 w-[30.625rem] max-w-full items-start gap-2.5 overflow-y-auto border-l p-6">
+                <div className="flex flex-col items-start gap-4">
+                  {currentSchools.map((school) => (
+                    <CheckboxList
+                      key={school}
+                      checked={selectedSchools.has(school)}
+                      onChange={(checked) => toggleSchool(school, checked)}
+                    >
+                      {school}
+                    </CheckboxList>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="border-teal-gray-200 flex flex-col items-start gap-2.5 border-t bg-white py-5 pr-8 pl-[2.375rem]">
+            <div className="flex w-full items-center gap-4">
+              <button
+                type="button"
+                onClick={() => setSelectedSchools(new Set())}
+                className="flex items-center gap-2.5"
+              >
+                <span
+                  className={cn(
+                    "leading-[140%] text-teal-600",
+                    hasSelection ? "font-semibold" : "font-medium",
+                  )}
+                >
+                  선택 {selectedList.length}
+                </span>
+                <ResetIcon className="text-teal-gray-300 h-4 w-4" />
+              </button>
+              <div className="bg-teal-gray-100 h-[1.1875rem] w-px shrink-0" />
+              <div className="flex flex-1 items-center gap-1 overflow-x-auto">
+                {selectedList.map((school) => (
+                  <button
+                    key={school}
+                    type="button"
+                    onClick={() => removeSchool(school)}
+                    className="text-teal-gray-600 flex h-7 shrink-0 items-center gap-1 px-1 leading-[140%] font-medium"
+                  >
+                    {school}
+                    <CloseThinIcon className="h-2.5 w-2.5" />
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex items-start gap-2.5 px-8 pt-0 pb-8">
+            <Button
+              type="button"
+              variant="weak"
+              color="neutral"
+              size="s"
+              className="h-11 min-w-16 rounded-[0.625rem]"
+              onClick={onCancel}
+            >
+              돌아가기
+            </Button>
+            <Button
+              type="button"
+              variant="fill"
+              color="primary"
+              size="s"
+              className="h-11 min-w-19 rounded-[0.625rem]"
+              disabled={!hasSelection}
+              onClick={() => onConfirm(selectedList)}
+            >
+              복제하기
+            </Button>
+          </div>
+        </Modal.Content>
+      </Modal.Portal>
+    </Modal.Root>
+  )
+}

--- a/src/features/recruiting/ui/RecruitmentListPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentListPage.tsx
@@ -132,6 +132,7 @@ export function RecruitmentListPage({
     isLoading: isRoundsLoading,
     isError: isRoundsError,
     isForbidden,
+    refetch: refetchRounds,
   } = useAdminRecruitingRounds(sort)
 
   // 편집 권한은 role이 아니라 시즌 단위 실제 EDIT 권한으로 판정한다(canEditRecruitmentPost 참고).
@@ -269,22 +270,35 @@ export function RecruitmentListPage({
       })
       return
     }
+    if (cloneRound.isPending) return
     const post = basePosts.find((item) => item.postId === postId)
     if (!post) return
-    // 같은 글을 여러 번 복제해도 제목이 겹치지 않도록 사용 가능한 제목을 먼저 찾는다.
-    void resolveAvailableTitle(`${post.title} 복제본`, (title) =>
-      checkRecruitingRoundTitleAvailability(post.seasonId, title).catch(
-        () => true,
-      ),
-    ).then((title) => {
-      cloneRound.mutate({
-        seasonId: post.seasonId,
-        roundId: postId,
-        payload: {
-          targetSeasonId: post.seasonId,
-          title,
-          type: post.type,
-        },
+    // roundNo는 화면에 캐시된 groups(staleTime 5분)가 아니라 매번 새로 받아온
+    // 목록으로 계산해야 한다. 캐시가 갱신되기 전에 연달아 복제하면 직전 복제로
+    // 이미 쓰인 번호를 또 계산해 RECRUITING-0116("이전 차수 다음 번호") 충돌이 난다.
+    void refetchRounds().then(({ data: freshGroups }) => {
+      const sameSeasonRounds =
+        freshGroups?.find((group) => group.seasonId === post.seasonId)
+          ?.rounds ?? []
+      const nextRoundNo =
+        Math.max(0, ...sameSeasonRounds.map((round) => Number(round.roundNo))) +
+        1
+      // 같은 글을 여러 번 복제해도 제목이 겹치지 않도록 사용 가능한 제목을 먼저 찾는다.
+      void resolveAvailableTitle(`${post.title} 복제본`, (title) =>
+        checkRecruitingRoundTitleAvailability(post.seasonId, title).catch(
+          () => true,
+        ),
+      ).then((title) => {
+        cloneRound.mutate({
+          seasonId: post.seasonId,
+          roundId: postId,
+          payload: {
+            targetSeasonId: post.seasonId,
+            title,
+            type: "ADDITIONAL",
+            roundNo: nextRoundNo,
+          },
+        })
       })
     })
   }
@@ -432,6 +446,7 @@ export function RecruitmentListPage({
                     </div>
                     <RecruitmentPostListCard
                       chapter={chapter}
+                      role={role}
                       posts={scopedPosts}
                       permittedSeasonIds={permittedSeasonIds}
                       onPrivatize={handlePrivatize}
@@ -450,6 +465,7 @@ export function RecruitmentListPage({
                         </h2>
                         <RecruitmentDraftArchiveCard
                           chapter={chapter}
+                          role={role}
                           posts={scopedPosts}
                           permittedSeasonIds={permittedSeasonIds}
                           onPublish={handlePublish}
@@ -469,6 +485,7 @@ export function RecruitmentListPage({
           {!showChapterTabs && ownScopeChapter && (
             <RecruitmentOwnScopeSection
               chapter={ownScopeChapter}
+              role={role}
               posts={viewPosts}
               schoolTab={ownScopeSchoolTab}
               permittedSeasonIds={permittedSeasonIds}

--- a/src/features/recruiting/ui/RecruitmentNoticePage.tsx
+++ b/src/features/recruiting/ui/RecruitmentNoticePage.tsx
@@ -1,13 +1,15 @@
 import { useNavigate } from "@tanstack/react-router"
-import { useMemo, useState } from "react"
+import { useState } from "react"
 
 import FilterIcon from "@/shared/assets/icon/filter/FilterIcon"
 import { SCHOOLS_BY_BRANCH } from "@/shared/config/schools"
+import { formatSchoolName } from "@/shared/lib/formatSchoolName"
 import { PART_TAG_LABEL } from "@/shared/model/domain"
 import { FilterDropdown } from "@/shared/ui/FilterDropDown"
 import { Segment } from "@/shared/ui/segment/Segment"
 
 import { usePublicRecruitmentNotices } from "../hooks/usePublicRecruitmentNotices"
+import { TRACK_PART_TAG } from "../model/applicantMapper"
 import { formatNoticePeriod } from "../model/recruitmentNotice"
 import { RecruitmentApplyConfirmModal } from "./RecruitmentApplyConfirmModal"
 import { RecruitmentNoticeCard } from "./RecruitmentNoticeCard"
@@ -25,10 +27,20 @@ const NOTICE_TABS: { id: NoticeTab; label: string }[] = [
   { id: "past", label: "이미 지난 모집" },
 ]
 
-// 검색 자동완성은 지부 상관없이 전체 학교를 대상으로 한다.
+// 검색 자동완성과 학교 필터는 지부 상관없이 전체 학교를 대상으로 한다.
 const ALL_SCHOOLS = Object.values(SCHOOLS_BY_BRANCH).flat()
+const SCHOOL_FILTER_OPTIONS = ALL_SCHOOLS.map((school) => ({
+  value: school,
+  label: school,
+}))
 
-const NOTICE_FILTER_PARTS: PartTag[] = ["pm", "design", "web-pe", "mobile-pe"]
+const NOTICE_FILTER_PARTS = Array.from(
+  new Set(
+    Object.values(TRACK_PART_TAG).filter(
+      (part): part is PartTag => part != null,
+    ),
+  ),
+)
 const PART_FILTER_OPTIONS = NOTICE_FILTER_PARTS.map((part) => ({
   value: part,
   label: PART_TAG_LABEL[part],
@@ -50,19 +62,12 @@ export function RecruitmentNoticePage() {
 
   const { items: allItems, isLoading, isError } = usePublicRecruitmentNotices()
 
-  const schoolFilterOptions = useMemo(
-    () =>
-      Array.from(new Set(allItems.map((item) => item.schoolName))).map(
-        (school) => ({ value: school, label: school }),
-      ),
-    [allItems],
-  )
-
   const items = allItems.filter((item) => {
     if (tab === "recruiting" && item.isClosed) return false
     if (tab === "past" && !item.isClosed) return false
-    if (search && !item.schoolName.includes(search)) return false
-    if (schoolFilters.length > 0 && !schoolFilters.includes(item.schoolName))
+    const schoolName = formatSchoolName(item.schoolName)
+    if (search && !schoolName.includes(search)) return false
+    if (schoolFilters.length > 0 && !schoolFilters.includes(schoolName))
       return false
     if (
       partFilters.length > 0 &&
@@ -100,7 +105,7 @@ export function RecruitmentNoticePage() {
                 )
               }
               onRequestClose={() => setOpenFilterKey(null)}
-              options={schoolFilterOptions}
+              options={SCHOOL_FILTER_OPTIONS}
               selectedValues={schoolFilters}
               onSelectedValuesChange={(values) => {
                 setSchoolFilters(values)

--- a/src/features/recruiting/ui/RecruitmentOwnScopeSection.tsx
+++ b/src/features/recruiting/ui/RecruitmentOwnScopeSection.tsx
@@ -4,10 +4,12 @@ import { RecruitmentPostListCard } from "./RecruitmentPostListCard"
 
 import type { Chapter } from "@/entities/organization/model/chapters"
 
+import type { RecruitingListRole } from "../model/recruitingListRole"
 import type { RecruitmentPost } from "../model/recruitmentList"
 
 interface RecruitmentOwnScopeSectionProps {
   chapter: Chapter
+  role: RecruitingListRole
   posts: RecruitmentPost[]
   schoolTab: string
   permittedSeasonIds: ReadonlySet<string>
@@ -25,6 +27,7 @@ interface RecruitmentOwnScopeSectionProps {
 // chapterAdmin(본인 지부 전체)과 schoolStaff(본인 학교)가 공유하는 "내 스코프" 목록 + 공유 보관함 섹션
 export function RecruitmentOwnScopeSection({
   chapter,
+  role,
   posts,
   schoolTab,
   permittedSeasonIds,
@@ -53,6 +56,7 @@ export function RecruitmentOwnScopeSection({
       </div>
       <RecruitmentPostListCard
         chapter={chapter}
+        role={role}
         posts={posts}
         permittedSeasonIds={permittedSeasonIds}
         onPrivatize={onPrivatize}
@@ -71,6 +75,7 @@ export function RecruitmentOwnScopeSection({
           </h2>
           <RecruitmentDraftArchiveCard
             chapter={chapter}
+            role={role}
             posts={posts}
             permittedSeasonIds={permittedSeasonIds}
             onPublish={onPublish}

--- a/src/features/recruiting/ui/RecruitmentPostListCard.tsx
+++ b/src/features/recruiting/ui/RecruitmentPostListCard.tsx
@@ -14,10 +14,12 @@ import { RecruitmentSchoolSection } from "./RecruitmentSchoolSection"
 
 import type { Chapter } from "@/entities/organization/model/chapters"
 
+import type { RecruitingListRole } from "../model/recruitingListRole"
 import type { RecruitmentPost } from "../model/recruitmentList"
 
 interface RecruitmentPostListCardProps {
   chapter: Chapter
+  role: RecruitingListRole
   posts: RecruitmentPost[]
   permittedSeasonIds: ReadonlySet<string>
   onPrivatize: (postId: string) => void
@@ -32,6 +34,8 @@ interface RecruitmentPostListCardProps {
 
 function PostRow({
   post,
+  role,
+  chapter,
   permittedSeasonIds,
   onPrivatize,
   onDuplicate,
@@ -41,6 +45,8 @@ function PostRow({
   archiveVisibleOnPage,
 }: {
   post: RecruitmentPost
+  role: RecruitingListRole
+  chapter: Chapter
   permittedSeasonIds: ReadonlySet<string>
   onPrivatize: (postId: string) => void
   onDuplicate: (postId: string) => void
@@ -64,6 +70,8 @@ function PostRow({
       rightAction={
         <RecruitmentPostMoreMenu
           status={post.status}
+          role={role}
+          ownChapter={chapter}
           onPublish={() => {}}
           onPrivatize={() => onPrivatize(post.postId)}
           onEdit={() =>
@@ -86,6 +94,7 @@ function PostRow({
 
 export function RecruitmentPostListCard({
   chapter,
+  role,
   posts,
   permittedSeasonIds,
   onPrivatize,
@@ -178,6 +187,8 @@ export function RecruitmentPostListCard({
                       <PostRow
                         key={post.postId}
                         post={post}
+                        role={role}
+                        chapter={chapter}
                         permittedSeasonIds={permittedSeasonIds}
                         onPrivatize={onPrivatize}
                         onDuplicate={onDuplicate}
@@ -199,6 +210,8 @@ export function RecruitmentPostListCard({
             <PostRow
               key={post.postId}
               post={post}
+              role={role}
+              chapter={chapter}
               permittedSeasonIds={permittedSeasonIds}
               onPrivatize={onPrivatize}
               onDuplicate={onDuplicate}

--- a/src/features/recruiting/ui/RecruitmentPostMoreMenu.tsx
+++ b/src/features/recruiting/ui/RecruitmentPostMoreMenu.tsx
@@ -7,10 +7,20 @@ import { DropdownItem } from "@/shared/ui/dropdown/DropdownItem"
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
 import { useToastStore } from "@/shared/ui/toast/useToastStore"
 
+import { RecruitmentDuplicateModal } from "./RecruitmentDuplicateModal"
+
+import type { Chapter } from "@/entities/organization/model/chapters"
+
+import type { RecruitingListRole } from "../model/recruitingListRole"
 import type { RecruitmentPostStatus } from "../model/recruitmentList"
 
 interface RecruitmentPostMoreMenuProps {
   status: RecruitmentPostStatus
+  // 복제하기 분기 기준: central(최고관리자/총괄·부총괄/중앙운영·교육국)은 전 지부
+  // 학교 선택 모달, chapterAdmin(지부장)은 본인 지부 학교 선택 모달(기본 전체
+  // 선택), schoolStaff(교내 회장단/운영진)는 모달 없이 본인 학교로 즉시 복제.
+  role: RecruitingListRole
+  ownChapter?: Chapter
   onPublish: () => void
   onPrivatize: () => void
   onEdit?: () => void
@@ -25,6 +35,8 @@ interface RecruitmentPostMoreMenuProps {
 
 export function RecruitmentPostMoreMenu({
   status,
+  role,
+  ownChapter,
   onPublish,
   onPrivatize,
   onEdit,
@@ -38,8 +50,20 @@ export function RecruitmentPostMoreMenu({
   const [popoverOpen, setPopoverOpen] = useState(false)
   const [privatizeConfirmOpen, setPrivatizeConfirmOpen] = useState(false)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
-  const [duplicateConfirmOpen, setDuplicateConfirmOpen] = useState(false)
+  const [duplicateModalOpen, setDuplicateModalOpen] = useState(false)
   const shouldPreventFocusRestoreRef = useRef(false)
+
+  const duplicateSuccessToast = () =>
+    addToast({
+      message: "모집 공고가 공유 보관함에 복제되었습니다.",
+      color: "primary",
+      variant: "deep",
+      type: "default",
+      duration: 3000,
+      action: showArchiveLink
+        ? { label: "바로가기", onClick: () => onNavigateToArchive?.() }
+        : undefined,
+    })
 
   const withClose = (action?: () => void) => () => {
     setPopoverOpen(false)
@@ -72,9 +96,16 @@ export function RecruitmentPostMoreMenu({
   }
 
   const handleDuplicateClick = () => {
-    shouldPreventFocusRestoreRef.current = true
     setPopoverOpen(false)
-    setDuplicateConfirmOpen(true)
+    // schoolStaff(교내 회장단/운영진)는 학교 선택지가 본인 학교뿐이라
+    // 모달 없이 바로 본인 학교로 복제한다.
+    if (role === "schoolStaff") {
+      onDuplicate()
+      duplicateSuccessToast()
+      return
+    }
+    shouldPreventFocusRestoreRef.current = true
+    setDuplicateModalOpen(true)
   }
 
   return (
@@ -189,30 +220,20 @@ export function RecruitmentPostMoreMenu({
         }}
       />
 
-      <CtaModal
-        open={duplicateConfirmOpen}
-        title="모집을 복제할까요?"
-        content="선택한 학교의 공유 보관함에 사본으로 저장됩니다."
-        cancelText="돌아가기"
-        confirmText="복제하기"
-        variant="success"
-        onOpenChange={setDuplicateConfirmOpen}
-        onCancel={() => setDuplicateConfirmOpen(false)}
-        onConfirm={() => {
-          setDuplicateConfirmOpen(false)
-          onDuplicate()
-          addToast({
-            message: "모집 공고가 공유 보관함에 복제되었습니다.",
-            color: "primary",
-            variant: "deep",
-            type: "default",
-            duration: 3000,
-            action: showArchiveLink
-              ? { label: "바로가기", onClick: () => onNavigateToArchive?.() }
-              : undefined,
-          })
-        }}
-      />
+      {role !== "schoolStaff" && (
+        <RecruitmentDuplicateModal
+          open={duplicateModalOpen}
+          role={role}
+          ownChapter={ownChapter}
+          onOpenChange={setDuplicateModalOpen}
+          onCancel={() => setDuplicateModalOpen(false)}
+          onConfirm={() => {
+            setDuplicateModalOpen(false)
+            onDuplicate()
+            duplicateSuccessToast()
+          }}
+        />
+      )}
     </>
   )
 }

--- a/src/features/recruiting/ui/RecruitmentQuestionsEditSection.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuestionsEditSection.tsx
@@ -1,0 +1,92 @@
+import { useQuery } from "@tanstack/react-query"
+import { useEffect } from "react"
+
+import { recruitingKeys } from "../api/queryKeys"
+import { getRecruitingApplicationForm } from "../api/recruitingApi"
+import {
+  RecruitmentCreateStoreProvider,
+  useRecruitmentCreateStoreApi,
+} from "../model/useRecruitmentCreateStore"
+import { RecruitmentQuestionForm } from "./create/RecruitmentQuestionForm"
+
+import type { Chapter } from "@/entities/organization/model/chapters"
+
+import type { RecruitingRound } from "../api/types"
+
+interface RecruitmentQuestionsEditSectionProps {
+  seasonId: string
+  roundId: string
+  chapter: Chapter
+  school: string
+  round: RecruitingRound
+}
+
+// 문항 수정 화면 진입점. 생성 마법사 Step2(RecruitmentQuestionForm)를 edit
+// 모드로 재사용하려면 그 컴포넌트가 읽는 RecruitmentCreateStore에 이 Round의
+// seasonId/roundId/basicInfo를 먼저 채워 넣어야 한다. DRAFT/OPEN 둘 다 이
+// 화면을 쓴다.
+export function RecruitmentQuestionsEditSection(
+  props: RecruitmentQuestionsEditSectionProps,
+) {
+  return (
+    <RecruitmentCreateStoreProvider>
+      <RecruitmentQuestionsEditSectionInner {...props} />
+    </RecruitmentCreateStoreProvider>
+  )
+}
+
+function RecruitmentQuestionsEditSectionInner({
+  seasonId,
+  roundId,
+  chapter,
+  school,
+  round,
+}: RecruitmentQuestionsEditSectionProps) {
+  const storeApi = useRecruitmentCreateStoreApi()
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: recruitingKeys.adminFormStructure(seasonId, roundId),
+    queryFn: () => getRecruitingApplicationForm(seasonId, roundId),
+  })
+
+  // 스토어 세팅 순서가 중요하다: setSeasonId/patchBasicInfo(recruitmentType·
+  // roundNo 변경 시)는 부수효과로 roundId를 null로 되돌리므로, 기존 roundId를
+  // 세팅하는 setRoundId는 반드시 마지막에 호출해야 한다. 그래야 Step2가 저장 시
+  // createRecruitingRound가 아니라 upsertRecruitingApplicationForm으로만 간다.
+  useEffect(() => {
+    const { setSeasonId, patchBasicInfo, setRoundId } = storeApi.getState()
+    setSeasonId(seasonId)
+    patchBasicInfo({
+      chapter,
+      school,
+      recruitmentType: round.type,
+      roundNo: String(round.roundNo),
+    })
+    setRoundId(roundId)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [seasonId, roundId])
+
+  if (isLoading) {
+    return (
+      <div className="border-teal-gray-100 text-body-2-regular text-teal-gray-500 mt-6 flex min-h-50 w-full items-center justify-center rounded-[12px] border bg-white">
+        문항을 불러오는 중입니다...
+      </div>
+    )
+  }
+
+  if (isError) {
+    return (
+      <div className="border-teal-gray-100 text-body-2-regular text-teal-gray-500 mt-6 flex min-h-50 w-full items-center justify-center rounded-[12px] border bg-white">
+        모집 문항을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+      </div>
+    )
+  }
+
+  return (
+    <RecruitmentQuestionForm
+      mode="edit"
+      initialFormStructure={data}
+      sectionIndex={5}
+    />
+  )
+}

--- a/src/features/recruiting/ui/RecruitmentRoundEditPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentRoundEditPage.tsx
@@ -1,6 +1,8 @@
+import { isChapter } from "@/entities/organization/model/chapters"
 import { PageLabel } from "@/shared/ui/page-label/PageLabel"
 
 import { useAdminRecruitingRounds } from "../hooks/useAdminRecruitingRounds"
+import { RecruitmentQuestionsEditSection } from "./RecruitmentQuestionsEditSection"
 import { RecruitmentRoundSettingsEditForm } from "./RecruitmentRoundSettingsEditForm"
 
 interface RecruitmentRoundEditPageProps {
@@ -16,8 +18,8 @@ function EditNotice({ message }: { message: string }) {
   )
 }
 
-// OPEN 상태 차수의 설정(기간·트랙·2지망·공고)만 고치는 화면. DRAFT는 아직 생성
-// 마법사 재사용 편집이 없고(Step2 문항 프리필 미구현), CLOSED는 목록 화면
+// DRAFT/OPEN 둘 다 설정(기간·트랙·2지망·공고)과 지원 문항(GET/PUT
+// .../rounds/{roundId}/form)을 같은 화면에서 고친다. CLOSED는 목록 화면
 // 메뉴에서부터 "수정하기" 진입 자체를 막는다.
 export function RecruitmentRoundEditPage({
   seasonId,
@@ -26,6 +28,8 @@ export function RecruitmentRoundEditPage({
   const { groups, isLoading, isForbidden, isError } = useAdminRecruitingRounds()
   const group = groups.find((g) => g.seasonId === seasonId)
   const round = group?.rounds.find((r) => r.roundId === roundId)
+  const chapter =
+    group && isChapter(group.chapterName) ? group.chapterName : undefined
 
   return (
     <div className="flex w-full max-w-286.5 flex-col">
@@ -44,18 +48,25 @@ export function RecruitmentRoundEditPage({
         <EditNotice message="불러오는 중입니다..." />
       ) : isForbidden ? (
         <EditNotice message="이 화면을 조회할 권한이 없습니다." />
-      ) : isError || !group || !round || round.status == null ? (
+      ) : isError || !group || !round || round.status == null || !chapter ? (
         <EditNotice message="모집 정보를 찾을 수 없습니다." />
-      ) : round.status === "DRAFT" ? (
-        <EditNotice message="아직 공개되지 않은 모집은 모집 목록의 공유 보관함에서 수정해 주세요." />
       ) : round.status === "CLOSED" ? (
         <EditNotice message="마감된 모집은 수정할 수 없습니다." />
       ) : (
-        <RecruitmentRoundSettingsEditForm
-          seasonId={seasonId}
-          roundId={roundId}
-          round={round}
-        />
+        <div className="flex flex-col gap-6">
+          <RecruitmentRoundSettingsEditForm
+            seasonId={seasonId}
+            roundId={roundId}
+            round={round}
+          />
+          <RecruitmentQuestionsEditSection
+            seasonId={seasonId}
+            roundId={roundId}
+            chapter={chapter}
+            school={group.schoolName}
+            round={round}
+          />
+        </div>
       )}
     </div>
   )

--- a/src/features/recruiting/ui/RecruitmentRoundSettingsEditForm.tsx
+++ b/src/features/recruiting/ui/RecruitmentRoundSettingsEditForm.tsx
@@ -69,24 +69,19 @@ function validatePeriodOrder(
   return null
 }
 
-// 면접 관련 값은 이 폼에서 편집하지 않는다(availability form 빌더 미구현이라
-// 앱 전역에서 interviewRequired=false로 강제 중). 기존 값을 그대로 되돌려 보낸다.
+// 면접 관련 값은 이 폼에서 편집하지 않는다. 기존 값을 그대로 되돌려 보낸다.
 // interviewRequired가 true인데 나머지 값이 비어있는 비정상 상태면, 그걸 조용히
 // false로 낮춰버리지 않고 null을 반환해 저장 자체를 막는다.
+// 면접 일정 Form(availabilityFormId)은 서버가 자동으로 만들어 주므로 여기서는 다루지 않는다.
 function resolveInterviewFields(
   round: RecruitingRound,
 ): CreateRecruitingRoundInterviewFields | null {
   if (!round.interviewRequired) return { interviewRequired: false }
-  if (
-    round.interviewStartAt &&
-    round.interviewEndAt &&
-    round.availabilityFormId
-  ) {
+  if (round.interviewStartAt && round.interviewEndAt) {
     return {
       interviewRequired: true,
       interviewStartAt: round.interviewStartAt,
       interviewEndAt: round.interviewEndAt,
-      availabilityFormId: round.availabilityFormId,
     }
   }
   return null
@@ -434,7 +429,11 @@ export function RecruitmentRoundSettingsEditForm({
         onOpenChange={setConfirmOpen}
         variant="success"
         title="변경 사항을 저장할까요?"
-        content="이미 공개된 모집 공고의 설정이 변경됩니다."
+        content={
+          round.status === "DRAFT"
+            ? "임시 저장된 모집 공고의 설정이 저장됩니다."
+            : "이미 공개된 모집 공고의 설정이 변경됩니다."
+        }
         cancelText="돌아가기"
         confirmText="저장하기"
         onCancel={() => setConfirmOpen(false)}

--- a/src/features/recruiting/ui/create/RecruitmentAnnouncementForm.tsx
+++ b/src/features/recruiting/ui/create/RecruitmentAnnouncementForm.tsx
@@ -84,15 +84,15 @@ export function RecruitmentAnnouncementForm({
 
   // Round PUT은 완전 교체라 recruitableTracks/기간 등 필수 필드를 스토어의
   // 최신 값으로 매번 전부 채워 보내야 한다(announcement만 담아 보내면 400).
-  // interviewRequired는 2단계 진입 시점에 이미 false로 고정된 상태로만 Round가
-  // 만들어졌으므로(면접 있는 모집은 그 전에 막힘) 여기서도 동일하게 false로 보낸다.
+  // interviewRequired도 1단계에서 고른 값을 그대로 보내야 한다 — 여기서 false로
+  // 고정하면 1·2단계에서 설정한 면접 여부·기간이 게시 시점에 사라진다.
   const buildRoundUpdatePayload = () =>
     buildRoundConfigurationPayload({
       title: composeRecruitmentTitle(previewTitle, basicInfo.footer),
       recruitableTracks: getRecruitableTracks(enabledParts),
       secondChoiceEnabled,
       periodForm: basicInfo.periodForm,
-      interviewRequired: false,
+      interviewRequired: basicInfo.interviewRequired,
       announcement,
       contactText,
     })
@@ -251,7 +251,7 @@ export function RecruitmentAnnouncementForm({
         title="임시 저장 완료"
         content="임시저장이 완료되었습니다."
         confirmText="확인"
-        onConfirm={() => navigate({ to: "/recruiting/recruitments" })}
+        onConfirm={() => setShowTempSaveModal(false)}
       />
     </div>
   )

--- a/src/features/recruiting/ui/create/RecruitmentBasicInfoForm.tsx
+++ b/src/features/recruiting/ui/create/RecruitmentBasicInfoForm.tsx
@@ -1,5 +1,4 @@
 import { useQuery } from "@tanstack/react-query"
-import { useNavigate } from "@tanstack/react-router"
 import { isAxiosError } from "axios"
 import { useEffect, useRef, useState } from "react"
 
@@ -202,7 +201,6 @@ export function RecruitmentBasicInfoForm({
   initialSchool,
 }: RecruitmentBasicInfoFormProps) {
   const addToast = useToastStore((state) => state.addToast)
-  const navigate = useNavigate()
   const [showTempSaveModal, setShowTempSaveModal] = useState(false)
   const [tempSaveMessage, setTempSaveMessage] =
     useState("임시저장이 완료되었습니다.")
@@ -272,9 +270,7 @@ export function RecruitmentBasicInfoForm({
     staleTime: 5 * 60 * 1000,
   })
   const chapterEntries = chaptersQuery.data?.chapters ?? []
-  const chapterOptions = chapterEntries
-    .map((entry) => entry.chapterName)
-    .filter(isChapter)
+  const chapterOptions = CHAPTERS
   const selectedChapterEntry = chapterEntries.find(
     (entry) => entry.chapterName === chapter,
   )
@@ -316,11 +312,23 @@ export function RecruitmentBasicInfoForm({
   // 로그인 정보가 늦게 도착해도 다시 채운다.
   useEffect(() => {
     if (!isRoleResolved) return
-    patchBasicInfo({
+    const prefill = {
       chapter:
         initialChapter ?? (role === "central" ? CHAPTERS[0] : viewerChapter),
       school:
         initialSchool ?? (role === "schoolStaff" ? viewerSchool : undefined),
+    }
+    patchBasicInfo(prefill)
+    // 이 프리필은 사용자 입력이 아니라 초기값 채움이므로, 스냅샷 캡처(마운트) 이후에
+    // 반영되더라도 기준선에 포함시켜 이탈 모달이 곧바로 뜨지 않게 한다.
+    savedSnapshotRef.current = JSON.stringify({
+      chapter: prefill.chapter,
+      school: prefill.school,
+      recruitmentType,
+      roundNo,
+      interviewRequired,
+      footer,
+      periodForm,
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isRoleResolved, role, viewerChapter, viewerSchool])
@@ -545,7 +553,15 @@ export function RecruitmentBasicInfoForm({
       return
     }
 
-    savedSnapshotRef.current = currentSnapshot
+    savedSnapshotRef.current = JSON.stringify({
+      chapter,
+      school,
+      recruitmentType,
+      roundNo,
+      interviewRequired,
+      footer: resolvedFooter,
+      periodForm,
+    })
     setIsSaving(false)
     setTempSaveMessage(
       roundId
@@ -687,10 +703,10 @@ export function RecruitmentBasicInfoForm({
     isPeriodFieldComplete(periodForm.documentStartAt) &&
     isPeriodFieldComplete(periodForm.documentEndAt) &&
     isPeriodFieldComplete(periodForm.documentResultPublishedAt) &&
+    isPeriodFieldComplete(periodForm.finalResultPublishedAt) &&
     (!interviewRequired ||
       (isPeriodFieldComplete(periodForm.interviewStartAt) &&
-        isPeriodFieldComplete(periodForm.interviewEndAt))) &&
-    isPeriodFieldComplete(periodForm.finalResultPublishedAt)
+        isPeriodFieldComplete(periodForm.interviewEndAt)))
 
   const handleNext = async () => {
     if (isAdvancing) return
@@ -981,11 +997,14 @@ export function RecruitmentBasicInfoForm({
                         ? `${periodForm.documentStartAt.date} ${periodForm.documentStartAt.time}`
                         : "2000-00-00 00:00"
                     }
-                    endLabel={
-                      periodForm.finalResultPublishedAt.date
-                        ? `${periodForm.finalResultPublishedAt.date.slice(5)} ${periodForm.finalResultPublishedAt.time}`
+                    endLabel={(() => {
+                      const endField = interviewRequired
+                        ? periodForm.finalResultPublishedAt
+                        : periodForm.documentResultPublishedAt
+                      return endField.date
+                        ? `${endField.date.slice(5)} ${endField.time}`
                         : "00-00 23:59"
-                    }
+                    })()}
                     className="flex-1"
                   />
                 </div>
@@ -1276,7 +1295,7 @@ export function RecruitmentBasicInfoForm({
         title="임시 저장 완료"
         content={tempSaveMessage}
         confirmText="확인"
-        onConfirm={() => navigate({ to: "/recruiting/recruitments" })}
+        onConfirm={() => setShowTempSaveModal(false)}
       />
     </>
   )

--- a/src/features/recruiting/ui/create/RecruitmentQuestionForm.tsx
+++ b/src/features/recruiting/ui/create/RecruitmentQuestionForm.tsx
@@ -1,4 +1,3 @@
-import { useNavigate } from "@tanstack/react-router"
 import { isAxiosError } from "axios"
 import { useEffect, useRef, useState } from "react"
 
@@ -47,6 +46,7 @@ import {
   buildTrackSectionUpsertRequest,
   getRecruitmentFieldTypePatch,
   makeRecruitmentQuestion,
+  mapAdminFormToQuestionDraft,
   RECRUITMENT_DEFAULT_QUESTIONS,
   validateRecruitmentQuestionForm,
 } from "../../model/recruitmentQuestion"
@@ -56,6 +56,7 @@ import { RecruitmentSectionHeader } from "../RecruitmentSectionHeader"
 
 import type { FieldTypeOption } from "@/shared/ui/button/FieldTypeButtonGroup"
 
+import type { RecruitingAdminFormStructureResponse } from "../../api/types"
 import type { PartKey } from "../../model/parts"
 import type {
   RecruitmentDefaultQuestion,
@@ -472,10 +473,15 @@ function DefaultRadioQuestion({
 }
 
 interface RecruitmentQuestionFormProps {
-  onPrev: () => void
-  onNext: () => void
+  onPrev?: () => void
+  onNext?: () => void
   onDirtyChange?: (dirty: boolean) => void
   onBlankPartsChange?: (hasBlankEnabledPart: boolean) => void
+  // "edit"는 모집 공고 수정 화면 전용. 생성 마법사의 이전/다음 이동 없이
+  // 문항만 불러와 고치고 그 자리에서 저장한다.
+  mode?: "create" | "edit"
+  initialFormStructure?: RecruitingAdminFormStructureResponse
+  sectionIndex?: number
 }
 
 export function RecruitmentQuestionForm({
@@ -483,9 +489,20 @@ export function RecruitmentQuestionForm({
   onNext,
   onDirtyChange,
   onBlankPartsChange,
+  mode = "create",
+  initialFormStructure,
+  sectionIndex = 3,
 }: RecruitmentQuestionFormProps) {
-  const navigate = useNavigate()
   const addToast = useToastStore((state) => state.addToast)
+  const initialDraft = useState(() =>
+    mapAdminFormToQuestionDraft(initialFormStructure),
+  )[0]
+  // 기존 섹션을 저장 시 새 섹션처럼 보내면 백엔드가 지우고 다시 만들어버리므로,
+  // GET 응답에서 받은 sectionId를 그대로 들고 있다가 Upsert 요청에 되돌려 보낸다.
+  const commonSectionId = initialDraft?.commonSectionId
+  const [sectionIdByPart] = useState<Partial<Record<PartKey, number>>>(
+    () => initialDraft?.sectionIdByPart ?? {},
+  )
   const enabledParts = useRecruitmentCreateStore((s) => s.enabledParts)
   const setEnabledParts = useRecruitmentCreateStore((s) => s.setEnabledParts)
   const setSecondChoiceEnabled = useRecruitmentCreateStore(
@@ -498,14 +515,21 @@ export function RecruitmentQuestionForm({
   const setRoundId = useRecruitmentCreateStore((s) => s.setRoundId)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [removedOptionsByQuestionIndex, setRemovedOptionsByQuestionIndex] =
-    useState<Record<string, string[]>>({})
+    useState<Record<string, string[]>>(
+      () => initialDraft?.removedOptionsByQuestionIndex ?? {},
+    )
   // 파트별 섹션의 문항 목록 편집 상태. 파트당 여러 문항을 가질 수 있다.
   const [partQuestionDrafts, setPartQuestionDrafts] = useState<
     Record<PartKey, RecruitmentQuestion[]>
   >(
     () =>
       Object.fromEntries(
-        PARTS.map((part) => [part.key, [makeRecruitmentQuestion()]]),
+        PARTS.map((part) => [
+          part.key,
+          initialDraft?.partQuestionDrafts[part.key] ?? [
+            makeRecruitmentQuestion(),
+          ],
+        ]),
       ) as Record<PartKey, RecruitmentQuestion[]>,
   )
   // 파트별로 현재 편집 중(카드가 펼쳐진 상태)인 문항 id.
@@ -523,24 +547,57 @@ export function RecruitmentQuestionForm({
   const [questionToggleState, setQuestionToggleState] = useState<
     Record<string, { enabled: boolean; required: boolean }>
   >(() =>
-    Object.fromEntries(
-      OPTIONAL_TOGGLE_QUESTION_INDEXES.map((index) => [
-        index,
-        { enabled: true, required: true },
-      ]),
-    ),
+    initialDraft
+      ? initialDraft.questionToggleState
+      : Object.fromEntries(
+          OPTIONAL_TOGGLE_QUESTION_INDEXES.map((index) => [
+            index,
+            { enabled: true, required: true },
+          ]),
+        ),
   )
+  // 공통 문항 섹션에 운영진이 자유롭게 추가하는 문항 목록. 파트별 섹션과 동일하게
+  // 문항 하나로 시작해 추가/삭제/유형 변경이 가능하다.
+  const [commonQuestionDrafts, setCommonQuestionDrafts] = useState<
+    RecruitmentQuestion[]
+  >(() => initialDraft?.commonQuestionDrafts ?? [makeRecruitmentQuestion()])
+  const [focusedCommonQuestionId, setFocusedCommonQuestionId] = useState<
+    string | null
+  >(() => commonQuestionDrafts[0]?.id ?? null)
   const [isSaving, setIsSaving] = useState(false)
   const [showTempSaveModal, setShowTempSaveModal] = useState(false)
 
+  // enabledParts/secondChoiceEnabled는 스토어 소유라 로컬 state로 못 seed한다 —
+  // 마운트 시 한 번만 prefill 값으로 덮어쓴다.
   const savedSnapshotRef = useRef(
     JSON.stringify({
       enabledParts,
       removedOptionsByQuestionIndex,
       questionToggleState,
       partQuestionDrafts,
+      commonQuestionDrafts,
     }),
   )
+
+  useEffect(() => {
+    if (!initialDraft) return
+    const nextEnabledParts = {
+      ...enabledParts,
+      ...initialDraft.enabledParts,
+    }
+    setEnabledParts(nextEnabledParts)
+    setSecondChoiceEnabled(initialDraft.secondChoiceEnabled)
+    // draft 프리필은 사용자 입력이 아니라 초기값 채움이므로, 스냅샷 캡처(마운트) 이후에
+    // 반영되더라도 기준선에 포함시켜 이탈 모달이 곧바로 뜨지 않게 한다.
+    savedSnapshotRef.current = JSON.stringify({
+      enabledParts: nextEnabledParts,
+      removedOptionsByQuestionIndex,
+      questionToggleState,
+      partQuestionDrafts,
+      commonQuestionDrafts,
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const updatePartQuestionDraft = (
     part: PartKey,
@@ -578,6 +635,33 @@ export function RecruitmentQuestionForm({
 
   const focusPartQuestion = (part: PartKey, questionId: string) => {
     setFocusedQuestionIdByPart((prev) => ({ ...prev, [part]: questionId }))
+  }
+
+  const updateCommonQuestionDraft = (
+    questionId: string,
+    patch: Partial<RecruitmentQuestion>,
+  ) => {
+    setCommonQuestionDrafts((prev) =>
+      prev.map((question) =>
+        question.id === questionId ? { ...question, ...patch } : question,
+      ),
+    )
+  }
+
+  const addCommonQuestion = () => {
+    const newQuestion = makeRecruitmentQuestion()
+    setCommonQuestionDrafts((prev) => [...prev, newQuestion])
+    setFocusedCommonQuestionId(newQuestion.id)
+  }
+
+  const deleteCommonQuestion = (questionId: string) => {
+    const nextQuestions = commonQuestionDrafts.filter(
+      (q) => q.id !== questionId,
+    )
+    setCommonQuestionDrafts(nextQuestions)
+    setFocusedCommonQuestionId((prev) =>
+      prev === questionId ? (nextQuestions[0]?.id ?? null) : prev,
+    )
   }
 
   const removeOption = (questionIndex: string, option: string) => {
@@ -627,9 +711,11 @@ export function RecruitmentQuestionForm({
     removedOptionsByQuestionIndex,
     questionToggleState,
     partQuestionDrafts,
+    commonQuestionDrafts,
   })
   const hasUnsavedChanges = savedSnapshotRef.current !== currentSnapshot
-  const canTempSave = hasUnsavedChanges && !isSaving
+  const isSavingOrSubmitting = isSaving || isSubmitting
+  const canTempSave = hasUnsavedChanges && !isSavingOrSubmitting
 
   useEffect(() => {
     onDirtyChange?.(hasUnsavedChanges)
@@ -644,7 +730,10 @@ export function RecruitmentQuestionForm({
     }),
   )
   const hasBlankEnabledPart =
-    validateRecruitmentQuestionForm([], partSectionsForValidation).length > 0
+    validateRecruitmentQuestionForm(
+      commonQuestionDrafts,
+      partSectionsForValidation,
+    ).length > 0
 
   useEffect(() => {
     onBlankPartsChange?.(hasBlankEnabledPart)
@@ -701,6 +790,7 @@ export function RecruitmentQuestionForm({
             part.label,
             PART_KEY_TO_TRACK[part.key],
             partQuestionDrafts[part.key],
+            sectionIdByPart[part.key],
           ),
       )
       await upsertRecruitingApplicationForm(seasonId!, currentRoundId, {
@@ -708,6 +798,8 @@ export function RecruitmentQuestionForm({
           buildCommonSectionUpsertRequest(
             removedOptionsByQuestionIndex,
             questionToggleState,
+            commonQuestionDrafts,
+            commonSectionId,
           ),
           ...trackSections,
         ],
@@ -734,7 +826,7 @@ export function RecruitmentQuestionForm({
   }
 
   const handleTempSave = async () => {
-    if (isSaving) return
+    if (isSavingOrSubmitting) return
     const validationError = validateBeforeSave()
     if (validationError) {
       showErrorToast(validationError)
@@ -756,6 +848,7 @@ export function RecruitmentQuestionForm({
   }
 
   const handleNext = async () => {
+    if (isSavingOrSubmitting) return
     const validationError = validateBeforeSave()
     if (validationError) {
       showErrorToast(validationError)
@@ -765,7 +858,7 @@ export function RecruitmentQuestionForm({
     setIsSubmitting(true)
     try {
       await ensureRoundAndSaveForm()
-      onNext()
+      onNext?.()
     } catch (error) {
       showErrorToast(
         error instanceof Error
@@ -779,7 +872,7 @@ export function RecruitmentQuestionForm({
 
   return (
     <div className="border-teal-gray-150 mt-6 flex flex-col gap-8 rounded-2xl border bg-white px-8 py-8.5">
-      <RecruitmentSectionHeader index={3} title="모집 문항 작성" />
+      <RecruitmentSectionHeader index={sectionIndex} title="모집 문항 작성" />
       <div className="flex flex-col">
         <FormHeader variant="basic" />
         <div className="bg-teal-gray-50 flex flex-col gap-10 rounded-b-xl border-r border-b border-l border-teal-300 px-5 pt-8.5 pb-9.5">
@@ -844,29 +937,17 @@ export function RecruitmentQuestionForm({
           })}
         </div>
       </div>
-      {/* 공통 문항이 하나도 없으면(엣지 케이스) 지원자 화면에는 이 섹션 자체가 노출되지 않는다.
-          여기 보이는 빈 상태(01 질문을 작성하세요.)는 관리자 작성 화면 전용 placeholder다. */}
+      {/* 공통 문항이 하나도 없으면(엣지 케이스) 지원자 화면에는 이 섹션 자체가 노출되지 않는다. */}
       <div className="flex flex-col">
         <FormHeader variant="common" />
-        <div className="bg-teal-gray-50 flex flex-col gap-10 rounded-b-xl border-r border-b border-l border-teal-300 px-5 pt-8.5 pb-9.5">
-          <div className="flex flex-col gap-2.5">
-            <div className="flex items-start gap-1.5">
-              <span className="text-heading-7-semibold text-teal-gray-400 w-7 shrink-0">
-                01
-              </span>
-              <span className="text-heading-7-semibold text-teal-gray-400">
-                질문을 작성하세요.
-              </span>
-            </div>
-            <div className="pl-3">
-              <QuestionFieldBox>
-                <span className="text-body-1-regular text-teal-gray-400">
-                  답변을 작성하세요.
-                </span>
-              </QuestionFieldBox>
-            </div>
-          </div>
-        </div>
+        <PartSectionBody
+          questions={commonQuestionDrafts}
+          focusedQuestionId={focusedCommonQuestionId}
+          onFocus={setFocusedCommonQuestionId}
+          onUpdate={updateCommonQuestionDraft}
+          onAdd={addCommonQuestion}
+          onDelete={deleteCommonQuestion}
+        />
       </div>
       <div className="flex flex-col gap-4">
         {PARTS.map((part) => (
@@ -897,30 +978,41 @@ export function RecruitmentQuestionForm({
           * 지원자의 파트에 따라 해당하는 섹션의 질문만 노출됩니다.
         </span>
       </div>
-      <div className="flex items-center justify-between">
-        <Button type="button" variant="weak" color="neutral" onClick={onPrev}>
-          이전
-        </Button>
-        <div className="flex items-center gap-3">
+      <div className="flex items-center justify-end">
+        {mode === "create" && (
           <Button
             type="button"
             variant="weak"
+            color="neutral"
+            onClick={onPrev}
+            className="mr-auto"
+          >
+            이전
+          </Button>
+        )}
+        <div className="flex items-center gap-3">
+          <Button
+            type="button"
+            variant={mode === "edit" ? "fill" : "weak"}
             color="primary"
             disabled={!canTempSave}
             isLoading={isSaving}
             onClick={handleTempSave}
           >
-            임시 저장
+            {mode === "edit" ? "저장하기" : "임시 저장"}
           </Button>
-          <Button
-            type="button"
-            variant="fill"
-            color="primary"
-            isLoading={isSubmitting}
-            onClick={handleNext}
-          >
-            다음
-          </Button>
+          {mode === "create" && (
+            <Button
+              type="button"
+              variant="fill"
+              color="primary"
+              disabled={isSaving}
+              isLoading={isSubmitting}
+              onClick={handleNext}
+            >
+              다음
+            </Button>
+          )}
         </div>
       </div>
 
@@ -928,10 +1020,14 @@ export function RecruitmentQuestionForm({
         open={showTempSaveModal}
         onOpenChange={setShowTempSaveModal}
         variant="success"
-        title="임시 저장 완료"
-        content="임시저장이 완료되었습니다."
+        title={mode === "edit" ? "저장 완료" : "임시 저장 완료"}
+        content={
+          mode === "edit"
+            ? "모집 문항이 저장되었습니다."
+            : "임시저장이 완료되었습니다."
+        }
         confirmText="확인"
-        onConfirm={() => navigate({ to: "/recruiting/recruitments" })}
+        onConfirm={() => setShowTempSaveModal(false)}
       />
     </div>
   )

--- a/src/routes/test/recruitment-post-row.tsx
+++ b/src/routes/test/recruitment-post-row.tsx
@@ -26,6 +26,7 @@ function RecruitmentPostRowTestPage() {
           rightAction={
             <RecruitmentPostMoreMenu
               status="OPEN"
+              role="central"
               onPublish={() => {}}
               onPrivatize={() => {}}
               onEdit={() => console.info("TODO: 모집 공고 수정")}
@@ -61,6 +62,7 @@ function RecruitmentPostRowTestPage() {
           rightAction={
             <RecruitmentPostMoreMenu
               status="CLOSED"
+              role="central"
               onPublish={() => {}}
               onPrivatize={() => {}}
               onDuplicate={() => {}}
@@ -82,6 +84,7 @@ function RecruitmentPostRowTestPage() {
           rightAction={
             <RecruitmentPostMoreMenu
               status="DRAFT"
+              role="central"
               onPublish={() => {}}
               onPrivatize={() => {}}
               onEdit={() => console.info("TODO: 모집 공고 수정")}
@@ -113,6 +116,7 @@ function RecruitmentPostRowTestPage() {
               rightAction={
                 <RecruitmentPostMoreMenu
                   status="DRAFT"
+                  role="central"
                   onPublish={() => {}}
                   onPrivatize={() => {}}
                   onEdit={() => console.info("TODO: 모집 공고 수정")}
@@ -129,6 +133,7 @@ function RecruitmentPostRowTestPage() {
               rightAction={
                 <RecruitmentPostMoreMenu
                   status="DRAFT"
+                  role="central"
                   onPublish={() => {}}
                   onPrivatize={() => {}}
                   onEdit={() => console.info("TODO: 모집 공고 수정")}
@@ -145,6 +150,7 @@ function RecruitmentPostRowTestPage() {
               rightAction={
                 <RecruitmentPostMoreMenu
                   status="DRAFT"
+                  role="central"
                   onPublish={() => {}}
                   onPrivatize={() => {}}
                   onEdit={() => console.info("TODO: 모집 공고 수정")}
@@ -164,6 +170,7 @@ function RecruitmentPostRowTestPage() {
               rightAction={
                 <RecruitmentPostMoreMenu
                   status="OPEN"
+                  role="central"
                   onPublish={() => {}}
                   onPrivatize={() => {}}
                   onEdit={() => console.info("TODO: 모집 공고 수정")}

--- a/src/shared/ui/question-field/QuestionForm.tsx
+++ b/src/shared/ui/question-field/QuestionForm.tsx
@@ -31,7 +31,9 @@ interface QuestionFormProps {
 function autoResize(el: HTMLTextAreaElement | null) {
   if (!el) return
   el.style.height = "auto"
-  el.style.height = `${el.scrollHeight}px`
+  if (el.scrollHeight > 0) {
+    el.style.height = `${el.scrollHeight}px`
+  }
 }
 
 export function QuestionForm({

--- a/src/shared/ui/question-field/TextQuestionField.tsx
+++ b/src/shared/ui/question-field/TextQuestionField.tsx
@@ -53,7 +53,9 @@ export function TextQuestionField({
     const el = textareaRef.current
     if (!el) return
     el.style.height = "auto"
-    el.style.height = `${el.scrollHeight}px`
+    if (el.scrollHeight > 0) {
+      el.style.height = `${el.scrollHeight}px`
+    }
   }, [value, textareaRef])
 
   return (


### PR DESCRIPTION
## 📸 작업 내용

- 모집 공고 수정(Edit) 화면에서 DRAFT/OPEN 상태 모두 동일한 문항 수정 UI(생성 마법사 Step2 재사용)를 노출하도록 통일
- 문항 수정 시 기존 섹션의 `sectionId`를 GET 응답에서 그대로 들고 있다가 저장 요청에 되돌려 보내도록 수정 — 기존에는 `sectionId`가 빠져서 저장할 때마다 백엔드가 기존 COMMON/TRACK 섹션을 삭제하고 새로 생성해, 문항을 고칠 때마다 결과가 꼬이는 문제가 있었음
- 문항 입력창 자동 높이 계산 시 `scrollHeight`가 0인 순간 높이가 찌그러지는 문제 수정
- 모집 목록 화면 및 공고 복제 모달 개선

## 🎞️ 주요 코드 설명

### sectionId 라운드트립 버그 수정

```TypeScript
// mapAdminFormToQuestionDraft (recruitmentQuestion.ts)
for (const section of trackSections) {
  const partKey = section.track && TRACK_TO_PART_KEY[section.track]
  if (!partKey) continue
  enabledParts[partKey] = true
  partQuestionDrafts[partKey] = section.questions.map((question) =>
    mapAdminQuestionResponseToRecruitmentQuestion(question),
  )
  if (section.sectionId != null) sectionIdByPart[partKey] = section.sectionId
}
```

- GET .../rounds/{roundId}/form 응답의 sectionId를 draft state에 같이 담아두고, 저장(upsertRecruitingApplicationForm) 시 buildCommonSectionUpsertRequest/buildTrackSectionUpsertRequest가 이 값을 그대로 실어 보내도록 함
- API 타입 주석(types.ts)에 "신규 section/question/option은 sectionId 없이 clientKey로만 식별한다"고 명시돼 있는데, 기존 섹션도 sectionId 없이 보내고 있었던 게 원인

### DRAFT/OPEN 문항 수정 화면 통일
```TypeScript
// RecruitmentRoundEditPage.tsx
<RecruitmentQuestionsEditSection
  seasonId={seasonId}
  roundId={roundId}
  chapter={chapter}
  school={group.schoolName}
  round={round}
/>
```

- 기존에는 round.status === "DRAFT"일 때만 문항 섹션을 노출했는데, OPEN에서도 동일하게 노출하도록 조건을 제거(RecruitmentDraftQuestionsEditSection → RecruitmentQuestionsEditSection으로 일반화)

## 🖥️ 구현화면

## 🔗 연결된 이슈
- Connected: #718 

## 📚 참고자료
## 💬 기타 더 이야기해볼 점
- [미해결] DRAFT 상태에서 파트 트랙 구성에 따라 저장 시 RECRUITING-0205("모집 트랙이 올바르지 않아요") 에러가 재현됨. 모집 설정 폼의 "모집 대상 트랙"(Round.recruitableTracks)과 문항 섹션의 "파트 사용" 토글이 서로 다른 백엔드 필드라 UI에서 자동 동기화가 안 되는 게 원인으로 추정됨. 백엔드팀과 트랙 목록 정합성 확인 필요.
- [알려진 제약] OPEN 상태에서 문항 저장 시 RECRUITING-0201("현재 지원 폼 상태에서는 할 수 없는 작업이에요") 에러가 발생함. 백엔드가 Form Upsert를 DRAFT 전용으로 제한하고 있어서, OPEN에서는 화면은 뜨지만 저장은 안 되는 상태. OPEN에서 문항 수정을 정말 허용할지(백엔드 정책 변경 필요) 아니면 프론트에서 조회 전용으로 막을지 후속 논의 필요.
- 설정(Round) 저장과 문항(Form) 저장이 서로 다른 API·버튼으로 분리돼 있어, 두 상태가 어긋날 수 있는 구조적 리스크가 있음 — 위 RECRUITING-0205도 이 구조에서 비롯된 것으로 보임.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 모집 공고의 지원서 문항을 조회하고 수정할 수 있습니다.
  * 공통 추가 문항, 선택지, 섹션을 편집하고 기존 설정을 유지할 수 있습니다.
  * 임시 저장 공고도 문항 및 설정을 수정할 수 있습니다.
  * 모집 공고 복제 시 역할에 따라 학교를 선택하거나 본인 학교로 즉시 복제할 수 있습니다.
* **버그 수정**
  * 학교 검색·필터와 모집 파트 필터의 정확도를 개선했습니다.
  * 임시 저장 완료 후 불필요한 목록 이동을 제거했습니다.
  * 텍스트 입력 영역의 자동 높이 조정 문제를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->