### PR TITLE
🐛 fix: FAQ 전체 탭에서 파트별 문답이 함께 노출되던 문제

### DIFF
--- a/src/features/about/ui/sections/RecruitingGuideFaqSection.tsx
+++ b/src/features/about/ui/sections/RecruitingGuideFaqSection.tsx
@@ -112,10 +112,10 @@ export function RecruitingGuideFaqSection() {
     tabRefs.current[next as number]?.focus()
   }
 
-  const visibleItems = RECRUITING_GUIDE_FAQ.items.filter(
-    (item) =>
-      activeFilterId === "all" ||
-      item.parts.some((part) => part === activeFilterId),
+  const visibleItems = RECRUITING_GUIDE_FAQ.items.filter((item) =>
+    activeFilterId === "all"
+      ? item.parts.length === 0
+      : item.parts.some((part) => part === activeFilterId),
   )
 
   return (


### PR DESCRIPTION
## 📸 작업 내용

- `/recruiting-guide` FAQ 섹션의 `전체` 탭이 공통 문답 6개만 노출하도록 필터 조건을 수정했습니다.
- 기존에는 `전체` 선택 시 파트별 문답(PM / Design / Web PE / Mobile PE) 12개까지 합쳐 18개가 모두 표시되어, 파트 탭과 내용이 중복되고 목록이 불필요하게 길어졌습니다.
- FAQ 데이터는 손대지 않고 필터 조건만 조정했습니다. 각 파트 탭은 기존과 동일하게 해당 파트 문답 3개씩 노출합니다.

## 🎞️ 주요 코드 설명

### 전체 탭의 필터 조건

```TypeScript
const visibleItems = RECRUITING_GUIDE_FAQ.items.filter((item) =>
  activeFilterId === "all"
    ? item.parts.length === 0
    : item.parts.some((part) => part === activeFilterId),
)
```

- `activeFilterId === "all"` 일 때 무조건 통과시키던 조건을, `parts` 가 빈 항목만 통과시키도록 바꿨습니다.
- `recruitingGuideConstants.ts` 의 `RecruitingGuideFaqItem.parts` 는 이미 "비어 있으면 전체 필터에서만 보이는 공통 문답" 으로 정의되어 있었고, 데이터도 상위 6개만 `parts: []` 입니다. 즉 타입 정의가 기술하던 동작에 구현을 맞추는 변경이며, 항목을 지우지 않으므로 파트 탭 동작에는 영향이 없습니다.
- 디자인상 필터 라벨은 `전체` 로 확정되어 문구를 `공통` 으로 바꿀 수 없기 때문에, 라벨 대신 노출 범위를 의도에 맞췄습니다.

## 🔗 스크린샷
- 수정 전
<img width="1917" height="917" alt="스크린샷 2026-08-15 오후 5 24 37" src="https://github.com/user-attachments/assets/f826e121-679a-4358-b2dd-4c75c9fce03b" />

- 수정 후
<img width="1917" height="917" alt="스크린샷 2026-08-15 오후 5 24 52" src="https://github.com/user-attachments/assets/f288b86f-8e56-4bea-9fcf-5c93a40bf96e" />


## 🔗 연결된 이슈

- Connected: #792
- Closes #792

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - FAQ 필터에서 ‘전체’ 선택 시 분류되지 않은 FAQ만 표시되도록 동작을 수정했습니다.
  - 특정 필터를 선택하면 해당 분류에 속한 FAQ가 계속 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->