### PR TITLE
✨ feat: 지원서 폼 기본 문항을 기본/공통 2단계로 분리하고 1·2지망 중복 선택 방지

### DIFF
--- a/src/features/recruiting/ui/apply/ApplyAnswerField.tsx
+++ b/src/features/recruiting/ui/apply/ApplyAnswerField.tsx
@@ -26,6 +26,7 @@ interface ApplyAnswerFieldProps {
   value: ApplyAnswerValue
   onChange: (value: ApplyAnswerValue) => void
   error?: string
+  disabledOptionIds?: Set<string>
 }
 
 function OptionError({ error }: { error?: string }) {
@@ -235,6 +236,7 @@ export function ApplyAnswerField({
   value,
   onChange,
   error,
+  disabledOptionIds,
 }: ApplyAnswerFieldProps) {
   switch (question.type) {
     case "shortText":
@@ -274,6 +276,7 @@ export function ApplyAnswerField({
               <RadioList
                 key={option.optionId}
                 checked={value === option.optionId}
+                disabled={disabledOptionIds?.has(option.optionId)}
                 allowDeselect
                 onChange={(checked) => {
                   onChange(checked ? option.optionId : "")

--- a/src/features/recruiting/ui/apply/RecruitingApplyForm.tsx
+++ b/src/features/recruiting/ui/apply/RecruitingApplyForm.tsx
@@ -21,6 +21,7 @@ import {
   toDirtySnapshot,
 } from "../../model/applyForm"
 import { PART_KEY_TO_TRACK, PARTS } from "../../model/parts"
+import { RECRUITMENT_DEFAULT_QUESTIONS } from "../../model/recruitmentQuestion"
 import { AnonymousPrivacyConsent } from "./AnonymousPrivacyConsent"
 import { ApplyAnswerField } from "./ApplyAnswerField"
 
@@ -34,6 +35,10 @@ import type { ApplicationSection } from "../../model/applicationDetail"
 type ApplyModalKind = "draftSaved" | "leave" | "submitConfirm" | "complete"
 
 const BASIC_SECTION_TITLE = "기본 문항"
+const COMMON_SECTION_TITLE = "공통 문항"
+const DEFAULT_QUESTION_TITLES = new Set(
+  RECRUITMENT_DEFAULT_QUESTIONS.map((question) => question.title),
+)
 
 type ApplicantInfoPatch = {
   applicantName?: string
@@ -77,6 +82,10 @@ function questionByKeyword(
   keyword: string,
 ) {
   return section?.questions.find((question) => question.title.includes(keyword))
+}
+
+function optionIdSet(value: unknown): Set<string> | undefined {
+  return typeof value === "string" && value ? new Set([value]) : undefined
 }
 
 interface RecruitingApplyFormProps {
@@ -201,7 +210,7 @@ export function RecruitingApplyForm({
 }: RecruitingApplyFormProps) {
   const addToast = useToastStore((state) => state.addToast)
   const [openModal, setOpenModal] = useState<ApplyModalKind | null>(null)
-  const [step, setStep] = useState<1 | 2>(1)
+  const [step, setStep] = useState<1 | 2 | 3>(1)
 
   const defaultValues = useMemo(() => {
     const values = buildDefaultApplyValues(config.sections)
@@ -283,13 +292,51 @@ export function RecruitingApplyForm({
     [config, defaultValues, watchedValues],
   )
 
-  const visibleSections = config.sections.filter((section) => {
-    if (step === 1) return section.title === BASIC_SECTION_TITLE
-    return (
-      section.title !== BASIC_SECTION_TITLE &&
-      enabledSectionIds.has(section.sectionId)
+  const basicSection = config.sections.find(
+    (section) => section.title === BASIC_SECTION_TITLE,
+  )
+  const defaultQuestions =
+    basicSection?.questions.filter((question) =>
+      DEFAULT_QUESTION_TITLES.has(question.title),
+    ) ?? []
+  const commonQuestions =
+    basicSection?.questions.filter(
+      (question) => !DEFAULT_QUESTION_TITLES.has(question.title),
+    ) ?? []
+  const hasCommonQuestionsStep = commonQuestions.length > 0
+
+  const visibleSections = (() => {
+    if (step === 1) {
+      return basicSection
+        ? [{ ...basicSection, questions: defaultQuestions }]
+        : []
+    }
+    if (step === 2) {
+      return basicSection
+        ? [
+            {
+              ...basicSection,
+              title: COMMON_SECTION_TITLE,
+              questions: commonQuestions,
+            },
+          ]
+        : []
+    }
+    return config.sections.filter(
+      (section) =>
+        section.title !== BASIC_SECTION_TITLE &&
+        enabledSectionIds.has(section.sectionId),
     )
-  })
+  })()
+
+  const firstChoiceQuestion = questionByKeyword(basicSection, "1지망")
+  const secondChoiceQuestion = questionByKeyword(basicSection, "2지망")
+  const firstChoiceValue = firstChoiceQuestion
+    ? watchedValues[firstChoiceQuestion.questionId]
+    : undefined
+  const secondChoiceValue = secondChoiceQuestion
+    ? watchedValues[secondChoiceQuestion.questionId]
+    : undefined
 
   const isUploading = hasPendingUpload(watchedValues, config.sections)
 
@@ -397,7 +444,10 @@ export function RecruitingApplyForm({
   }
 
   const handleNext = () => {
-    setStep(2)
+    setStep((current) => {
+      if (current === 1) return hasCommonQuestionsStep ? 2 : 3
+      return 3
+    })
   }
 
   // 저장이 실패하면 스냅샷을 갱신하지 않는다. 갱신해 버리면 서버에 없는 내용을
@@ -490,6 +540,15 @@ export function RecruitingApplyForm({
                           value={field.value ?? null}
                           onChange={field.onChange}
                           error={fieldState.error?.message}
+                          disabledOptionIds={
+                            question.questionId ===
+                            firstChoiceQuestion?.questionId
+                              ? optionIdSet(secondChoiceValue)
+                              : question.questionId ===
+                                  secondChoiceQuestion?.questionId
+                                ? optionIdSet(firstChoiceValue)
+                                : undefined
+                          }
                         />
                       )}
                     />
@@ -499,7 +558,7 @@ export function RecruitingApplyForm({
             />
           ))}
         </div>
-        {step === 2 && isAnonymous && (
+        {step === 3 && isAnonymous && (
           <AnonymousPrivacyConsent
             term={privacyTerm}
             checked={privacyAgreed}
@@ -507,7 +566,7 @@ export function RecruitingApplyForm({
             onChange={(checked) => onPrivacyChange?.(checked)}
           />
         )}
-        {step === 1 ? (
+        {step !== 3 ? (
           <div className="mt-3 flex justify-end">
             <Button
               type="button"


### PR DESCRIPTION
## 📸 작업 내용

> 모집 생성 단계에서와 같이 기본 문항 스텝을 기본 문항(이름/이메일 등)과 공통 문항, 파트별 섹션으로 나눠 3단계 흐름으로 바꿈

- `RecruitingApplyForm`의 스텝을 `1 | 2` → `1 | 2 | 3`으로 확장하고, 기존 "기본 문항" 섹션을 `RECRUITMENT_DEFAULT_QUESTIONS`(이름/이메일 등 고정 문항) 기준으로 기본/공통 두 섹션으로 나눴습니다.
- 공통 문항이 없는 폼(파트별 공통 문항을 설정하지 않은 경우)은 2단계를 건너뛰고 바로 3단계로 넘어가도록 `handleNext`를 분기했습니다.
- 1지망 문항에서 고른 값을 2지망 선택지에서 비활성화하도록 `ApplyAnswerField`에 `disabledOptionIds`를 추가하고, `RadioList`의 `disabled` prop으로 연결했습니다.

## 🎞️ 주요 코드 설명

### 기본 문항 → 기본/공통 2단계 분리

```TypeScript
const basicSection = config.sections.find(
  (section) => section.title === BASIC_SECTION_TITLE,
)
const defaultQuestions =
  basicSection?.questions.filter((question) =>
    DEFAULT_QUESTION_TITLES.has(question.title),
  ) ?? []
const commonQuestions =
  basicSection?.questions.filter(
    (question) => !DEFAULT_QUESTION_TITLES.has(question.title),
  ) ?? []
const hasCommonQuestionsStep = commonQuestions.length > 0

const handleNext = () => {
  setStep((current) => {
    if (current === 1) return hasCommonQuestionsStep ? 2 : 3
    return 3
  })
}
```

- "기본 문항" 섹션 하나를 문항 제목 기준(RECRUITMENT_DEFAULT_QUESTIONS)으로 기본/공통 두 그룹으로 나눠서 각각 1, 2단계에 렌더링합니다.
- 공통 문항이 아예 없는 폼에서 빈 2단계가 보이지 않도록, hasCommonQuestionsStep이 false면 1단계에서 바로 3단계로 건너뜁니다.

### 1·2지망 중복 선택 방지

```TypeScript
function optionIdSet(value: unknown): Set<string> | undefined {
  return typeof value === "string" && value ? new Set([value]) : undefined
}

// ...

disabledOptionIds={
  question.questionId === firstChoiceQuestion?.questionId
    ? optionIdSet(secondChoiceValue)
    : question.questionId === secondChoiceQuestion?.questionId
      ? optionIdSet(firstChoiceValue)
      : undefined
}
```

- 1지망 문항을 렌더링할 땐 2지망에 이미 선택된 값을, 2지망 문항을 렌더링할 땐 1지망에 선택된 값을 disabledOptionIds로 넘겨 같은 트랙을 양쪽에서 중복 선택할 수 없게 막습니다.

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #796 

## 📚 참고자료

## 💬 기타 더 이야기해볼 점
