### PR TITLE
fix: 평가 담당자 배정 시 본인 학교 그룹 지정 및 공고 빈 상태 처리

### DIFF
--- a/src/features/recruiting/ui/evaluations/DroppableRecruitmentBox.tsx
+++ b/src/features/recruiting/ui/evaluations/DroppableRecruitmentBox.tsx
@@ -1,27 +1,39 @@
 import { useDroppable } from "@dnd-kit/core"
+import dayjs from "dayjs"
 
 import ResetIcon from "@/shared/assets/icon/reset/ResetIcon"
 
 import { AssignedStaffChip } from "./AssignedStaffChip"
 
+import type { RecruitingRound } from "../../api/types"
 import type { Staff } from "../../model/evaluatorAllocation"
 
 interface DroppableRecruitmentBoxProps {
   id: string
+  round: RecruitingRound
   assignedEvaluators: Staff[]
   selectedChipId: string | null
   onSelectChip: (id: string | null) => void
   onClear: () => void
 }
 
+function formatDateTime(dateStr: string | null | undefined): string {
+  if (!dateStr) return "-"
+  const d = dayjs(dateStr)
+  return d.isValid() ? d.format("YYYY-MM-DD HH:mm") : dateStr
+}
+
 export function DroppableRecruitmentBox({
   id,
+  round,
   assignedEvaluators,
   selectedChipId,
   onSelectChip,
   onClear,
 }: DroppableRecruitmentBoxProps) {
   const { setNodeRef } = useDroppable({ id })
+
+  const roundTypeLabel = round.type === "ADDITIONAL" ? "추가 모집" : "정규 모집"
 
   return (
     <div
@@ -32,7 +44,7 @@ export function DroppableRecruitmentBox({
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-1.5">
             <span className="text-heading-6-semibold text-teal-700">
-              정규 모집
+              {roundTypeLabel}
             </span>
             <span className="text-heading-6-semibold text-teal-gray-800">
               평가 담당자
@@ -42,20 +54,23 @@ export function DroppableRecruitmentBox({
           <div className="flex flex-col gap-0.5">
             <div className="flex items-center gap-2">
               <p className="text-body-2-regular text-teal-gray-400">
-                서류 모집 마감: 2026-07-07 12:00
+                서류 모집 마감: {formatDateTime(round.documentEndAt)}
               </p>
               <div className="bg-teal-gray-200 h-3 w-[1px] rounded-[0.5px]" />
               <p className="text-body-2-regular text-teal-gray-400">
-                결과 발표: 2026-07-07 12:00
+                결과 발표: {formatDateTime(round.documentResultPublishedAt)}
               </p>
             </div>
             <div className="flex items-center gap-2">
               <p className="text-body-2-regular text-teal-gray-400">
-                면접 진행 기간: 2026-07-07 12:00 ~ 2026-07-07 12:00
+                면접 진행 기간:{" "}
+                {round.interviewRequired
+                  ? `${formatDateTime(round.interviewStartAt)} ~ ${formatDateTime(round.interviewEndAt)}`
+                  : "면접 없음"}
               </p>
               <div className="bg-teal-gray-200 h-3 w-[1px] rounded-[0.5px]" />
               <p className="text-body-2-regular text-teal-gray-400">
-                결과 발표: 2026-07-07 12:00
+                결과 발표: {formatDateTime(round.finalResultPublishedAt)}
               </p>
             </div>
           </div>

--- a/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
+++ b/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
@@ -71,20 +71,26 @@ export function EvaluatorAllocationPage({
     return groups[0] ?? null
   }, [groups, me?.schoolId, viewerSchool])
 
-  const activeRoundId = roundId ?? mySchoolGroup?.rounds[0]?.roundId ?? null
+  const requestedRoundId = roundId ?? mySchoolGroup?.rounds[0]?.roundId ?? null
 
-  const activeGroup = activeRoundId
+  const activeGroup = requestedRoundId
     ? (groups.find((group) =>
-        group.rounds.some((r) => String(r.roundId) === String(activeRoundId)),
+        group.rounds.some(
+          (r) => String(r.roundId) === String(requestedRoundId),
+        ),
       ) ?? mySchoolGroup)
     : mySchoolGroup
 
   const activeRound =
     activeGroup?.rounds.find(
-      (r) => String(r.roundId) === String(activeRoundId),
+      (r) => String(r.roundId) === String(requestedRoundId),
     ) ??
     activeGroup?.rounds[0] ??
     null
+
+  const resolvedRoundId = activeRound?.roundId
+    ? String(activeRound.roundId)
+    : null
 
   // 배정 권한은 시즌 단위다. 권한을 확인하기 전에는 잠가 둔다.
   const seasonIds = activeGroup?.seasonId ? [activeGroup.seasonId] : []
@@ -110,7 +116,7 @@ export function EvaluatorAllocationPage({
     data: serverEvaluators,
     isSuccess: isEvaluatorsSuccess,
     isFetching,
-  } = useRoundEvaluators(activeRoundId)
+  } = useRoundEvaluators(resolvedRoundId)
   const saveMutation = useSaveEvaluatorAllocation()
 
   const [assignedEvaluators, setAssignedEvaluators] = useState<Staff[]>([])
@@ -123,7 +129,7 @@ export function EvaluatorAllocationPage({
   const savedSnapshotRef = useRef<Staff[] | null>(null)
 
   const isInitialized = Boolean(
-    activeRoundId && initializedRoundId === activeRoundId,
+    resolvedRoundId && initializedRoundId === resolvedRoundId,
   )
 
   useEffect(() => {
@@ -132,7 +138,7 @@ export function EvaluatorAllocationPage({
     savedSnapshotRef.current = null
     editRevisionRef.current = 0
     sessionTokenRef.current += 1
-  }, [activeRoundId])
+  }, [resolvedRoundId])
 
   useEffect(() => {
     if (!serverEvaluators || isDirty) return
@@ -147,15 +153,15 @@ export function EvaluatorAllocationPage({
 
     savedSnapshotRef.current = null
     setAssignedEvaluators(serverStaff)
-    if (activeRoundId && isStaffSuccess && isEvaluatorsSuccess) {
-      setInitializedRoundId(activeRoundId)
+    if (resolvedRoundId && isStaffSuccess && isEvaluatorsSuccess) {
+      setInitializedRoundId(resolvedRoundId)
     }
   }, [
     serverEvaluators,
     staffList,
     isDirty,
     isFetching,
-    activeRoundId,
+    resolvedRoundId,
     isStaffSuccess,
     isEvaluatorsSuccess,
   ])
@@ -178,14 +184,14 @@ export function EvaluatorAllocationPage({
   })
 
   function handleSave() {
-    if (!activeRoundId || !isInitialized) return
+    if (!resolvedRoundId || !isInitialized) return
     const requestRevision = editRevisionRef.current
     const requestSnapshot = assignedEvaluators
     const requestToken = sessionTokenRef.current
 
     saveMutation.mutate(
       {
-        roundId: activeRoundId,
+        roundId: resolvedRoundId,
         assignedEvaluators: requestSnapshot,
       },
       {

--- a/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
+++ b/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
@@ -46,6 +46,8 @@ export function EvaluatorAllocationPage({
 
   const mySchoolGroup = useMemo(() => {
     if (!groups.length) return null
+    const hasSchoolIdentity = Boolean(me?.schoolId || viewerSchool)
+
     if (me?.schoolId) {
       const foundById = groups.find(
         (group) => String(group.schoolId) === String(me.schoolId),
@@ -60,6 +62,8 @@ export function EvaluatorAllocationPage({
           formatSchoolName(group.schoolName) === formattedViewer,
       )
       if (foundByName) return foundByName
+    }
+    if (hasSchoolIdentity) {
       // 접속자 학교 정보가 존재하지만 groups에 해당 학교 모집이 없는 경우
       // 타 학교(groups[0])로 폴백하지 않고 null을 반환합니다.
       return null

--- a/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
+++ b/src/features/recruiting/ui/evaluations/EvaluatorAllocationPage.tsx
@@ -60,6 +60,9 @@ export function EvaluatorAllocationPage({
           formatSchoolName(group.schoolName) === formattedViewer,
       )
       if (foundByName) return foundByName
+      // 접속자 학교 정보가 존재하지만 groups에 해당 학교 모집이 없는 경우
+      // 타 학교(groups[0])로 폴백하지 않고 null을 반환합니다.
+      return null
     }
     return groups[0] ?? null
   }, [groups, me?.schoolId, viewerSchool])
@@ -72,6 +75,13 @@ export function EvaluatorAllocationPage({
       ) ?? mySchoolGroup)
     : mySchoolGroup
 
+  const activeRound =
+    activeGroup?.rounds.find(
+      (r) => String(r.roundId) === String(activeRoundId),
+    ) ??
+    activeGroup?.rounds[0] ??
+    null
+
   // 배정 권한은 시즌 단위다. 권한을 확인하기 전에는 잠가 둔다.
   const seasonIds = activeGroup?.seasonId ? [activeGroup.seasonId] : []
   const { permittedSeasonIds, isLoading: isPermissionLoading } =
@@ -81,7 +91,7 @@ export function EvaluatorAllocationPage({
     activeGroup?.seasonId != null &&
     permittedSeasonIds.has(String(activeGroup.seasonId))
 
-  const schoolId = activeGroup?.schoolId
+  const schoolId = activeGroup?.schoolId ?? me?.schoolId
   const gisuId = activeGroup?.gisuId
   const chapterId = activeGroup?.chapterId
   const schoolName =
@@ -302,19 +312,26 @@ export function EvaluatorAllocationPage({
 
             {/* 공고 */}
             <div className="flex flex-1 flex-col gap-4 overflow-y-auto">
-              <DroppableRecruitmentBox
-                id={RECRUITMENT_BOX_ID}
-                assignedEvaluators={assignedEvaluators}
-                selectedChipId={selectedChipId}
-                onSelectChip={setSelectedChipId}
-                onClear={() => {
-                  if (!isInitialized || !canEdit) return
-                  editRevisionRef.current += 1
-                  setAssignedEvaluators([])
-                  setIsDirty(true)
-                  setSelectedChipId(null)
-                }}
-              />
+              {activeRound ? (
+                <DroppableRecruitmentBox
+                  id={RECRUITMENT_BOX_ID}
+                  round={activeRound}
+                  assignedEvaluators={assignedEvaluators}
+                  selectedChipId={selectedChipId}
+                  onSelectChip={setSelectedChipId}
+                  onClear={() => {
+                    if (!isInitialized || !canEdit) return
+                    editRevisionRef.current += 1
+                    setAssignedEvaluators([])
+                    setIsDirty(true)
+                    setSelectedChipId(null)
+                  }}
+                />
+              ) : (
+                <div className="border-teal-gray-100 text-body-2-medium text-teal-gray-400 box-border flex h-68.5 w-full items-center justify-center rounded-[12px] border bg-white">
+                  배정할 모집 공고가 없습니다
+                </div>
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
## 📸 작업 내용

평가 담당자 배정 페이지(`/recruiting/evaluations`) 진입 시 접속자의 본인 학교 모집 그룹이 선택되도록 하고, 하드코딩되었던 모집 정보를 동적 데이터 및 빈 상태 안내로 개선하였습니다.

- `EvaluatorAllocationPage.tsx`에서 접속자의 본인 학교(`me.schoolId`, `viewerSchool`)에 해당하는 `mySchoolGroup`을 지정하여 `groups[0]`(이화여대)으로 고정/전환되던 현상 방지
- `DroppableRecruitmentBox.tsx`의 하드코딩된 일자(`2026-07-07 12:00`) 및 타이틀을 실제 `round` 동적 데이터로 교체
- 해당 기수에 진행 중인 모집 차수가 없는 경우 "배정할 모집 공고가 없습니다" 안내 카드 표시

## 🎞️ 주요 코드 설명

### 1. 접속자 본인 학교 그룹(`mySchoolGroup`) 탐색 및 폴백 방지

```TypeScript
const { data: me } = useMe()
const viewerSchool = resolveViewerSchool(me)
const { groups } = useAdminRecruitingRounds()

const mySchoolGroup = useMemo(() => {
  if (!groups.length) return null
  if (me?.schoolId) {
    const foundById = groups.find(
      (group) => String(group.schoolId) === String(me.schoolId),
    )
    if (foundById) return foundById
  }
  if (viewerSchool) {
    const formattedViewer = formatSchoolName(viewerSchool)
    const foundByName = groups.find(
      (group) =>
        group.schoolName === viewerSchool ||
        formatSchoolName(group.schoolName) === formattedViewer,
    )
    if (foundByName) return foundByName
    return null // 접속자 학교 정보가 있으나 groups에 없을 경우 타 학교(groups[0])로 폴백 방지
  }
  return groups[0] ?? null
}, [groups, me?.schoolId, viewerSchool])
```

### 2. 모집 차수 데이터 동적 연동 및 빈 상태 안내 렌더링

```TypeScript
{activeRound ? (
  <DroppableRecruitmentBox
    id={RECRUITMENT_BOX_ID}
    round={activeRound}
    assignedEvaluators={assignedEvaluators}
    selectedChipId={selectedChipId}
    onSelectChip={setSelectedChipId}
    onClear={...}
  />
) : (
  <div className="border-teal-gray-100 text-body-2-medium text-teal-gray-400 box-border flex h-68.5 w-full items-center justify-center rounded-[12px] border bg-white">
    배정할 모집 공고가 없습니다
  </div>
)}
```

## 🖥️ 구현화면


## 🔗 연결된 이슈

- Connected: #747 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 모집 유형을 정규 모집과 추가 모집으로 구분해 표시합니다.
  * 모집, 발표, 면접 일정을 `YYYY-MM-DD HH:mm` 형식으로 표시합니다.
  * 일정이 없거나 유효하지 않은 경우 원문 또는 `-`로 안내합니다.
  * 면접 일정이 없으면 `면접 없음`으로 표시합니다.
  * 모집 공고가 없을 때 다른 모집으로 잘못 연결되지 않으며, 안내 메시지가 표시됩니다.
  * 선택된 모집 정보가 배정 화면에 정확히 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->