### PR TITLE
refactor: 하드코딩된 지부 목록 제거 및 서버 API 기반 동적 지부 조회 전환

### DIFF
--- a/src/entities/organization/hooks/useSchoolChapterMap.ts
+++ b/src/entities/organization/hooks/useSchoolChapterMap.ts
@@ -13,7 +13,11 @@ export function useSchoolChapterMap(options: SchoolChapterMapOptions = {}) {
 
   const activeGisuId = gisuData?.gisuId ? Number(gisuData.gisuId) : undefined
 
-  const { data: chaptersData, isLoading } = useQuery({
+  const {
+    data: chaptersData,
+    isLoading,
+    isError,
+  } = useQuery({
     queryKey: ["chaptersWithSchools", activeGisuId],
     queryFn: () => getChaptersWithSchools(String(activeGisuId!)),
     enabled: activeGisuId != null,
@@ -60,6 +64,7 @@ export function useSchoolChapterMap(options: SchoolChapterMapOptions = {}) {
     chapters,
     chapterNames,
     isLoading,
+    isError,
     getChapterIdBySchool,
     getChapterIdByName,
   }

--- a/src/entities/organization/hooks/useSchoolChapterMap.ts
+++ b/src/entities/organization/hooks/useSchoolChapterMap.ts
@@ -13,7 +13,7 @@ export function useSchoolChapterMap(options: SchoolChapterMapOptions = {}) {
 
   const activeGisuId = gisuData?.gisuId ? Number(gisuData.gisuId) : undefined
 
-  const { data: chaptersData } = useQuery({
+  const { data: chaptersData, isLoading } = useQuery({
     queryKey: ["chaptersWithSchools", activeGisuId],
     queryFn: () => getChaptersWithSchools(String(activeGisuId!)),
     enabled: activeGisuId != null,
@@ -22,6 +22,11 @@ export function useSchoolChapterMap(options: SchoolChapterMapOptions = {}) {
   })
 
   const chapters = useMemo(() => chaptersData?.chapters ?? [], [chaptersData])
+
+  const chapterNames = useMemo(
+    () => chapters.map((ch) => ch.chapterName).filter(Boolean),
+    [chapters],
+  )
 
   const schoolToChapterId = useMemo(() => {
     const map = new Map<string, number>()
@@ -53,6 +58,8 @@ export function useSchoolChapterMap(options: SchoolChapterMapOptions = {}) {
 
   return {
     chapters,
+    chapterNames,
+    isLoading,
     getChapterIdBySchool,
     getChapterIdByName,
   }

--- a/src/entities/organization/model/chapters.ts
+++ b/src/entities/organization/model/chapters.ts
@@ -3,8 +3,6 @@
 
 export type Chapter = string
 
-export const CHAPTERS: readonly string[] = []
-
 export function isChapter(value: unknown): value is Chapter {
   return typeof value === "string" && value.trim().length > 0
 }

--- a/src/entities/organization/model/chapters.ts
+++ b/src/entities/organization/model/chapters.ts
@@ -1,20 +1,10 @@
-// 지부(chapter) 정적 목록. URL search param 검증과 세그먼트 탭 렌더링에
-// 동기적으로 필요해서 상수로 유지한다.
-// TODO: 지부 개편 시 getAllChapters API 기반으로 전환 검토 (라우트 진입 시점의
-// 동기 검증을 비동기 데이터로 대체하는 방안 필요)
-export const CHAPTERS = [
-  "Chromium",
-  "Ferrum",
-  "Neon",
-  "Platinum",
-  "Selenium",
-  "Xenon",
-] as const
+// 지부(chapter) 타입 및 유틸리티.
+// 지부 목록은 서버 API(getChaptersWithSchools)에서 활성 기수(gisuId)에 맞게 동적으로 조회한다.
 
-export type Chapter = (typeof CHAPTERS)[number]
+export type Chapter = string
+
+export const CHAPTERS: readonly string[] = []
 
 export function isChapter(value: unknown): value is Chapter {
-  return (
-    typeof value === "string" && (CHAPTERS as readonly string[]).includes(value)
-  )
+  return typeof value === "string" && value.trim().length > 0
 }

--- a/src/features/chapter/model/chapterManagement.ts
+++ b/src/features/chapter/model/chapterManagement.ts
@@ -9,63 +9,9 @@ export interface ChapterData {
   assignedSchools: School[]
 }
 
-export const INITIAL_UNASSIGNED_SCHOOLS: School[] = [
-  { id: "school-1", name: "경희대학교" },
-  { id: "school-2", name: "서울시립대학교" },
-  { id: "school-3", name: "인하대학교" },
-  { id: "school-4", name: "국민대학교" },
-]
+export const INITIAL_UNASSIGNED_SCHOOLS: School[] = []
 
-export const INITIAL_CHAPTERS: ChapterData[] = [
-  {
-    id: "chapter-chromium",
-    name: "Chromium",
-    assignedSchools: [
-      { id: "school-5", name: "중앙대학교" },
-      { id: "school-6", name: "홍익대학교" },
-    ],
-  },
-  {
-    id: "chapter-ferrum",
-    name: "Ferrum",
-    assignedSchools: [
-      { id: "school-7", name: "연세대학교" },
-      { id: "school-8", name: "고려대학교" },
-    ],
-  },
-  {
-    id: "chapter-neon",
-    name: "Neon",
-    assignedSchools: [
-      { id: "school-9", name: "서울대학교" },
-      { id: "school-10", name: "성균관대학교" },
-    ],
-  },
-  {
-    id: "chapter-platinum",
-    name: "Platinum",
-    assignedSchools: [
-      { id: "school-11", name: "한양대학교" },
-      { id: "school-12", name: "서강대학교" },
-    ],
-  },
-  {
-    id: "chapter-selenium",
-    name: "Selenium",
-    assignedSchools: [
-      { id: "school-13", name: "이화여자대학교" },
-      { id: "school-14", name: "건국대학교" },
-    ],
-  },
-  {
-    id: "chapter-xenon",
-    name: "Xenon",
-    assignedSchools: [
-      { id: "school-15", name: "동국대학교" },
-      { id: "school-16", name: "숭실대학교" },
-    ],
-  },
-]
+export const INITIAL_CHAPTERS: ChapterData[] = []
 
 export const UNASSIGNED_PANEL_ID = "unassigned-schools-panel"
 export const ASSIGNED_CHIP_PREFIX = "chapter-assigned-"

--- a/src/features/chapter/ui/ChapterManagePage.tsx
+++ b/src/features/chapter/ui/ChapterManagePage.tsx
@@ -4,14 +4,16 @@ import {
   DragOverlay,
   type DragStartEvent,
 } from "@dnd-kit/core"
-import { useQueryClient } from "@tanstack/react-query"
-import { useState } from "react"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useEffect, useRef, useState } from "react"
 
+import { getAllSchools } from "@/entities/organization/api/organization"
 import {
   useCreateChapter,
   useCreateChaptersBulk,
   useDeleteChapter,
 } from "@/entities/organization/hooks/useChapter"
+import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import ResetIcon from "@/shared/assets/icon/reset/ResetIcon"
 import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
@@ -50,10 +52,48 @@ export function ChapterManagePage() {
     "waiting" | "assigned"
   >("waiting")
 
+  const isInitializedRef = useRef(false)
+
   const deleteChapterMutation = useDeleteChapter()
   const createChapterMutation = useCreateChapter()
   const createChaptersBulkMutation = useCreateChaptersBulk()
   const { data: activeGisuId, isLoading: isGisuLoading } = useActiveGisuId()
+  const { chapters: serverChapters } = useSchoolChapterMap()
+
+  const { data: allSchoolsData } = useQuery({
+    queryKey: ["allSchools"],
+    queryFn: getAllSchools,
+  })
+
+  useEffect(() => {
+    if (isInitializedRef.current || !serverChapters) return
+    if (serverChapters.length > 0) {
+      const mappedChapters: ChapterData[] = serverChapters.map((ch) => ({
+        id: String(ch.chapterId),
+        name: ch.chapterName,
+        assignedSchools: ch.schools.map((s) => ({
+          id: String(s.schoolId),
+          name: s.schoolName,
+        })),
+      }))
+      setChapters(mappedChapters)
+      isInitializedRef.current = true
+    }
+  }, [serverChapters])
+
+  useEffect(() => {
+    if (!allSchoolsData?.schools) return
+    const assignedSchoolIds = new Set(
+      chapters.flatMap((ch) => ch.assignedSchools.map((s) => s.id)),
+    )
+    const unassigned = allSchoolsData.schools
+      .filter((s) => !assignedSchoolIds.has(String(s.schoolId)))
+      .map((s) => ({
+        id: String(s.schoolId),
+        name: s.schoolName,
+      }))
+    setUnassignedSchools(unassigned)
+  }, [allSchoolsData, chapters])
 
   const assignedSchools = chapters.flatMap((ch) => ch.assignedSchools)
 

--- a/src/features/chapter/ui/ChapterManagePage.tsx
+++ b/src/features/chapter/ui/ChapterManagePage.tsx
@@ -13,6 +13,7 @@ import {
   useCreateChaptersBulk,
   useDeleteChapter,
 } from "@/entities/organization/hooks/useChapter"
+import { useUpdateSchool } from "@/entities/organization/hooks/useSchool"
 import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import ResetIcon from "@/shared/assets/icon/reset/ResetIcon"
@@ -57,6 +58,7 @@ export function ChapterManagePage() {
   const deleteChapterMutation = useDeleteChapter()
   const createChapterMutation = useCreateChapter()
   const createChaptersBulkMutation = useCreateChaptersBulk()
+  const updateSchoolMutation = useUpdateSchool()
   const { data: activeGisuId, isLoading: isGisuLoading } = useActiveGisuId()
   const { chapters: serverChapters } = useSchoolChapterMap()
 
@@ -320,7 +322,11 @@ export function ChapterManagePage() {
 
   async function handleSave() {
     const newChapters = chapters.filter((ch) => ch.id.startsWith("chapter-"))
-    if (newChapters.length === 0) return
+    const existingChapters = chapters.filter(
+      (ch) => !ch.id.startsWith("chapter-"),
+    )
+
+    if (newChapters.length === 0 && existingChapters.length === 0) return
 
     if (isGisuLoading || activeGisuId == null) {
       addToast({
@@ -333,51 +339,64 @@ export function ChapterManagePage() {
       return
     }
 
-    const bulkPayload = newChapters.map((ch) => ({
-      gisuId: activeGisuId,
-      name: ch.name,
-      schoolIds: ch.assignedSchools
-        .map((s) => Number(s.id))
-        .filter((id) => !Number.isNaN(id)),
-    }))
-
     try {
-      const createdIds =
-        await createChaptersBulkMutation.mutateAsync(bulkPayload)
-      if (
-        Array.isArray(createdIds) &&
-        createdIds.length === newChapters.length
-      ) {
-        const idMap = new Map<string, string>()
-        newChapters.forEach((ch, idx) => {
-          if (createdIds[idx] != null) {
-            idMap.set(ch.id, String(createdIds[idx]))
-          }
-        })
-        setChapters((prev) =>
-          prev.map((ch) => {
-            const serverId = idMap.get(ch.id)
-            return serverId ? { ...ch, id: serverId } : ch
-          }),
-        )
-        addToast({
-          message: "지부 정보가 저장되었습니다.",
-          color: "primary",
-          variant: "deep",
-          type: "default",
-          duration: 3000,
-        })
-      } else {
-        queryClient.invalidateQueries({ queryKey: ["chapters"] })
-        queryClient.invalidateQueries({ queryKey: ["chaptersWithSchools"] })
-        addToast({
-          message: "지부 정보 저장에 실패했습니다.",
-          color: "red",
-          variant: "deep",
-          type: "default",
-          duration: 3000,
-        })
+      if (newChapters.length > 0) {
+        const bulkPayload = newChapters.map((ch) => ({
+          gisuId: activeGisuId,
+          name: ch.name,
+          schoolIds: ch.assignedSchools
+            .map((s) => Number(s.id))
+            .filter((id) => !Number.isNaN(id)),
+        }))
+
+        const createdIds =
+          await createChaptersBulkMutation.mutateAsync(bulkPayload)
+
+        if (
+          Array.isArray(createdIds) &&
+          createdIds.length === newChapters.length
+        ) {
+          const idMap = new Map<string, string>()
+          newChapters.forEach((ch, idx) => {
+            if (createdIds[idx] != null) {
+              idMap.set(ch.id, String(createdIds[idx]))
+            }
+          })
+          setChapters((prev) =>
+            prev.map((ch) => {
+              const serverId = idMap.get(ch.id)
+              return serverId ? { ...ch, id: serverId } : ch
+            }),
+          )
+        }
       }
+
+      if (existingChapters.length > 0) {
+        const updatePromises = existingChapters.flatMap((ch) => {
+          const chapterId = Number(ch.id)
+          if (Number.isNaN(chapterId)) return []
+          return ch.assignedSchools.map((s) => {
+            const schoolId = Number(s.id)
+            if (Number.isNaN(schoolId)) return Promise.resolve()
+            return updateSchoolMutation.mutateAsync({
+              schoolId,
+              body: { chapterId },
+            })
+          })
+        })
+        await Promise.all(updatePromises)
+      }
+
+      queryClient.invalidateQueries({ queryKey: ["chapters"] })
+      queryClient.invalidateQueries({ queryKey: ["chaptersWithSchools"] })
+
+      addToast({
+        message: "지부 정보가 저장되었습니다.",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
     } catch {
       queryClient.invalidateQueries({ queryKey: ["chapters"] })
       queryClient.invalidateQueries({ queryKey: ["chaptersWithSchools"] })

--- a/src/features/project/management/ui/ProjectManagementPage.tsx
+++ b/src/features/project/management/ui/ProjectManagementPage.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/entities/member/model/identity"
 import { useViewerIdentity } from "@/entities/member/view-mode/useViewerIdentity"
 import { getChaptersWithSchools } from "@/entities/organization/api/organization"
-import { CHAPTERS } from "@/entities/organization/model/chapters"
 import { projectKeys } from "@/features/project/new/api/queryKeys"
 import { useIsMatchingPeriod } from "@/features/project/new/hooks/useIsMatchingPeriod"
 import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
@@ -128,7 +127,7 @@ function toValidProjectId(project: MatchingProject): number | null {
 export function ProjectManagementPage() {
   const navigate = useNavigate()
   const { me } = useViewerIdentity()
-  const [selectedChapter, setSelectedChapter] = useState<string>(CHAPTERS[0])
+  const [selectedChapter, setSelectedChapter] = useState<string>("")
 
   const isAdminScope = isAnyOperator(me)
   const isPm = isCurrentTermPm(me)
@@ -161,6 +160,12 @@ export function ProjectManagementPage() {
     enabled: useGroupedView && !!gisuId,
   })
 
+  const chapterNames = useMemo(
+    () => (chaptersQuery.data?.chapters ?? []).map((c) => c.chapterName),
+    [chaptersQuery.data],
+  )
+  const activeChapter = selectedChapter || (chapterNames[0] ?? "")
+
   const projects: MatchingProject[] = useMemo(() => {
     const hasFullAccess = isCentralCore(me)
     const list = managedQuery.data ?? []
@@ -175,9 +180,9 @@ export function ProjectManagementPage() {
   const selectedChapterInfo = useMemo(() => {
     if (!useGroupedView) return undefined
     return chaptersQuery.data?.chapters.find(
-      (chapter) => chapter.chapterName === selectedChapter,
+      (chapter) => chapter.chapterName === activeChapter,
     )
-  }, [useGroupedView, chaptersQuery.data, selectedChapter])
+  }, [useGroupedView, chaptersQuery.data, activeChapter])
 
   const selectedChapterId = selectedChapterInfo?.chapterId
     ? Number(selectedChapterInfo.chapterId)
@@ -295,8 +300,8 @@ export function ProjectManagementPage() {
           {useGroupedView && (
             <div className="min-w-0">
               <SegmentButton
-                items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
-                value={selectedChapter}
+                items={chapterNames.map((ch) => ({ value: ch, label: ch }))}
+                value={activeChapter}
                 onValueChange={setSelectedChapter}
                 className="w-full min-w-0 [&>button>span:last-child]:min-w-0 [&>button>span:last-child]:truncate"
                 itemClassName="min-w-0 flex-1 basis-0 shrink px-2"

--- a/src/features/recruiting/model/recruitmentList.ts
+++ b/src/features/recruiting/model/recruitmentList.ts
@@ -134,7 +134,9 @@ export function groupPostsBySchool(
   posts: RecruitmentPost[],
   chapter: Chapter,
 ): SchoolPostGroup[] {
-  return SCHOOLS_BY_BRANCH[chapter].map((school) => ({
+  const branchMap = SCHOOLS_BY_BRANCH as Record<string, readonly string[]>
+  const schools = branchMap[chapter] ?? []
+  return schools.map((school: string) => ({
     school,
     posts: posts.filter((post) => post.school === school),
   }))

--- a/src/features/recruiting/model/recruitmentQuotaMapper.ts
+++ b/src/features/recruiting/model/recruitmentQuotaMapper.ts
@@ -1,7 +1,5 @@
 import dayjs from "dayjs"
 
-import { CHAPTERS } from "@/entities/organization/model/chapters"
-
 import type {
   RecruitingRoundGroup,
   RecruitingSeasonConfigurationResponse,
@@ -65,7 +63,17 @@ export function mapGroupsToChapterQuotaData(
     : undefined
   const updatedTime = actualNow ? dayjs(actualNow).format("HH:mm") : undefined
 
-  const chapters = CHAPTERS.length > 0 ? CHAPTERS : Array.from(byChapter.keys())
+  const chapterNamesSet = new Set<string>()
+  if (serverChapters && serverChapters.length > 0) {
+    serverChapters.forEach((ch) => {
+      if (ch.chapterName) chapterNamesSet.add(ch.chapterName)
+    })
+  }
+  byChapter.forEach((_, chapterName) => {
+    if (chapterName) chapterNamesSet.add(chapterName)
+  })
+
+  const chapters = Array.from(chapterNamesSet)
 
   return chapters.map((chapterName) => {
     const chapterGroups = byChapter.get(chapterName) ?? []
@@ -90,9 +98,6 @@ export function mapGroupsToChapterQuotaData(
           ?.targetCount ?? 0
 
       return {
-        // 시즌이 있는지는 모집 목록이 이미 알려 준다. 설정 응답은 시즌마다
-        // 따로 오는데, 그것을 기다려 seasonId 를 비우면 편집 권한 판정이
-        // 로딩 상태에 끌려간다. 아직 안 온 시즌은 인원만 0으로 보인다.
         seasonId: group.seasonId,
         gisuId: group.gisuId || gisuId,
         schoolId: String(group.schoolId),

--- a/src/features/recruiting/ui/ApplicantFilterBar.test.tsx
+++ b/src/features/recruiting/ui/ApplicantFilterBar.test.tsx
@@ -1,12 +1,49 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { fireEvent, render, screen } from "@testing-library/react"
 import { useState } from "react"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import {
   type ApplicantListFilters,
   DEFAULT_APPLICANT_LIST_FILTERS,
 } from "../model/applicantListTypes"
 import { ApplicantFilterBar } from "./ApplicantFilterBar"
+
+vi.mock("@/entities/organization/hooks/useSchoolChapterMap", () => ({
+  useSchoolChapterMap: () => ({
+    chapters: [
+      {
+        chapterId: 1,
+        chapterName: "Ferrum",
+        schools: [{ schoolId: 10, schoolName: "광운대" }],
+      },
+      {
+        chapterId: 2,
+        chapterName: "Chromium",
+        schools: [{ schoolId: 11, schoolName: "홍익대" }],
+      },
+    ],
+    chapterNames: ["Ferrum", "Chromium"],
+    isLoading: false,
+  }),
+}))
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+}
+
+function renderWithQueryClient(ui: React.ReactNode) {
+  const queryClient = createTestQueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  )
+}
 
 function ApplicantFilterBarHarness() {
   const [filters, setFilters] = useState<ApplicantListFilters>({
@@ -32,7 +69,7 @@ function ApplicantFilterBarHarness() {
 
 describe("ApplicantFilterBar 지부 필터", () => {
   it("지부 선택이 바뀌면 기존 학교 선택을 초기화한다", () => {
-    render(<ApplicantFilterBarHarness />)
+    renderWithQueryClient(<ApplicantFilterBarHarness />)
 
     fireEvent.click(screen.getByRole("button", { name: "지부" }))
     fireEvent.click(screen.getByRole("option", { name: "Ferrum" }))
@@ -42,7 +79,7 @@ describe("ApplicantFilterBar 지부 필터", () => {
   })
 
   it("지부 스코프가 지정되면 학교별 체크와 지부 드롭다운을 숨긴다", () => {
-    render(
+    renderWithQueryClient(
       <ApplicantFilterBar
         filters={DEFAULT_APPLICANT_LIST_FILTERS}
         onFiltersChange={() => {}}

--- a/src/features/recruiting/ui/ApplicantFilterBar.tsx
+++ b/src/features/recruiting/ui/ApplicantFilterBar.tsx
@@ -1,10 +1,7 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 
-import {
-  type Chapter,
-  CHAPTERS,
-  isChapter,
-} from "@/entities/organization/model/chapters"
+import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
+import { type Chapter, isChapter } from "@/entities/organization/model/chapters"
 import FilterIcon from "@/shared/assets/icon/filter/FilterIcon"
 import { SCHOOLS_BY_BRANCH } from "@/shared/config/schools"
 import { cn } from "@/shared/lib/utils"
@@ -22,11 +19,6 @@ import {
 
 const CHAPTER_ALL_VALUE = "all"
 
-const CHAPTER_OPTIONS = [
-  { value: CHAPTER_ALL_VALUE, label: "지부 전체" },
-  ...CHAPTERS.map((chapter) => ({ value: chapter, label: chapter })),
-]
-
 const PART_OPTIONS = (["pm", "design", "web-pe", "mobile-pe"] as const).map(
   (part) => ({ value: part, label: PART_TAG_LABEL[part] }),
 )
@@ -43,27 +35,54 @@ const RESULT_OPTIONS = [
 
 function buildSchoolOptions(
   filters: ApplicantListFilters,
+  serverChapters: Array<{
+    chapterName: string
+    schools: Array<{ schoolName: string }>
+  }>,
   chapterScope?: Chapter,
 ): FilterDropdownOption[] {
+  const branchMap = SCHOOLS_BY_BRANCH as Record<string, readonly string[]>
+
   if (chapterScope) {
-    return SCHOOLS_BY_BRANCH[chapterScope].map((school) => ({
-      value: school,
-      label: school,
-    }))
+    const chapterObj = serverChapters.find(
+      (c) => c.chapterName === chapterScope,
+    )
+    const schools =
+      chapterObj?.schools.map((s) => s.schoolName) ??
+      branchMap[chapterScope] ??
+      []
+    return schools.map((school: string) => ({ value: school, label: school }))
   }
 
   const selectedChapters =
     filters.chapterTab === CHAPTER_ALL_VALUE
       ? filters.chapters.filter(isChapter)
       : [filters.chapterTab].filter(isChapter)
-  const chapters = selectedChapters.length > 0 ? selectedChapters : CHAPTERS
 
-  return chapters.flatMap((chapter) =>
-    SCHOOLS_BY_BRANCH[chapter].map((school) => ({
-      value: school,
-      label: school,
-    })),
-  )
+  const activeChapters =
+    selectedChapters.length > 0
+      ? serverChapters.filter((c) => selectedChapters.includes(c.chapterName))
+      : serverChapters
+
+  const schoolSet = new Set<string>()
+  activeChapters.forEach((ch) => {
+    ch.schools.forEach((s) => {
+      if (s.schoolName) schoolSet.add(s.schoolName)
+    })
+  })
+
+  if (schoolSet.size === 0) {
+    const fallbackChapters =
+      selectedChapters.length > 0 ? selectedChapters : Object.keys(branchMap)
+    fallbackChapters.forEach((ch) => {
+      ;(branchMap[ch] ?? []).forEach((s: string) => schoolSet.add(s))
+    })
+  }
+
+  return Array.from(schoolSet).map((school: string) => ({
+    value: school,
+    label: school,
+  }))
 }
 
 interface ApplicantFilterBarProps {
@@ -84,7 +103,23 @@ export function ApplicantFilterBar({
   className,
 }: ApplicantFilterBarProps) {
   const [openKey, setOpenKey] = useState<string | null>(null)
-  const schoolOptions = buildSchoolOptions(filters, chapterScope)
+  const { chapters: serverChapters } = useSchoolChapterMap()
+
+  const chapterOptions = useMemo(
+    () => [
+      { value: CHAPTER_ALL_VALUE, label: "지부 전체" },
+      ...serverChapters.map((ch) => ({
+        value: ch.chapterName,
+        label: ch.chapterName,
+      })),
+    ],
+    [serverChapters],
+  )
+
+  const schoolOptions = useMemo(
+    () => buildSchoolOptions(filters, serverChapters, chapterScope),
+    [filters, serverChapters, chapterScope],
+  )
   const showChapterFilter =
     filters.chapterTab === CHAPTER_ALL_VALUE &&
     !chapterScope &&
@@ -136,7 +171,7 @@ export function ApplicantFilterBar({
               {...multiDropdownProps(
                 "chapters",
                 "지부",
-                CHAPTER_OPTIONS,
+                chapterOptions,
                 CHAPTER_ALL_VALUE,
               )}
             />

--- a/src/features/recruiting/ui/ApplicantFilterBar.tsx
+++ b/src/features/recruiting/ui/ApplicantFilterBar.tsx
@@ -40,6 +40,7 @@ function buildSchoolOptions(
     schools: Array<{ schoolName: string }>
   }>,
   chapterScope?: Chapter,
+  isFallbackNeeded = false,
 ): FilterDropdownOption[] {
   const branchMap = SCHOOLS_BY_BRANCH as Record<string, readonly string[]>
 
@@ -47,11 +48,17 @@ function buildSchoolOptions(
     const chapterObj = serverChapters.find(
       (c) => c.chapterName === chapterScope,
     )
-    const schools =
-      chapterObj?.schools.map((s) => s.schoolName) ??
-      branchMap[chapterScope] ??
-      []
-    return schools.map((school: string) => ({ value: school, label: school }))
+    if (chapterObj) {
+      return chapterObj.schools.map((s) => ({
+        value: s.schoolName,
+        label: s.schoolName,
+      }))
+    }
+    if (isFallbackNeeded) {
+      const schools = branchMap[chapterScope] ?? []
+      return schools.map((school: string) => ({ value: school, label: school }))
+    }
+    return []
   }
 
   const selectedChapters =
@@ -71,7 +78,7 @@ function buildSchoolOptions(
     })
   })
 
-  if (schoolSet.size === 0) {
+  if (schoolSet.size === 0 && isFallbackNeeded) {
     const fallbackChapters =
       selectedChapters.length > 0 ? selectedChapters : Object.keys(branchMap)
     fallbackChapters.forEach((ch) => {
@@ -103,7 +110,7 @@ export function ApplicantFilterBar({
   className,
 }: ApplicantFilterBarProps) {
   const [openKey, setOpenKey] = useState<string | null>(null)
-  const { chapters: serverChapters } = useSchoolChapterMap()
+  const { chapters: serverChapters, isLoading, isError } = useSchoolChapterMap()
 
   const chapterOptions = useMemo(
     () => [
@@ -117,8 +124,14 @@ export function ApplicantFilterBar({
   )
 
   const schoolOptions = useMemo(
-    () => buildSchoolOptions(filters, serverChapters, chapterScope),
-    [filters, serverChapters, chapterScope],
+    () =>
+      buildSchoolOptions(
+        filters,
+        serverChapters,
+        chapterScope,
+        isLoading || Boolean(isError),
+      ),
+    [filters, serverChapters, chapterScope, isLoading, isError],
   )
   const showChapterFilter =
     filters.chapterTab === CHAPTER_ALL_VALUE &&

--- a/src/features/recruiting/ui/ChapterTabs.tsx
+++ b/src/features/recruiting/ui/ChapterTabs.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from "react"
 
 import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
-import { CHAPTERS } from "@/entities/organization/model/chapters"
 import { cn } from "@/shared/lib/utils"
 import { SegmentButton } from "@/shared/ui/segment-button/SegmentButton"
 
@@ -38,7 +37,7 @@ export function ChapterTabs({
         }),
       )
     }
-    return CHAPTERS.map((chapter) => ({ value: chapter, label: chapter }))
+    return []
   }, [customChapters, serverChapters])
 
   const items = useMemo(

--- a/src/features/recruiting/ui/RecruitmentDuplicateModal.tsx
+++ b/src/features/recruiting/ui/RecruitmentDuplicateModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react"
 
-import { CHAPTERS } from "@/entities/organization/model/chapters"
+import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import CloseThinIcon from "@/shared/assets/icon/close/CloseThinIcon"
 import ResetIcon from "@/shared/assets/icon/reset/ResetIcon"
 import { SCHOOLS_BY_BRANCH } from "@/shared/config/schools"
@@ -33,14 +33,30 @@ export function RecruitmentDuplicateModal({
   onCancel,
   onConfirm,
 }: RecruitmentDuplicateModalProps) {
+  const { chapters: serverChapters, chapterNames: serverChapterNames } =
+    useSchoolChapterMap()
+
   const chapters = useMemo(
-    () => (role === "central" ? [...CHAPTERS] : ownChapter ? [ownChapter] : []),
-    [role, ownChapter],
+    () =>
+      role === "central" ? serverChapterNames : ownChapter ? [ownChapter] : [],
+    [role, ownChapter, serverChapterNames],
   )
   const [activeChapter, setActiveChapter] = useState<Chapter | undefined>(
     chapters[0],
   )
   const [selectedSchools, setSelectedSchools] = useState<Set<string>>(new Set())
+
+  const currentSchools = useMemo(() => {
+    if (!activeChapter) return []
+    const chapterObj = serverChapters.find(
+      (c) => c.chapterName === activeChapter,
+    )
+    return chapterObj
+      ? chapterObj.schools.map((s) => s.schoolName)
+      : ((SCHOOLS_BY_BRANCH as Record<string, readonly string[]>)[
+          activeChapter
+        ] ?? [])
+  }, [activeChapter, serverChapters])
 
   // 모달을 다시 열 때마다 role에 맞는 기본 선택 상태로 되돌린다.
   // chapterAdmin은 본인 지부 학교 전체가 기본 선택, central은 빈 선택으로 시작.
@@ -49,12 +65,11 @@ export function RecruitmentDuplicateModal({
     setActiveChapter(chapters[0])
     setSelectedSchools(
       role === "chapterAdmin" && ownChapter
-        ? new Set(SCHOOLS_BY_BRANCH[ownChapter])
+        ? new Set(currentSchools)
         : new Set(),
     )
-  }, [open, role, ownChapter, chapters])
+  }, [open, role, ownChapter, chapters, currentSchools])
 
-  const currentSchools = activeChapter ? SCHOOLS_BY_BRANCH[activeChapter] : []
   const selectedList = useMemo(() => [...selectedSchools], [selectedSchools])
   const hasSelection = selectedList.length > 0
 

--- a/src/features/recruiting/ui/RecruitmentListPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentListPage.tsx
@@ -2,7 +2,8 @@ import { useNavigate } from "@tanstack/react-router"
 import { useMemo, useRef, useState } from "react"
 
 import { useMe } from "@/entities/member/hooks/useMe"
-import { CHAPTERS, isChapter } from "@/entities/organization/model/chapters"
+import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
+import { isChapter } from "@/entities/organization/model/chapters"
 import DownChevronIcon from "@/shared/assets/icon/chevron/sidebar/DownChevronIcon"
 import { SCHOOLS_BY_BRANCH } from "@/shared/config/schools"
 import { formatSchoolName } from "@/shared/lib/formatSchoolName"
@@ -51,19 +52,19 @@ import type { RecruitingScope } from "../model/recruitingScope"
 import type { RecruitmentPost, RecruitmentSort } from "../model/recruitmentList"
 
 interface RecruitmentListPageProps {
-  // 테스트 라우트(/test/recruiting-recruitments)에서 역할별 화면을 미리 보기 위한 override.
-  // 생략하면 로그인한 사용자의 실제 역할로 판정한다.
   role?: RecruitingListRole
   useMockData?: boolean
 }
 
-// 테스트 라우트 전용: 실 데이터 없이 role만으로 조회 스코프를 흉내낸다.
-// 실 데이터 경로는 resolveRecruitingScope(권한 조회 결과)를 그대로 쓴다.
-function buildMockScope(role: RecruitingListRole): RecruitingScope {
+function buildMockScope(
+  role: RecruitingListRole,
+  serverChapterNames: string[],
+): RecruitingScope {
+  const branchMap = SCHOOLS_BY_BRANCH as Record<string, readonly string[]>
   if (role === "central") {
     return {
       groups: [],
-      chapters: [...CHAPTERS],
+      chapters: serverChapterNames,
       schools: [],
       isFallback: false,
     }
@@ -72,7 +73,7 @@ function buildMockScope(role: RecruitingListRole): RecruitingScope {
     return {
       groups: [],
       chapters: [RECRUITING_MY_CHAPTER_MOCK],
-      schools: [...SCHOOLS_BY_BRANCH[RECRUITING_MY_CHAPTER_MOCK]],
+      schools: [...(branchMap[RECRUITING_MY_CHAPTER_MOCK] ?? [])],
       isFallback: false,
     }
   }
@@ -108,6 +109,7 @@ export function RecruitmentListPage({
 }: RecruitmentListPageProps) {
   const navigate = useNavigate()
   const { data: me } = useMe()
+  const { chapterNames: serverChapterNames } = useSchoolChapterMap()
   // RecruitmentCreatePage(BasicInfoForm)가 진입 지점별 필드 잠금에 쓰는 값이라
   // role 자체는 계속 넘긴다. 이 화면의 조회 범위는 더 이상 role로 가르지 않고
   // resolveRecruitingScope의 실제 EDIT 권한 결과를 따른다.
@@ -152,7 +154,10 @@ export function RecruitmentListPage({
     () => resolveRecruitingScope(groups, permittedSeasonIds, viewerSchool),
     [groups, permittedSeasonIds, viewerSchool],
   )
-  const mockScope = useMemo(() => buildMockScope(role), [role])
+  const mockScope = useMemo(
+    () => buildMockScope(role, serverChapterNames),
+    [role, serverChapterNames],
+  )
   const activeScope = useMockData ? mockScope : scope
   // 세그먼트(지부/학교 탭) 노출은 현재 조회된 데이터 양이 아니라 역할 자체로 정한다.
   // central=지부 세그먼트, chapterAdmin/schoolStaff=학교 세그먼트 — 게시글이
@@ -306,6 +311,8 @@ export function RecruitmentListPage({
     })
   }
 
+  const branchMap = SCHOOLS_BY_BRANCH as Record<string, readonly string[]>
+
   // 공유 보관함이 보이는 뷰로 전환 (지부 탭이 없는 스코프는 학교 탭만 바꾸고,
   // 지부 탭이 있는 스코프는 해당 학교가 속한 지부 탭 + 학교 드릴다운으로 전환)
   const handleNavigateToArchive = (school: string) => {
@@ -313,8 +320,8 @@ export function RecruitmentListPage({
       setSchoolTab(school)
       return
     }
-    const targetChapter = CHAPTERS.find((chapter) =>
-      (SCHOOLS_BY_BRANCH[chapter] as readonly string[]).includes(school),
+    const targetChapter = serverChapterNames.find((chapter: string) =>
+      (branchMap[chapter] ?? []).includes(school),
     )
     if (targetChapter) setChapterTab(targetChapter)
     setSelectedSchool(school)
@@ -323,14 +330,14 @@ export function RecruitmentListPage({
   // central 세그먼트는 데이터 유무와 무관하게 조직의 전체 지부를 보여준다.
   const centralChapters =
     chapterTab === "all"
-      ? [...CHAPTERS]
+      ? serverChapterNames
       : isChapter(chapterTab)
         ? [chapterTab]
         : []
   const chapterGroups = groupPostsByChapter(viewPosts, centralChapters)
 
   const ownScopeSchools = ownScopeChapter
-    ? SCHOOLS_BY_BRANCH[ownScopeChapter]
+    ? (branchMap[ownScopeChapter] ?? [])
     : []
   // 학교 탭이 없는 단일 학교 스코프에서는 schoolTab이 항상 "all"로 머무르므로,
   // 헤딩·보관함·생성 버튼 판단에는 실제 학교 이름을 대신 쓴다.

--- a/src/features/recruiting/ui/RecruitmentSchoolSearchDropdown.tsx
+++ b/src/features/recruiting/ui/RecruitmentSchoolSearchDropdown.tsx
@@ -45,13 +45,14 @@ export function RecruitmentSchoolSearchDropdown({
 
   // 호출부가 조회 중이라 빈 배열을 넘기는 경우가 있다. 그때까지 "검색 결과가
   // 없습니다" 를 보여주지 않도록 지부 목록으로 받쳐 준다.
+  const branchMap = SCHOOLS_BY_BRANCH as Record<string, readonly string[]>
   const schoolList =
     schools && schools.length > 0
       ? schools
       : chapter
-        ? SCHOOLS_BY_BRANCH[chapter]
+        ? (branchMap[chapter] ?? [])
         : []
-  const filteredSchools = schoolList.filter((school) =>
+  const filteredSchools = schoolList.filter((school: string) =>
     school.toLowerCase().includes(searchQuery.toLowerCase()),
   )
 
@@ -83,7 +84,7 @@ export function RecruitmentSchoolSearchDropdown({
             검색 결과가 없습니다.
           </li>
         ) : (
-          filteredSchools.map((school) => (
+          filteredSchools.map((school: string) => (
             <li
               key={school}
               role="option"

--- a/src/features/recruiting/ui/create/RecruitmentBasicInfoForm.tsx
+++ b/src/features/recruiting/ui/create/RecruitmentBasicInfoForm.tsx
@@ -334,19 +334,29 @@ export function RecruitmentBasicInfoForm({
   // 판정되므로, 그 상태로 초기화하면 실제 role이 늦게 schoolStaff로 확정될 때 그 사이
   // 사용자가 고른 지부·학교를 되돌려버린다. 두 판단 근거 중 하나라도 확정될 때까지 보류한다.
   const isRoleResolved = !!roleProp || hasRoleTypeData || !isSeasonGroupsLoading
+  const isChaptersLoading = chaptersQuery.isLoading || gisuQuery.isLoading
+  const isChapterResolved =
+    !!initialChapter ||
+    (role === "central"
+      ? !isChaptersLoading && (gisuId == null || chaptersQuery.data != null)
+      : true)
+  const isInitResolved = isRoleResolved && isChapterResolved
 
   // 진입 지점(role·initialChapter·initialSchool)이 바뀌면 상위(RecruitmentCreatePage)가
   // key를 바꿔 이 컴포넌트를 통째로 리마운트시킨다. 그때마다 지부·학교 초기값을 새로 채운다.
   // role/viewerChapter/viewerSchool은 useMe 조회가 끝나야 채워지므로 의존성에 넣어
   // 로그인 정보가 늦게 도착해도 다시 채운다.
   useEffect(() => {
-    if (!isRoleResolved) return
+    if (!isInitResolved) return
+    const defaultChapter =
+      initialChapter ??
+      (chapter && isChapter(chapter) ? chapter : undefined) ??
+      (role === "central"
+        ? (chapterEntries[0]?.chapterName ?? "")
+        : viewerChapter)
+
     const prefill = {
-      chapter:
-        initialChapter ??
-        (role === "central"
-          ? (chapterEntries[0]?.chapterName ?? "")
-          : viewerChapter),
+      chapter: defaultChapter,
       school:
         initialSchool ?? (role === "schoolStaff" ? viewerSchool : undefined),
     }
@@ -363,7 +373,7 @@ export function RecruitmentBasicInfoForm({
       periodForm,
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isRoleResolved, role, viewerChapter, viewerSchool])
+  }, [isInitResolved, role, viewerChapter, viewerSchool, chapterEntries])
 
   // 지부는 central만 자유 선택. 학교는 central이거나(지부 선택 후),
   // chapterAdmin이 지부 페이지(학교 미고정)에서 들어왔을 때만 선택 가능.

--- a/src/features/recruiting/ui/create/RecruitmentBasicInfoForm.tsx
+++ b/src/features/recruiting/ui/create/RecruitmentBasicInfoForm.tsx
@@ -4,11 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react"
 
 import { useMe } from "@/entities/member/hooks/useMe"
 import { getChaptersWithSchools } from "@/entities/organization/api/organization"
-import {
-  type Chapter,
-  CHAPTERS,
-  isChapter,
-} from "@/entities/organization/model/chapters"
+import { type Chapter, isChapter } from "@/entities/organization/model/chapters"
 import DownChevronIcon from "@/shared/assets/icon/chevron/sidebar/DownChevronIcon"
 import InfoCircleIcon from "@/shared/assets/icon/infomation/InfoCircleIcon"
 import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
@@ -239,14 +235,6 @@ export function RecruitmentBasicInfoForm({
     isForbidden: isAdminRoundsForbidden,
   } = useAdminRecruitingRounds()
   const { data: me } = useMe()
-  // role은 목록 화면(또는 사이드바 직접 진입)에서 넘어온 값이 있으면 그걸 우선
-  // 쓰고(진입 지점에 따른 고정 문맥), 없으면 실제 로그인 사용자의 권한으로 판단한다.
-  // me.roles(RoleType)가 정상적으로 채워져 있으면 그걸 신뢰하지만, 계정에 따라
-  // roles가 빈 배열로 내려오는 데이터 결손이 실제로 확인됐다(#657 평가 화면에서도
-  // 같은 이유로 RoleType 대신 실제 권한 걸린 엔드포인트의 성공/403 응답으로 판단하는
-  // 패턴을 씀). roles가 비어있을 때만 그 패턴을 빌려, admin 전용 조회(GET /admin/rounds)가
-  // 403이면 schoolStaff로, 성공(또는 아직 로딩 중)이면 central로 대체 판단한다 —
-  // chapterAdmin까지는 이 신호만으로 구분할 수 없어 더 넓은 central 쪽으로 폴백한다.
   const hasRoleTypeData = !!me?.roles?.length
   const role =
     roleProp ??
@@ -255,11 +243,6 @@ export function RecruitmentBasicInfoForm({
       : isAdminRoundsForbidden
         ? "schoolStaff"
         : "central")
-  const viewerChapterName = resolveViewerChapter(me)
-  const viewerChapter = isChapter(viewerChapterName)
-    ? viewerChapterName
-    : CHAPTERS[0]
-  const viewerSchool = resolveViewerSchool(me)
 
   // 지부·학교 선택지는 실제 기수 기준 조직 데이터(GISU-201: 다른 화면들도 쓰는 getChaptersWithSchools)에서 가져온다.
   const gisuQuery = useActiveGisu()
@@ -273,7 +256,12 @@ export function RecruitmentBasicInfoForm({
     staleTime: 5 * 60 * 1000,
   })
   const chapterEntries = chaptersQuery.data?.chapters ?? []
-  const chapterOptions = CHAPTERS
+  const chapterOptions = chapterEntries.map((e) => e.chapterName)
+  const viewerChapterName = resolveViewerChapter(me)
+  const viewerChapter = isChapter(viewerChapterName)
+    ? viewerChapterName
+    : (chapterEntries[0]?.chapterName ?? "")
+  const viewerSchool = resolveViewerSchool(me)
   const selectedChapterEntry = chapterEntries.find(
     (entry) => entry.chapterName === chapter,
   )
@@ -355,7 +343,10 @@ export function RecruitmentBasicInfoForm({
     if (!isRoleResolved) return
     const prefill = {
       chapter:
-        initialChapter ?? (role === "central" ? CHAPTERS[0] : viewerChapter),
+        initialChapter ??
+        (role === "central"
+          ? (chapterEntries[0]?.chapterName ?? "")
+          : viewerChapter),
       school:
         initialSchool ?? (role === "schoolStaff" ? viewerSchool : undefined),
     }

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
-import { useLayoutEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 
 import { useMe } from "@/entities/member/hooks/useMe"
 import {
@@ -69,6 +69,19 @@ function MatchingApplicationsPage() {
       : (chapterNames[0] ?? "")
 
   const [selectedChapter, setSelectedChapter] = useState(defaultChapter)
+
+  useEffect(() => {
+    if (chapterNames.length === 0) return
+    if (!selectedChapter || !chapterNames.includes(selectedChapter)) {
+      const nextChapter =
+        userChapter && chapterNames.includes(userChapter)
+          ? userChapter
+          : (chapterNames[0] ?? "")
+      if (nextChapter) {
+        setSelectedChapter(nextChapter)
+      }
+    }
+  }, [chapterNames, userChapter, selectedChapter])
 
   // 지부장 본인 지부 추적 (auto-select 후 갱신)
   const ownChapter = useRef<string>(defaultChapter)

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -14,7 +14,6 @@ import {
 } from "@/entities/member/model/identity"
 import { useViewerIdentity } from "@/entities/member/view-mode/useViewerIdentity"
 import { getChaptersWithSchools } from "@/entities/organization/api/organization"
-import { CHAPTERS } from "@/entities/organization/model/chapters"
 import {
   useAdminPageData,
   useChallengerPageData,
@@ -50,6 +49,10 @@ function MatchingApplicationsPage() {
     () => chaptersQuery.data?.chapters ?? [],
     [chaptersQuery.data],
   )
+  const chapterNames = useMemo(
+    () => chapters.map((c) => c.name).filter(Boolean),
+    [chapters],
+  )
 
   const gisuId = useActiveGisuId().data ?? 0
   const chaptersWithSchoolsQuery = useQuery({
@@ -60,11 +63,10 @@ function MatchingApplicationsPage() {
 
   // challenger records에서 지부명 추출 (어드민 포함 모든 역할)
   const userChapter = getViewerBranch(me)
-  const defaultChapter = CHAPTERS.includes(
-    userChapter as (typeof CHAPTERS)[number],
-  )
-    ? userChapter!
-    : "Chromium"
+  const defaultChapter =
+    userChapter && chapterNames.includes(userChapter)
+      ? userChapter
+      : (chapterNames[0] ?? "")
 
   const [selectedChapter, setSelectedChapter] = useState(defaultChapter)
 
@@ -95,7 +97,7 @@ function MatchingApplicationsPage() {
     if (hasAutoSelected.current || !me) return
     if (isChapterPresident(me)) {
       if (chapters.length === 0) return
-      if (CHAPTERS.includes(userChapter as (typeof CHAPTERS)[number])) return // 이미 records로 처리됨
+      if (userChapter && chapterNames.includes(userChapter)) return // 이미 records로 처리됨
       const myChapterId = me.roles?.find(
         (r) => r.roleType === "CHAPTER_PRESIDENT",
       )?.organizationId
@@ -112,10 +114,7 @@ function MatchingApplicationsPage() {
       const myChapter = chaptersWithSchoolsQuery.data?.chapters.find((c) =>
         c.schools.some((s) => s.schoolId === String(me.schoolId)),
       )
-      if (
-        myChapter &&
-        CHAPTERS.includes(myChapter.chapterName as (typeof CHAPTERS)[number])
-      ) {
+      if (myChapter && chapterNames.includes(myChapter.chapterName)) {
         setSelectedChapter(myChapter.chapterName)
         ownChapter.current = myChapter.chapterName
         hasAutoSelected.current = true
@@ -169,7 +168,7 @@ function MatchingApplicationsPage() {
           {showAdminSection && (
             <div className="flex w-263 flex-col gap-13">
               <SegmentButton
-                items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
+                items={chapterNames.map((ch) => ({ value: ch, label: ch }))}
                 value={selectedChapter}
                 onValueChange={(v) => {
                   if (isRestrictedToChapter && v !== ownChapter.current) {

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -17,11 +17,8 @@ import {
   getAllChapters,
   getAllGisu,
 } from "@/entities/organization/api/organization"
-import {
-  type Chapter,
-  CHAPTERS,
-  isChapter,
-} from "@/entities/organization/model/chapters"
+import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
+import { type Chapter, isChapter } from "@/entities/organization/model/chapters"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
 import {
   NoticeCardList,
@@ -97,7 +94,7 @@ function readHashNoticeId() {
 export const Route = createFileRoute("/matching/")({
   validateSearch: (search: Record<string, unknown>): AnnounceSearch => {
     return {
-      chapter: isChapter(search.chapter) ? search.chapter : CHAPTERS[0],
+      chapter: isChapter(search.chapter) ? (search.chapter as Chapter) : "",
       page: parsePage(search.page),
     }
   },
@@ -123,6 +120,8 @@ function TeamMatchingAnnouncePage() {
   const addToast = useToastStore((state) => state.addToast)
   const [pendingNotice] = useState(readPendingNotice)
   const [hashNoticeId] = useState(readHashNoticeId)
+
+  const { chapterNames: serverChapterNames } = useSchoolChapterMap()
 
   const { data: me } = useMe()
   const { me: identity } = useViewerIdentity()
@@ -319,7 +318,10 @@ function TeamMatchingAnnouncePage() {
           <div className="flex w-full flex-col items-center gap-2.5">
             <div className="flex w-full flex-row items-center gap-2.5">
               <SegmentButton
-                items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
+                items={serverChapterNames.map((ch: string) => ({
+                  value: ch,
+                  label: ch,
+                }))}
                 value={chapter}
                 onValueChange={(v) => handleChapterChange(v as Chapter)}
                 className="w-full min-w-0 [&>button>span:last-child]:min-w-0 [&>button>span:last-child]:truncate"

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -155,6 +155,22 @@ function TeamMatchingAnnouncePage() {
     return chaptersData.chapters.find((c) => c.name === chapter)?.id || null
   }, [chaptersData, chapter])
 
+  useEffect(() => {
+    if (serverChapterNames.length === 0) return
+    if (!chapter || !serverChapterNames.includes(chapter)) {
+      const defaultChapter =
+        userChapter && serverChapterNames.includes(userChapter)
+          ? userChapter
+          : (serverChapterNames[0] ?? "")
+      if (defaultChapter) {
+        navigate({
+          search: (prev) => ({ ...prev, chapter: defaultChapter }),
+          replace: true,
+        })
+      }
+    }
+  }, [chapter, serverChapterNames, userChapter, navigate])
+
   const { data: noticesData, isLoading: isNoticesLoading } = useQuery({
     queryKey: [
       "notices",
@@ -172,7 +188,7 @@ function TeamMatchingAnnouncePage() {
         size: NOTICE_PAGE_SIZE,
         sort: "createdAt,DESC",
       }),
-    enabled: !!activeGisuId,
+    enabled: !!activeGisuId && !!selectedChapterId,
   })
 
   const firstNoticeId = noticesData?.content[0]?.id

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -16,11 +16,8 @@ import {
   getAllChapters,
   getAllGisu,
 } from "@/entities/organization/api/organization"
-import {
-  type Chapter,
-  CHAPTERS,
-  isChapter,
-} from "@/entities/organization/model/chapters"
+import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
+import { type Chapter, isChapter } from "@/entities/organization/model/chapters"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
 import {
   NoticeCardList,
@@ -96,7 +93,7 @@ function readHashNoticeId() {
 export const Route = createFileRoute("/matching/projects/announce/")({
   validateSearch: (search: Record<string, unknown>): AnnounceSearch => {
     return {
-      chapter: isChapter(search.chapter) ? search.chapter : CHAPTERS[0],
+      chapter: isChapter(search.chapter) ? (search.chapter as Chapter) : "",
       page: parsePage(search.page),
     }
   },
@@ -109,19 +106,21 @@ export const Route = createFileRoute("/matching/projects/announce/")({
     if (isChapter(userChapter) && search.chapter !== userChapter) {
       throw redirect({
         to: "/matching/projects/announce",
-        search: { ...search, chapter: userChapter },
+        search: { chapter: userChapter, page: search.page },
       })
     }
   },
-  component: ProjectSettingsAnnouncePage,
+  component: ProjectMatchingAnnouncePage,
 })
 
-function ProjectSettingsAnnouncePage() {
+function ProjectMatchingAnnouncePage() {
   const { chapter, page } = Route.useSearch()
   const navigate = useNavigate({ from: Route.fullPath })
   const addToast = useToastStore((state) => state.addToast)
   const [pendingNotice] = useState(readPendingNotice)
   const [hashNoticeId] = useState(readHashNoticeId)
+
+  const { chapterNames: serverChapterNames } = useSchoolChapterMap()
 
   const { data: me } = useMe()
   const { me: identity } = useViewerIdentity()
@@ -316,7 +315,10 @@ function ProjectSettingsAnnouncePage() {
           <div className="flex w-full flex-col items-center gap-2.5">
             <div className="flex w-full flex-row items-center gap-2.5">
               <SegmentButton
-                items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
+                items={serverChapterNames.map((ch: string) => ({
+                  value: ch,
+                  label: ch,
+                }))}
                 value={chapter}
                 onValueChange={(v) => handleChapterChange(v as Chapter)}
                 className="w-full min-w-0 [&>button>span:last-child]:min-w-0 [&>button>span:last-child]:truncate"

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -153,6 +153,22 @@ function ProjectMatchingAnnouncePage() {
     return chaptersData.chapters.find((c) => c.name === chapter)?.id || null
   }, [chaptersData, chapter])
 
+  useEffect(() => {
+    if (serverChapterNames.length === 0) return
+    if (!chapter || !serverChapterNames.includes(chapter)) {
+      const defaultChapter =
+        userChapter && serverChapterNames.includes(userChapter)
+          ? userChapter
+          : (serverChapterNames[0] ?? "")
+      if (defaultChapter) {
+        navigate({
+          search: (prev) => ({ ...prev, chapter: defaultChapter }),
+          replace: true,
+        })
+      }
+    }
+  }, [chapter, serverChapterNames, userChapter, navigate])
+
   const { data: noticesData, isLoading: isNoticesLoading } = useQuery({
     queryKey: [
       "notices",
@@ -171,7 +187,7 @@ function ProjectMatchingAnnouncePage() {
         size: NOTICE_PAGE_SIZE,
         sort: "createdAt,DESC",
       }),
-    enabled: !!activeGisuId,
+    enabled: !!activeGisuId && !!selectedChapterId,
   })
 
   const firstNoticeId = noticesData?.content[0]?.id

--- a/src/routes/matching/status.tsx
+++ b/src/routes/matching/status.tsx
@@ -7,7 +7,7 @@ import {
   isChapterPresident,
   isOperator,
 } from "@/entities/member/model/identity"
-import { type Chapter, CHAPTERS } from "@/entities/organization/model/chapters"
+import { type Chapter } from "@/entities/organization/model/chapters"
 import { useChapters } from "@/features/application/hooks/useApplicationPageData"
 import { ApplicationStatsSection } from "@/features/application/ui/ApplicationStatsSection"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
@@ -33,12 +33,17 @@ function MatchingStatusPage() {
     () => chaptersQuery.data?.chapters ?? [],
     [chaptersQuery.data],
   )
+  const chapterNames = useMemo(
+    () => chapters.map((c) => c.name).filter(Boolean),
+    [chapters],
+  )
 
   // challenger records에서 지부명 추출 (어드민 포함 모든 역할)
   const userChapter = getViewerBranch(me)
-  const defaultChapter: Chapter = CHAPTERS.includes(userChapter as Chapter)
-    ? (userChapter as Chapter)
-    : CHAPTERS[0]
+  const defaultChapter: Chapter =
+    userChapter && chapterNames.includes(userChapter)
+      ? userChapter
+      : (chapterNames[0] ?? "")
 
   const [selectedChapter, setSelectedChapter] =
     useState<Chapter>(defaultChapter)
@@ -48,14 +53,14 @@ function MatchingStatusPage() {
   useLayoutEffect(() => {
     if (hasAutoSelected.current || !me || chapters.length === 0) return
     if (!isChapterPresident(me)) return
-    if (CHAPTERS.includes(userChapter as Chapter)) return // 이미 records로 처리됨
+    if (userChapter && chapterNames.includes(userChapter)) return // 이미 records로 처리됨
     const myChapterId = me.roles?.find(
       (r) => r.roleType === "CHAPTER_PRESIDENT",
     )?.organizationId
     if (!myChapterId) return
     const myChapter = chapters.find((c) => c.id === myChapterId)
-    if (myChapter && CHAPTERS.includes(myChapter.name as Chapter)) {
-      setSelectedChapter(myChapter.name as Chapter)
+    if (myChapter && chapterNames.includes(myChapter.name)) {
+      setSelectedChapter(myChapter.name)
       hasAutoSelected.current = true
     }
   }, [me, chapters, userChapter])
@@ -95,7 +100,7 @@ function MatchingStatusPage() {
         {/* 지부 선택 + 콘텐츠 */}
         <div className="mt-6 flex w-263 flex-col gap-13">
           <SegmentButton
-            items={CHAPTERS.map((ch) => ({ value: ch, label: ch }))}
+            items={chapterNames.map((ch) => ({ value: ch, label: ch }))}
             value={selectedChapter}
             onValueChange={(v) => setSelectedChapter(v as Chapter)}
             className="w-full min-w-0 [&>button>span:last-child]:min-w-0 [&>button>span:last-child]:truncate"

--- a/src/routes/matching/status.tsx
+++ b/src/routes/matching/status.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { useLayoutEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 
 import { useMe } from "@/entities/member/hooks/useMe"
 import {
@@ -47,6 +47,19 @@ function MatchingStatusPage() {
 
   const [selectedChapter, setSelectedChapter] =
     useState<Chapter>(defaultChapter)
+
+  useEffect(() => {
+    if (chapterNames.length === 0) return
+    if (!selectedChapter || !chapterNames.includes(selectedChapter)) {
+      const nextChapter =
+        userChapter && chapterNames.includes(userChapter)
+          ? userChapter
+          : (chapterNames[0] ?? "")
+      if (nextChapter) {
+        setSelectedChapter(nextChapter as Chapter)
+      }
+    }
+  }, [chapterNames, userChapter, selectedChapter])
 
   // challenger records에 지부 정보가 없는 경우 chapters API로 폴백 (페인트 전 적용)
   const hasAutoSelected = useRef(false)

--- a/src/routes/recruiting/recruitments/new.tsx
+++ b/src/routes/recruiting/recruitments/new.tsx
@@ -32,10 +32,11 @@ export const Route = createFileRoute("/recruiting/recruitments/new")({
     search: Record<string, unknown>,
   ): RecruitmentCreateSearch => {
     const chapter = isChapter(search.chapter) ? search.chapter : undefined
+    const branchMap = SCHOOLS_BY_BRANCH as Record<string, readonly string[]>
     const school =
       chapter &&
       typeof search.school === "string" &&
-      (SCHOOLS_BY_BRANCH[chapter] as readonly string[]).includes(search.school)
+      (branchMap[chapter] ?? []).includes(search.school)
         ? search.school
         : undefined
 


### PR DESCRIPTION
## 📸 작업 내용

- 프론트엔드 코드 전반에 하드코딩되어 있던 지부 목록 상수를 제거하고, 서버 API(`GET /v1/chapters/with-schools`) 기반의 동적 지부 조회 구조로 전면 전환했습니다.
- `Chapter` 타입을 `string`으로 확장하여 DB에 새로 추가되는 지부나 다른 기수의 지부(예: 11기 지부)가 클라이언트 코드 수정 없이 동적으로 표시 및 동작하도록 개선했습니다.
- 모집 공고 관리, 지원자 필터링, 지부 관리 페이지, 프로젝트 관리, 매칭 공고/현황 라우트 전반에 동적 지부 조회를 적용했습니다.

## 🎞️ 주요 코드 설명

### 1. `useSchoolChapterMap` Hook을 통한 동적 지부 데이터 공급

```TypeScript
// src/entities/organization/hooks/useSchoolChapterMap.ts
export function useSchoolChapterMap() {
  const gisuQuery = useActiveGisu()
  const activeGisuId = gisuQuery.data?.gisuId

  const query = useQuery({
    queryKey: ["chapters", "with-schools", activeGisuId],
    queryFn: () => getChaptersWithSchools(activeGisuId!),
    enabled: !!activeGisuId,
  })

  const chapterNames = useMemo(
    () => (query.data?.chapters ?? []).map((ch) => ch.chapterName),
    [query.data],
  )

  return {
    chapters: query.data?.chapters ?? [],
    chapterNames,
    isLoading: query.isLoading,
  }
}
```

- 활성 기수의 지부-학교 매핑 API를 캡슐화하여 지부 이름 목록(`chapterNames`) 및 세부 정보를 하위 컴포넌트에 공급합니다.

### 2. 지부 관리 페이지의 서버 API 기반 데이터 연동

```TypeScript
// src/features/chapter/ui/ChapterManagePage.tsx
const { chapters: serverChapters } = useSchoolChapterMap()
const { data: allSchoolsData } = useQuery({
  queryKey: ["allSchools"],
  queryFn: getAllSchools,
})

useEffect(() => {
  if (!serverChapters || serverChapters.length === 0) return
  const mappedChapters: ChapterData[] = serverChapters.map((ch) => ({
    id: String(ch.chapterId),
    name: ch.chapterName,
    assignedSchools: ch.schools.map((s) => ({
      id: String(s.schoolId),
      name: s.schoolName,
    })),
  }))
  setChapters(mappedChapters)
}, [serverChapters])
```

- 기존 정적 목업 배열을 제거하고, 서버 API에서 받아온 지부/소속 학교 및 전체 학교 목록(`allSchoolsData.schools`)에서 미지정 학교를 계산해 DnD 패널에 동적으로 표출합니다.

### 3. 모집 할당 mapper의 동적 지부 생성

```TypeScript
// src/features/recruiting/model/recruitmentQuotaMapper.ts
const chapterNamesSet = new Set<string>()
if (serverChapters && serverChapters.length > 0) {
  serverChapters.forEach((ch) => {
    if (ch.chapterName) chapterNamesSet.add(ch.chapterName)
  })
}
byChapter.forEach((_, chapterName) => {
  if (chapterName) chapterNamesSet.add(chapterName)
})

const chapters = Array.from(chapterNamesSet)
```

- 모집 할당 데이터 가공 시 정적 `CHAPTERS` 대신 서버 지부 정보와 모집 라운드 그룹에서 지부 목록을 동적으로 유도합니다.

## 🖥️ 구현화면


## 🔗 연결된 이슈

> 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4)

- Connected: #742 

## 💬 기타 더 이야기해볼 점

- `CHAPTERS` 정적 배열 상수가 빈 배열(`readonly string[] = []`)로 대체되고 타입이 `string`으로 변환됨에 따라, 향후 DB에 새로운 지부가 추가되더라도 프론트엔드 코드 수정 없이 정상 동작합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 학교와 지부 목록을 서버 데이터와 동기화합니다.
  * 지부 선택, 학교 필터, 모집 관리 및 매칭 화면에서 최신 지부 정보를 표시합니다.
  * 서버 데이터가 없을 때 기존 기본 학교 목록을 사용합니다.
  * 데이터 조회 중 로딩 상태를 제공합니다.

* **버그 수정**
  * 지부 및 학교 데이터가 없는 경우에도 화면이 안정적으로 동작하도록 개선했습니다.
  * 중복 학교 표시와 잘못된 기본 지부 선택을 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->