### PR TITLE
💄 style: 랜딩 배경과 히어로 연출 개선

### DIFF
--- a/src/features/about/ui/AboutPage.tsx
+++ b/src/features/about/ui/AboutPage.tsx
@@ -1,4 +1,4 @@
-import { LandingBackground } from "./LandingBackground"
+import { LandingArtifact, LandingBackground } from "./LandingBackground"
 import { ClosingSection } from "./sections/ClosingSection"
 import { HeroSection } from "./sections/HeroSection"
 import { IntroSection } from "./sections/IntroSection"
@@ -6,28 +6,12 @@ import { PossibilitySection } from "./sections/PossibilitySection"
 import { RecruitPartsSection } from "./sections/RecruitPartsSection"
 import { SchoolsSection } from "./sections/SchoolsSection"
 
-// 앱 전체는 밝은 배경(__root 의 bg-teal-gray-50)인데 이 페이지만 다크다.
-// 라우트 안에서 자체 배경을 깐다.
-//
-// 시안 배경은 두 겹이다. 아래는 페이지 전체에 깔린 청록 글로우 두 덩어리(1440
-// 프레임 fill), 위는 첫 섹션을 가로지르는 BG Grapic 이다.
-//
-// 글로우는 시안 원본 해상도 렌더에서 콘텐츠 없는 구간의 픽셀을 뽑아 최소제곱으로
-// 맞췄다. 둘 다 x·y 에 대해 선형이라 linear-gradient 로 정확히 떨어진다.
-const LEFT_GLOW =
-  "linear-gradient(97.82deg, rgba(46, 209, 190, 0.189) 0%, rgba(46, 209, 190, 0) 48.3%)"
-
-const RIGHT_GLOW =
-  "linear-gradient(95.65deg, rgba(46, 209, 190, 0) 63.6%, rgba(46, 209, 190, 0.269) 100%)"
-
 export function AboutPage() {
   return (
-    <div
-      className="relative min-h-screen overflow-hidden bg-black"
-      style={{ backgroundImage: `${RIGHT_GLOW}, ${LEFT_GLOW}` }}
-    >
+    <div className="relative min-h-screen overflow-hidden bg-black">
       <LandingBackground />
-      <div className="relative z-10 mx-auto w-full max-w-[1440px] px-8 xl:px-30">
+      <LandingArtifact />
+      <div className="relative z-10 w-full px-8 xl:px-30">
         <HeroSection />
         <IntroSection />
         <PossibilitySection />

--- a/src/features/about/ui/LandingBackground.tsx
+++ b/src/features/about/ui/LandingBackground.tsx
@@ -2,7 +2,23 @@ import { useEffect, useState } from "react"
 
 import bgGraphic from "@/shared/assets/image/about/bg-graphic.svg"
 
+const LEFT_GLOW =
+  "linear-gradient(97.82deg, rgba(46, 209, 190, 0.189) 0%, rgba(46, 209, 190, 0) 48.3%)"
+
+const RIGHT_GLOW =
+  "linear-gradient(95.65deg, rgba(46, 209, 190, 0) 63.6%, rgba(46, 209, 190, 0.269) 100%)"
+
 export function LandingBackground() {
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none fixed inset-0 z-0 bg-black"
+      style={{ backgroundImage: `${RIGHT_GLOW}, ${LEFT_GLOW}` }}
+    />
+  )
+}
+
+export function LandingArtifact() {
   const [opacity, setOpacity] = useState(1)
 
   useEffect(() => {
@@ -19,13 +35,13 @@ export function LandingBackground() {
   return (
     <div
       aria-hidden
-      className="pointer-events-none fixed inset-0 z-0 overflow-hidden transition-opacity duration-300 ease-out"
+      className="pointer-events-none fixed top-0 left-0 z-[1] h-screen w-full overflow-hidden transition-opacity duration-300 ease-out"
       style={{ opacity }}
     >
       <img
         src={bgGraphic}
         alt=""
-        className="absolute top-0 left-1/2 h-354 w-360 origin-top -translate-x-1/2 scale-90"
+        className="absolute top-0 left-1/2 h-auto w-full origin-top -translate-x-1/2 -translate-y-[23%] scale-100 blur-[10px]"
       />
     </div>
   )

--- a/src/features/about/ui/LandingBackground.tsx
+++ b/src/features/about/ui/LandingBackground.tsx
@@ -41,7 +41,7 @@ export function LandingArtifact() {
       <img
         src={bgGraphic}
         alt=""
-        className="absolute top-[clamp(0px,calc(686px_-_47.6vw),500px)] left-1/2 h-auto w-full origin-top -translate-x-1/2 -translate-y-[23%] scale-100 blur-[10px]"
+        className="absolute top-[clamp(0px,calc(548px_-_38vw),400px)] left-1/2 h-auto w-full origin-top -translate-x-1/2 -translate-y-[23%] scale-100 blur-[10px]"
       />
     </div>
   )

--- a/src/features/about/ui/LandingBackground.tsx
+++ b/src/features/about/ui/LandingBackground.tsx
@@ -41,7 +41,7 @@ export function LandingArtifact() {
       <img
         src={bgGraphic}
         alt=""
-        className="absolute top-0 left-1/2 h-auto w-full origin-top -translate-x-1/2 -translate-y-[23%] scale-100 blur-[10px]"
+        className="absolute top-[clamp(0px,calc(686px_-_47.6vw),500px)] left-1/2 h-auto w-full origin-top -translate-x-1/2 -translate-y-[23%] scale-100 blur-[10px]"
       />
     </div>
   )

--- a/src/features/about/ui/RecruitingGuidePage.tsx
+++ b/src/features/about/ui/RecruitingGuidePage.tsx
@@ -2,28 +2,19 @@ import {
   RECRUITING_GUIDE_PARTS_CTA,
   RECRUITING_GUIDE_SCHOOLS,
 } from "../recruitingGuideConstants"
-import { LandingBackground } from "./LandingBackground"
+import { LandingArtifact, LandingBackground } from "./LandingBackground"
 import { RecruitingGuideFaqSection } from "./sections/RecruitingGuideFaqSection"
 import { RecruitingGuideHeroSection } from "./sections/RecruitingGuideHeroSection"
 import { RecruitingGuideScheduleSection } from "./sections/RecruitingGuideScheduleSection"
 import { RecruitPartsSection } from "./sections/RecruitPartsSection"
 import { SchoolsSection } from "./sections/SchoolsSection"
 
-// 소개 랜딩과 같은 배경을 쓴다. 두 화면이 이어진 한 벌로 보여야 한다.
-const LEFT_GLOW =
-  "linear-gradient(97.82deg, rgba(46, 209, 190, 0.189) 0%, rgba(46, 209, 190, 0) 48.3%)"
-
-const RIGHT_GLOW =
-  "linear-gradient(95.65deg, rgba(46, 209, 190, 0) 63.6%, rgba(46, 209, 190, 0.269) 100%)"
-
 export function RecruitingGuidePage() {
   return (
-    <div
-      className="relative min-h-screen overflow-hidden bg-black"
-      style={{ backgroundImage: `${RIGHT_GLOW}, ${LEFT_GLOW}` }}
-    >
+    <div className="relative min-h-screen overflow-hidden bg-black">
       <LandingBackground />
-      <div className="relative z-10 mx-auto w-full max-w-[1440px] px-8 xl:px-30">
+      <LandingArtifact />
+      <div className="relative z-10 w-full px-8 xl:px-30">
         <RecruitingGuideHeroSection />
         <RecruitPartsSection
           ctaLabel={RECRUITING_GUIDE_PARTS_CTA.label}

--- a/src/features/about/ui/sections/HeroSection.tsx
+++ b/src/features/about/ui/sections/HeroSection.tsx
@@ -7,7 +7,7 @@ import { GlassCtaButton } from "../GlassCtaButton"
 
 export function HeroSection() {
   return (
-    <section className="flex items-center justify-center pt-70 pb-45 md:pt-90 md:pb-50 lg:px-12 lg:pb-67.5">
+    <section className="flex min-h-svh items-center justify-center lg:px-12">
       <div className="flex w-full flex-col items-center gap-6.5">
         <div className="flex w-full flex-col items-start gap-3 md:gap-6.5">
           <div className="flex w-full flex-col items-start gap-3.5 text-center md:gap-6.25">
@@ -17,7 +17,7 @@ export function HeroSection() {
             {/* 390~767 은 폭에 따라 벡터가 커져 칸을 고정하면 넘친다. 최소
                 높이만 잡고 벡터가 칸을 정하게 둔다. 나머지 구간은 벡터 최대
                 크기가 칸 안에 들어가 시안대로 고정해도 된다. */}
-            <div className="xs:h-auto xs:min-h-32 flex h-48 w-full items-center justify-center md:h-50 lg:h-25 lg:min-h-0">
+            <div className="animate-hero-title xs:h-auto xs:min-h-32 flex h-48 w-full items-center justify-center transition-transform duration-300 ease-out hover:-translate-y-1 hover:scale-[1.02] md:h-50 lg:h-25 lg:min-h-0">
               {/* 헤드라인은 글자를 접을 수 없는 벡터라 줄 수마다 파일이 다르다.
                   1024 부터 한 줄, 그 아래는 두 줄이다. */}
               <BreakTheRulesTriple

--- a/src/features/about/ui/sections/RecruitPartsSection.tsx
+++ b/src/features/about/ui/sections/RecruitPartsSection.tsx
@@ -64,7 +64,7 @@ export function RecruitPartsSection({
 
   return (
     <section className="flex flex-col items-center gap-13.5 pt-37.5 md:pt-60 lg:pt-75">
-      <div className="flex w-full flex-col items-start gap-25">
+      <div className="flex w-full max-w-300 flex-col items-center gap-25">
         <div className="flex w-full max-w-300 flex-col items-center gap-16 lg:gap-18">
           <div className="flex w-full flex-col items-center gap-6">
             <h2 className="text-center text-[30px] leading-[1.2] font-bold tracking-[-0.6px] text-white md:text-[32px] md:tracking-[-0.64px] lg:text-[38px] lg:tracking-[-0.76px] xl:text-5xl xl:tracking-[-1.44px]">

--- a/src/features/about/ui/sections/RecruitingGuideHeroSection.tsx
+++ b/src/features/about/ui/sections/RecruitingGuideHeroSection.tsx
@@ -5,7 +5,7 @@ import { GlassCtaButton } from "../GlassCtaButton"
 
 export function RecruitingGuideHeroSection() {
   return (
-    <section className="flex flex-col items-center gap-6.5 pt-70 pb-45 md:pt-90 md:pb-50 lg:pb-67.5">
+    <section className="flex min-h-svh flex-col items-center justify-center gap-6.5">
       <div className="flex w-full flex-col items-center gap-3 md:gap-6.5">
         <div className="flex flex-col items-start gap-3.5 text-center md:gap-4 lg:gap-6.25">
           <p className="w-full text-base leading-[20.8px] font-medium tracking-[1px] text-teal-400 uppercase md:text-[22px] md:tracking-[2px]">
@@ -13,7 +13,7 @@ export function RecruitingGuideHeroSection() {
           </p>
           {/* 헤드라인은 글자를 접을 수 없는 벡터다. 마무리 섹션과 같은 칸 높이를
               써서 두 화면의 UMC 11th 가 같은 크기로 보이게 한다. */}
-          <div className="flex h-16 w-full items-center justify-center md:h-25 lg:h-25.5">
+          <div className="animate-hero-title flex h-16 w-full items-center justify-center transition-transform duration-300 ease-out hover:-translate-y-1 hover:scale-[1.02] md:h-25 lg:h-25.5">
             <UmcEleventh
               className="h-auto w-full max-w-112.5 text-white"
               role="img"

--- a/src/shared/assets/image/about/bg-graphic.svg
+++ b/src/shared/assets/image/about/bg-graphic.svg
@@ -1,58 +1,58 @@
-<svg width="1440" height="1416" viewBox="0 0 1440 1416" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="3072" height="2515" viewBox="0 0 3072 2515" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g opacity="0.5">
-<g filter="url(#filter0_f_13114_127878)">
-<ellipse cx="901.822" cy="385.866" rx="912.584" ry="255.086" transform="rotate(148.406 901.822 385.866)" fill="#36D3C0" fill-opacity="0.4"/>
+<g filter="url(#filter0_f_13363_1597)">
+<ellipse cx="1293.43" cy="1484.67" rx="912.584" ry="255.086" transform="rotate(148.406 1293.43 1484.67)" fill="#36D3C0" fill-opacity="0.4"/>
 </g>
-<g filter="url(#filter1_f_13114_127878)">
-<path d="M84.687 751.364C-70.481 499.081 310.864 -17.3506 936.446 -402.118C1562.03 -786.885 2194.95 -894.284 2350.12 -642.001C2505.29 -389.718 2433.01 84.0763 1563.5 578.499C693.994 1072.92 239.855 1003.65 84.687 751.364Z" fill="url(#paint0_radial_13114_127878)"/>
+<g filter="url(#filter1_f_13363_1597)">
+<path d="M476.297 1850.16C321.129 1597.88 702.474 1081.45 1328.06 696.682C1953.64 311.915 2586.56 204.516 2741.73 456.799C2896.9 709.082 2824.62 1182.88 1955.11 1677.3C1085.6 2171.72 631.465 2102.45 476.297 1850.16Z" fill="url(#paint0_radial_13363_1597)"/>
 </g>
 </g>
 <g opacity="0.5">
-<g filter="url(#filter2_f_13114_127878)">
-<ellipse cx="901.822" cy="385.866" rx="912.584" ry="255.086" transform="rotate(148.406 901.822 385.866)" fill="#36D3C0" fill-opacity="0.4"/>
+<g filter="url(#filter2_f_13363_1597)">
+<ellipse cx="1293.43" cy="1484.67" rx="912.584" ry="255.086" transform="rotate(148.406 1293.43 1484.67)" fill="#36D3C0" fill-opacity="0.4"/>
 </g>
-<g filter="url(#filter3_f_13114_127878)">
-<path d="M84.687 751.364C-70.481 499.081 310.864 -17.3507 936.446 -402.118C1562.03 -786.885 2194.95 -894.284 2350.12 -642.001C2505.29 -389.718 2433.01 84.0762 1563.5 578.499C693.994 1072.92 239.855 1003.65 84.687 751.364Z" fill="url(#paint1_radial_13114_127878)"/>
+<g filter="url(#filter3_f_13363_1597)">
+<path d="M476.297 1850.16C321.129 1597.88 702.474 1081.45 1328.06 696.682C1953.64 311.915 2586.56 204.516 2741.73 456.799C2896.9 709.082 2824.62 1182.88 1955.11 1677.3C1085.6 2171.72 631.465 2102.45 476.297 1850.16Z" fill="url(#paint1_radial_13363_1597)"/>
 </g>
 </g>
-<g filter="url(#filter4_f_13114_127878)">
-<path d="M78.5145 739.443C-74.9114 489.992 262.198 11.1035 861.502 -357.501C569.656 -92.8571 -232.423 672.048 -78.9973 921.499C74.4286 1170.95 2344.01 133.499 1562 591.999C779.997 1050.5 231.94 988.894 78.5145 739.443Z" fill="url(#paint2_radial_13114_127878)"/>
+<g filter="url(#filter4_f_13363_1597)">
+<path d="M470.124 1838.24C316.699 1588.79 653.808 1109.9 1253.11 741.3C961.266 1005.94 159.187 1770.85 312.613 2020.3C466.038 2269.75 2735.62 1232.3 1953.61 1690.8C1171.61 2149.3 623.55 2087.69 470.124 1838.24Z" fill="url(#paint2_radial_13363_1597)"/>
 </g>
 <defs>
-<filter id="filter0_f_13114_127878" x="-367.674" y="-620.056" width="2538.99" height="2011.84" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_f_13363_1597" x="23.9362" y="478.745" width="2538.99" height="2011.84" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
-<feGaussianBlur stdDeviation="240.32" result="effect1_foregroundBlur_13114_127878"/>
+<feGaussianBlur stdDeviation="240.32" result="effect1_foregroundBlur_13363_1597"/>
 </filter>
-<filter id="filter1_f_13114_127878" x="-49.9114" y="-878.499" width="2564.93" height="1924.81" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter1_f_13363_1597" x="341.699" y="220.301" width="2564.92" height="1924.81" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
-<feGaussianBlur stdDeviation="4.06615" result="effect1_foregroundBlur_13114_127878"/>
+<feGaussianBlur stdDeviation="4.06615" result="effect1_foregroundBlur_13363_1597"/>
 </filter>
-<filter id="filter2_f_13114_127878" x="-367.674" y="-620.056" width="2538.99" height="2011.84" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter2_f_13363_1597" x="23.9361" y="478.745" width="2538.99" height="2011.84" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
-<feGaussianBlur stdDeviation="240.32" result="effect1_foregroundBlur_13114_127878"/>
+<feGaussianBlur stdDeviation="240.32" result="effect1_foregroundBlur_13363_1597"/>
 </filter>
-<filter id="filter3_f_13114_127878" x="-49.9114" y="-878.499" width="2564.93" height="1924.81" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter3_f_13363_1597" x="341.699" y="220.301" width="2564.92" height="1924.81" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
-<feGaussianBlur stdDeviation="4.06615" result="effect1_foregroundBlur_13114_127878"/>
+<feGaussianBlur stdDeviation="4.06615" result="effect1_foregroundBlur_13363_1597"/>
 </filter>
-<filter id="filter4_f_13114_127878" x="-148.313" y="-407.501" width="1923.77" height="1418.31" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter4_f_13363_1597" x="243.297" y="691.299" width="1923.77" height="1418.31" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
-<feGaussianBlur stdDeviation="3.90094" result="effect1_foregroundBlur_13114_127878"/>
+<feGaussianBlur stdDeviation="3.90094" result="effect1_foregroundBlur_13363_1597"/>
 </filter>
-<radialGradient id="paint0_radial_13114_127878" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1197.24 12.4806) rotate(-121.594) scale(536.286 1329.82)">
+<radialGradient id="paint0_radial_13363_1597" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1588.85 1111.28) rotate(-121.594) scale(536.286 1329.82)">
 <stop offset="0.947115" stop-color="#031211" stop-opacity="0.5"/>
 <stop offset="1" stop-color="#00FFF1" stop-opacity="0.92"/>
 </radialGradient>
-<radialGradient id="paint1_radial_13114_127878" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1197.24 12.4805) rotate(-121.594) scale(536.286 1329.82)">
+<radialGradient id="paint1_radial_13363_1597" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(1588.85 1111.28) rotate(-121.594) scale(536.286 1329.82)">
 <stop offset="0.947115" stop-color="#031211" stop-opacity="0.5"/>
 <stop offset="1" stop-color="#00FFF1" stop-opacity="0.92"/>
 </radialGradient>
-<radialGradient id="paint2_radial_13114_127878" cx="0" cy="0" r="1" gradientTransform="matrix(-303.678 -493.284 1185.09 -729.615 1169.46 71.9908)" gradientUnits="userSpaceOnUse">
+<radialGradient id="paint2_radial_13363_1597" cx="0" cy="0" r="1" gradientTransform="matrix(-303.678 -493.284 1185.09 -729.615 1561.07 1170.79)" gradientUnits="userSpaceOnUse">
 <stop offset="0.947115" stop-color="#051918" stop-opacity="0.5"/>
 <stop offset="1" stop-color="white" stop-opacity="0.92"/>
 </radialGradient>

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -54,6 +54,29 @@
   }
 }
 
+@keyframes hero-title-enter {
+  from {
+    opacity: 0;
+    transform: translateY(20px) scale(0.96);
+    filter: blur(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    filter: blur(0);
+  }
+}
+
+@utility animate-hero-title {
+  animation: hero-title-enter 700ms cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform, opacity, filter;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
 /* 스크롤은 되지만 스크롤바는 안 보이게. 카드 내부 리스트처럼 스크롤이
    콘텐츠임을 암시하지 않아도 되는 좁은 영역에 사용 */
 @utility scrollbar-hide {


### PR DESCRIPTION
## 📸 작업 내용

- 소개 및 모집 안내 페이지의 배경 글로우와 SVG 아티팩트를 별도 레이어로 구성했습니다.
- 아티팩트가 스크롤 위치에 따라 자연스럽게 투명해지도록 하고, 전체 너비·23% 상단 크롭·10px 블러를 적용했습니다.
- 두 페이지 히어로 콘텐츠를 뷰포트 중앙에 맞추고, 메인 타이틀에 진입 및 호버 인터랙션을 추가했습니다.

## 🎞️ 주요 코드 설명

### 배경 레이어 분리

- 고정 배경 글로우와 스크롤 반응 SVG 아티팩트를 독립 컴포넌트로 분리해 각 레이어의 크기와 효과를 독립적으로 조정할 수 있도록 했습니다.

## 🔗 연결된 이슈

- Connected: #771
- Closes #771

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 소개 및 채용 안내 페이지에 장식용 아티팩트와 좌우 글로우 배경을 추가했습니다.
  - 히어로 제목에 진입 애니메이션과 호버 효과를 적용했습니다.

- **개선 사항**
  - 히어로 영역을 다양한 화면 크기에 맞게 반응형으로 개선했습니다.
  - 콘텐츠 너비와 정렬을 조정해 페이지 구성을 더 균형 있게 표시합니다.
  - 동작 감소 설정을 사용하는 환경에서는 제목 애니메이션을 비활성화합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->