### PR TITLE
fix: 회원가입 이름 입력 공백 제거 및 10자 제한 유효성 검증 추가

### DIFF
--- a/src/features/signup/ui/ProfileInfoStep.tsx
+++ b/src/features/signup/ui/ProfileInfoStep.tsx
@@ -59,8 +59,15 @@ export function ProfileInfoStep() {
           {...register("name")}
           type="default"
           value={name}
+          state={name !== "" && !!errors.name ? "error" : "default"}
           className="w-full"
         />
+
+        {errors.name?.message && (
+          <p className="text-body-2-medium text-error-500">
+            {errors.name.message}
+          </p>
+        )}
       </div>
 
       <div className="flex w-full flex-col gap-1.5">

--- a/src/features/signup/validation.test.ts
+++ b/src/features/signup/validation.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest"
+
+import { nameSchema, oauthSignUpSchema, signUpSchema } from "./validation"
+
+describe("nameSchema", () => {
+  it("공백을 자동으로 제거(.trim())하고 1~10자 이름을 허용한다", () => {
+    const result = nameSchema.safeParse("  홍길동  ")
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toBe("홍길동")
+    }
+  })
+
+  it("공백으로만 이루어진 이름 입력 시 에러 메시지를 반환한다", () => {
+    const result = nameSchema.safeParse("   ")
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe("이름을 입력해 주세요.")
+    }
+  })
+
+  it("10자를 초과하는 이름 입력 시 에러 메시지를 반환한다", () => {
+    const result = nameSchema.safeParse("가나다라마바사아자차카타파하")
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        "이름은 10자 이하로 입력해 주세요.",
+      )
+    }
+  })
+
+  it("앞뒤 공백 제거 후 10자를 초과하는 경우 에러를 반환한다", () => {
+    const result = nameSchema.safeParse("  가나다라마바사아자차카타파하  ")
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe(
+        "이름은 10자 이하로 입력해 주세요.",
+      )
+    }
+  })
+})
+
+describe("signUpSchema name validation", () => {
+  const baseValidData = {
+    email: "test@example.com",
+    code: "123456",
+    id: "test@example.com",
+    password: "password1!",
+    confirmPassword: "password1!",
+    school: "한국대학교",
+    nickname: "홍길동",
+    termsAgreements: {},
+  }
+
+  it("signUpSchema에서 10자 초과 이름 검증 실패", () => {
+    const result = signUpSchema.safeParse({
+      ...baseValidData,
+      name: "가나다라마바사아자차카타파하",
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("signUpSchema에서 정상 이름 및 공백 포함 이름 검증 성공 및 trim 반영", () => {
+    const result = signUpSchema.safeParse({
+      ...baseValidData,
+      name: "  홍길동  ",
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.name).toBe("홍길동")
+    }
+  })
+})
+
+describe("oauthSignUpSchema name validation", () => {
+  const baseValidData = {
+    email: "test@example.com",
+    code: "123456",
+    school: "한국대학교",
+    nickname: "홍길동",
+    termsAgreements: {},
+  }
+
+  it("oauthSignUpSchema에서 10자 초과 이름 검증 실패", () => {
+    const result = oauthSignUpSchema.safeParse({
+      ...baseValidData,
+      name: "가나다라마바사아자차카타파하",
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it("oauthSignUpSchema에서 정상 이름 및 공백 포함 이름 검증 성공 및 trim 반영", () => {
+    const result = oauthSignUpSchema.safeParse({
+      ...baseValidData,
+      name: "  홍길동  ",
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.name).toBe("홍길동")
+    }
+  })
+})

--- a/src/features/signup/validation.test.ts
+++ b/src/features/signup/validation.test.ts
@@ -15,7 +15,7 @@ describe("nameSchema", () => {
     const result = nameSchema.safeParse("   ")
     expect(result.success).toBe(false)
     if (!result.success) {
-      expect(result.error.issues[0].message).toBe("이름을 입력해 주세요.")
+      expect(result.error.issues[0]?.message).toBe("이름을 입력해 주세요.")
     }
   })
 
@@ -23,7 +23,7 @@ describe("nameSchema", () => {
     const result = nameSchema.safeParse("가나다라마바사아자차카타파하")
     expect(result.success).toBe(false)
     if (!result.success) {
-      expect(result.error.issues[0].message).toBe(
+      expect(result.error.issues[0]?.message).toBe(
         "이름은 10자 이하로 입력해 주세요.",
       )
     }
@@ -33,7 +33,7 @@ describe("nameSchema", () => {
     const result = nameSchema.safeParse("  가나다라마바사아자차카타파하  ")
     expect(result.success).toBe(false)
     if (!result.success) {
-      expect(result.error.issues[0].message).toBe(
+      expect(result.error.issues[0]?.message).toBe(
         "이름은 10자 이하로 입력해 주세요.",
       )
     }

--- a/src/features/signup/validation.ts
+++ b/src/features/signup/validation.ts
@@ -4,12 +4,20 @@ import {
   codeSchema,
   emailSchema,
   idSchema,
+  nameSchema,
   nicknameSchema,
   passwordSchema,
 } from "@/shared/lib/validationSchemas"
 
 // 하위 호환: 기존 소비자(routes 등)가 signup/validation 경유로 참조하던 primitive re-export
-export { codeSchema, emailSchema, idSchema, nicknameSchema, passwordSchema }
+export {
+  codeSchema,
+  emailSchema,
+  idSchema,
+  nameSchema,
+  nicknameSchema,
+  passwordSchema,
+}
 
 export const signUpSchemaObject = z.object({
   email: emailSchema,
@@ -18,7 +26,7 @@ export const signUpSchemaObject = z.object({
   password: passwordSchema,
   confirmPassword: z.string(),
   school: z.string().min(1, "학교를 선택해주세요."),
-  name: z.string().min(1, "이름을 입력해 주세요."),
+  name: nameSchema,
   nickname: nicknameSchema,
   termsAgreements: z.record(z.coerce.number(), z.boolean()),
 })
@@ -35,7 +43,7 @@ export const oauthSignUpSchema = z.object({
   email: emailSchema,
   code: codeSchema,
   school: z.string().min(1, "학교를 선택해주세요."),
-  name: z.string().min(1, "이름을 입력해 주세요."),
+  name: nameSchema,
   nickname: nicknameSchema,
   termsAgreements: z.record(z.coerce.number(), z.boolean()),
 })

--- a/src/routes/signup/index.tsx
+++ b/src/routes/signup/index.tsx
@@ -449,7 +449,7 @@ function SignUpPage() {
 
     const payload: EmailRegisterMemberRequest = {
       rawPassword: password,
-      name,
+      name: name.trim(),
       nickname,
       emailVerificationToken,
       schoolId: Number(selectedSchool.schoolId),
@@ -500,6 +500,7 @@ function SignUpPage() {
   const isPasswordValid = password !== "" && !errors.password
   const isPasswordMatch = password !== "" && password === confirmPassword
 
+  const isNameValid = name.trim() !== "" && !errors.name
   const isNicknameValid = nickname !== "" && !errors.nickname
 
   const currentStep = resolveEmailSignupStep({
@@ -516,7 +517,7 @@ function SignUpPage() {
       : currentStep === "PASSWORD"
         ? !isPasswordValid || !isPasswordMatch
         : currentStep === "PROFILE"
-          ? !school || !name || !isNicknameValid
+          ? !school || !isNameValid || !isNicknameValid
           : currentStep === "TERMS"
             ? terms
                 .filter((t) => t.isMandatory)

--- a/src/routes/signup/oauth.tsx
+++ b/src/routes/signup/oauth.tsx
@@ -446,7 +446,7 @@ function OAuthSignupPage() {
 
     const payload: RegisterMemberRequest = {
       oAuthVerificationToken,
-      name,
+      name: name.trim(),
       nickname,
       emailVerificationToken,
       schoolId: Number(selectedSchool.schoolId),
@@ -494,6 +494,7 @@ function OAuthSignupPage() {
       ? "다시 받기"
       : "인증하기"
 
+  const isNameValid = name.trim() !== "" && !errors.name
   const isNicknameValid = nickname !== "" && !errors.nickname
 
   // 단계별 완료 여부 (상태 A에서 유도)
@@ -511,7 +512,7 @@ function OAuthSignupPage() {
         state.email.isCodeInvalid ||
         state.email.isCodeExpired
       : currentStep === "PROFILE"
-        ? !school || !name || !isNicknameValid
+        ? !school || !isNameValid || !isNicknameValid
         : currentStep === "TERMS"
           ? terms
               .filter((t) => t.isMandatory)

--- a/src/shared/lib/validationSchemas.ts
+++ b/src/shared/lib/validationSchemas.ts
@@ -33,3 +33,9 @@ export const nicknameSchema = z
   .min(1)
   .max(5)
   .regex(/^[가-힣]*$/, "공백 없이 한글 1-5자")
+
+export const nameSchema = z
+  .string()
+  .trim()
+  .min(1, "이름을 입력해 주세요.")
+  .max(10, "이름은 10자 이하로 입력해 주세요.")


### PR DESCRIPTION
## 📸 작업 내용

- 회원가입 진행 시 이름 입력란의 앞뒤 공백 자동 제거(`.trim()`) 및 10자 이하 글자 수 제한 프론트엔드 유효성 검증을 추가하였습니다.

## 🎞️ 주요 코드 설명

### 1. 공용 이름 검증 스키마 정의 (`src/shared/lib/validationSchemas.ts`)

```TypeScript
export const nameSchema = z
  .string()
  .trim()
  .min(1, "이름을 입력해 주세요.")
  .max(10, "이름은 10자 이하로 입력해 주세요.")
```

- 이름 입력 시 `.trim()`으로 앞뒤 공백을 자동 제거하고 1~10자 이내 검증을 수행합니다.
- 공백만 입력 시 `"이름을 입력해 주세요."`, 10자 초과 시 `"이름은 10자 이하로 입력해 주세요."` 에러 메시지를 반환합니다.

### 2. 프로필 단계 에러 상태 및 메시지 표시 (`src/features/signup/ui/ProfileInfoStep.tsx`)

```TypeScript
<InputBox
  {...register("name")}
  type="default"
  value={name}
  state={name !== "" && !!errors.name ? "error" : "default"}
  className="w-full"
/>

{errors.name?.message && (
  <p className="text-body-2-medium text-error-500">
    {errors.name.message}
  </p>
)}
```

- `InputBox`에 `errors.name` 상태를 연동하여 유효하지 않을 경우 에러 스타일 및 하단 에러 메시지를 노출합니다.

### 3. 회원가입 단계 버튼 비활성화 및 Payload 처리 (`src/routes/signup/index.tsx`, `oauth.tsx`)

```TypeScript
const isNameValid = name.trim() !== "" && !errors.name

// nextButtonDisabled 중
currentStep === "PROFILE" ? !school || !isNameValid || !isNicknameValid : ...
```

- 이름 유효성(`isNameValid`) 미충족 시 다음 버튼 입력을 방지하고, 최종 회원가입 요청 시 `name: name.trim()`으로 정리하여 백엔드로 전달합니다.

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #784 