### PR TITLE
fix: 매칭 도메인의 지부 세그먼트에 지난 기수 지부까지 전부 노출되던 문제 수정

### DIFF
--- a/scripts/check-boundaries.mjs
+++ b/scripts/check-boundaries.mjs
@@ -16,9 +16,10 @@
 
 import { execSync } from "node:child_process"
 
-// 2026-07-10 기준 lateral 위반 13건(features 슬라이스 간 수평 결합).
+// 2026-08-13 기준 lateral 위반 12건(features 슬라이스 간 수평 결합).
+// matching 이 지부 목록을 application 슬라이스에서 받아 오던 결합을 걷어내며 1건 줄었다.
 // upward(역방향) 위반은 0이며 baseline 없이 무조건 차단한다.
-const LATERAL_BASELINE = 13
+const LATERAL_BASELINE = 12
 const RULE = "boundaries/dependencies"
 
 // 레이어 상하 순서(위->아래). 숫자가 클수록 하위 레이어다.

--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -302,7 +302,11 @@ export function useAdminPageData(
   const projectsQuery = useQuery({
     queryKey: applicationKeys.allProjects(gisuId, chapterId),
     queryFn: () => getAllProjects(gisuId, { chapterId, size: 100 }),
-    enabled: enabled && gisuId > 0,
+    // 지부를 고른 상태라면 그 ID 가 확정된 뒤에만 조회한다. chapterId 를 파라미터로
+    // 넘기면서 여기서 안 막으면, 매핑 전에는 필터가 빠진 채 전체 기수 프로젝트를
+    // 받아 잠깐 다른 지부 데이터까지 보인다. 같은 파일의 다른 조회들은 이미
+    // chapterId 를 확인하고 있어 여기만 빠져 있었다.
+    enabled: enabled && gisuId > 0 && (!chapterName || chapterId !== undefined),
   })
 
   const projects = useMemo(

--- a/src/features/application/hooks/useApplicationPageData.ts
+++ b/src/features/application/hooks/useApplicationPageData.ts
@@ -18,11 +18,9 @@ import {
 } from "@/entities/application/model/mappers"
 import { useMe } from "@/entities/member/hooks/useMe"
 import { getLatestChallengerRecord } from "@/entities/member/model/identity"
-import {
-  getAllChapters,
-  getChaptersWithSchools,
-} from "@/entities/organization/api/organization"
+import { getAllChapters } from "@/entities/organization/api/organization"
 import { useAllSchools } from "@/entities/organization/hooks/useAllSchools"
+import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import { getProjectDetail } from "@/entities/project/api/matchingProject"
 import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
 
@@ -277,34 +275,28 @@ export function useAdminPageData(
   const gisuQuery = useActiveGisuId({ enabled })
   const gisuId = gisuQuery.data ?? 0
 
-  const chaptersQuery = useChapters({ enabled })
-  const chapters = useMemo(
-    () => chaptersQuery.data?.chapters ?? [],
-    [chaptersQuery.data],
-  )
+  // 지부 목록과 지부별 학교 ID 를 한 곳에서 받는다. 예전에는 기수 구분이 없는
+  // 목록으로 이름->ID 를 찾고, 학교 ID 는 따로 with-schools 를 받아 같은 데이터를
+  // 두 번 조회했다.
+  const {
+    chapters,
+    getChapterIdByName,
+    isLoading: chaptersLoading,
+    isError: chaptersError,
+  } = useSchoolChapterMap()
 
-  // 지부별 학교 ID 조회 (schoolMatchingStatistics 필터링용)
-  const chaptersWithSchoolsQuery = useQuery({
-    queryKey: ["chapters-with-schools", gisuId],
-    queryFn: () => getChaptersWithSchools(String(gisuId)),
-    enabled: enabled && gisuId > 0,
-    staleTime: Infinity,
-  })
   const chapterSchoolIds = useMemo(() => {
-    if (!chapterName || !chaptersWithSchoolsQuery.data) return null
-    const chapter = chaptersWithSchoolsQuery.data.chapters.find(
-      (c) => c.chapterName === chapterName,
-    )
+    if (!chapterName) return null
+    const chapter = chapters.find((c) => c.chapterName === chapterName)
     if (!chapter) return null
     return new Set(chapter.schools.map((s) => String(s.schoolId)))
-  }, [chapterName, chaptersWithSchoolsQuery.data])
+  }, [chapterName, chapters])
 
   // 선택된 챕터 이름 -> chapterId 매핑
-  const chapterId = useMemo(() => {
-    if (!chapterName || chapters.length === 0) return undefined
-    const found = chapters.find((c) => c.name === chapterName)
-    return found ? Number(found.id) : undefined
-  }, [chapterName, chapters])
+  const chapterId = useMemo(
+    () => (chapterName ? getChapterIdByName(chapterName) : undefined),
+    [chapterName, getChapterIdByName],
+  )
 
   // 전체 프로젝트 목록 조회 (지원자 테이블용)
   const projectsQuery = useQuery({
@@ -519,14 +511,13 @@ export function useAdminPageData(
     isLoading:
       enabled &&
       (gisuQuery.isLoading ||
-        chaptersQuery.isLoading ||
+        chaptersLoading ||
         roundsQuery.isLoading ||
         projectsQuery.isLoading ||
         chapterStatsQuery.isLoading ||
-        chaptersWithSchoolsQuery.isLoading),
+        false),
     isError:
-      enabled &&
-      (gisuQuery.isError || chaptersQuery.isError || projectsQuery.isError),
-    error: gisuQuery.error ?? chaptersQuery.error ?? projectsQuery.error,
+      enabled && (gisuQuery.isError || chaptersError || projectsQuery.isError),
+    error: gisuQuery.error ?? projectsQuery.error,
   }
 }

--- a/src/features/matching/hooks/useMatchingStatusData.ts
+++ b/src/features/matching/hooks/useMatchingStatusData.ts
@@ -8,8 +8,8 @@ import {
 import { applicationKeys } from "@/entities/application/api/applicationKeys"
 import { useViewModeStore } from "@/entities/member/view-mode"
 import { useAllSchools } from "@/entities/organization/hooks/useAllSchools"
+import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import { getProjectMembersBatch } from "@/entities/project/api/matchingProject"
-import { useChapters } from "@/features/application/hooks/useApplicationPageData"
 import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
 
 import { matchingResponseToStats } from "../model/matchingStatsMapper"
@@ -35,18 +35,17 @@ export function useMatchingStatusData(chapterName?: string) {
   const gisuQuery = useActiveGisuId()
   const gisuId = gisuQuery.data ?? 0
 
-  const chaptersQuery = useChapters()
-  const chapters = useMemo(
-    () => chaptersQuery.data?.chapters ?? [],
-    [chaptersQuery.data],
+  // 챕터 필터링. 활성 기수의 지부로만 매핑한다. 기수 구분이 없는 목록으로 찾으면
+  // 같은 이름의 지난 기수 지부 ID 가 잡혀 엉뚱한 데이터를 조회하게 된다.
+  const {
+    getChapterIdByName,
+    isLoading: chaptersLoading,
+    isError: chaptersError,
+  } = useSchoolChapterMap()
+  const chapterId = useMemo(
+    () => (chapterName ? getChapterIdByName(chapterName) : undefined),
+    [chapterName, getChapterIdByName],
   )
-
-  // 챕터 필터링
-  const chapterId = useMemo(() => {
-    if (!chapterName || chapters.length === 0) return undefined
-    const found = chapters.find((c) => c.name === chapterName)
-    return found ? Number(found.id) : undefined
-  }, [chapterName, chapters])
 
   // 전체 프로젝트 조회 (매칭 결과 시트용)
   const projectsQuery = useQuery({
@@ -170,7 +169,7 @@ export function useMatchingStatusData(chapterName?: string) {
     isAdmin,
     isLoading:
       gisuQuery.isLoading ||
-      chaptersQuery.isLoading ||
+      chaptersLoading ||
       projectsQuery.isLoading ||
       schoolsQuery.isLoading ||
       (projects.length > 0 &&
@@ -179,12 +178,7 @@ export function useMatchingStatusData(chapterName?: string) {
       (!!chapterId &&
         matchingStatsQuery.data === undefined &&
         !matchingStatsQuery.isError),
-    isError:
-      gisuQuery.isError || chaptersQuery.isError || projectsQuery.isError,
-    error:
-      gisuQuery.error ??
-      chaptersQuery.error ??
-      projectsQuery.error ??
-      matchingStatsQuery.error,
+    isError: gisuQuery.isError || chaptersError || projectsQuery.isError,
+    error: gisuQuery.error ?? projectsQuery.error ?? matchingStatsQuery.error,
   }
 }

--- a/src/features/matching/hooks/useMatchingStatusData.ts
+++ b/src/features/matching/hooks/useMatchingStatusData.ts
@@ -76,7 +76,11 @@ export function useMatchingStatusData(chapterName?: string) {
 
       return { ...firstPage, content: projects }
     },
-    enabled: gisuId > 0,
+    // 지부를 고른 상태라면 그 ID 가 확정된 뒤에만 조회한다. chapterId 를 파라미터로
+    // 넘기면서 여기서 안 막으면, 매핑 전에는 필터가 빠진 채 전체 기수 프로젝트를
+    // 받아 잠깐 다른 지부 데이터까지 보인다. 지난 기수 지부명이 남아 매핑이 아예
+    // 실패하면 그 화면이 계속 유지된다.
+    enabled: gisuId > 0 && (!chapterName || chapterId !== undefined),
     staleTime: 1000 * 60 * 5,
   })
 

--- a/src/routes/matching/applications.tsx
+++ b/src/routes/matching/applications.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 
@@ -13,11 +12,10 @@ import {
   isSchoolLeadership,
 } from "@/entities/member/model/identity"
 import { useViewerIdentity } from "@/entities/member/view-mode/useViewerIdentity"
-import { getChaptersWithSchools } from "@/entities/organization/api/organization"
+import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import {
   useAdminPageData,
   useChallengerPageData,
-  useChapters,
 } from "@/features/application/hooks/useApplicationPageData"
 import { useProjectsPermissions } from "@/features/application/hooks/useProjectsPermissions"
 import { resolveMatchingApplicationView } from "@/features/application/model/applicationViewMode"
@@ -27,7 +25,6 @@ import { ChallengerApplicationView } from "@/features/application/ui/ChallengerA
 import { MyApplicationView } from "@/features/application/ui/MyApplicationView"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
 import { useIsMatchingPeriod } from "@/features/project/new/hooks/useIsMatchingPeriod"
-import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
 import { ProjectTitleCard } from "@/shared/ui/ProjectTitleCard"
 import { SegmentButton } from "@/shared/ui/segment-button/SegmentButton"
 import { useToastStore } from "@/shared/ui/toast/useToastStore"
@@ -44,22 +41,9 @@ function MatchingApplicationsPage() {
   const { me: identity, viewContext } = useViewerIdentity()
   const schoolLeadership = isSchoolLeadership(identity)
   const addToast = useToastStore((s) => s.addToast)
-  const chaptersQuery = useChapters()
-  const chapters = useMemo(
-    () => chaptersQuery.data?.chapters ?? [],
-    [chaptersQuery.data],
-  )
-  const chapterNames = useMemo(
-    () => chapters.map((c) => c.name).filter(Boolean),
-    [chapters],
-  )
-
-  const gisuId = useActiveGisuId().data ?? 0
-  const chaptersWithSchoolsQuery = useQuery({
-    queryKey: ["chapters-with-schools", gisuId],
-    queryFn: () => getChaptersWithSchools(String(gisuId)),
-    enabled: gisuId > 0 && schoolLeadership,
-  })
+  // 활성 기수의 지부만 받는다. 기수 구분이 없는 /v1/chapters 를 쓰면 지난 기수
+  // 지부까지 탭에 깔린다. 학교 목록도 같이 오므로 학교 회장 폴백까지 이 하나로 덮는다.
+  const { chapters, chapterNames } = useSchoolChapterMap()
 
   // challenger records에서 지부명 추출 (어드민 포함 모든 역할)
   const userChapter = getViewerBranch(me)
@@ -115,16 +99,16 @@ function MatchingApplicationsPage() {
         (r) => r.roleType === "CHAPTER_PRESIDENT",
       )?.organizationId
       if (!myChapterId) return
-      const myChapter = chapters.find((c) => c.id === myChapterId)
+      const myChapter = chapters.find((c) => c.chapterId === myChapterId)
       if (myChapter) {
-        setSelectedChapter(myChapter.name)
-        ownChapter.current = myChapter.name
+        setSelectedChapter(myChapter.chapterName)
+        ownChapter.current = myChapter.chapterName
         hasAutoSelected.current = true
       }
       return
     }
     if (isSchoolLeadership(me)) {
-      const myChapter = chaptersWithSchoolsQuery.data?.chapters.find((c) =>
+      const myChapter = chapters.find((c) =>
         c.schools.some((s) => s.schoolId === String(me.schoolId)),
       )
       if (myChapter && chapterNames.includes(myChapter.chapterName)) {
@@ -133,7 +117,7 @@ function MatchingApplicationsPage() {
         hasAutoSelected.current = true
       }
     }
-  }, [me, chapters, userChapter, chaptersWithSchoolsQuery.data])
+  }, [me, chapters, userChapter])
 
   // 차수 제한 대상: 지부장·교내 회장/부회장·Plan 챌린저 (최고관리자·중앙 총괄단 제외)
   const isRoundRestrictedRole =

--- a/src/routes/matching/index.tsx
+++ b/src/routes/matching/index.tsx
@@ -13,10 +13,7 @@ import {
   isSuperAdmin,
 } from "@/entities/member/model/identity"
 import { useViewerIdentity } from "@/entities/member/view-mode/useViewerIdentity"
-import {
-  getAllChapters,
-  getAllGisu,
-} from "@/entities/organization/api/organization"
+import { getAllGisu } from "@/entities/organization/api/organization"
 import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import { type Chapter, isChapter } from "@/entities/organization/model/chapters"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
@@ -121,7 +118,8 @@ function TeamMatchingAnnouncePage() {
   const [pendingNotice] = useState(readPendingNotice)
   const [hashNoticeId] = useState(readHashNoticeId)
 
-  const { chapterNames: serverChapterNames } = useSchoolChapterMap()
+  const { chapterNames: serverChapterNames, getChapterIdByName } =
+    useSchoolChapterMap()
 
   const { data: me } = useMe()
   const { me: identity } = useViewerIdentity()
@@ -138,22 +136,18 @@ function TeamMatchingAnnouncePage() {
     queryFn: getAllGisu,
   })
 
-  // 지부 정보 조회
-  const { data: chaptersData } = useQuery({
-    queryKey: ["chapters", "all"],
-    queryFn: getAllChapters,
-  })
-
   const activeGisuId = useMemo(() => {
     if (!gisuData) return null
     const active = gisuData.gisuList.find((g) => g.isActive)
     return active ? active.gisuId : gisuData.gisuList[0]?.gisuId || null
   }, [gisuData])
 
-  const selectedChapterId = useMemo(() => {
-    if (!chaptersData) return null
-    return chaptersData.chapters.find((c) => c.name === chapter)?.id || null
-  }, [chaptersData, chapter])
+  // 이름->ID 매핑도 활성 기수 목록으로 한다. 기수 구분이 없는 목록으로 찾으면
+  // 같은 이름의 지난 기수 지부 ID 가 잡힐 수 있다.
+  const selectedChapterId = useMemo(
+    () => (chapter ? (getChapterIdByName(chapter) ?? null) : null),
+    [chapter, getChapterIdByName],
+  )
 
   useEffect(() => {
     if (serverChapterNames.length === 0) return

--- a/src/routes/matching/projects/announce/index.tsx
+++ b/src/routes/matching/projects/announce/index.tsx
@@ -12,10 +12,7 @@ import {
   isSuperAdmin,
 } from "@/entities/member/model/identity"
 import { useViewerIdentity } from "@/entities/member/view-mode/useViewerIdentity"
-import {
-  getAllChapters,
-  getAllGisu,
-} from "@/entities/organization/api/organization"
+import { getAllGisu } from "@/entities/organization/api/organization"
 import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import { type Chapter, isChapter } from "@/entities/organization/model/chapters"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
@@ -120,7 +117,8 @@ function ProjectMatchingAnnouncePage() {
   const [pendingNotice] = useState(readPendingNotice)
   const [hashNoticeId] = useState(readHashNoticeId)
 
-  const { chapterNames: serverChapterNames } = useSchoolChapterMap()
+  const { chapterNames: serverChapterNames, getChapterIdByName } =
+    useSchoolChapterMap()
 
   const { data: me } = useMe()
   const { me: identity } = useViewerIdentity()
@@ -136,22 +134,18 @@ function ProjectMatchingAnnouncePage() {
     queryFn: getAllGisu,
   })
 
-  // 지부 정보 조회
-  const { data: chaptersData } = useQuery({
-    queryKey: ["chapters", "all"],
-    queryFn: getAllChapters,
-  })
-
   const activeGisuId = useMemo(() => {
     if (!gisuData) return null
     const active = gisuData.gisuList.find((g) => g.isActive)
     return active ? active.gisuId : gisuData.gisuList[0]?.gisuId || null
   }, [gisuData])
 
-  const selectedChapterId = useMemo(() => {
-    if (!chaptersData) return null
-    return chaptersData.chapters.find((c) => c.name === chapter)?.id || null
-  }, [chaptersData, chapter])
+  // 이름->ID 매핑도 활성 기수 목록으로 한다. 기수 구분이 없는 목록으로 찾으면
+  // 같은 이름의 지난 기수 지부 ID 가 잡힐 수 있다.
+  const selectedChapterId = useMemo(
+    () => (chapter ? (getChapterIdByName(chapter) ?? null) : null),
+    [chapter, getChapterIdByName],
+  )
 
   useEffect(() => {
     if (serverChapterNames.length === 0) return

--- a/src/routes/matching/rounds.tsx
+++ b/src/routes/matching/rounds.tsx
@@ -14,7 +14,7 @@ import {
   canManageMatchingRounds,
   isChapterPresident,
 } from "@/entities/member/model/identity"
-import { useChapters } from "@/features/application/hooks/useApplicationPageData"
+import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
 import {
   type Branch,
@@ -105,12 +105,10 @@ function MatchingRoundsPage() {
   const addToast = useToastStore((s) => s.addToast)
   const { data: me } = useMe()
 
-  // 지부 목록 조회 -> branch name -> chapterId 매핑
-  const chaptersQuery = useChapters()
-  const chapters = useMemo(
-    () => chaptersQuery.data?.chapters ?? [],
-    [chaptersQuery.data],
-  )
+  // 지부 목록 조회 -> branch name -> chapterId 매핑.
+  // 활성 기수의 지부만 받는다. 기수 구분이 없는 /v1/chapters 를 쓰면 지난 기수
+  // 지부까지 섞여 잘못된 chapterId 로 해석될 수 있다.
+  const { chapters } = useSchoolChapterMap()
 
   // 로그인한 계정의 지부 정보가 있으면 최초 1회 자동 선택
   useEffect(() => {
@@ -119,16 +117,16 @@ function MatchingRoundsPage() {
       (r) => r.roleType === "CHAPTER_PRESIDENT",
     )?.organizationId
     if (!myChapterId) return
-    const myChapter = chapters.find((c) => c.id === myChapterId)
+    const myChapter = chapters.find((c) => c.chapterId === myChapterId)
     if (myChapter) {
-      setSelectedBranch(myChapter.name as Branch)
+      setSelectedBranch(myChapter.chapterName as Branch)
       hasAutoSelectedBranch.current = true
     }
   }, [me, chapters])
 
   const chapterId = useMemo(() => {
-    const found = chapters.find((c) => c.name === selectedBranch)
-    return found ? Number(found.id) : undefined
+    const found = chapters.find((c) => c.chapterName === selectedBranch)
+    return found ? Number(found.chapterId) : undefined
   }, [selectedBranch, chapters])
 
   // 매칭 차수 목록 조회
@@ -199,8 +197,8 @@ function MatchingRoundsPage() {
       const myChapterId = me?.roles?.find(
         (r) => r.roleType === "CHAPTER_PRESIDENT",
       )?.organizationId
-      const targetChapter = chapters.find((c) => c.name === branch)
-      if (!targetChapter || String(targetChapter.id) !== myChapterId) {
+      const targetChapter = chapters.find((c) => c.chapterName === branch)
+      if (!targetChapter || targetChapter.chapterId !== myChapterId) {
         addToast({
           message: "소속된 지부의 매칭 기간만 설정할 수 있습니다.",
           color: "red",

--- a/src/routes/matching/status.tsx
+++ b/src/routes/matching/status.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useLayoutEffect, useRef, useState } from "react"
 
 import { useMe } from "@/entities/member/hooks/useMe"
 import {
@@ -7,8 +7,8 @@ import {
   isChapterPresident,
   isOperator,
 } from "@/entities/member/model/identity"
+import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import { type Chapter } from "@/entities/organization/model/chapters"
-import { useChapters } from "@/features/application/hooks/useApplicationPageData"
 import { ApplicationStatsSection } from "@/features/application/ui/ApplicationStatsSection"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
 import { useMatchingStatusData } from "@/features/matching/hooks/useMatchingStatusData"
@@ -28,15 +28,9 @@ export const Route = createFileRoute("/matching/status")({
 function MatchingStatusPage() {
   const { data: me } = useMe()
   const isAdmin = isOperator(me)
-  const chaptersQuery = useChapters()
-  const chapters = useMemo(
-    () => chaptersQuery.data?.chapters ?? [],
-    [chaptersQuery.data],
-  )
-  const chapterNames = useMemo(
-    () => chapters.map((c) => c.name).filter(Boolean),
-    [chapters],
-  )
+  // 활성 기수의 지부만 받는다. 기수 구분이 없는 /v1/chapters 를 쓰면 지난 기수
+  // 지부까지 탭에 깔린다.
+  const { chapters, chapterNames } = useSchoolChapterMap()
 
   // challenger records에서 지부명 추출 (어드민 포함 모든 역할)
   const userChapter = getViewerBranch(me)
@@ -71,9 +65,9 @@ function MatchingStatusPage() {
       (r) => r.roleType === "CHAPTER_PRESIDENT",
     )?.organizationId
     if (!myChapterId) return
-    const myChapter = chapters.find((c) => c.id === myChapterId)
-    if (myChapter && chapterNames.includes(myChapter.name)) {
-      setSelectedChapter(myChapter.name)
+    const myChapter = chapters.find((c) => c.chapterId === myChapterId)
+    if (myChapter && chapterNames.includes(myChapter.chapterName)) {
+      setSelectedChapter(myChapter.chapterName)
       hasAutoSelected.current = true
     }
   }, [me, chapters, userChapter])


### PR DESCRIPTION
## 📸 작업 내용

- 매칭 도메인의 지부 세그먼트에 **지난 기수 지부까지 전부 노출되던 문제**를 수정합니다.
- 지원 현황·평가 현황·매칭 차수 화면이 기수 구분이 없는 `GET /v1/chapters` 를 쓰고 있었습니다. 리크루팅 도메인은 이미 활성 기수 기준으로 조회하고 있어, 매칭 도메인만 옛 경로에 남아 있던 상황입니다.

- **서버 데이터가 바뀌면서 드러난 버그입니다.**
    - 10기 하나뿐이던 동안에는 "전체 목록 = 그 기수 목록"이라 우연히 맞아떨어졌는데, 11기 지부가 생성되면서 같은 API가 두 기수를 모두 내려주기 시작했습니다.
 
| 커밋 | 내용 |
|---|---|
| `57101334` 지부 탭에 지난 기수 지부가 함께 보이던 문제 | 눈에 보이는 버그 |
| `68f4afec` 훅의 지부 이름→ID 매핑이 기수를 가리지 않던 문제 | 안 보이지만 결과가 틀어지는 버그 |
| `d9917f6f` 매칭 목록·공고의 지부 ID 매핑 통일 | 증상 없는 정합성 정리 |

## 🖥️ 구현화면

<img width="1440" height="690" alt="image" src="https://github.com/user-attachments/assets/1f14c922-0710-445e-ac11-80d8129eaf0e" />

## 🔗 연결된 이슈

- Closed #789


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 매칭 관련 화면에서 활성 기수의 지부·학교 정보가 정확히 표시되고 선택됩니다.
  - 동일한 지부명이 과거 기수에 존재해도 잘못된 지부로 연결되지 않습니다.
  - 지부 및 프로젝트 정보의 로딩·오류 상태가 화면에 일관되게 반영됩니다.

- **개선 사항**
  - 신청, 프로젝트 공지, 라운드, 상태 화면의 지부 선택 및 권한 확인이 활성 기수 기준으로 통일되었습니다.
  - 지부·학교 정보 조회 흐름이 간소화되어 관련 화면의 데이터 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->