### PR TITLE
fix: 평가 담당자 배정 시 접속자의 본인 학교 그룹이 기본 선택되도록 수정

### DIFF
--- a/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
+++ b/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
@@ -4,10 +4,12 @@ import {
   DragOverlay,
   type DragStartEvent,
 } from "@dnd-kit/core"
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 
+import { useMe } from "@/entities/member/hooks/useMe"
 import HamburgerIcon from "@/shared/assets/icon/hamburger/HamburgerIcon"
 import ResetIcon from "@/shared/assets/icon/reset/ResetIcon"
+import { formatSchoolName } from "@/shared/lib/formatSchoolName"
 import { useChipAssignment } from "@/shared/lib/useChipAssignment"
 import { Button } from "@/shared/ui/Button"
 import { PageLabel } from "@/shared/ui/page-label/PageLabel"
@@ -26,6 +28,7 @@ import {
   SCHOOL_STAFF_PANEL_ID,
   type Staff,
 } from "../../model/evaluatorAllocation"
+import { resolveViewerSchool } from "../../model/recruitingRole"
 import { DroppableRecruitmentBox } from "./DroppableRecruitmentBox"
 import { EvaluatorSharedNote } from "./EvaluatorSharedNote"
 import { SchoolStaffPanel } from "./SchoolStaffPanel"
@@ -37,14 +40,37 @@ interface EvaluatorAllocationPageProps {
 export function EvaluatorAllocationPage({
   roundId,
 }: EvaluatorAllocationPageProps = {}) {
+  const { data: me } = useMe()
+  const viewerSchool = resolveViewerSchool(me)
   const { groups } = useAdminRecruitingRounds()
-  const activeRoundId = roundId ?? groups[0]?.rounds[0]?.roundId ?? null
+
+  const mySchoolGroup = useMemo(() => {
+    if (!groups.length) return null
+    if (me?.schoolId) {
+      const foundById = groups.find(
+        (group) => String(group.schoolId) === String(me.schoolId),
+      )
+      if (foundById) return foundById
+    }
+    if (viewerSchool) {
+      const formattedViewer = formatSchoolName(viewerSchool)
+      const foundByName = groups.find(
+        (group) =>
+          group.schoolName === viewerSchool ||
+          formatSchoolName(group.schoolName) === formattedViewer,
+      )
+      if (foundByName) return foundByName
+    }
+    return groups[0] ?? null
+  }, [groups, me?.schoolId, viewerSchool])
+
+  const activeRoundId = roundId ?? mySchoolGroup?.rounds[0]?.roundId ?? null
 
   const activeGroup = activeRoundId
     ? (groups.find((group) =>
         group.rounds.some((r) => String(r.roundId) === String(activeRoundId)),
-      ) ?? groups[0])
-    : groups[0]
+      ) ?? mySchoolGroup)
+    : mySchoolGroup
 
   // 배정 권한은 시즌 단위다. 권한을 확인하기 전에는 잠가 둔다.
   const seasonIds = activeGroup?.seasonId ? [activeGroup.seasonId] : []
@@ -58,7 +84,8 @@ export function EvaluatorAllocationPage({
   const schoolId = activeGroup?.schoolId
   const gisuId = activeGroup?.gisuId
   const chapterId = activeGroup?.chapterId
-  const schoolName = activeGroup?.schoolName ?? "교내"
+  const schoolName =
+    activeGroup?.schoolName ?? formatSchoolName(viewerSchool) ?? "교내"
 
   const { data: staffList = [], isSuccess: isStaffSuccess } = useSchoolStaff(
     schoolId,


### PR DESCRIPTION
## 📸 작업 내용

평가 담당자 배정 페이지(`/recruiting/evaluations`) 진입 시 지부장 또는 타 학교 회장 계정으로 로그인해도 목록의 첫 학교(`groups[0]`)로 고정되던 문제를 접속자의 본인 학교 그룹이 기본 선택되도록 수정하였습니다.

- [`EvaluatorAllocationPage.tsx`](file:///c:/Users/doldo/Desktop/PROJECT/UMC/Product/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx)에서 `useMe()` 및 `resolveViewerSchool()`을 이용해 접속자의 학교(`schoolId`, `viewerSchool`)를 확인하도록 추가
- `groups` 목록 중 접속자의 학교와 일치하는 모집 그룹(`mySchoolGroup`)을 찾아 `activeGroup` 및 `activeRoundId`의 기본값으로 할당

## 🎞️ 주요 코드 설명

### 1. 접속자 본인 학교 그룹(`mySchoolGroup`) 탐색 및 activeGroup 기본값 설정

```TypeScript
const { data: me } = useMe()
const viewerSchool = resolveViewerSchool(me)
const { groups } = useAdminRecruitingRounds()

const mySchoolGroup = useMemo(() => {
  if (!groups.length) return null
  if (me?.schoolId) {
    const foundById = groups.find(
      (group) => String(group.schoolId) === String(me.schoolId),
    )
    if (foundById) return foundById
  }
  if (viewerSchool) {
    const formattedViewer = formatSchoolName(viewerSchool)
    const foundByName = groups.find(
      (group) =>
        group.schoolName === viewerSchool ||
        formatSchoolName(group.schoolName) === formattedViewer,
    )
    if (foundByName) return foundByName
  }
  return groups[0] ?? null
}, [groups, me?.schoolId, viewerSchool])

const activeRoundId = roundId ?? mySchoolGroup?.rounds[0]?.roundId ?? null

const activeGroup = activeRoundId
  ? (groups.find((group) =>
      group.rounds.some((r) => String(r.roundId) === String(activeRoundId)),
    ) ?? mySchoolGroup)
  : mySchoolGroup
```

- 기존에는 스코핑 없이 `groups[0]`(이화여대)을 무조건 참조하여 타 학교 회장이나 지부장 로그인 시 이화여대 교내 운영진이 노출되었습니다.
- `me.schoolId` 및 `viewerSchool`을 기반으로 본인 학교 모집 그룹을 우선 찾은 뒤, `activeGroup`으로 지정하도록 변경했습니다.

## 🖥️ 구현화면


## 🔗 연결된 이슈

- Connected: #747 