### PR TITLE
fix: 이메일 인증 실패 시 로그인 페이지 강제 리다이렉트되는 현상 수정

### DIFF
--- a/src/shared/lib/axios.test.ts
+++ b/src/shared/lib/axios.test.ts
@@ -154,6 +154,21 @@ describe("토큰 갱신 실패", () => {
     expect(redirectToLogin).not.toHaveBeenCalled()
   })
 
+  it("이메일 인증 하위 경로의 401은 토큰 갱신 및 리다이렉트 대상에서 제외한다", async () => {
+    const adapter = vi.fn<AxiosAdapter>(async (config) => {
+      return rejectUnauthorized(config)
+    })
+    const { api, clear, redirectToLogin } = await createSubject(adapter)
+
+    await expect(
+      api.post("/v1/auth/email-verification/code"),
+    ).rejects.toBeInstanceOf(AxiosError)
+
+    expect(adapter).toHaveBeenCalledOnce()
+    expect(clear).not.toHaveBeenCalled()
+    expect(redirectToLogin).not.toHaveBeenCalled()
+  })
+
   it("동시 요청 중 갱신이 실패하면 대기열의 요청도 모두 reject한다", async () => {
     let releaseRenew: () => void = () => undefined
     const renewGate = new Promise<void>((resolve) => {

--- a/src/shared/lib/axios.test.ts
+++ b/src/shared/lib/axios.test.ts
@@ -154,20 +154,24 @@ describe("토큰 갱신 실패", () => {
     expect(redirectToLogin).not.toHaveBeenCalled()
   })
 
-  it("이메일 인증 하위 경로의 401은 토큰 갱신 및 리다이렉트 대상에서 제외한다", async () => {
-    const adapter = vi.fn<AxiosAdapter>(async (config) => {
-      return rejectUnauthorized(config)
-    })
-    const { api, clear, redirectToLogin } = await createSubject(adapter)
+  it.each([
+    { path: "/v1/auth/email-verification", label: "이메일 인증" },
+    { path: "/v1/auth/email-verification/code", label: "이메일 인증 하위" },
+  ])(
+    "$label 경로의 401은 토큰 갱신 및 리다이렉트 대상에서 제외한다",
+    async ({ path }) => {
+      const adapter = vi.fn<AxiosAdapter>(async (config) => {
+        return rejectUnauthorized(config)
+      })
+      const { api, clear, redirectToLogin } = await createSubject(adapter)
 
-    await expect(
-      api.post("/v1/auth/email-verification/code"),
-    ).rejects.toBeInstanceOf(AxiosError)
+      await expect(api.post(path)).rejects.toBeInstanceOf(AxiosError)
 
-    expect(adapter).toHaveBeenCalledOnce()
-    expect(clear).not.toHaveBeenCalled()
-    expect(redirectToLogin).not.toHaveBeenCalled()
-  })
+      expect(adapter).toHaveBeenCalledOnce()
+      expect(clear).not.toHaveBeenCalled()
+      expect(redirectToLogin).not.toHaveBeenCalled()
+    },
+  )
 
   it("동시 요청 중 갱신이 실패하면 대기열의 요청도 모두 reject한다", async () => {
     let releaseRenew: () => void = () => undefined

--- a/src/shared/lib/axios.ts
+++ b/src/shared/lib/axios.ts
@@ -19,6 +19,7 @@ declare module "axios" {
 
 const AUTH_LOGIN_PATH = "/v1/auth/login"
 const TOKEN_RENEW_PATH = "/v1/auth/token/renew"
+const AUTH_EMAIL_VERIFICATION_PATH = "/v1/auth/email-verification"
 
 function getRequestPathname(url: string | undefined) {
   if (!url) return null
@@ -34,6 +35,14 @@ function isLoginRequest(url: string | undefined) {
 
 function isTokenRenewRequest(url: string | undefined) {
   return getRequestPathname(url) === TOKEN_RENEW_PATH
+}
+
+function isEmailVerificationRequest(url: string | undefined) {
+  const pathname = getRequestPathname(url)
+  return (
+    pathname === AUTH_EMAIL_VERIFICATION_PATH ||
+    pathname?.startsWith(`${AUTH_EMAIL_VERIFICATION_PATH}/`)
+  )
 }
 
 export const api = axios.create({
@@ -117,7 +126,8 @@ api.interceptors.response.use(
     if (
       error.response?.status !== 401 ||
       isLoginRequest(originalRequest.url) ||
-      isTokenRenewRequest(originalRequest.url)
+      isTokenRenewRequest(originalRequest.url) ||
+      isEmailVerificationRequest(originalRequest.url)
     ) {
       return Promise.reject(error)
     }


### PR DESCRIPTION
## 📸 작업 내용

회원가입 이메일 인증 단계에서 인증번호 오기입 시 로그인 페이지로 강제 이동되는 버그를 수정했습니다.

- 회원가입 진행 중 이메일 인증번호 오기입(`401 Unauthorized`) 시 `axios` interceptor에 의해 로그인 페이지(`/login`)로 강제 리다이렉트되어 작성 내용이 초기화되던 문제를 해결했습니다.
- `axios` response interceptor의 401 토큰 갱신/리다이렉트 예외 처리 대상에 이메일 인증 API 경로(`/v1/auth/email-verification`)를 추가했습니다.
- 이제 인증번호 오기입 시 페이지 이동 없이 현재 폼이 유지되며 `"인증번호가 일치하지 않아요."` 에러 메시지가 정상 노출됩니다.

## 🎞️ 주요 코드 설명

### 1. 이메일 인증 경로 401 예외 처리 (`src/shared/lib/axios.ts`)

```typescript
const AUTH_EMAIL_VERIFICATION_PATH = "/v1/auth/email-verification"

function isEmailVerificationRequest(url: string | undefined) {
  const pathname = getRequestPathname(url)
  return (
    pathname === AUTH_EMAIL_VERIFICATION_PATH ||
    pathname?.startsWith(`${AUTH_EMAIL_VERIFICATION_PATH}/`)
  )
}

// response interceptor
if (
  error.response?.status !== 401 ||
  isLoginRequest(originalRequest.url) ||
  isTokenRenewRequest(originalRequest.url) ||
  isEmailVerificationRequest(originalRequest.url)
) {
  return Promise.reject(error)
}
```

- `/v1/auth/email-verification` 및 하위 경로 요청에서 401 에러가 반환되더라도 `terminateAuthentication` (세션 만료 처리 및 로그인 이동)이 호출되지 않고 에러를 reject 하도록 수정했습니다.

### 2. axios 인터셉터 단위 테스트 추가 (`src/shared/lib/axios.test.ts`)

```typescript
it("이메일 인증 하위 경로의 401은 토큰 갱신 및 리다이렉트 대상에서 제외한다", async () => {
  const adapter = vi.fn<AxiosAdapter>(async (config) => {
    return rejectUnauthorized(config)
  })
  const { api, clear, redirectToLogin } = await createSubject(adapter)

  await expect(
    api.post("/v1/auth/email-verification/code"),
  ).rejects.toBeInstanceOf(AxiosError)

  expect(adapter).toHaveBeenCalledOnce()
  expect(clear).not.toHaveBeenCalled()
  expect(redirectToLogin).not.toHaveBeenCalled()
})
```

- 이메일 인증 코드 검증 API에서 401 응답 발생 시 토큰 갱신이나 로그인 리다이렉트가 발생하지 않음을 검증하는 테스트를 작성했습니다.

## 🖥️ 구현화면


## 🔗 연결된 이슈

- Connected: #783 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 이메일 인증 코드 요청에서 401 응답이 발생해도 불필요한 토큰 갱신이나 인증 상태 초기화가 실행되지 않도록 개선했습니다.
  - 이메일 인증 중 로그인 화면으로 잘못 리다이렉트되는 문제를 수정했습니다.

- **테스트**
  - 이메일 인증 요청의 401 응답 처리 시나리오를 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->