### PR TITLE
🐛 fix: 이메일 회원가입에서 비밀번호 단계가 건너뛰어지는 문제 수정

### DIFF
--- a/src/features/about/ui/AboutPage.tsx
+++ b/src/features/about/ui/AboutPage.tsx
@@ -1,5 +1,4 @@
-import bgGraphic from "@/shared/assets/image/about/bg-graphic.svg"
-
+import { LandingBackground } from "./LandingBackground"
 import { ClosingSection } from "./sections/ClosingSection"
 import { HeroSection } from "./sections/HeroSection"
 import { IntroSection } from "./sections/IntroSection"
@@ -27,21 +26,8 @@ export function AboutPage() {
       className="relative min-h-screen overflow-hidden bg-black"
       style={{ backgroundImage: `${RIGHT_GLOW}, ${LEFT_GLOW}` }}
     >
-      {/* 시안에서 이미 1440x1416 으로 잘려 나온 에셋이라 페이지 좌표에 그대로
-          얹는다.
-          시안은 화면 폭이 달라져도 이 그래픽의 크기·위치를 바꾸지 않는다. 390
-          프레임과 1440 프레임의 배치가 같고, 좁은 쪽은 왼쪽부터 잘라 보여 준다.
-          390 시안과 아크 밝기를 맞춰 보면 177 대 179, 235 대 235 로 겹친다.
-          그래서 1440 아래에서는 늘이지 않고 왼쪽에 붙인 채 잘라 낸다.
-          1440 위로는 대응 시안이 없고 잘린 에셋이라 오른쪽이 비므로 화면을 따라
-          늘인다. */}
-      <img
-        src={bgGraphic}
-        alt=""
-        aria-hidden
-        className="pointer-events-none absolute top-0 left-0 h-354 w-full min-w-[1440px] object-fill"
-      />
-      <div className="relative mx-auto w-full max-w-[1440px] px-8 xl:px-30">
+      <LandingBackground />
+      <div className="relative z-10 mx-auto w-full max-w-[1440px] px-8 xl:px-30">
         <HeroSection />
         <IntroSection />
         <PossibilitySection />

--- a/src/features/about/ui/LandingBackground.tsx
+++ b/src/features/about/ui/LandingBackground.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react"
+
+import bgGraphic from "@/shared/assets/image/about/bg-graphic.svg"
+
+export function LandingBackground() {
+  const [opacity, setOpacity] = useState(1)
+
+  useEffect(() => {
+    const updateOpacity = () => {
+      setOpacity(Math.max(0.35, 1 - window.scrollY / 700))
+    }
+
+    updateOpacity()
+    window.addEventListener("scroll", updateOpacity, { passive: true })
+
+    return () => window.removeEventListener("scroll", updateOpacity)
+  }, [])
+
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none fixed inset-0 z-0 overflow-hidden transition-opacity duration-300 ease-out"
+      style={{ opacity }}
+    >
+      <img
+        src={bgGraphic}
+        alt=""
+        className="absolute top-0 left-1/2 h-354 w-360 origin-top -translate-x-1/2 scale-90"
+      />
+    </div>
+  )
+}

--- a/src/features/about/ui/RecruitingGuidePage.tsx
+++ b/src/features/about/ui/RecruitingGuidePage.tsx
@@ -2,6 +2,7 @@ import {
   RECRUITING_GUIDE_PARTS_CTA,
   RECRUITING_GUIDE_SCHOOLS,
 } from "../recruitingGuideConstants"
+import { LandingBackground } from "./LandingBackground"
 import { RecruitingGuideFaqSection } from "./sections/RecruitingGuideFaqSection"
 import { RecruitingGuideHeroSection } from "./sections/RecruitingGuideHeroSection"
 import { RecruitingGuideScheduleSection } from "./sections/RecruitingGuideScheduleSection"
@@ -21,7 +22,8 @@ export function RecruitingGuidePage() {
       className="relative min-h-screen overflow-hidden bg-black"
       style={{ backgroundImage: `${RIGHT_GLOW}, ${LEFT_GLOW}` }}
     >
-      <div className="relative mx-auto w-full max-w-[1440px] px-8 xl:px-30">
+      <LandingBackground />
+      <div className="relative z-10 mx-auto w-full max-w-[1440px] px-8 xl:px-30">
         <RecruitingGuideHeroSection />
         <RecruitPartsSection
           ctaLabel={RECRUITING_GUIDE_PARTS_CTA.label}

--- a/src/features/auth/model/signupStep.test.ts
+++ b/src/features/auth/model/signupStep.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveEmailSignupStep } from "./signupStep"
+
+describe("resolveEmailSignupStep", () => {
+  it("이메일 인증 전에는 EMAIL 단계다", () => {
+    expect(resolveEmailSignupStep({})).toBe("EMAIL")
+    expect(resolveEmailSignupStep({ emailVerificationToken: "" })).toBe("EMAIL")
+    expect(resolveEmailSignupStep({ emailVerificationToken: null })).toBe(
+      "EMAIL",
+    )
+  })
+
+  it("이메일 인증을 마쳤고 비밀번호가 없으면 PASSWORD 단계다", () => {
+    expect(
+      resolveEmailSignupStep({ emailVerificationToken: "email-token" }),
+    ).toBe("PASSWORD")
+  })
+
+  it("비밀번호를 아직 입력하지 않았으면 어떤 상태에서도 PASSWORD 를 건너뛰지 않는다", () => {
+    expect(
+      resolveEmailSignupStep({
+        emailVerificationToken: "email-token",
+        rawPassword: "",
+        isTermsOpen: true,
+      }),
+    ).toBe("PASSWORD")
+  })
+
+  it("비밀번호까지 입력하면 PROFILE 단계다", () => {
+    expect(
+      resolveEmailSignupStep({
+        emailVerificationToken: "email-token",
+        rawPassword: "password12!",
+      }),
+    ).toBe("PROFILE")
+  })
+
+  it("약관을 펼치면 TERMS 단계다", () => {
+    expect(
+      resolveEmailSignupStep({
+        emailVerificationToken: "email-token",
+        rawPassword: "password12!",
+        isTermsOpen: true,
+      }),
+    ).toBe("TERMS")
+  })
+})

--- a/src/features/auth/model/signupStep.ts
+++ b/src/features/auth/model/signupStep.ts
@@ -1,0 +1,17 @@
+export type EmailSignupStep = "EMAIL" | "PASSWORD" | "PROFILE" | "TERMS"
+
+export interface EmailSignupStepInput {
+  emailVerificationToken?: string | null
+  rawPassword?: string | null
+  isTermsOpen?: boolean
+}
+
+export function resolveEmailSignupStep({
+  emailVerificationToken,
+  rawPassword,
+  isTermsOpen = false,
+}: EmailSignupStepInput): EmailSignupStep {
+  if (!emailVerificationToken) return "EMAIL"
+  if (!rawPassword) return "PASSWORD"
+  return isTermsOpen ? "TERMS" : "PROFILE"
+}

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -14,12 +14,10 @@ export const Route = createFileRoute("/about")({
   component: AboutRoute,
 })
 
-// 시안은 헤더가 자리를 차지하지 않고 히어로 위에 겹쳐 뜬다(mb-[-80px]). 히어로의
-// 위쪽 여백이 이미 헤더 높이를 포함한 값이라 absolute 로 띄운다.
 function AboutRoute() {
   return (
     <div className="about-landing relative">
-      <div className="absolute inset-x-0 top-0 z-50">
+      <div className="sticky top-0 z-50 -mb-20">
         <RecruitingHeader tone="glass" />
       </div>
       <AboutPage />

--- a/src/routes/recruiting-guide.tsx
+++ b/src/routes/recruiting-guide.tsx
@@ -14,12 +14,10 @@ export const Route = createFileRoute("/recruiting-guide")({
   component: RecruitingGuideRoute,
 })
 
-// 헤더가 자리를 차지하지 않고 히어로 위에 겹쳐 뜬다. 히어로의 위쪽 여백이 이미
-// 헤더 높이를 포함한 값이라 absolute 로 띄운다.
 function RecruitingGuideRoute() {
   return (
     <div className="relative">
-      <div className="absolute inset-x-0 top-0 z-50">
+      <div className="sticky top-0 z-50 -mb-20">
         <RecruitingHeader tone="glass" />
       </div>
       <RecruitingGuidePage />

--- a/src/routes/signup/index.tsx
+++ b/src/routes/signup/index.tsx
@@ -14,6 +14,7 @@ import { registerMemberByEmail } from "@/features/auth/api/register"
 import { getTerms } from "@/features/auth/api/terms"
 import { useSchools } from "@/features/auth/hooks/useSchools"
 import { OAUTH_VERIFICATION_TOKEN_KEY } from "@/features/auth/lib/handleLoginResponse"
+import { resolveEmailSignupStep } from "@/features/auth/model/signupStep"
 import {
   AccountCreationStep,
   ProfileInfoStep,
@@ -51,13 +52,11 @@ type SignUpState = {
     verificationId: number | null
   }
 
-  oAuthVerificationToken: string | null
   schoolList: SchoolNameItem[]
   isSignupLoading: boolean
 }
 
 type SignUpAction =
-  | { type: "SET_OAUTH_TOKEN"; payload: string | null }
   | { type: "SET_SCHOOL_LIST"; payload: SchoolNameItem[] }
   | { type: "EMAIL_REQUEST_START" }
   | { type: "EMAIL_REQUEST_SUCCESS"; payload: { id: number; value: string } }
@@ -91,15 +90,12 @@ const initialState: SignUpState = {
     verificationId: null,
   },
 
-  oAuthVerificationToken: null,
   schoolList: [],
   isSignupLoading: false,
 }
 
 function signUpReducer(state: SignUpState, action: SignUpAction): SignUpState {
   switch (action.type) {
-    case "SET_OAUTH_TOKEN":
-      return { ...state, oAuthVerificationToken: action.payload }
     case "SET_SCHOOL_LIST":
       return { ...state, schoolList: action.payload }
     case "EMAIL_REQUEST_START":
@@ -252,12 +248,6 @@ function SignUpPage() {
   const { schools: hookSchools, isError: isSchoolsError } = useSchools({
     nameType: "short",
   })
-
-  // 초기 로드: OAuth 토큰
-  useEffect(() => {
-    const token = sessionStorage.getItem(OAUTH_VERIFICATION_TOKEN_KEY)
-    dispatch({ type: "SET_OAUTH_TOKEN", payload: token })
-  }, [])
 
   useEffect(() => {
     if (hookSchools.length > 0) {
@@ -424,6 +414,19 @@ function SignUpPage() {
       return
     }
 
+    if (!password) {
+      addToast({
+        message: "비밀번호를 먼저 설정해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      dispatch({ type: "SET_PASSWORD", payload: "" })
+      setShowTerms(false)
+      return
+    }
+
     const selectedSchool = state.schoolList.find((s) => s.schoolName === school)
     if (!selectedSchool) {
       addToast({
@@ -456,6 +459,7 @@ function SignUpPage() {
     dispatch({ type: "SIGNUP_START" })
     try {
       await registerMemberByEmail(payload)
+      sessionStorage.removeItem(OAUTH_VERIFICATION_TOKEN_KEY)
       setIsSuccessModalOpen(true)
     } catch (err) {
       const message =
@@ -498,18 +502,11 @@ function SignUpPage() {
 
   const isNicknameValid = nickname !== "" && !errors.nickname
 
-  // 단계별 완료 여부 (상태 A에서 유도)
-  const isAccountCreated =
-    !!state.oAuthVerificationToken || !!state.signupData.rawPassword
-
-  // 현재 활성 단계 결정
-  const currentStep = !isEmailVerified
-    ? "EMAIL"
-    : !isAccountCreated
-      ? "PASSWORD"
-      : showTerms
-        ? "TERMS"
-        : "PROFILE"
+  const currentStep = resolveEmailSignupStep({
+    emailVerificationToken: state.signupData.emailVerificationToken,
+    rawPassword: state.signupData.rawPassword,
+    isTermsOpen: showTerms,
+  })
 
   const nextButtonDisabled =
     currentStep === "EMAIL"


### PR DESCRIPTION
## 📸 작업 내용

- **이메일 회원가입이 소셜 가입 토큰을 읽어 비밀번호 단계를 건너뛰던 문제를 고쳤습니다.** 소셜 로그인을 시도했다가 가입을 끝내지 않고 이메일 가입으로 넘어오면, 이메일 인증 후 비밀번호 화면 없이 프로필 단계로 넘어가고 빈 비밀번호로 가입 요청이 나가 400 으로 실패했습니다.
- 단계 판정을 `resolveEmailSignupStep` 순수 함수로 분리하고, 라우트에서 `oAuthVerificationToken` 상태·액션·리듀서 케이스와 마운트 시 sessionStorage 읽기를 모두 제거했습니다.
- 제출 직전 빈 비밀번호를 차단하고 비밀번호 단계로 되돌리는 방어선을 추가했습니다.
- 가입 성공 시 남아 있던 소셜 가입 토큰을 정리합니다.
- 단계 전이 테스트 5건을 추가했습니다.

`src/routes/signup/oauth.tsx`(소셜 가입)는 토큰을 실제 payload 에 실어 쓰므로 정상이며 건드리지 않았습니다.

> 이 브랜치에는 앞서 커밋된 소개 랜딩 배경·헤더 조정(`b7d89af9`)이 함께 포함되어 있습니다.

## 🎞️ 주요 코드 설명

### 단계 판정에서 소셜 토큰 제거

기존에는 소셜 가입 전용 토큰이 있으면 계정이 생성된 것으로 보고 비밀번호 단계를 건너뛰었습니다. 그 토큰은 이메일 가입 요청에 실리지도 않아, 단계만 건너뛰게 만드는 죽은 신호였습니다.

```TypeScript
// Before — src/routes/signup/index.tsx
const isAccountCreated =
  !!state.oAuthVerificationToken || !!state.signupData.rawPassword

const currentStep = !isEmailVerified
  ? "EMAIL"
  : !isAccountCreated
    ? "PASSWORD"
    : showTerms
      ? "TERMS"
      : "PROFILE"
```

```TypeScript
// After — src/features/auth/model/signupStep.ts
export function resolveEmailSignupStep({
  emailVerificationToken,
  rawPassword,
  isTermsOpen = false,
}: EmailSignupStepInput): EmailSignupStep {
  if (!emailVerificationToken) return "EMAIL"
  if (!rawPassword) return "PASSWORD"
  return isTermsOpen ? "TERMS" : "PROFILE"
}
```

이 함수는 소셜 토큰을 **매개변수로 아예 받지 않습니다.** 같은 회귀를 다시 만들려면 시그니처를 바꿔야 하므로 구조적으로 막힙니다.

### 제출 직전 방어선

단계 계산이 어긋나더라도 빈 비밀번호로 가입 요청이 나가지 않게 합니다.

```TypeScript
if (!password) {
  addToast({ message: "비밀번호를 먼저 설정해 주세요.", color: "red", ... })
  dispatch({ type: "SET_PASSWORD", payload: "" })
  setShowTerms(false)
  return
}
```

## 🖥️ 구현화면

로컬(5173)에서 sessionStorage 에 소셜 가입 토큰을 남겨 둔 상태로 전 과정을 확인했습니다.

- `/signup` 이메일 인증 후 **비밀번호 단계 정상 표시** (수정 전에는 건너뜀)
- 가입 완료 후 잔여 토큰 제거 확인
- `/login/default` 에서 해당 계정으로 **아이디/비밀번호 로그인 성공**

검증: `tsc -b` 통과, lint 0 error, FSD 경계 신규 위반 없음, 테스트 911건 통과, 빌드 성공

## 🔗 연결된 이슈

- Connected: #768
- Closes #768

## 💬 기타 더 이야기해볼 점

이미 소셜로 가입해 로컬 비밀번호가 없는 계정은 **프론트에 비밀번호를 등록할 화면이 없어** 아이디/비밀번호 로그인을 되찾을 수 없습니다. 이번 PR 범위 밖이라 #769 로 분리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 회원가입 진행 상태를 이메일 인증, 비밀번호, 프로필, 약관 단계로 정확히 안내합니다.
  * 가입 완료 전 비밀번호 설정 여부를 확인하고 필요한 안내를 제공합니다.
  * 소개 및 모집 안내 페이지에 스크롤에 따라 자연스럽게 변화하는 배경 그래픽을 추가했습니다.

* **개선 사항**
  * 페이지 헤더가 스크롤 시 상단에 고정되어 탐색이 편리해졌습니다.
  * 페이지 콘텐츠가 배경 위에 선명하게 표시되도록 시각적 배치를 개선했습니다.

* **버그 수정**
  * OAuth 기반 회원가입 상태 및 완료 후 인증 정보 정리를 안정화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->