### PR TITLE
✨ feat: 임시저장한 모집을 생성 마법사에서 이어쓰기

### DIFF
--- a/src/features/recruiting/api/queryKeys.ts
+++ b/src/features/recruiting/api/queryKeys.ts
@@ -14,6 +14,14 @@ export const recruitingKeys = {
     [...recruitingKeys.rounds(), gisuId, "OPEN"] as const,
   pastRoundList: (gisuId: string) =>
     [...recruitingKeys.rounds(), gisuId, "PAST"] as const,
+  adminDraftRound: (gisuId: string, roundId: string, seasonId?: string) =>
+    [
+      ...recruitingKeys.rounds(),
+      "admin-draft",
+      gisuId,
+      roundId,
+      seasonId ?? "",
+    ] as const,
   adminRoundList: (gisuId: string, sort?: string, chapterId?: string) =>
     [
       ...recruitingKeys.rounds(),

--- a/src/features/recruiting/hooks/useRecruitmentDraft.ts
+++ b/src/features/recruiting/hooks/useRecruitmentDraft.ts
@@ -47,6 +47,7 @@ export function useRecruitmentDraft(
     gisuQuery.data?.generation != null
       ? Number(gisuQuery.data.generation)
       : null
+  const isActiveGisuMissing = gisuQuery.isSuccess && gisuId == null
 
   const draftQuery = useQuery({
     queryKey: recruitingKeys.adminDraftRound(
@@ -94,5 +95,6 @@ export function useRecruitmentDraft(
     isLoading: gisuQuery.isLoading || draftQuery.isLoading,
     isError: gisuQuery.isError || draftQuery.isError,
     error: draftQuery.error ?? gisuQuery.error ?? null,
+    isActiveGisuMissing,
   }
 }

--- a/src/features/recruiting/hooks/useRecruitmentDraft.ts
+++ b/src/features/recruiting/hooks/useRecruitmentDraft.ts
@@ -1,0 +1,78 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
+
+import { recruitingKeys } from "../api/queryKeys"
+import {
+  getAdminRounds,
+  getRecruitingApplicationForm,
+} from "../api/recruitingApi"
+import { mapRoundToDraftBasicInfo } from "../model/recruitmentDraftBasicInfo"
+
+import type { RecruitingAdminFormStructureResponse } from "../api/types"
+import type { RecruitmentDraftBasicInfo } from "../model/recruitmentDraftBasicInfo"
+
+export interface RecruitmentDraft extends RecruitmentDraftBasicInfo {
+  gisuGeneration: number | null
+  formStructure: RecruitingAdminFormStructureResponse
+}
+
+// 임시저장한 모집을 생성 마법사에 되돌린다. 차수 자체(기간·파트·공지)는 관리자
+// 차수 목록에서, 문항은 Form 구조에서 각각 받아 온다. 공개 목록은 DRAFT 를
+// 내려주지 않아 관리자 목록을 써야 한다.
+export function useRecruitmentDraft(
+  draftRoundId?: string,
+  draftSeasonId?: string,
+) {
+  const gisuQuery = useActiveGisu()
+  const gisuId =
+    gisuQuery.data?.gisuId != null ? String(gisuQuery.data.gisuId) : null
+  const generation =
+    gisuQuery.data?.generation != null
+      ? Number(gisuQuery.data.generation)
+      : null
+
+  const draftQuery = useQuery({
+    queryKey: recruitingKeys.adminDraftRound(
+      gisuId ?? "",
+      draftRoundId ?? "",
+      draftSeasonId,
+    ),
+    queryFn: async (): Promise<RecruitmentDraft> => {
+      const groups = await getAdminRounds({
+        gisuId: gisuId!,
+        seasonId: draftSeasonId,
+      })
+      const group = groups.find((item) =>
+        item.rounds.some((round) => String(round.roundId) === draftRoundId),
+      )
+      const round = group?.rounds.find(
+        (item) => String(item.roundId) === draftRoundId,
+      )
+
+      // 이미 공개된 차수를 이 화면으로 끌고 오면 생성 흐름이 기존 공고를 덮어쓴다.
+      if (!group || !round || round.status !== "DRAFT") {
+        throw new Error("임시저장한 모집을 찾을 수 없습니다.")
+      }
+
+      const formStructure = await getRecruitingApplicationForm(
+        group.seasonId,
+        round.roundId,
+      )
+
+      return {
+        ...mapRoundToDraftBasicInfo(group, round, generation),
+        gisuGeneration: generation,
+        formStructure,
+      }
+    },
+    enabled: gisuId != null && draftRoundId != null,
+    retry: false,
+  })
+
+  return {
+    draft: draftQuery.data ?? null,
+    isLoading: gisuQuery.isLoading || draftQuery.isLoading,
+    isError: gisuQuery.isError || draftQuery.isError,
+  }
+}

--- a/src/features/recruiting/hooks/useRecruitmentDraft.ts
+++ b/src/features/recruiting/hooks/useRecruitmentDraft.ts
@@ -17,6 +17,22 @@ export interface RecruitmentDraft extends RecruitmentDraftBasicInfo {
   formStructure: RecruitingAdminFormStructureResponse
 }
 
+export type RecruitmentDraftErrorReason = "NOT_FOUND" | "NOT_DRAFT"
+
+export class RecruitmentDraftError extends Error {
+  readonly reason: RecruitmentDraftErrorReason
+
+  constructor(reason: RecruitmentDraftErrorReason) {
+    super(
+      reason === "NOT_DRAFT"
+        ? "임시 저장 상태가 아닌 모집입니다."
+        : "임시 저장한 모집을 찾을 수 없습니다.",
+    )
+    this.name = "RecruitmentDraftError"
+    this.reason = reason
+  }
+}
+
 // 임시저장한 모집을 생성 마법사에 되돌린다. 차수 자체(기간·파트·공지)는 관리자
 // 차수 목록에서, 문항은 Form 구조에서 각각 받아 온다. 공개 목록은 DRAFT 를
 // 내려주지 않아 관리자 목록을 써야 한다.
@@ -51,8 +67,11 @@ export function useRecruitmentDraft(
       )
 
       // 이미 공개된 차수를 이 화면으로 끌고 오면 생성 흐름이 기존 공고를 덮어쓴다.
-      if (!group || !round || round.status !== "DRAFT") {
-        throw new Error("임시저장한 모집을 찾을 수 없습니다.")
+      if (!group || !round) {
+        throw new RecruitmentDraftError("NOT_FOUND")
+      }
+      if (round.status !== "DRAFT") {
+        throw new RecruitmentDraftError("NOT_DRAFT")
       }
 
       const formStructure = await getRecruitingApplicationForm(
@@ -74,5 +93,6 @@ export function useRecruitmentDraft(
     draft: draftQuery.data ?? null,
     isLoading: gisuQuery.isLoading || draftQuery.isLoading,
     isError: gisuQuery.isError || draftQuery.isError,
+    error: draftQuery.error ?? gisuQuery.error ?? null,
   }
 }

--- a/src/features/recruiting/model/recruitmentCreate.test.ts
+++ b/src/features/recruiting/model/recruitmentCreate.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest"
+
+import { periodFieldToInstant } from "./recruitmentCreate"
+
+describe("periodFieldToInstant", () => {
+  it("시간 입력을 timezone과 무관하게 UTC wall-clock instant로 만든다", () => {
+    expect(
+      periodFieldToInstant({ date: "2026-08-01", time: "09:30" }),
+    ).toBe("2026-08-01T09:30:00.000Z")
+  })
+})

--- a/src/features/recruiting/model/recruitmentCreate.ts
+++ b/src/features/recruiting/model/recruitmentCreate.ts
@@ -50,7 +50,7 @@ export function buildRecruitmentPreviewTitle({
 // periodForm의 {date: "YYYY-MM-DD", time: "HH:mm"}을 백엔드가 요구하는
 // Instant(ISO 8601, UTC) 문자열로 변환한다.
 export function periodFieldToInstant(value: PeriodFieldValue): string {
-  return new Date(`${value.date}T${value.time}:00`).toISOString()
+  return new Date(`${value.date}T${value.time}:00Z`).toISOString()
 }
 
 export function composeRecruitmentTitle(baseTitle: string, footer: string) {

--- a/src/features/recruiting/model/recruitmentDraftBasicInfo.test.ts
+++ b/src/features/recruiting/model/recruitmentDraftBasicInfo.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest"
+
+import { mapRoundToDraftBasicInfo } from "./recruitmentDraftBasicInfo"
+
+import type { RecruitingRound, RecruitingRoundGroup } from "../api/types"
+
+const group = (
+  overrides: Partial<RecruitingRoundGroup> = {},
+): RecruitingRoundGroup => ({
+  seasonId: "9",
+  gisuId: "5",
+  chapterId: "1",
+  chapterName: "Neon",
+  schoolId: "3",
+  schoolName: "가천대학교",
+  rounds: [],
+  ...overrides,
+})
+
+const round = (overrides: Partial<RecruitingRound> = {}): RecruitingRound => ({
+  roundId: "13",
+  title: "가천대 UMC 10기 정규 모집",
+  type: "REGULAR",
+  roundNo: 1,
+  recruitableTracks: [],
+  secondChoiceEnabled: false,
+  documentStartAt: null,
+  documentEndAt: null,
+  documentResultPublishedAt: null,
+  interviewRequired: false,
+  interviewStartAt: null,
+  interviewEndAt: null,
+  finalResultPublishedAt: null,
+  announcement: null,
+  ...overrides,
+})
+
+describe("mapRoundToDraftBasicInfo", () => {
+  it("지부와 학교를 폼이 쓰는 형태로 되돌린다", () => {
+    const result = mapRoundToDraftBasicInfo(group(), round(), 10)
+
+    expect(result.seasonId).toBe("9")
+    expect(result.roundId).toBe("13")
+    expect(result.basicInfo.chapter).toBe("Neon")
+    expect(result.basicInfo.school).toBe("가천대")
+    expect(result.basicInfo.recruitmentType).toBe("REGULAR")
+    expect(result.basicInfo.roundNo).toBe("1")
+  })
+
+  // 지부 이름이 우리가 아는 목록에 없으면 폼 선택지에 없는 값이라 비워 둔다
+  it("알 수 없는 지부는 비운다", () => {
+    const result = mapRoundToDraftBasicInfo(
+      group({ chapterName: "없는지부" }),
+      round(),
+      10,
+    )
+
+    expect(result.basicInfo.chapter).toBeUndefined()
+  })
+
+  it("기간을 날짜와 시간 칸으로 쪼갠다", () => {
+    const documentStartAt = new Date(2026, 7, 1, 9, 30).toISOString()
+    const result = mapRoundToDraftBasicInfo(
+      group(),
+      round({ documentStartAt }),
+      10,
+    )
+
+    expect(result.basicInfo.periodForm.documentStartAt).toEqual({
+      date: "2026-08-01",
+      time: "09:30",
+    })
+  })
+
+  it("비어 있는 기간은 초기값으로 둔다", () => {
+    const result = mapRoundToDraftBasicInfo(group(), round(), 10)
+
+    expect(result.basicInfo.periodForm.documentEndAt).toEqual({
+      date: "",
+      time: "23:59",
+    })
+  })
+
+  it("깨진 기간 값도 초기값으로 떨어진다", () => {
+    const result = mapRoundToDraftBasicInfo(
+      group(),
+      round({ documentStartAt: "언제였더라" }),
+      10,
+    )
+
+    expect(result.basicInfo.periodForm.documentStartAt).toEqual({
+      date: "",
+      time: "00:00",
+    })
+  })
+
+  // 제목은 저장할 때 접두사가 붙는다. 되돌릴 때 떼지 않으면 다시 저장할 때마다
+  // 접두사가 겹쳐 쌓인다.
+  it("제목에서 자동 접두사를 떼어 꼬리말만 남긴다", () => {
+    const result = mapRoundToDraftBasicInfo(
+      group(),
+      round({ title: "가천대 UMC 10기 정규 모집 프론트엔드 집중" }),
+      10,
+    )
+
+    expect(result.basicInfo.footer).toBe("프론트엔드 집중")
+  })
+
+  it("추가 모집은 차수까지 포함해 접두사를 뗀다", () => {
+    const result = mapRoundToDraftBasicInfo(
+      group(),
+      round({
+        type: "ADDITIONAL",
+        roundNo: 3,
+        title: "가천대 UMC 10기 3차 추가 모집 마지막 모집",
+      }),
+      10,
+    )
+
+    expect(result.basicInfo.footer).toBe("마지막 모집")
+  })
+
+  it("접두사 규칙에 맞지 않는 제목은 꼬리말을 비운다", () => {
+    const result = mapRoundToDraftBasicInfo(
+      group(),
+      round({ title: "손으로 쓴 제목" }),
+      10,
+    )
+
+    expect(result.basicInfo.footer).toBe("")
+  })
+
+  it("공지와 문의는 없으면 빈 문자열로 준다", () => {
+    const result = mapRoundToDraftBasicInfo(group(), round(), 10)
+
+    expect(result.announcement).toBe("")
+    expect(result.contactText).toBe("")
+  })
+
+  it("공지와 문의가 있으면 그대로 싣는다", () => {
+    const result = mapRoundToDraftBasicInfo(
+      group(),
+      round({ announcement: "지원 전 확인", contactText: "010-0000-0000" }),
+      10,
+    )
+
+    expect(result.announcement).toBe("지원 전 확인")
+    expect(result.contactText).toBe("010-0000-0000")
+  })
+})

--- a/src/features/recruiting/model/recruitmentDraftBasicInfo.test.ts
+++ b/src/features/recruiting/model/recruitmentDraftBasicInfo.test.ts
@@ -59,7 +59,7 @@ describe("mapRoundToDraftBasicInfo", () => {
   })
 
   it("기간을 날짜와 시간 칸으로 쪼갠다", () => {
-    const documentStartAt = new Date(2026, 7, 1, 9, 30).toISOString()
+    const documentStartAt = "2026-08-01T09:30:00.000Z"
     const result = mapRoundToDraftBasicInfo(
       group(),
       round({ documentStartAt }),

--- a/src/features/recruiting/model/recruitmentDraftBasicInfo.ts
+++ b/src/features/recruiting/model/recruitmentDraftBasicInfo.ts
@@ -19,8 +19,6 @@ export interface RecruitmentDraftBasicInfo {
   contactText: string
 }
 
-// 서버는 기간을 instant 로 주고 폼은 날짜·시간 칸을 따로 받는다. 사용자가 입력한
-// 시각 그대로 되돌려야 하므로 표시 기준(로컬)으로 쪼갠다.
 function toPeriodField(
   value: string | null | undefined,
   fallback: PeriodFieldValue,
@@ -32,8 +30,8 @@ function toPeriodField(
 
   const pad = (part: number) => String(part).padStart(2, "0")
   return {
-    date: `${parsed.getFullYear()}-${pad(parsed.getMonth() + 1)}-${pad(parsed.getDate())}`,
-    time: `${pad(parsed.getHours())}:${pad(parsed.getMinutes())}`,
+    date: `${parsed.getUTCFullYear()}-${pad(parsed.getUTCMonth() + 1)}-${pad(parsed.getUTCDate())}`,
+    time: `${pad(parsed.getUTCHours())}:${pad(parsed.getUTCMinutes())}`,
   }
 }
 

--- a/src/features/recruiting/model/recruitmentDraftBasicInfo.ts
+++ b/src/features/recruiting/model/recruitmentDraftBasicInfo.ts
@@ -1,0 +1,111 @@
+import { isChapter } from "@/entities/organization/model/chapters"
+import { formatSchoolName } from "@/shared/lib/formatSchoolName"
+
+import {
+  buildRecruitmentPreviewTitle,
+  INITIAL_PERIOD_FORM,
+  type PeriodFieldKey,
+  type PeriodFieldValue,
+} from "./recruitmentCreate"
+
+import type { RecruitingRound, RecruitingRoundGroup } from "../api/types"
+import type { RecruitmentBasicInfo } from "./useRecruitmentCreateStore"
+
+export interface RecruitmentDraftBasicInfo {
+  roundId: string
+  seasonId: string
+  basicInfo: RecruitmentBasicInfo
+  announcement: string
+  contactText: string
+}
+
+// 서버는 기간을 instant 로 주고 폼은 날짜·시간 칸을 따로 받는다. 사용자가 입력한
+// 시각 그대로 되돌려야 하므로 표시 기준(로컬)으로 쪼갠다.
+function toPeriodField(
+  value: string | null | undefined,
+  fallback: PeriodFieldValue,
+): PeriodFieldValue {
+  if (!value) return fallback
+
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) return fallback
+
+  const pad = (part: number) => String(part).padStart(2, "0")
+  return {
+    date: `${parsed.getFullYear()}-${pad(parsed.getMonth() + 1)}-${pad(parsed.getDate())}`,
+    time: `${pad(parsed.getHours())}:${pad(parsed.getMinutes())}`,
+  }
+}
+
+function toPeriodForm(
+  round: RecruitingRound,
+): Record<PeriodFieldKey, PeriodFieldValue> {
+  return {
+    documentStartAt: toPeriodField(
+      round.documentStartAt,
+      INITIAL_PERIOD_FORM.documentStartAt,
+    ),
+    documentEndAt: toPeriodField(
+      round.documentEndAt,
+      INITIAL_PERIOD_FORM.documentEndAt,
+    ),
+    documentResultPublishedAt: toPeriodField(
+      round.documentResultPublishedAt,
+      INITIAL_PERIOD_FORM.documentResultPublishedAt,
+    ),
+    interviewStartAt: toPeriodField(
+      round.interviewStartAt,
+      INITIAL_PERIOD_FORM.interviewStartAt,
+    ),
+    interviewEndAt: toPeriodField(
+      round.interviewEndAt,
+      INITIAL_PERIOD_FORM.interviewEndAt,
+    ),
+    finalResultPublishedAt: toPeriodField(
+      round.finalResultPublishedAt,
+      INITIAL_PERIOD_FORM.finalResultPublishedAt,
+    ),
+  }
+}
+
+// 저장할 때 제목은 "<학교> <기수> <차수> <꼬리말>" 로 조립된다. 되돌릴 때 같은
+// 규칙으로 앞부분을 떼어내야 꼬리말 칸에 접두사가 중복으로 쌓이지 않는다.
+function extractFooter(
+  round: RecruitingRound,
+  school: string | undefined,
+  gisuGeneration: number | null | undefined,
+): string {
+  const prefix = `${buildRecruitmentPreviewTitle({
+    school,
+    recruitmentType: round.type,
+    roundNo: String(round.roundNo),
+    gisuGeneration,
+  })} `
+  return round.title.startsWith(prefix)
+    ? round.title.slice(prefix.length).trim()
+    : ""
+}
+
+export function mapRoundToDraftBasicInfo(
+  group: RecruitingRoundGroup,
+  round: RecruitingRound,
+  gisuGeneration: number | null | undefined,
+): RecruitmentDraftBasicInfo {
+  const school = formatSchoolName(group.schoolName)
+
+  return {
+    roundId: round.roundId,
+    seasonId: group.seasonId,
+    basicInfo: {
+      chapter: isChapter(group.chapterName) ? group.chapterName : undefined,
+      school,
+      recruitmentType: round.type,
+      roundNo: String(round.roundNo),
+      interviewRequired: round.interviewRequired,
+      footer: extractFooter(round, school, gisuGeneration),
+      periodForm: toPeriodForm(round),
+    },
+    announcement: round.announcement ?? "",
+    contactText: round.contactText ?? "",
+  }
+}

--- a/src/features/recruiting/ui/RecruitmentCreatePage.tsx
+++ b/src/features/recruiting/ui/RecruitmentCreatePage.tsx
@@ -7,6 +7,10 @@ import { useToastStore } from "@/shared/ui/toast/useToastStore"
 
 import { useRecruitmentDraft } from "../hooks/useRecruitmentDraft"
 import {
+  type RecruitmentDraft,
+  RecruitmentDraftError,
+} from "../hooks/useRecruitmentDraft"
+import {
   RecruitmentCreateStoreProvider,
   useRecruitmentCreateStore,
   useRecruitmentCreateStoreApi,
@@ -18,7 +22,6 @@ import { RecruitmentStepper } from "./RecruitmentStepper"
 
 import type { Chapter } from "@/entities/organization/model/chapters"
 
-import type { RecruitmentDraft } from "../hooks/useRecruitmentDraft"
 import type { RecruitingListRole } from "../model/recruitingListRole"
 
 interface RecruitmentCreatePageProps {
@@ -51,6 +54,11 @@ function DraftNotice({ message }: { message: string }) {
   )
 }
 
+function getDraftErrorMessage(error: unknown) {
+  if (error instanceof RecruitmentDraftError) return error.message
+  return "임시 저장한 모집을 불러오지 못했습니다."
+}
+
 export function RecruitmentCreatePage({
   role,
   initialChapter,
@@ -58,7 +66,7 @@ export function RecruitmentCreatePage({
   draftRoundId,
   draftSeasonId,
 }: RecruitmentCreatePageProps = {}) {
-  const { draft, isLoading, isError } = useRecruitmentDraft(
+  const { draft, isLoading, isError, error } = useRecruitmentDraft(
     draftRoundId,
     draftSeasonId,
   )
@@ -71,7 +79,7 @@ export function RecruitmentCreatePage({
   }
 
   if (isDraftMode && (isError || !draft)) {
-    return <DraftNotice message="임시 저장한 모집을 불러오지 못했습니다." />
+    return <DraftNotice message={getDraftErrorMessage(error)} />
   }
 
   return (

--- a/src/features/recruiting/ui/RecruitmentCreatePage.tsx
+++ b/src/features/recruiting/ui/RecruitmentCreatePage.tsx
@@ -66,7 +66,8 @@ export function RecruitmentCreatePage({
   draftRoundId,
   draftSeasonId,
 }: RecruitmentCreatePageProps = {}) {
-  const { draft, isLoading, isError, error } = useRecruitmentDraft(
+  const { draft, isLoading, isError, error, isActiveGisuMissing } =
+    useRecruitmentDraft(
     draftRoundId,
     draftSeasonId,
   )
@@ -76,6 +77,10 @@ export function RecruitmentCreatePage({
   // 끝나기 전에 그리면 빈 문항으로 굳어 버리므로, 다 받은 뒤에 그린다.
   if (isDraftMode && isLoading) {
     return <DraftNotice message="임시 저장한 모집을 불러오는 중입니다..." />
+  }
+
+  if (isDraftMode && isActiveGisuMissing) {
+    return <DraftNotice message="활성 기수를 찾을 수 없습니다." />
   }
 
   if (isDraftMode && (isError || !draft)) {

--- a/src/features/recruiting/ui/RecruitmentCreatePage.tsx
+++ b/src/features/recruiting/ui/RecruitmentCreatePage.tsx
@@ -1,11 +1,16 @@
 import { useBlocker } from "@tanstack/react-router"
-import { useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import { CtaModal } from "@/shared/ui/modal/CtaModal"
 import { PageLabel } from "@/shared/ui/page-label/PageLabel"
 import { useToastStore } from "@/shared/ui/toast/useToastStore"
 
-import { RecruitmentCreateStoreProvider } from "../model/useRecruitmentCreateStore"
+import { useRecruitmentDraft } from "../hooks/useRecruitmentDraft"
+import {
+  RecruitmentCreateStoreProvider,
+  useRecruitmentCreateStore,
+  useRecruitmentCreateStoreApi,
+} from "../model/useRecruitmentCreateStore"
 import { RecruitmentAnnouncementForm } from "./create/RecruitmentAnnouncementForm"
 import { RecruitmentBasicInfoForm } from "./create/RecruitmentBasicInfoForm"
 import { RecruitmentQuestionForm } from "./create/RecruitmentQuestionForm"
@@ -13,19 +18,88 @@ import { RecruitmentStepper } from "./RecruitmentStepper"
 
 import type { Chapter } from "@/entities/organization/model/chapters"
 
+import type { RecruitmentDraft } from "../hooks/useRecruitmentDraft"
 import type { RecruitingListRole } from "../model/recruitingListRole"
 
 interface RecruitmentCreatePageProps {
   role?: RecruitingListRole
   initialChapter?: Chapter
   initialSchool?: string
+  draftRoundId?: string
+  draftSeasonId?: string
+}
+
+const CREATE_BREADCRUMB = [
+  { id: "recruiting", label: "리크루팅" },
+  { id: "recruitment-management", label: "모집 관리" },
+  { id: "recruitment-create", label: "모집 생성" },
+]
+
+function DraftNotice({ message }: { message: string }) {
+  return (
+    <div className="flex w-full max-w-286.5 flex-col">
+      <PageLabel
+        breadcrumb={CREATE_BREADCRUMB}
+        title="임시 저장 모집 이어쓰기"
+        description="임시 저장한 모집을 다시 작성합니다."
+        className="pl-3"
+      />
+      <div className="border-teal-gray-100 text-body-2-regular text-teal-gray-500 mt-8 flex min-h-50 w-full items-center justify-center rounded-[12px] border bg-white">
+        {message}
+      </div>
+    </div>
+  )
 }
 
 export function RecruitmentCreatePage({
   role,
   initialChapter,
   initialSchool,
+  draftRoundId,
+  draftSeasonId,
 }: RecruitmentCreatePageProps = {}) {
+  const { draft, isLoading, isError } = useRecruitmentDraft(
+    draftRoundId,
+    draftSeasonId,
+  )
+  const isDraftMode = draftRoundId != null
+
+  // 2단계 폼은 마운트 시점의 문항 구조로 편집 상태를 한 번만 세운다. 조회가
+  // 끝나기 전에 그리면 빈 문항으로 굳어 버리므로, 다 받은 뒤에 그린다.
+  if (isDraftMode && isLoading) {
+    return <DraftNotice message="임시 저장한 모집을 불러오는 중입니다..." />
+  }
+
+  if (isDraftMode && (isError || !draft)) {
+    return <DraftNotice message="임시 저장한 모집을 불러오지 못했습니다." />
+  }
+
+  return (
+    <RecruitmentCreateStoreProvider>
+      <RecruitmentCreatePageInner
+        role={role}
+        initialChapter={initialChapter}
+        initialSchool={initialSchool}
+        draftRoundId={draftRoundId}
+        draft={draft}
+      />
+    </RecruitmentCreateStoreProvider>
+  )
+}
+
+function RecruitmentCreatePageInner({
+  role,
+  initialChapter,
+  initialSchool,
+  draftRoundId,
+  draft,
+}: {
+  role?: RecruitingListRole
+  initialChapter?: Chapter
+  initialSchool?: string
+  draftRoundId?: string
+  draft: RecruitmentDraft | null
+}) {
   const [step, setStep] = useState(1)
   const [isStep1Dirty, setIsStep1Dirty] = useState(false)
   const [isStep2Dirty, setIsStep2Dirty] = useState(false)
@@ -35,6 +109,43 @@ export function RecruitmentCreatePage({
   const [step2HasBlankPart, setStep2HasBlankPart] = useState(false)
   const stepperRef = useRef<HTMLDivElement>(null)
   const addToast = useToastStore((state) => state.addToast)
+
+  const storeApi = useRecruitmentCreateStoreApi()
+  const seasonId = useRecruitmentCreateStore((s) => s.seasonId)
+  const roundId = useRecruitmentCreateStore((s) => s.roundId)
+  const setRoundId = useRecruitmentCreateStore((s) => s.setRoundId)
+
+  // 문항은 2단계 폼이 formStructure 로 직접 세운다. 여기서는 차수 자체에 딸린
+  // 값(기간·파트 구성·공지·문의)만 돌려놓는다.
+  useEffect(() => {
+    if (!draft) return
+    const {
+      setSeasonId,
+      setGisuGeneration,
+      patchBasicInfo,
+      setAnnouncement,
+      setContactText,
+      setRoundId: seedRoundId,
+    } = storeApi.getState()
+
+    setSeasonId(draft.seasonId)
+    setGisuGeneration(draft.gisuGeneration)
+    patchBasicInfo(draft.basicInfo)
+    setAnnouncement(draft.announcement)
+    setContactText(draft.contactText)
+    // seasonId·차수 번호가 바뀌면 스토어가 roundId 를 지우므로 마지막에 넣는다.
+    seedRoundId(draft.roundId)
+  }, [draft, storeApi])
+
+  // 1단계 폼은 학교가 정해질 때마다 seasonId 를 다시 잡는데, 시즌 조회가 끝나기
+  // 전에는 빈 값을 넣어 roundId 까지 함께 지운다. 이어쓰기 중에 차수를 잃으면
+  // 저장이 기존 공고 수정이 아니라 새 차수 생성으로 새 나가므로 되붙인다.
+  useEffect(() => {
+    if (!draft) return
+    if (seasonId !== draft.seasonId) return
+    if (roundId === draft.roundId) return
+    setRoundId(draft.roundId)
+  }, [draft, seasonId, roundId, setRoundId])
 
   const moveToStep = (target: number) => {
     setStep(target)
@@ -79,75 +190,79 @@ export function RecruitmentCreatePage({
 
   const isLeaveModalOpen = leaveBlockStatus === "blocked"
 
+  // 초안의 지부·학교는 1단계 폼의 초기값 경로로 넘긴다. 그 폼은 진입 지점 기준
+  // 프리필을 따로 돌리는데, 여기서 알려 주지 않으면 복원한 값을 덮어쓴다.
+  const resolvedChapter = draft?.basicInfo.chapter ?? initialChapter
+  const resolvedSchool = draft?.basicInfo.school ?? initialSchool
+
   return (
-    <RecruitmentCreateStoreProvider>
-      <div className="flex w-full max-w-286.5 flex-col">
-        <PageLabel
-          breadcrumb={[
-            { id: "recruiting", label: "리크루팅" },
-            { id: "recruitment-management", label: "모집 관리" },
-            { id: "recruitment-create", label: "모집 생성" },
-          ]}
-          title="모집 생성"
-          description="모집 공고를 만들고 공개할 준비를 합니다."
-          className="pl-3"
-        />
+    <div className="flex w-full max-w-286.5 flex-col">
+      <PageLabel
+        breadcrumb={CREATE_BREADCRUMB}
+        title={draft ? "임시 저장 모집 이어쓰기" : "모집 생성"}
+        description={
+          draft
+            ? "임시 저장한 모집을 다시 작성합니다."
+            : "모집 공고를 만들고 공개할 준비를 합니다."
+        }
+        className="pl-3"
+      />
 
-        <div ref={stepperRef}>
-          <RecruitmentStepper
-            step={step}
-            onStepChange={handleStepChange}
-            className="mt-8"
-          />
-        </div>
-
-        {/* 단계 전환 시 입력값이 사라지지 않도록 언마운트하지 않고 보이기/숨기기만 전환한다. */}
-        <div className={step === 1 ? undefined : "hidden"}>
-          <RecruitmentBasicInfoForm
-            key={`${role ?? "central"}:${initialChapter ?? ""}:${initialSchool ?? ""}`}
-            onNext={() => moveToStep(2)}
-            onDirtyChange={setIsStep1Dirty}
-            role={role}
-            initialChapter={initialChapter}
-            initialSchool={initialSchool}
-          />
-        </div>
-        <div className={step === 2 ? undefined : "hidden"}>
-          <RecruitmentQuestionForm
-            onPrev={() => moveToStep(1)}
-            onNext={() => handleStepChange(3)}
-            onDirtyChange={setIsStep2Dirty}
-            onBlankPartsChange={setStep2HasBlankPart}
-          />
-        </div>
-        <div className={step === 3 ? undefined : "hidden"}>
-          <RecruitmentAnnouncementForm
-            onPrev={() => moveToStep(2)}
-            onDirtyChange={setIsStep3Dirty}
-          />
-        </div>
-
-        {/* 페이지 이탈 모달 */}
-        <CtaModal
-          open={isLeaveModalOpen}
-          onOpenChange={(open) => {
-            if (!open) resetLeave?.()
-          }}
-          variant="warning"
-          title="페이지 이탈"
-          content={
-            <>
-              작성 중인 내용이 저장되지 않습니다.
-              <br />
-              나가시겠습니까?
-            </>
-          }
-          cancelText="돌아가기"
-          confirmText="나가기"
-          onCancel={() => resetLeave?.()}
-          onConfirm={() => proceedLeave?.()}
+      <div ref={stepperRef}>
+        <RecruitmentStepper
+          step={step}
+          onStepChange={handleStepChange}
+          className="mt-8"
         />
       </div>
-    </RecruitmentCreateStoreProvider>
+
+      {/* 단계 전환 시 입력값이 사라지지 않도록 언마운트하지 않고 보이기/숨기기만 전환한다. */}
+      <div className={step === 1 ? undefined : "hidden"}>
+        <RecruitmentBasicInfoForm
+          key={`${role ?? "central"}:${resolvedChapter ?? ""}:${resolvedSchool ?? ""}:${draftRoundId ?? "new"}`}
+          onNext={() => moveToStep(2)}
+          onDirtyChange={setIsStep1Dirty}
+          role={role}
+          initialChapter={resolvedChapter}
+          initialSchool={resolvedSchool}
+        />
+      </div>
+      <div className={step === 2 ? undefined : "hidden"}>
+        <RecruitmentQuestionForm
+          onPrev={() => moveToStep(1)}
+          onNext={() => handleStepChange(3)}
+          onDirtyChange={setIsStep2Dirty}
+          onBlankPartsChange={setStep2HasBlankPart}
+          initialFormStructure={draft?.formStructure}
+        />
+      </div>
+      <div className={step === 3 ? undefined : "hidden"}>
+        <RecruitmentAnnouncementForm
+          onPrev={() => moveToStep(2)}
+          onDirtyChange={setIsStep3Dirty}
+        />
+      </div>
+
+      {/* 페이지 이탈 모달 */}
+      <CtaModal
+        open={isLeaveModalOpen}
+        onOpenChange={(open) => {
+          if (!open) resetLeave?.()
+        }}
+        variant="warning"
+        title="페이지 이탈"
+        content={
+          <>
+            작성 중인 내용이 저장되지 않습니다.
+            <br />
+            나가시겠습니까?
+          </>
+        }
+        cancelText="돌아가기"
+        confirmText="나가기"
+        onCancel={() => resetLeave?.()}
+        onConfirm={() => proceedLeave?.()}
+      />
+    </div>
   )
 }

--- a/src/features/recruiting/ui/RecruitmentCreatePage.tsx
+++ b/src/features/recruiting/ui/RecruitmentCreatePage.tsx
@@ -47,7 +47,11 @@ function DraftNotice({ message }: { message: string }) {
         description="임시 저장한 모집을 다시 작성합니다."
         className="pl-3"
       />
-      <div className="border-teal-gray-100 text-body-2-regular text-teal-gray-500 mt-8 flex min-h-50 w-full items-center justify-center rounded-[12px] border bg-white">
+      <div
+        role="status"
+        aria-live="polite"
+        className="border-teal-gray-100 text-body-2-regular text-teal-gray-500 mt-8 flex min-h-50 w-full items-center justify-center rounded-[12px] border bg-white"
+      >
         {message}
       </div>
     </div>

--- a/src/features/recruiting/ui/RecruitmentCreatePage.tsx
+++ b/src/features/recruiting/ui/RecruitmentCreatePage.tsx
@@ -242,6 +242,7 @@ function RecruitmentCreatePageInner({
           role={role}
           initialChapter={resolvedChapter}
           initialSchool={resolvedSchool}
+          lockOrganization={draft != null}
         />
       </div>
       <div className={step === 2 ? undefined : "hidden"}>

--- a/src/features/recruiting/ui/RecruitmentDraftArchiveCard.tsx
+++ b/src/features/recruiting/ui/RecruitmentDraftArchiveCard.tsx
@@ -69,14 +69,15 @@ function DraftPostRow({
           onPublish={() => onPublish(post.postId)}
           // 임시 보관함 안에서는 이미 DRAFT라 비공개 액션이 노출되지 않음
           onPrivatize={() => {}}
-          // DRAFT는 문항 프리필용 조회 API가 아직 없어 생성 마법사 재사용 편집은
-          // 못 만든다. 우선 OPEN과 같은 수정 화면으로 보내고, 그 화면이 DRAFT
-          // 상태를 보고 "아직 지원하지 않음" 안내를 보여주도록 한다.
+          // DRAFT는 아직 공개된 적이 없어 처음 쓰던 흐름 그대로 이어 쓰는 편이
+          // 자연스럽다. 문항만 고치는 수정 화면 대신 생성 마법사로 되돌린다.
           onEdit={() =>
             navigate({
-              to: "/recruiting/recruitments/edit/$roundId",
-              params: { roundId: post.postId },
-              search: { seasonId: post.seasonId },
+              to: "/recruiting/recruitments/new",
+              search: {
+                draftRoundId: post.postId,
+                draftSeasonId: post.seasonId,
+              },
             })
           }
           onDuplicate={() => onDuplicate(post.postId)}

--- a/src/features/recruiting/ui/RecruitmentRoundSettingsEditForm.tsx
+++ b/src/features/recruiting/ui/RecruitmentRoundSettingsEditForm.tsx
@@ -32,8 +32,8 @@ function instantToPeriodField(iso: string | null): PeriodFieldValue {
   const d = new Date(iso)
   const pad = (n: number) => String(n).padStart(2, "0")
   return {
-    date: `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`,
-    time: `${pad(d.getHours())}:${pad(d.getMinutes())}`,
+    date: `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())}`,
+    time: `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`,
   }
 }
 

--- a/src/features/recruiting/ui/create/RecruitmentBasicInfoForm.tsx
+++ b/src/features/recruiting/ui/create/RecruitmentBasicInfoForm.tsx
@@ -194,6 +194,7 @@ interface RecruitmentBasicInfoFormProps {
   // - chapterAdmin: 값이 있으면(학교 페이지에서 진입) 학교도 텍스트로 고정, 없으면(지부 페이지에서 진입) 드롭다운으로 선택 가능
   // - schoolStaff: 항상 고정
   initialSchool?: string
+  lockOrganization?: boolean
 }
 
 export function RecruitmentBasicInfoForm({
@@ -202,6 +203,7 @@ export function RecruitmentBasicInfoForm({
   role: roleProp,
   initialChapter,
   initialSchool,
+  lockOrganization = false,
 }: RecruitmentBasicInfoFormProps) {
   const addToast = useToastStore((state) => state.addToast)
   const [showTempSaveModal, setShowTempSaveModal] = useState(false)
@@ -376,9 +378,10 @@ export function RecruitmentBasicInfoForm({
 
   // 지부는 central만 자유 선택. 학교는 central이거나(지부 선택 후),
   // chapterAdmin이 지부 페이지(학교 미고정)에서 들어왔을 때만 선택 가능.
-  const isChapterEditable = role === "central"
+  const isChapterEditable = !lockOrganization && role === "central"
   const isSchoolEditable =
-    role === "central" || (role === "chapterAdmin" && !initialSchool)
+    !lockOrganization &&
+    (role === "central" || (role === "chapterAdmin" && !initialSchool))
   const [calendarMonth, setCalendarMonth] = useState(() => {
     const today = new Date()
     return { year: today.getFullYear(), month: today.getMonth() + 1 }

--- a/src/routes/recruiting/recruitments/new.tsx
+++ b/src/routes/recruiting/recruitments/new.tsx
@@ -16,6 +16,16 @@ interface RecruitmentCreateSearch {
   role?: RecruitingListRole
   chapter?: Chapter
   school?: string
+  draftRoundId?: string
+  draftSeasonId?: string
+}
+
+// 식별자가 숫자로만 되어 있으면 주소에서 따옴표 없이 실려 number 로 되돌아온다.
+// 문자열만 받으면 이어쓰기 진입이 조용히 무시된다.
+function toSearchId(value: unknown): string | undefined {
+  if (typeof value === "string") return value === "" ? undefined : value
+  if (typeof value === "number" && Number.isFinite(value)) return String(value)
+  return undefined
 }
 
 export const Route = createFileRoute("/recruiting/recruitments/new")({
@@ -43,18 +53,23 @@ export const Route = createFileRoute("/recruiting/recruitments/new")({
       role: isRecruitingListRole(search.role) ? search.role : undefined,
       chapter,
       school,
+      draftRoundId: toSearchId(search.draftRoundId),
+      draftSeasonId: toSearchId(search.draftSeasonId),
     }
   },
   component: RouteComponent,
 })
 
 function RouteComponent() {
-  const { role, chapter, school } = Route.useSearch()
+  const { role, chapter, school, draftRoundId, draftSeasonId } =
+    Route.useSearch()
   return (
     <RecruitmentCreatePage
       role={role}
       initialChapter={chapter}
       initialSchool={school}
+      draftRoundId={draftRoundId}
+      draftSeasonId={draftSeasonId}
     />
   )
 }


### PR DESCRIPTION
## 📸 작업 내용

- 공유 보관함의 임시저장(DRAFT) 모집 [수정]이 **모집 생성 마법사로** 이동합니다. 기존에는 문항만 고칠 수 있는 수정 화면으로 갔습니다.
- 진입 시 차수 정보와 지원 Form 구조를 함께 조회해 1~3단계를 모두 되돌립니다. 기간·모집 파트·공지·문의처럼 그동안 손댈 수 없던 값을 이어서 고칠 수 있습니다.
- 문항 복원은 기존 경로(`mapAdminFormToQuestionDraft`)를 그대로 재사용하고, 이 PR은 **차수 자체에 딸린 값**의 복원과 진입 경로만 새로 만듭니다.
- 임시저장이 아닌 차수로 들어오면 막습니다. 이미 공개된 공고를 생성 흐름으로 끌고 오면 새 차수가 만들어질 수 있습니다.
- 되돌리는 중에는 안내를 보여주고, 조회에 실패하면 실패했음을 알립니다.

## 🎞️ 주요 코드 설명

**제목 접두사를 떼어낸다** — 저장할 때 제목은 `<학교> UMC <기수>기 <차수> <꼬리말>`로 조립됩니다. 되돌릴 때 같은 규칙으로 앞부분을 떼지 않으면 저장할 때마다 접두사가 겹쳐 쌓입니다.

**2단계는 다 받은 뒤에 그린다** — 문항 폼은 마운트 시점의 구조로 편집 상태를 한 번만 세웁니다. 조회 중에 그리면 빈 문항으로 굳어 버려 복원이 통째로 날아갑니다.

**차수 식별자를 잃지 않게 되붙인다** — 1단계 폼은 학교가 정해질 때마다 시즌을 다시 잡는데, 시즌 조회가 끝나기 전에는 빈 값을 넣어 차수 식별자까지 함께 지웁니다. 이어쓰기 중에 차수를 잃으면 저장이 기존 공고 수정이 아니라 새 차수 생성으로 새 나가므로, 시즌이 제자리를 찾으면 다시 붙입니다.

**주소로 오는 식별자를 숫자까지 받는다** — 식별자가 숫자로만 되어 있으면 주소에서 따옴표 없이 실려 number로 돌아옵니다. 문자열만 받으면 이어쓰기 진입이 조용히 무시됩니다.

**지부·학교는 초기값 경로로 넘긴다** — 1단계 폼은 진입 지점 기준으로 지부·학교를 따로 프리필하므로, 복원한 값을 알려 주지 않으면 덮어씁니다.

## 🔗 연결된 이슈

- Connected: #744
- Closes #744

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 저장된 모집 초안을 생성 마법사에서 불러와 이어서 작성할 수 있습니다.
  - 초안의 기본 정보, 공지사항, 문의 내용, 모집 문항 구조가 자동으로 복원됩니다.
  - 초안 로딩 및 조회 실패 시 진행 상태와 안내 메시지가 표시됩니다.
  - 모집 초안 카드에서 생성 마법사로 바로 이동할 수 있습니다.

- **버그 수정**
  - 잘못되거나 누락된 날짜·시간 정보와 제목, 연락처 값이 안정적으로 처리됩니다.

- **테스트**
  - 초안 기본 정보 변환 및 예외 상황에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->