### PR TITLE
feat: 학교 교표 칩 모바일 구간 반응형

### DIFF
--- a/src/features/about/ui/SchoolChip.tsx
+++ b/src/features/about/ui/SchoolChip.tsx
@@ -3,10 +3,13 @@ interface SchoolChipProps {
   logo: string
 }
 
+// 모바일 시안은 44 높이에 py 14 를 적어 두었는데 로고 28 과 합치면 56 이라 맞지
+// 않는다. Figma 가 고정 높이를 우선해 패딩을 흘린 값이라, 높이에 맞는 8 로 옮긴다.
+// md 부터는 14+40+14 = 68 로 떨어져 시안 값을 그대로 쓴다.
 export function SchoolChip({ name, logo }: SchoolChipProps) {
   return (
-    <div className="flex h-17 shrink-0 items-center gap-3.5 rounded-[50px] bg-[rgba(255,255,255,0.1)] py-3.5 pr-6 pl-4">
-      <span className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-white">
+    <div className="flex h-11 shrink-0 items-center gap-2.5 rounded-[50px] bg-[rgba(255,255,255,0.1)] py-2 pr-3 pl-2 md:h-17 md:gap-3.5 md:py-3.5 md:pr-6 md:pl-4">
+      <span className="flex size-7 shrink-0 items-center justify-center overflow-hidden rounded-full bg-white md:size-10">
         {/* 교표 21장이 합쳐 380KB 가 넘는데 모두 화면 몇 개 아래에 있다. 먼저
             받아 두면 첫 화면이 그만큼 늦어진다. */}
         <img
@@ -19,7 +22,7 @@ export function SchoolChip({ name, logo }: SchoolChipProps) {
           className="size-full object-contain"
         />
       </span>
-      <span className="text-2xl leading-[1.35] font-semibold tracking-[-0.48px] text-[#999]">
+      <span className="text-lg leading-[1.4] font-semibold tracking-[-0.18px] text-[#999] md:text-2xl md:leading-[1.35] md:tracking-[-0.48px]">
         {name}
       </span>
     </div>

--- a/src/features/about/ui/sections/SchoolsSection.tsx
+++ b/src/features/about/ui/sections/SchoolsSection.tsx
@@ -8,7 +8,7 @@ function SchoolTrack() {
   return (
     <ul className="flex">
       {ABOUT_SCHOOLS.schools.map((school) => (
-        <li key={school.name} className="pr-5">
+        <li key={school.name} className="pr-2 md:pr-5">
           <SchoolChip name={school.name} logo={school.logo} />
         </li>
       ))}
@@ -68,7 +68,7 @@ export function SchoolsSection({
           </p>
         </div>
         {variant === "static" ? (
-          <ul className="flex flex-wrap justify-center gap-x-5 gap-y-7.5">
+          <ul className="flex flex-wrap justify-center gap-x-2 gap-y-6 md:gap-x-5 md:gap-y-7.5">
             {ABOUT_SCHOOLS.schools.map((school) => (
               <li key={school.name}>
                 <SchoolChip name={school.name} logo={school.logo} />
@@ -78,7 +78,7 @@ export function SchoolsSection({
         ) : (
           // 학교줄은 콘텐츠 폭을 넘어 화면 끝까지 흐른다. 부모가 items-center 라
           // 폭만 늘리면 가운데를 기준으로 양옆으로 똑같이 번져 나간다.
-          <div className="flex w-screen flex-col gap-7.5 overflow-hidden">
+          <div className="flex w-screen flex-col gap-6 overflow-hidden md:gap-7.5">
             <SchoolMarqueeRow direction="right" />
             <div aria-hidden>
               <SchoolMarqueeRow direction="left" />


### PR DESCRIPTION
## 📸 작업 내용

- 소개 랜딩 학교 칩 모바일 대응

| 항목        | ~767  | 768~ |
|-------------|-------|------|
| 칩 높이     | 44    | 68   |
| 로고        | 28    | 40   |
| 로고-텍스트 | 10    | 14   |
| 좌/우 패딩  | 8/12  | 16/24|
| 폰트        | 18    | 24   |
| tracking    | -0.18 | -0.48|
| 칩 간격     | 8     | 20   |
| 줄 간격     | 24    | 30   |


## 🔗 연결된 이슈

- Closed #774 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 모바일 화면에서 학교 칩의 높이, 여백, 로고 및 글자 크기를 줄여 더 компакт하게 표시합니다.
  * 화면 크기에 따라 학교 칩과 목록 간 간격이 조정됩니다.
  * 중간 크기 이상 화면에서는 기존 디자인을 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->