### PR TITLE
chore: 모집 분야 설명 문구 11기 기준으로 교체

### DIFF
--- a/src/features/about/constants.ts
+++ b/src/features/about/constants.ts
@@ -23,8 +23,7 @@ import { APPLY_ENTRY_PATH } from "@/shared/config/headerRecruitingWindow"
 export const ABOUT_RECRUIT = {
   headline: "UMC 11기 모집 분야",
   descriptionLines: [
-    "하나의 프로덕트를 완성하는 4가지 핵심 분야.",
-    "당신의 역량을 가장 명확하게 보여줄 파트에 지원하세요!",
+    "AI를 활용해 기획하고, 디자인하고, 직접 서비스를 만드는 11기 UMC",
   ],
   traitsHeadline: "이런 분이면 좋아요 !",
   ctaLabel: "모집 안내 보러 가기 →",


### PR DESCRIPTION
## 📸 작업 내용

- 모집 분야 설명 문구 11기 기준으로 교체

## 🖥️ 구현화면

<img width="1439" height="616" alt="image" src="https://github.com/user-attachments/assets/7218df98-374c-4591-bb03-cc8c31d057af" />

## 🔗 연결된 이슈

- Connected: #754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **콘텐츠 업데이트**
  * UMC 11기 소개 문구가 AI 활용, 기획, 디자인 및 서비스 개발 내용을 담은 한 문장으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->