### PR TITLE
🐛 fix: 모집 인원 설정 저장 실패 수정

### DIFF
--- a/src/features/recruiting/api/recruitingApi.ts
+++ b/src/features/recruiting/api/recruitingApi.ts
@@ -542,6 +542,12 @@ export function normalizeRecruitingSeasonConfigurationResponse(
     gisuId: String(raw.gisuId ?? ""),
     schoolId: String(raw.schoolId ?? ""),
     memo: raw.memo ?? null,
+    // 한 번도 저장된 적 없으면 서버가 null 을 준다. 0 과 구분해야 해서 toCount
+    // 로 접지 않는다.
+    chapterTotalTargetCount:
+      raw.chapterTotalTargetCount == null
+        ? null
+        : toCount(raw.chapterTotalTargetCount),
     quotas: (raw.quotas ?? [])
       .filter((quota) => Boolean(quota.track))
       .map((quota) => ({

--- a/src/features/recruiting/api/types.ts
+++ b/src/features/recruiting/api/types.ts
@@ -146,18 +146,28 @@ export interface RecruitingSeasonConfigurationResponse {
   gisuId: string
   schoolId: string
   memo: string | null
+  // 이 학교가 속한 지부 전체의 목표 인원. 지부 단위로 한 번도 저장된 적이
+  // 없으면 null 이다.
+  chapterTotalTargetCount: number | null
   quotas: RecruitingSeasonTrackQuota[]
   rounds: RecruitingRound[]
 }
 
 export type RawRecruitingSeasonConfigurationResponse = Omit<
   RecruitingSeasonConfigurationResponse,
-  "id" | "gisuId" | "schoolId" | "memo" | "quotas" | "rounds"
+  | "id"
+  | "gisuId"
+  | "schoolId"
+  | "memo"
+  | "chapterTotalTargetCount"
+  | "quotas"
+  | "rounds"
 > & {
   id?: RawId
   gisuId?: RawId
   schoolId?: RawId
   memo?: string | null
+  chapterTotalTargetCount?: RawCount | null
   quotas?: {
     track?: RecruitingTrack
     targetCount?: RawCount
@@ -172,6 +182,14 @@ export interface RecruitingSeasonTrackQuotaRequest {
 }
 
 export interface ReplaceRecruitingSeasonTrackQuotasRequest {
+  /**
+   * 이 학교가 속한 지부 전체의 목표 인원. 필수다.
+   *
+   * 사용자가 정하는 값이 아니라 검산값이다. 서버는 "이번 요청의 트랙 합 + 같은
+   * 지부 다른 학교들의 현재 저장값" 과 같은지 보고, 다르면 RECRUITING-0330 을
+   * 던진다. 그래서 여러 학교를 잇달아 저장할 때는 요청마다 값이 달라진다.
+   */
+  chapterTotalTargetCount: number
   quotas: RecruitingSeasonTrackQuotaRequest[]
 }
 

--- a/src/features/recruiting/hooks/useRecruitingSeasonQuotas.test.tsx
+++ b/src/features/recruiting/hooks/useRecruitingSeasonQuotas.test.tsx
@@ -28,6 +28,7 @@ function createConfiguration(
     gisuId: "15",
     schoolId: id,
     memo: null,
+    chapterTotalTargetCount: null,
     quotas: [],
     rounds: [],
   }
@@ -82,7 +83,7 @@ describe("useRecruitingSeasonQuotas 요청 페이싱", () => {
         {
           seasonId: "1",
           schoolName: "서울대학교",
-          payload: { quotas: [] },
+          payload: { chapterTotalTargetCount: 0, quotas: [] },
         },
       ])
     })

--- a/src/features/recruiting/hooks/useRecruitingSeasonQuotas.test.tsx
+++ b/src/features/recruiting/hooks/useRecruitingSeasonQuotas.test.tsx
@@ -96,3 +96,68 @@ describe("useRecruitingSeasonQuotas 요청 페이싱", () => {
     expect(seasonConfigurationRequests.at(-1)).toBe("1")
   })
 })
+
+describe("저장 실패가 같은 지부로 번지지 않는지", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  const variables = (seasonId: string, chapterKey: string) => ({
+    seasonId,
+    schoolName: `학교${seasonId}`,
+    chapterKey,
+    payload: { chapterTotalTargetCount: 0, quotas: [] },
+  })
+
+  // 지부 합계는 앞선 요청이 반영된 결과를 전제로 계산돼 있다. 하나가 실패하면
+  // 그 뒤 요청은 어차피 합계 불일치로 튕기므로 보내지 않는다.
+  it("같은 지부에서 하나가 실패하면 뒤 요청을 보내지 않는다", async () => {
+    vi.mocked(getRecruitingSeasonConfiguration).mockResolvedValue(
+      createConfiguration("1"),
+    )
+    vi.mocked(updateRecruitingSeasonQuotas)
+      .mockRejectedValueOnce(new Error("400"))
+      .mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useRecruitingSeasonQuotas(["1"]), {
+      wrapper: createWrapper(),
+    })
+
+    let outcome: Awaited<ReturnType<typeof result.current.updateQuotas>>
+    await act(async () => {
+      outcome = await result.current.updateQuotas([
+        variables("1", "Neon"),
+        variables("2", "Neon"),
+      ])
+    })
+
+    expect(vi.mocked(updateRecruitingSeasonQuotas)).toHaveBeenCalledTimes(1)
+    expect(outcome!.failedCount).toBe(2)
+    expect(outcome!.fulfilledCount).toBe(0)
+  })
+
+  it("다른 지부의 요청은 그대로 보낸다", async () => {
+    vi.mocked(getRecruitingSeasonConfiguration).mockResolvedValue(
+      createConfiguration("1"),
+    )
+    vi.mocked(updateRecruitingSeasonQuotas)
+      .mockRejectedValueOnce(new Error("400"))
+      .mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useRecruitingSeasonQuotas(["1"]), {
+      wrapper: createWrapper(),
+    })
+
+    let outcome: Awaited<ReturnType<typeof result.current.updateQuotas>>
+    await act(async () => {
+      outcome = await result.current.updateQuotas([
+        variables("1", "Neon"),
+        variables("2", "Xenon"),
+      ])
+    })
+
+    expect(vi.mocked(updateRecruitingSeasonQuotas)).toHaveBeenCalledTimes(2)
+    expect(outcome!.fulfilledCount).toBe(1)
+    expect(outcome!.failedCount).toBe(1)
+  })
+})

--- a/src/features/recruiting/hooks/useRecruitingSeasonQuotas.ts
+++ b/src/features/recruiting/hooks/useRecruitingSeasonQuotas.ts
@@ -21,6 +21,13 @@ import type {
 export interface UpdateSeasonQuotaVariables {
   seasonId: string
   schoolName?: string
+  /**
+   * 같은 지부끼리 묶는 열쇠.
+   *
+   * 지부 합계는 앞선 요청이 반영된 결과를 전제로 계산돼 있다. 하나가 실패하면
+   * 그 뒤 요청들은 전제가 깨진 값을 들고 있어, 같은 지부인지 알아야 멈출 수 있다.
+   */
+  chapterKey?: string
   payload: ReplaceRecruitingSeasonTrackQuotasRequest
 }
 
@@ -178,13 +185,31 @@ export function useRecruitingSeasonQuotas(
       // 한 지부 안에서는 순서가 결과를 가른다. 서버가 매 요청을 "그 시점에
       // 저장된 다른 학교 값" 과 대조하기 때문에, 동시에 던지면 처리 순서에 따라
       // 통과 여부가 달라진다. 호출부가 정해 준 차례대로 하나씩 보낸다.
+      //
+      // 그래서 하나가 실패하면 같은 지부의 남은 요청은 보내지 않는다. 그 값들은
+      // 실패한 요청이 반영됐다고 치고 계산돼 있어, 보내 봐야 합계 불일치로 다시
+      // 튕긴다. 실패 하나가 지부 전체의 실패로 번지는 것만 늘어난다.
       const results: PromiseSettledResult<UpdateSeasonQuotaVariables>[] = []
+      const failedChapterKeys = new Set<string>()
+
       for (const v of variablesList) {
+        const chapterKey = v.chapterKey
+        if (chapterKey !== undefined && failedChapterKeys.has(chapterKey)) {
+          results.push({
+            status: "rejected",
+            reason: new Error(
+              "같은 지부의 앞선 저장이 실패해 보내지 않았습니다.",
+            ),
+          })
+          continue
+        }
+
         try {
           await updateRecruitingSeasonQuotas(v.seasonId, v.payload)
           results.push({ status: "fulfilled", value: v })
         } catch (reason) {
           results.push({ status: "rejected", reason })
+          if (chapterKey !== undefined) failedChapterKeys.add(chapterKey)
         }
       }
 

--- a/src/features/recruiting/hooks/useRecruitingSeasonQuotas.ts
+++ b/src/features/recruiting/hooks/useRecruitingSeasonQuotas.ts
@@ -175,12 +175,18 @@ export function useRecruitingSeasonQuotas(
     mutationFn: async (
       variablesList: UpdateSeasonQuotaVariables[],
     ): Promise<UpdateSeasonQuotasResult> => {
-      const results = await Promise.allSettled(
-        variablesList.map(async (v) => {
+      // 한 지부 안에서는 순서가 결과를 가른다. 서버가 매 요청을 "그 시점에
+      // 저장된 다른 학교 값" 과 대조하기 때문에, 동시에 던지면 처리 순서에 따라
+      // 통과 여부가 달라진다. 호출부가 정해 준 차례대로 하나씩 보낸다.
+      const results: PromiseSettledResult<UpdateSeasonQuotaVariables>[] = []
+      for (const v of variablesList) {
+        try {
           await updateRecruitingSeasonQuotas(v.seasonId, v.payload)
-          return v
-        }),
-      )
+          results.push({ status: "fulfilled", value: v })
+        } catch (reason) {
+          results.push({ status: "rejected", reason })
+        }
+      }
 
       const successfulVariables: UpdateSeasonQuotaVariables[] = []
       const failedVariables: UpdateSeasonQuotaVariables[] = []

--- a/src/features/recruiting/model/recruitmentQuota.test.ts
+++ b/src/features/recruiting/model/recruitmentQuota.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  buildChapterTotalSteps,
   findMatchingSchoolQuotaRow,
   getChangedSchoolQuotaRows,
+  getChapterStoredTotals,
   getConflictedSchoolQuotaRows,
   getSchoolQuotaIdentity,
   getSchoolQuotaRowsSignature,
+  getSchoolQuotaRowTotal,
   mergeSchoolQuotaRows,
   type SchoolQuotaEdits,
   type SchoolQuotaRow,
@@ -169,5 +172,102 @@ describe("편집 중인 모집 인원 동기화", () => {
     ])
 
     expect(getConflictedSchoolQuotaRows([originalRow], edits)).toEqual([])
+  })
+})
+
+describe("getChapterStoredTotals", () => {
+  it("시즌이 있는 학교만 담는다", () => {
+    const withSeason = createRow({ seasonId: "1", schoolId: "10" })
+    const withoutSeason = createRow({
+      seasonId: undefined,
+      schoolId: "11",
+      schoolName: "연세대학교",
+    })
+
+    const totals = getChapterStoredTotals([withSeason, withoutSeason])
+
+    expect([...totals.keys()]).toEqual(["1"])
+    expect(totals.get("1")).toBe(10)
+  })
+
+  it("합은 total 필드가 아니라 파트 값에서 다시 센다", () => {
+    // total 이 낡은 값으로 남아 있어도 파트 합이 정답이다
+    const row = createRow({
+      seasonId: "1",
+      pm: 2,
+      design: 0,
+      webPe: 0,
+      mobilePe: 0,
+      total: 999,
+    })
+
+    expect(getChapterStoredTotals([row]).get("1")).toBe(2)
+    expect(getSchoolQuotaRowTotal(row)).toBe(2)
+  })
+})
+
+describe("buildChapterTotalSteps", () => {
+  it("한 학교만 고치면 그 학교 변화분만 반영한다", () => {
+    const stored = new Map([
+      ["1", 10],
+      ["2", 5],
+    ])
+
+    expect(
+      buildChapterTotalSteps(stored, [{ seasonId: "1", nextTotal: 13 }]),
+    ).toEqual([{ seasonId: "1", chapterTotalTargetCount: 18 }])
+  })
+
+  // 서버가 요청 시점의 저장값으로 검산하므로 두 요청의 값이 달라야 한다
+  it("같은 지부 두 학교를 고치면 요청마다 합계가 다르다", () => {
+    const stored = new Map([
+      ["1", 10],
+      ["2", 5],
+    ])
+
+    expect(
+      buildChapterTotalSteps(stored, [
+        { seasonId: "1", nextTotal: 13 },
+        { seasonId: "2", nextTotal: 7 },
+      ]),
+    ).toEqual([
+      { seasonId: "1", chapterTotalTargetCount: 18 },
+      { seasonId: "2", chapterTotalTargetCount: 20 },
+    ])
+  })
+
+  it("마지막 값은 모든 변경이 반영된 지부 합계다", () => {
+    const stored = new Map([
+      ["1", 10],
+      ["2", 5],
+      ["3", 1],
+    ])
+
+    const steps = buildChapterTotalSteps(stored, [
+      { seasonId: "1", nextTotal: 0 },
+      { seasonId: "2", nextTotal: 0 },
+    ])
+
+    expect(steps.at(-1)?.chapterTotalTargetCount).toBe(1)
+  })
+
+  it("저장된 적 없는 시즌은 0 에서 더한다", () => {
+    const stored = new Map([["1", 10]])
+
+    expect(
+      buildChapterTotalSteps(stored, [{ seasonId: "9", nextTotal: 4 }]),
+    ).toEqual([{ seasonId: "9", chapterTotalTargetCount: 14 }])
+  })
+
+  it("넘겨받은 Map 을 건드리지 않는다", () => {
+    const stored = new Map([["1", 10]])
+
+    buildChapterTotalSteps(stored, [{ seasonId: "1", nextTotal: 99 }])
+
+    expect(stored.get("1")).toBe(10)
+  })
+
+  it("고칠 학교가 없으면 빈 배열이다", () => {
+    expect(buildChapterTotalSteps(new Map([["1", 10]]), [])).toEqual([])
   })
 })

--- a/src/features/recruiting/model/recruitmentQuota.ts
+++ b/src/features/recruiting/model/recruitmentQuota.ts
@@ -154,6 +154,58 @@ export function getChangedSchoolQuotaRows(
   })
 }
 
+export function getSchoolQuotaRowTotal(row: SchoolQuotaRow): number {
+  return QUOTA_FIELDS.reduce((sum, field) => sum + (row[field] || 0), 0)
+}
+
+/**
+ * 지부에 시즌이 있는 학교들의 현재 목표 인원 합.
+ *
+ * 시즌이 없는 학교는 뺀다. 서버도 시즌이 있는 학교만 세기 때문에, 여기서 0 이라도
+ * 더해 놓으면 학교 수와 무관하게 값은 같지만 시즌이 생기는 순간 기준이 어긋난다.
+ */
+export function getChapterStoredTotals(
+  rows: SchoolQuotaRow[],
+): Map<string, number> {
+  const totals = new Map<string, number>()
+  rows.forEach((row) => {
+    if (!row.seasonId) return
+    totals.set(String(row.seasonId), getSchoolQuotaRowTotal(row))
+  })
+  return totals
+}
+
+export interface ChapterTotalStep {
+  seasonId: string
+  /** 이 요청과 함께 보낼 지부 전체 목표 인원 */
+  chapterTotalTargetCount: number
+}
+
+/**
+ * 학교를 하나씩 저장할 때 요청마다 실어 보낼 지부 합계를 미리 계산한다.
+ *
+ * 서버는 매 요청을 "이번 요청의 트랙 합 + 같은 지부 다른 학교들의 **그 시점 저장값**"
+ * 과 대조한다. 그래서 마지막 합계를 모든 요청에 똑같이 보내면 첫 요청부터 어긋난다.
+ * 앞선 요청이 반영된 결과를 누적해 가며 요청마다 다른 값을 만든다.
+ *
+ * 이 규칙 때문에 한 지부 안에서는 요청을 순서대로 보내야 한다. 병렬로 던지면
+ * 서버가 어떤 순서로 처리하느냐에 따라 통과 여부가 갈린다.
+ */
+export function buildChapterTotalSteps(
+  storedTotals: ReadonlyMap<string, number>,
+  updates: readonly { seasonId: string; nextTotal: number }[],
+): ChapterTotalStep[] {
+  const current = new Map(storedTotals)
+  let runningTotal = [...current.values()].reduce((sum, n) => sum + n, 0)
+
+  return updates.map(({ seasonId, nextTotal }) => {
+    const key = String(seasonId)
+    runningTotal = runningTotal - (current.get(key) ?? 0) + nextTotal
+    current.set(key, nextTotal)
+    return { seasonId: key, chapterTotalTargetCount: runningTotal }
+  })
+}
+
 export interface PartCounts {
   pm: number
   design: number

--- a/src/features/recruiting/model/recruitmentQuotaMapper.test.ts
+++ b/src/features/recruiting/model/recruitmentQuotaMapper.test.ts
@@ -40,6 +40,7 @@ describe("mapGroupsToChapterQuotaData", () => {
         gisuId: "15",
         schoolId: "10",
         memo: null,
+        chapterTotalTargetCount: null,
         quotas: [
           { track: "PLAN", targetCount: 2 },
           { track: "DESIGN", targetCount: 3 },
@@ -56,6 +57,7 @@ describe("mapGroupsToChapterQuotaData", () => {
         gisuId: "15",
         schoolId: "20",
         memo: null,
+        chapterTotalTargetCount: null,
         quotas: [
           { track: "PLAN", targetCount: 1 },
           { track: "DESIGN", targetCount: 1 },

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.test.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.test.tsx
@@ -162,6 +162,7 @@ describe("RecruitmentQuotaPage 저장 경로 분류", () => {
           gisuId: "15",
           schoolId: "10",
           memo: null,
+          chapterTotalTargetCount: null,
           quotas: [
             { track: "PLAN", targetCount: 1 },
             { track: "DESIGN", targetCount: 1 },
@@ -215,6 +216,7 @@ describe("RecruitmentQuotaPage 저장 경로 분류", () => {
       gisuId: "15",
       schoolId: "10",
       memo: null,
+      chapterTotalTargetCount: null,
       quotas: [
         { track: "PLAN", targetCount: 3 },
         { track: "DESIGN", targetCount: 1 },
@@ -349,6 +351,7 @@ describe("RecruitmentQuotaPage 저장 경로 분류", () => {
             gisuId: "15",
             schoolId: "10",
             memo: null,
+            chapterTotalTargetCount: null,
             quotas: [
               { track: "PLAN", targetCount: 1 },
               { track: "DESIGN", targetCount: 1 },
@@ -365,6 +368,7 @@ describe("RecruitmentQuotaPage 저장 경로 분류", () => {
             gisuId: "15",
             schoolId: "20",
             memo: null,
+            chapterTotalTargetCount: null,
             quotas: [
               { track: "PLAN", targetCount: 2 },
               { track: "DESIGN", targetCount: 2 },

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -21,10 +21,13 @@ import { useRecruitingPermissions } from "../hooks/useRecruitingPermissions"
 import { useRecruitingSeasonQuotas } from "../hooks/useRecruitingSeasonQuotas"
 import { hasAnyEditableSeason } from "../model/recruitingEditLock"
 import {
+  buildChapterTotalSteps,
   findMatchingSchoolQuotaRow,
   getChangedSchoolQuotaRows,
+  getChapterStoredTotals,
   getConflictedSchoolQuotaRows,
   getSchoolQuotaIdentity,
+  getSchoolQuotaRowTotal,
   mergeSchoolQuotaRows,
   type SchoolQuotaEdits,
   type SchoolQuotaRow,
@@ -416,23 +419,74 @@ export function RecruitmentQuotaPage() {
       },
     )
 
-    const payloadList = existingSeasonRows.map((row) => ({
-      seasonId: row.seasonId,
-      schoolName: row.schoolName,
-      payload: {
-        quotas: [
-          { track: "PLAN" as const, targetCount: row.pm },
-          { track: "DESIGN" as const, targetCount: row.design },
-          { track: "WEB_PRODUCT_ENGINEER" as const, targetCount: row.webPe },
-          {
-            track: "MOBILE_PRODUCT_ENGINEER" as const,
-            targetCount: row.mobilePe,
-          },
-        ],
-      },
-    }))
+    // 서버는 학교 TO 를 저장할 때마다 지부 전체 합계를 함께 받아 검산한다. 그
+    // 기준이 "요청 시점에 저장돼 있는 다른 학교 값" 이라, 한 지부에서 여러 학교를
+    // 고치면 요청마다 실어야 할 합계가 달라진다. 방금 만든 시즌도 그 시점에는
+    // 이미 저장된 값이므로, 생성이 끝난 뒤에 계산해야 기준이 맞는다.
+    const buildPayloadList = (createdRows: SchoolQuotaRow[]) => {
+      const chapterTotalBySeasonId = new Map<string, number>()
 
-    if (payloadList.length === 0 && newSeasonRows.length === 0) {
+      targetChapters.forEach((chapterData) => {
+        const rowsToUpdate = existingSeasonRows.filter((row) =>
+          chapterData.schools.some(
+            (school) => String(school.seasonId) === String(row.seasonId),
+          ),
+        )
+        if (rowsToUpdate.length === 0) return
+
+        const storedTotals = getChapterStoredTotals(chapterData.schools)
+        // 이번에 만들어진 학교는 시즌이 없던 자리라 기준값에 빠져 있다.
+        // 식별자가 없어 자리만 채우면 되므로 임시 키로 더한다.
+        createdRows
+          .filter((created) =>
+            chapterData.schools.some(
+              (school) =>
+                String(school.schoolId) === String(created.schoolId) &&
+                !school.seasonId,
+            ),
+          )
+          .forEach((created) => {
+            storedTotals.set(
+              `created:${created.schoolId}`,
+              getSchoolQuotaRowTotal(created),
+            )
+          })
+
+        buildChapterTotalSteps(
+          storedTotals,
+          rowsToUpdate.map((row) => ({
+            seasonId: row.seasonId,
+            nextTotal: getSchoolQuotaRowTotal(row),
+          })),
+        ).forEach((step) => {
+          chapterTotalBySeasonId.set(
+            step.seasonId,
+            step.chapterTotalTargetCount,
+          )
+        })
+      })
+
+      return existingSeasonRows.map((row) => ({
+        seasonId: row.seasonId,
+        schoolName: row.schoolName,
+        payload: {
+          chapterTotalTargetCount:
+            chapterTotalBySeasonId.get(String(row.seasonId)) ??
+            getSchoolQuotaRowTotal(row),
+          quotas: [
+            { track: "PLAN" as const, targetCount: row.pm },
+            { track: "DESIGN" as const, targetCount: row.design },
+            { track: "WEB_PRODUCT_ENGINEER" as const, targetCount: row.webPe },
+            {
+              track: "MOBILE_PRODUCT_ENGINEER" as const,
+              targetCount: row.mobilePe,
+            },
+          ],
+        },
+      }))
+    }
+
+    if (existingSeasonRows.length === 0 && newSeasonRows.length === 0) {
       setIsDirty(false)
       return
     }
@@ -440,6 +494,7 @@ export function RecruitmentQuotaPage() {
     try {
       let hasSuccessfulWrite = false
       let hasWriteFailure = false
+      const createdRows: SchoolQuotaRow[] = []
 
       if (newSeasonRows.length > 0) {
         const createResults = await Promise.allSettled(
@@ -467,6 +522,7 @@ export function RecruitmentQuotaPage() {
 
           if (result.status === "fulfilled") {
             hasSuccessfulWrite = true
+            createdRows.push(row)
           } else {
             hasWriteFailure = true
             failedCreateSchoolNames.push(row.schoolName)
@@ -501,6 +557,8 @@ export function RecruitmentQuotaPage() {
           })
         }
       }
+
+      const payloadList = buildPayloadList(createdRows)
 
       if (payloadList.length > 0) {
         const updateResult = await updateQuotas(payloadList)

--- a/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
+++ b/src/features/recruiting/ui/RecruitmentQuotaPage.tsx
@@ -40,6 +40,8 @@ import {
 import { ChapterTabs } from "./ChapterTabs"
 import { QuotaApplicantStatusCard } from "./QuotaApplicantStatusCard"
 
+import type { ReplaceRecruitingSeasonTrackQuotasRequest } from "../api/types"
+
 const QUOTA_PAGE_REFETCH_INTERVAL = 30_000
 
 export function RecruitmentQuotaPage() {
@@ -423,8 +425,15 @@ export function RecruitmentQuotaPage() {
     // 기준이 "요청 시점에 저장돼 있는 다른 학교 값" 이라, 한 지부에서 여러 학교를
     // 고치면 요청마다 실어야 할 합계가 달라진다. 방금 만든 시즌도 그 시점에는
     // 이미 저장된 값이므로, 생성이 끝난 뒤에 계산해야 기준이 맞는다.
-    const buildPayloadList = (createdRows: SchoolQuotaRow[]) => {
-      const chapterTotalBySeasonId = new Map<string, number>()
+    const buildPayloadList = (
+      createdRows: { row: SchoolQuotaRow; seasonId: string }[],
+    ) => {
+      const payloads: {
+        seasonId: string
+        schoolName: string
+        chapterKey: string
+        payload: ReplaceRecruitingSeasonTrackQuotasRequest
+      }[] = []
 
       targetChapters.forEach((chapterData) => {
         const rowsToUpdate = existingSeasonRows.filter((row) =>
@@ -432,58 +441,62 @@ export function RecruitmentQuotaPage() {
             (school) => String(school.seasonId) === String(row.seasonId),
           ),
         )
-        if (rowsToUpdate.length === 0) return
+        const createdInChapter = createdRows.filter(({ row }) =>
+          chapterData.schools.some(
+            (school) =>
+              String(school.schoolId) === String(row.schoolId) &&
+              !school.seasonId,
+          ),
+        )
+        if (rowsToUpdate.length === 0 && createdInChapter.length === 0) return
 
+        // 방금 만든 시즌은 그 값이 이미 서버에 들어가 있다. 기준에 넣지 않으면
+        // 뒤따르는 요청이 그만큼 모자란 합계를 보내 튕긴다.
         const storedTotals = getChapterStoredTotals(chapterData.schools)
-        // 이번에 만들어진 학교는 시즌이 없던 자리라 기준값에 빠져 있다.
-        // 식별자가 없어 자리만 채우면 되므로 임시 키로 더한다.
-        createdRows
-          .filter((created) =>
-            chapterData.schools.some(
-              (school) =>
-                String(school.schoolId) === String(created.schoolId) &&
-                !school.seasonId,
-            ),
-          )
-          .forEach((created) => {
-            storedTotals.set(
-              `created:${created.schoolId}`,
-              getSchoolQuotaRowTotal(created),
-            )
-          })
+        createdInChapter.forEach(({ row, seasonId }) => {
+          storedTotals.set(String(seasonId), getSchoolQuotaRowTotal(row))
+        })
 
-        buildChapterTotalSteps(
+        // 시즌 생성 요청은 지부 합계를 받지 않는다. 그래서 새로 만들기만 하고
+        // 끝내면 지부 합계가 서버에 기록되지 않는다. 갱신할 학교가 하나도 없을
+        // 때만 만들어진 학교로 한 번 더 보내 합계를 남긴다.
+        const rowsToSend =
+          rowsToUpdate.length > 0
+            ? rowsToUpdate.map((row) => ({ row, seasonId: row.seasonId }))
+            : createdInChapter.slice(-1)
+
+        const steps = buildChapterTotalSteps(
           storedTotals,
-          rowsToUpdate.map((row) => ({
-            seasonId: row.seasonId,
+          rowsToSend.map(({ row, seasonId }) => ({
+            seasonId,
             nextTotal: getSchoolQuotaRowTotal(row),
           })),
-        ).forEach((step) => {
-          chapterTotalBySeasonId.set(
-            step.seasonId,
-            step.chapterTotalTargetCount,
-          )
+        )
+
+        rowsToSend.forEach(({ row, seasonId }, index) => {
+          payloads.push({
+            seasonId: String(seasonId),
+            schoolName: row.schoolName,
+            chapterKey: chapterData.chapter,
+            payload: {
+              chapterTotalTargetCount:
+                steps[index]?.chapterTotalTargetCount ??
+                getSchoolQuotaRowTotal(row),
+              quotas: [
+                { track: "PLAN", targetCount: row.pm },
+                { track: "DESIGN", targetCount: row.design },
+                { track: "WEB_PRODUCT_ENGINEER", targetCount: row.webPe },
+                {
+                  track: "MOBILE_PRODUCT_ENGINEER",
+                  targetCount: row.mobilePe,
+                },
+              ],
+            },
+          })
         })
       })
 
-      return existingSeasonRows.map((row) => ({
-        seasonId: row.seasonId,
-        schoolName: row.schoolName,
-        payload: {
-          chapterTotalTargetCount:
-            chapterTotalBySeasonId.get(String(row.seasonId)) ??
-            getSchoolQuotaRowTotal(row),
-          quotas: [
-            { track: "PLAN" as const, targetCount: row.pm },
-            { track: "DESIGN" as const, targetCount: row.design },
-            { track: "WEB_PRODUCT_ENGINEER" as const, targetCount: row.webPe },
-            {
-              track: "MOBILE_PRODUCT_ENGINEER" as const,
-              targetCount: row.mobilePe,
-            },
-          ],
-        },
-      }))
+      return payloads
     }
 
     if (existingSeasonRows.length === 0 && newSeasonRows.length === 0) {
@@ -494,12 +507,12 @@ export function RecruitmentQuotaPage() {
     try {
       let hasSuccessfulWrite = false
       let hasWriteFailure = false
-      const createdRows: SchoolQuotaRow[] = []
+      const createdRows: { row: SchoolQuotaRow; seasonId: string }[] = []
 
       if (newSeasonRows.length > 0) {
         const createResults = await Promise.allSettled(
           newSeasonRows.map(async (row) => {
-            await createSeason({
+            const seasonId = await createSeason({
               gisuId: row.gisuId,
               schoolId: row.schoolId,
               quotas: [
@@ -509,7 +522,7 @@ export function RecruitmentQuotaPage() {
                 { track: "MOBILE_PRODUCT_ENGINEER", targetCount: row.mobilePe },
               ],
             })
-            return row
+            return { row, seasonId }
           }),
         )
 
@@ -522,7 +535,7 @@ export function RecruitmentQuotaPage() {
 
           if (result.status === "fulfilled") {
             hasSuccessfulWrite = true
-            createdRows.push(row)
+            createdRows.push(result.value)
           } else {
             hasWriteFailure = true
             failedCreateSchoolNames.push(row.schoolName)


### PR DESCRIPTION
## 📸 작업 내용

- **모집 인원 설정에서 저장이 전부 실패하던 문제를 고쳤습니다.** 지부 전체 행뿐 아니라 학교 행 하나만 고쳐도 저장되지 않았습니다.
- 학교별 TO 교체 요청이 `chapterTotalTargetCount`(그 학교가 속한 지부의 전체 목표 인원) 를 필수로 받도록 바뀌었는데 보내지 않아 400 으로 거부되고 있었습니다.
- **요청 차례에 맞춰 지부 합계를 계산**해 싣습니다. 한 지부에서 여러 학교를 고치면 요청마다 값이 달라야 합니다.
- **저장 요청을 순차 호출로** 바꿨습니다. 동시에 던지면 처리 순서에 따라 통과 여부가 갈립니다.
- **시즌 생성이 섞이면 생성을 먼저 끝낸 뒤** 합계를 계산합니다.

## 🎞️ 주요 코드 설명

**`chapterTotalTargetCount` 는 사용자 입력이 아니라 검산값입니다.** API 계약상 `이번 요청의 트랙 합 + 같은 지부 다른 학교들의 현재 저장값` 과 정확히 같아야 하고, 다르면 `RECRUITING-0330` 으로 거부됩니다.

그래서 최종 합계를 모든 요청에 똑같이 보내면 첫 요청부터 튕깁니다. `buildChapterTotalSteps` 가 앞선 요청이 반영된 결과를 누적해 요청별 값을 미리 만듭니다.

| 요청 | 보내는 값 |
| --- | --- |
| 1. A 저장 | `newA + oldB` |
| 2. B 저장 | `newA + newB` |

이 규칙 때문에 **지부 안에서는 순서가 결과를 가릅니다.** 기존 `Promise.allSettled` 병렬 호출을 순차로 바꿨습니다.

**시즌이 없는 학교는 합계 기준에서 뺍니다.** 아직 만들어지지 않은 시즌은 서버도 세지 않습니다. 반대로 이번 저장에서 새로 만든 시즌은 이후 요청 시점에는 이미 저장된 값이므로, 생성 결과를 받아 기준에 더한 뒤 갱신 요청을 만듭니다.

**화면의 `지부 전체` 행은 건드리지 않았습니다.** 그 값은 자동배정의 분배 기준이자 학교 입력의 상한선으로 쓰이는 계획용 목표라, 서버에 저장되는 학교 합계와는 다른 개념입니다. 표시 전용으로 바꾸면 자동배정이 깨집니다.

## 🖥️ 구현화면

운영진 계정으로 로컬에서 요청·응답을 직접 확인했습니다.

| 상황 | 결과 |
| --- | --- |
| 수정 전, 학교 1곳 저장 | `PUT .../quotas` → **400** `chapterTotalTargetCount: 널이어서는 안됩니다` |
| 수정 후, 학교 1곳 저장 | `chapterTotalTargetCount: 4` → **200**, 새로고침 후 값 유지 |
| 수정 후, 같은 지부 2곳 저장 | 요청 1 `5`, 요청 2 `8` 로 각각 다르게 → **둘 다 200** |

## 🔗 연결된 이슈

- Connected: #763, #764
- Closes #763
- Closes #764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 모집 정원 저장 시 지부 전체 목표 인원을 함께 계산하고 반영합니다.
  * 학교별 모집 정원 합계와 시즌별 누적 목표 인원을 정확히 관리합니다.
  * 모집 시즌 설정에서 지부 전체 목표 인원 정보를 지원합니다.

* **버그 수정**
  * 여러 정원 변경 사항이 저장 순서에 따라 안정적으로 처리되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->