### PR TITLE
feat: 데스크톱 전용 화면에 모바일 접속 안내 오버레이 추가

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -32,6 +32,10 @@ async function run() {
       const page = await browser.newPage()
 
       try {
+        // 기본 뷰포트(800x600)로 두면 모바일 안내 오버레이가 뜬 상태로 HTML 이
+        // 굳는다. 앱이 정상 동작하는 폭으로 맞춰 데스크톱 화면을 받아낸다.
+        await page.setViewport({ width: 1440, height: 900 })
+
         await page.setRequestInterception(true)
         page.on("request", (req) => {
           const url = req.url()

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -59,19 +59,25 @@ function RootComponent() {
       <HeadContent />
       <AnalyticsProvider />
       {/*
-        안내가 뜰 때 본문을 숨긴다. 남겨두면 min-w-[1440px] 때문에 문서 폭이
-        1440 으로 유지되고, 모바일 브라우저가 거기에 맞춰 레이아웃 뷰포트를
-        넓혀 position:fixed 인 안내까지 1440 으로 그려진다.
+        안내가 뜰 때 본문을 통째로 걷어낸다. display:none 으로 감추기만 하면
+        라우트는 마운트된 채라 안내만 보이는 동안에도 그 아래 화면의 요청이
+        그대로 나간다. 인증이 필요한 화면이면 401 갱신까지 따라붙는다.
+
+        Outlet 만 빼도 안 된다. min-w-[1440px] 을 건 이 div 가 남아 문서 폭이
+        1440 으로 굳고, 모바일 브라우저가 거기에 맞춰 레이아웃 뷰포트를 넓혀
+        position:fixed 인 안내까지 1440 으로 그려진다. 폭을 만드는 주체가
+        사라져야 한다.
       */}
-      <div
-        className={cn(
-          "bg-teal-gray-50 h-full min-h-screen",
-          !isResponsive && "min-w-[1440px]",
-          showOverlay && "hidden",
-        )}
-      >
-        <Outlet />
-      </div>
+      {!showOverlay && (
+        <div
+          className={cn(
+            "bg-teal-gray-50 h-full min-h-screen",
+            !isResponsive && "min-w-[1440px]",
+          )}
+        >
+          <Outlet />
+        </div>
+      )}
       {showOverlay && <DesktopOnlyOverlay />}
       {/* 안내 위에서도 토스트가 떠야 하므로 숨김 대상 밖에 둔다. */}
       <ToastProvider />

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -8,7 +8,9 @@ import {
 import { NotFoundPage } from "@/features/error/ui/NotFoundPage"
 import { RootErrorComponent } from "@/features/error/ui/RootErrorComponent"
 import { AnalyticsProvider } from "@/shared/analytics"
+import { useIsDesktopWidth } from "@/shared/hooks/useIsDesktopWidth"
 import { cn } from "@/shared/lib/utils"
+import { DesktopOnlyOverlay } from "@/shared/ui/DesktopOnlyOverlay"
 import { ToastProvider } from "@/shared/ui/toast/ToastProvider"
 
 import type { QueryClient } from "@tanstack/react-query"
@@ -38,21 +40,41 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 // 쿼리는 걸려도 화면이 잘린다.
 const RESPONSIVE_PATHS = ["/about", "/recruiting-guide"]
 
+// 화면이 없는 경유 라우트다. 토큰 교환 후 곧바로 리다이렉트하므로 여기에 안내를
+// 덮으면 로그인이 콜백 단계에서 멈춘 것처럼 보인다.
+const OVERLAY_EXEMPT_PREFIXES = ["/oauth"]
+
 function RootComponent() {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
-  const isResponsive = RESPONSIVE_PATHS.includes(pathname.replace(/\/$/, ""))
+  const normalized = pathname.replace(/\/$/, "")
+  const isResponsive = RESPONSIVE_PATHS.includes(normalized)
+  const isOverlayExempt = OVERLAY_EXEMPT_PREFIXES.some(
+    (prefix) => normalized === prefix || normalized.startsWith(`${prefix}/`),
+  )
+  const isDesktop = useIsDesktopWidth()
+  const showOverlay = !isResponsive && !isOverlayExempt && !isDesktop
 
   return (
-    <div
-      className={cn(
-        "bg-teal-gray-50 h-full min-h-screen",
-        !isResponsive && "min-w-[1440px]",
-      )}
-    >
+    <>
       <HeadContent />
       <AnalyticsProvider />
-      <Outlet />
+      {/*
+        안내가 뜰 때 본문을 숨긴다. 남겨두면 min-w-[1440px] 때문에 문서 폭이
+        1440 으로 유지되고, 모바일 브라우저가 거기에 맞춰 레이아웃 뷰포트를
+        넓혀 position:fixed 인 안내까지 1440 으로 그려진다.
+      */}
+      <div
+        className={cn(
+          "bg-teal-gray-50 h-full min-h-screen",
+          !isResponsive && "min-w-[1440px]",
+          showOverlay && "hidden",
+        )}
+      >
+        <Outlet />
+      </div>
+      {showOverlay && <DesktopOnlyOverlay />}
+      {/* 안내 위에서도 토스트가 떠야 하므로 숨김 대상 밖에 둔다. */}
       <ToastProvider />
-    </div>
+    </>
   )
 }

--- a/src/shared/hooks/useIsDesktopWidth.ts
+++ b/src/shared/hooks/useIsDesktopWidth.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react"
+
+// 헤더가 모바일 판을 접는 기준(RecruitingHeader)과 같은 값을 쓴다. 두 값이
+// 어긋나면 안내가 뜬 화면 뒤에서 헤더만 데스크톱 모양으로 남는다.
+const DESKTOP_MIN_WIDTH = "(min-width: 64rem)"
+
+// 초기값은 데스크톱이다. 프리렌더(scripts/prerender.mjs)가 만드는 HTML 에 안내
+// 화면이 박히면 안 되므로, 좁은지 여부는 마운트 뒤에만 판단한다.
+export function useIsDesktopWidth() {
+  const [isDesktop, setIsDesktop] = useState(true)
+
+  useEffect(() => {
+    const desktop = window.matchMedia(DESKTOP_MIN_WIDTH)
+    const sync = () => setIsDesktop(desktop.matches)
+    sync()
+    desktop.addEventListener("change", sync)
+    return () => desktop.removeEventListener("change", sync)
+  }, [])
+
+  return isDesktop
+}

--- a/src/shared/ui/DesktopOnlyOverlay.tsx
+++ b/src/shared/ui/DesktopOnlyOverlay.tsx
@@ -1,0 +1,105 @@
+import errorCone from "@/shared/assets/icon/error/error-cone.svg"
+import { Button } from "@/shared/ui/Button"
+import { useToastStore } from "@/shared/ui/toast/useToastStore"
+
+// clipboard API 는 보안 컨텍스트(https, localhost)에서만 쓸 수 있다. 사내망 IP
+// 처럼 http 로 연 화면에서는 아예 없고, 있어도 문서 포커스나 권한 때문에 던진다.
+// 어느 쪽이든 구식 방식으로 한 번 더 시도한 뒤에 실패로 본다.
+async function copyText(text: string) {
+  if (window.isSecureContext && navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return
+    } catch {
+      // 아래 구식 방식으로 재시도한다.
+    }
+  }
+
+  const textarea = document.createElement("textarea")
+  textarea.value = text
+  textarea.setAttribute("readonly", "")
+  textarea.style.position = "fixed"
+  textarea.style.opacity = "0"
+  document.body.appendChild(textarea)
+  textarea.select()
+  const copied = document.execCommand("copy")
+  document.body.removeChild(textarea)
+  if (!copied) throw new Error("clipboard copy failed")
+}
+
+// 좁은 화면에서 앱 대부분은 min-w-[1440px] 때문에 가로로 잘린다. 리다이렉트로
+// 보내면 원래 주소를 잃어 "데스크톱에서 다시 열어달라"는 안내가 성립하지 않는다.
+// 그래서 주소는 그대로 두고 위를 덮는다.
+//
+// 이 화면만은 모바일에서 보이는 화면이므로 모바일 기준으로 짠다. 데스크톱 폭은
+// 고려하지 않는다 — 넓어지면 호출부(__root)가 이 컴포넌트를 걷어낸다.
+export function DesktopOnlyOverlay() {
+  const addToast = useToastStore((state) => state.addToast)
+
+  const handleCopy = async () => {
+    try {
+      await copyText(window.location.href)
+      addToast({
+        message: "주소가 복사되었어요",
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } catch {
+      // 복사가 막혀도 주소는 select-all 로 직접 집을 수 있다.
+      addToast({
+        message:
+          "주소를 복사하지 못했어요.\n위 주소를 길게 눌러 복사해 주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="데스크톱 환경 안내"
+      className="fixed inset-0 z-100 flex items-center justify-center overflow-y-auto px-6 py-10"
+      style={{
+        backgroundImage:
+          "linear-gradient(-63.18deg, rgba(34, 144, 132, 0.06) 10.77%, rgba(255, 255, 255, 0.2) 29.55%), linear-gradient(121.23deg, rgba(34, 144, 132, 0.1) 5.09%, rgba(255, 255, 255, 0.2) 42.81%), linear-gradient(90deg, rgba(143, 255, 243, 0.08) 0%, rgba(143, 255, 243, 0.08) 100%), linear-gradient(90deg, #fff 0%, #fff 100%)",
+      }}
+    >
+      <div className="flex w-full max-w-90 flex-col items-center gap-8">
+        <img src={errorCone} alt="" width={132} height={124} />
+
+        <div className="flex w-full flex-col items-center gap-7">
+          <div className="flex flex-col items-center gap-3 text-center">
+            <h1 className="text-heading-5-bold text-teal-500">
+              데스크톱에서 확인해 주세요
+            </h1>
+            <p className="text-body-1-regular text-teal-gray-600">
+              이 화면은 아직 모바일을 지원하지 않습니다.
+              <br />
+              아래 주소를 데스크톱 브라우저에서 열어 주세요.
+            </p>
+          </div>
+
+          <p className="text-label-1-medium text-teal-gray-500 bg-teal-gray-50 w-full rounded-[10px] px-4 py-3 text-center break-all select-all">
+            {window.location.href}
+          </p>
+
+          <Button
+            size="lg"
+            variant="fill"
+            color="primary"
+            className="w-full"
+            onClick={() => void handleCopy()}
+          >
+            주소 복사하기
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/shared/ui/DesktopOnlyOverlay.tsx
+++ b/src/shared/ui/DesktopOnlyOverlay.tsx
@@ -79,9 +79,9 @@ export function DesktopOnlyOverlay() {
               데스크톱에서 확인해 주세요
             </h1>
             <p className="text-body-1-regular text-teal-gray-600">
-              이 화면은 아직 모바일을 지원하지 않습니다.
+              현재 이 화면은 모바일 환경을 지원하지 않습니다.
               <br />
-              아래 주소를 데스크톱 브라우저에서 열어 주세요.
+              아래 주소를 데스크톱 브라우저에서 열어주세요.
             </p>
           </div>
 


### PR DESCRIPTION
## 📸 작업 내용

- 데스크톱 전용 화면에 모바일 접속 안내 오버레이 추가


## 🖥️ 구현화면
<img width="604" height="687" alt="image" src="https://github.com/user-attachments/assets/e2ca31c9-6be1-4634-900e-cbcd7edb8eb6" />


## 🔗 연결된 이슈

- Closed #794 
