### PR TITLE
fix: 모집 기간에 매칭 경로로 들어가지던 문제 수정

### DIFF
--- a/src/features/recruiting/lib/ensureMatchingAllowed.test.ts
+++ b/src/features/recruiting/lib/ensureMatchingAllowed.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  HEADER_RECRUITING_WINDOW_END,
+  HEADER_RECRUITING_WINDOW_START,
+} from "@/shared/config/headerRecruitingWindow"
+import { useToastStore } from "@/shared/ui/toast/useToastStore"
+
+import { ensureMatchingAllowed } from "./ensureMatchingAllowed"
+
+// redirect() 가 던지는 값은 목적지를 options 안에 담는다.
+function redirectTarget(error: unknown) {
+  return (error as { options?: { to?: string } }).options?.to
+}
+
+function callAt(iso: string) {
+  vi.setSystemTime(new Date(iso))
+  try {
+    ensureMatchingAllowed()
+    return undefined
+  } catch (error) {
+    return error
+  }
+}
+
+const START = Date.parse(HEADER_RECRUITING_WINDOW_START)
+const END = Date.parse(HEADER_RECRUITING_WINDOW_END)
+
+describe("ensureMatchingAllowed", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    useToastStore.setState({ toasts: [] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("모집 기간에는 프로젝트 목록으로 돌려보낸다", () => {
+    const error = callAt(new Date((START + END) / 2).toISOString())
+
+    expect(redirectTarget(error)).toBe("/projects")
+  })
+
+  it("막을 때 안내 토스트를 남긴다", () => {
+    callAt(new Date((START + END) / 2).toISOString())
+
+    expect(useToastStore.getState().toasts).toHaveLength(1)
+    expect(useToastStore.getState().toasts[0]?.color).toBe("red")
+  })
+
+  it("모집 시작 전에는 통과시킨다", () => {
+    const error = callAt(new Date(START - 1000).toISOString())
+
+    expect(error).toBeUndefined()
+    expect(useToastStore.getState().toasts).toHaveLength(0)
+  })
+
+  // 창은 시작 시각을 포함한다.
+  it("모집 시작 순간부터 막는다", () => {
+    expect(redirectTarget(callAt(new Date(START).toISOString()))).toBe(
+      "/projects",
+    )
+  })
+
+  // 끝 시각은 포함하지 않는다. 09-01 00:00 은 이미 닫힌 것으로 본다.
+  it("모집 종료 순간부터 통과시킨다", () => {
+    expect(callAt(new Date(END).toISOString())).toBeUndefined()
+  })
+
+  it("모집이 끝난 뒤에는 통과시킨다", () => {
+    expect(callAt(new Date(END + 1000).toISOString())).toBeUndefined()
+  })
+})

--- a/src/features/recruiting/lib/ensureMatchingAllowed.ts
+++ b/src/features/recruiting/lib/ensureMatchingAllowed.ts
@@ -1,0 +1,46 @@
+import { redirect } from "@tanstack/react-router"
+
+import { isWithinHeaderRecruitingWindow } from "@/shared/config/headerRecruitingWindow"
+import { useToastStore } from "@/shared/ui/toast/useToastStore"
+
+/** 모집 기간에 매칭으로 들어오면 여기로 돌려보낸다. */
+const FALLBACK_PATH = "/projects"
+
+/**
+ * 모집 기간에는 매칭 화면으로 들어갈 수 없다.
+ *
+ * 로그인 직후 착지 경로만 막으면 부족하다. 주소를 직접 치거나 이전 기록으로
+ * 돌아오는 경로가 남아, 진입 자체를 라우트 진입 지점에서 끊는다. `/matching` 아래
+ * 화면은 모두 이 라우트를 부모로 두므로 여기 한 곳이면 전부 덮는다.
+ *
+ * 역할 예외를 두지 않는다. 운영진도 같은 규칙을 받는다.
+ *
+ * 기간 판정을 서버 차수가 아니라 하드코딩한 창으로 한다. 이유가 둘이다.
+ *
+ * 첫째, 실제 지원 기간이 오기 전에 QA 로 이 차단이 제대로 도는지 확인해야 한다.
+ * 서버 차수에 매이면 차수가 열리기 전에는 막히는 화면을 재현할 방법이 없어, 정작
+ * 기간이 시작된 뒤에야 처음 동작을 보게 된다. 창은 값만 옮기면 QA 기간에 그대로
+ * 재현된다.
+ *
+ * 둘째, 서버 차수 목록(`useHeaderRecruitingStatus`)으로 판정하면 아직 아무 학교도
+ * 차수를 열지 않은 동안 "모집 기간이 아니다" 가 되어 매칭이 그대로 열린다. 헤더가
+ * 지원 진입로를 띄우는 근거와 같은 값을 쓴다.
+ *
+ * TODO: headerRecruitingWindow 는 차수가 열리는 대로 지우기로 되어 있다. 그때 이
+ * 판정도 함께 옮겨야 한다. 한쪽만 옮기면 헤더는 모집 중이라고 하는데 매칭은 열려
+ * 있는 상태가 생긴다. 다만 옮기더라도 위 QA 요구는 남으므로, 차수와 무관하게 기간을
+ * 강제할 수단은 어떤 형태로든 남겨 두어야 한다.
+ */
+export function ensureMatchingAllowed(): void {
+  if (!isWithinHeaderRecruitingWindow()) return
+
+  useToastStore.getState().addToast({
+    message: "모집 기간에는 접근할 수 없는 경로입니다.",
+    color: "red",
+    variant: "deep",
+    type: "default",
+    duration: 3000,
+  })
+
+  throw redirect({ to: FALLBACK_PATH })
+}

--- a/src/routes/matching/route.tsx
+++ b/src/routes/matching/route.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Outlet } from "@tanstack/react-router"
 
 import { ensureMe } from "@/features/auth/lib/ensureMe"
+import { ensureMatchingAllowed } from "@/features/recruiting/lib/ensureMatchingAllowed"
 import Footer from "@/widgets/footer/Footer"
 import RecruitingHeader from "@/widgets/navigation/header/RecruitingHeader"
 import { MatchingSegmentRegion } from "@/widgets/navigation/sidebar/MatchingSegmentRegion"
@@ -12,6 +13,9 @@ export const Route = createFileRoute("/matching")({
   }),
   beforeLoad: async ({ context, location }) => {
     await ensureMe(context.queryClient, location.href)
+    // 인증 확인이 먼저다. 로그인하지 않은 사람에게 모집 기간 안내를 띄우면
+    // 로그인하면 들어갈 수 있는 곳처럼 읽힌다.
+    ensureMatchingAllowed()
   },
   component: MatchingLayout,
 })

--- a/src/shared/lib/loginRedirect.ts
+++ b/src/shared/lib/loginRedirect.ts
@@ -1,5 +1,11 @@
 const LOGIN_RETURN_TO_STORAGE_KEY = "login_return_to"
-const DEFAULT_LOGIN_SUCCESS_PATH = "/matching/projects"
+/**
+ * 복귀 경로가 없을 때 로그인 후 착지할 곳.
+ *
+ * 매칭이 아니라 프로젝트 목록이다. 모집 기간에는 매칭으로 들어갈 수 없어, 기본값을
+ * 매칭으로 두면 로그아웃 뒤 다시 로그인한 사람이 매번 막히는 화면으로 떨어진다.
+ */
+const DEFAULT_LOGIN_SUCCESS_PATH = "/projects"
 
 export function normalizeReturnTo(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined


### PR DESCRIPTION
## 📸 작업 내용
### 문제

모집 기간인데도 `/matching` 이하로 들어갈 수 있었다. 로그인 경로에 따라 착지점도 갈렸다.

- 처음 로그인: `/projects?page=1`
- 로그아웃 후 다시 로그인: `/matching/projects?page=1`

### 원인

두 층이 겹쳐 있었다.

**로그인 기본 착지 경로가 매칭이었다.** `resolveLoginSuccessPath` 는 `URL 의 returnTo ?? sessionStorage ?? 기본값` 순으로 고르는데 그 기본값이 `/matching/projects` 였다. 처음 로그인은 보호 라우트에서 튕겨 나오며 returnTo 가 붙어 `/projects` 로 갔지만, 로그아웃은 `clearLoginReturnTo()` 로 복귀 경로를 지우고 `/login` 으로 직행해 returnTo 가 없다. 그래서 기본값이 그대로 드러났다.

**매칭 라우트에 기간 가드가 없었다.** `beforeLoad` 가 `ensureMe`(인증)만 했다. 착지 경로만 고쳐도 주소를 직접 치거나 이전 기록으로 돌아오면 그대로 뚫린다.

### 해결

`/matching` 진입 지점에서 끊는다. `/matching` 아래 화면은 모두 이 라우트를 부모로 두므로(routeTree 확인) 한 곳이면 전부 덮는다. 막을 때는 안내 토스트를 남기고
프로젝트 목록으로 돌려보낸다.

기본 착지 경로는 `/projects` 로 바꾼다. 매칭으로 두면 모집 기간에 로그인한 사람이 매번 막히는 화면으로 떨어진다.

### 기간 판정을 서버 차수가 아니라 하드코딩한 창으로 한 이유

처음에는 `queryClient.ensureQueryData` 로 공개 차수 목록을 받아 판정했다. 그런데 아직 아무 학교도 차수를 열지 않아 OPEN 이 비어 있고, 그러면 "모집 기간이 아니다" 가 되어 매칭이 그대로 열린다. 헤더가 지원 진입로를 띄우는 근거도 이 창이라 판정이
갈리면 헤더는 모집 중인데 매칭은 열린 상태가 된다.

더 중요한 이유는 QA 다. 실제 지원 기간이 오기 전에 이 차단이 제대로 도는지 확인해야 하는데, 서버 차수에 매이면 차수가 열리기 전에는 막히는 화면을 재현할 방법이 없다.
창은 값만 옮기면 QA 기간에 그대로 재현된다. 이 근거를 함수 주석에 남겼다.

서버 조회가 빠지면서 동기 함수가 되어 진입 지연도 없어졌다.

## 🖥️ 구현화면

<img width="638" height="430" alt="image" src="https://github.com/user-attachments/assets/852e8341-e0fd-4720-825d-fd167830a68e" />

## 🔗 연결된 이슈

- Closed #778 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 모집 기간 중 매칭 페이지 접근 시 안내 토스트를 표시하고 프로젝트 목록으로 이동합니다.
  - 모집 시작 전, 종료 시각, 종료 후에는 기존처럼 매칭 페이지에 접근할 수 있습니다.

- **개선**
  - 로그인 후 기본 이동 경로가 프로젝트 목록으로 변경되었습니다.

- **테스트**
  - 모집 기간별 접근 제한 및 페이지 이동 동작을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->