### PR TITLE
fix: 프로젝트 목록 UI 수정

### DIFF
--- a/src/features/project/list/ui/MatchingProjectCard.tsx
+++ b/src/features/project/list/ui/MatchingProjectCard.tsx
@@ -57,15 +57,15 @@ function GuestCardBody({ data }: { data: MatchingProject }) {
         />
       </div>
 
-      <div className="flex w-full min-w-0 flex-col items-start gap-3 p-5">
+      <div className="flex w-full min-w-0 flex-col items-start gap-1.5 p-5">
         <h3 className="text-heading-7-semibold text-teal-gray-900 w-full min-w-0 truncate">
           {data.title}
         </h3>
         {/* 로그인 카드는 한 줄이지만 게스트 카드는 두 줄까지 보여준다 */}
-        <p className="text-body-2-medium text-teal-gray-600 line-clamp-2 h-10.5 w-full min-w-0">
+        <p className="text-body-2-regular text-teal-gray-600 line-clamp-2 h-10.5 w-full min-w-0">
           {data.description}
         </p>
-        <p className="text-caption-2-regular text-teal-gray-500 line-clamp-1 w-full min-w-0">
+        <p className="text-body-3-regular text-teal-gray-500 line-clamp-1 w-full min-w-0">
           {partNames.join(" · ")}
         </p>
       </div>

--- a/src/features/project/list/ui/MatchingProjectsListPage.tsx
+++ b/src/features/project/list/ui/MatchingProjectsListPage.tsx
@@ -80,11 +80,19 @@ interface MatchingProjectsListPageProps {
    * 같은 열 수를 주면 한쪽 카드가 디자인보다 커진다.
    */
   columns?: 2 | 3
+  /**
+   * 공개 목록(/projects) 여부.
+   *
+   * 시안에는 흰 판·검색·필터가 없고 카드도 제목·소개·파트만 보여준다. 매칭
+   * 화면은 같은 목록을 쓰지만 필터와 모집 현황이 있어야 하므로 갈라 둔다.
+   */
+  publicView?: boolean
 }
 
 export function MatchingProjectsListPage({
   useMockData = false,
   columns = 2,
+  publicView = false,
 }: MatchingProjectsListPageProps) {
   const {
     openFilterId,
@@ -151,7 +159,7 @@ export function MatchingProjectsListPage({
 
   return (
     <section className="relative isolate flex w-full min-w-0 flex-col items-stretch justify-start">
-      {openFilterId && (
+      {!publicView && openFilterId && (
         <button
           type="button"
           aria-label="필터 드롭다운 닫기"
@@ -159,17 +167,31 @@ export function MatchingProjectsListPage({
           onClick={() => setOpenFilterId(null)}
         />
       )}
-      <div className="border-teal-gray-100 relative z-30 flex h-full w-full min-w-0 flex-col gap-5 rounded-[12px] border bg-white px-6 pt-8 pb-10">
-        <div className="flex flex-col items-start gap-1.5">
-          <span className="text-heading-6-semibold text-teal-gray-900">
-            프로젝트 목록
-          </span>
-          <span className="text-body-2-regular text-teal-gray-600">
-            모든 프로젝트를 한눈에 조회합니다.
-          </span>
-        </div>
+      {/* 공개 목록은 시안에 흰 판이 없다. 배경 위에 카드가 바로 놓인다. */}
+      <div
+        className={cn(
+          "relative z-30 flex h-full w-full min-w-0 flex-col gap-5",
+          !publicView &&
+            "border-teal-gray-100 rounded-[12px] border bg-white px-6 pt-8 pb-10",
+        )}
+      >
+        {!publicView && (
+          <div className="flex flex-col items-start gap-1.5">
+            <span className="text-heading-6-semibold text-teal-gray-900">
+              프로젝트 목록
+            </span>
+            <span className="text-body-2-regular text-teal-gray-600">
+              모든 프로젝트를 한눈에 조회합니다.
+            </span>
+          </div>
+        )}
 
-        <div className="relative z-30 mb-3 flex min-w-0 flex-col gap-3 self-stretch">
+        <div
+          className={cn(
+            "relative z-30 mb-3 flex min-w-0 flex-col gap-3 self-stretch",
+            publicView && "hidden",
+          )}
+        >
           <ProjectSearchField value={searchQuery} onChange={setSearchQuery} />
           <div
             ref={filterAreaRef}
@@ -238,7 +260,11 @@ export function MatchingProjectsListPage({
         <div
           className={cn(
             "grid min-w-0 gap-5",
-            columns === 3 ? "grid-cols-3" : "grid-cols-2",
+            // 사이드바 없는 /projects 는 시안이 348 고정 카드다. fr 로 두면
+            // 넓은 화면에서 카드만 늘어나 썸네일 비율이 시안과 어긋난다.
+            columns === 3
+              ? "grid-cols-[repeat(3,348px)] justify-center"
+              : "grid-cols-2",
             openFilterId && "pointer-events-none",
           )}
         >
@@ -249,7 +275,7 @@ export function MatchingProjectsListPage({
             Array.from({ length: SKELETON_CARD_COUNT }).map((_, index) => (
               <MatchingProjectCardSkeleton
                 key={index}
-                variant={isGuest ? "guest" : "default"}
+                variant={isGuest || publicView ? "guest" : "default"}
               />
             ))}
 
@@ -278,7 +304,7 @@ export function MatchingProjectsListPage({
                   }}
                 >
                   <MatchingProjectCard
-                    variant={isGuest ? "guest" : "default"}
+                    variant={isGuest || publicView ? "guest" : "default"}
                     data={project}
                   />
                 </button>
@@ -320,7 +346,7 @@ export function MatchingProjectsListPage({
         <Modal.Portal>
           <Modal.Overlay tone="deep" />
           <Modal.Content
-            className="shadow-drop-neutral-3 rounded-2xl"
+            className="shadow-drop-neutral-3 rounded-[20px]"
             aria-describedby={undefined}
           >
             <Modal.Title className="sr-only">프로젝트 상세</Modal.Title>
@@ -328,6 +354,7 @@ export function MatchingProjectsListPage({
               <ProjectDetailCard
                 projectId={selectedProjectId}
                 projectChapterId={selectedProjectChapterId}
+                publicView={publicView}
               />
             )}
           </Modal.Content>

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -81,6 +81,13 @@ interface ProjectDetailCardProps {
   /** 매칭 기간 중 수정하기 버튼 숨김 */
   isMatchingPeriod?: boolean
   canManageProject?: boolean
+  /**
+   * 공개 목록(/projects)에서 열린 상세 여부.
+   *
+   * 시안상 카드에는 프로젝트명·소개·파트만 남는다. 작성자 줄과 파트별 모집
+   * 현황은 매칭 화면에서만 쓴다.
+   */
+  publicView?: boolean
 }
 
 /**
@@ -173,6 +180,7 @@ export function ProjectDetailCard({
   hideMyApplication = false,
   isMatchingPeriod = false,
   canManageProject,
+  publicView = false,
 }: ProjectDetailCardProps) {
   const projectId = Number(projectIdProp)
   const navigate = useNavigate()
@@ -430,6 +438,11 @@ export function ProjectDetailCard({
 
   const cover = data?.coverImage
   const showLogo = logo === "on"
+  // 게스트는 애초에 작성자·모집 현황 데이터를 못 받는다. 공개 목록은 데이터가
+  // 있어도 시안대로 같은 모양으로 접는다.
+  const isSimpleCard = isGuest || publicView
+  // 시안 카드는 파트별 인원에서 끝난다. 액션도 그 아래 안내 문구도 두지 않는다.
+  const showCtaNotice = !isSimpleCard && !viewOnly
   const shouldShowEditCta =
     showEditCta && (resolvedEditPermissionLoading || resolvedCanEditProject)
 
@@ -458,7 +471,7 @@ export function ProjectDetailCard({
 
   return (
     <>
-      <div className="flex max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-135 min-w-0 flex-col items-start overflow-x-hidden overflow-y-auto rounded-2xl bg-white">
+      <div className="flex max-h-[calc(100dvh-2rem)] w-[calc(100vw-2rem)] max-w-135 min-w-0 flex-col items-start overflow-x-hidden overflow-y-auto rounded-[20px] bg-white">
         <div className="bg-teal-gray-200 flex aspect-[540/286] w-full shrink-0 items-center justify-center overflow-hidden">
           <ProjectThumbnail
             src={cover?.src}
@@ -483,9 +496,12 @@ export function ProjectDetailCard({
                   </h2>
                 )}
 
-                <p className="text-body-2-regular text-teal-gray-500 line-clamp-1 w-auto shrink-0 text-right">
-                  {data.authorSchoolLine}
-                </p>
+                {/* 시안 카드에는 작성자·학교가 없다. 매칭 화면에서만 쓴다. */}
+                {!isSimpleCard && (
+                  <p className="text-body-2-regular text-teal-gray-500 line-clamp-1 w-auto shrink-0 text-right">
+                    {data.authorSchoolLine}
+                  </p>
+                )}
               </div>
 
               <p className="text-body-2-regular text-teal-gray-600 w-full wrap-break-word whitespace-pre-wrap">
@@ -493,13 +509,18 @@ export function ProjectDetailCard({
               </p>
             </div>
 
-            {/* 게스트에게는 모집 현황 대신 파트와 모집 인원만 한 줄로 준다 */}
-            {isGuest ? (
-              <p className="text-body-2-medium text-teal-gray-600 w-full">
-                {data.recruitRows
-                  .map((row) => `${row.part} ${row.total}`)
-                  .join(" · ")}
-              </p>
+            {/* 시안 카드는 파트와 모집 인원만 한 줄로 준다. 파트 이름과 인원의
+                색이 달라 문자열로 이어 붙이지 않고 조각으로 그린다. */}
+            {isSimpleCard ? (
+              <div className="text-body-2-medium flex w-full flex-wrap items-start gap-1.5">
+                {data.recruitRows.map((row, index) => (
+                  <div key={row.part} className="flex items-center gap-1">
+                    {index > 0 && <span className="text-teal-gray-500">·</span>}
+                    <span className="text-teal-gray-700">{row.part}</span>
+                    <span className="text-teal-gray-500">{row.total}</span>
+                  </div>
+                ))}
+              </div>
             ) : (
               <div className="flex w-full flex-col items-start gap-1.5">
                 {data.recruitRows.map((row) => {
@@ -528,14 +549,15 @@ export function ProjectDetailCard({
           </div>
 
           {/* 게스트 상세에는 액션이 없다. 팀원·기획안·지원 모두 로그인이 필요해
-              눌러도 로그인으로 튕기므로 디자인대로 영역째 두지 않는다. */}
+              눌러도 로그인으로 튕기므로 디자인대로 영역째 두지 않는다. 공개
+              목록도 시안이 같아서 로그인 상태와 무관하게 접는다. */}
           <div
             className={cn(
               "scrollbar-none mt-8.5 w-full flex-nowrap items-start gap-2.5 overflow-x-auto pb-1",
-              isGuest ? "hidden" : "flex",
+              isSimpleCard ? "hidden" : "flex",
             )}
           >
-            {!isGuest && (
+            {!isSimpleCard && (
               <TeamMemberButton
                 variant="weak"
                 className="w-auto"
@@ -763,7 +785,7 @@ export function ProjectDetailCard({
               </>
             )}
           </div>
-          {!viewOnly && ctaMode === "apply-blocked-other" && (
+          {showCtaNotice && ctaMode === "apply-blocked-other" && (
             <div className="mt-2 flex w-full items-center justify-center gap-1">
               <CheckIcon className="text-teal-gray-500 h-4 w-4 shrink-0" />
               <p className="text-caption-2-regular text-teal-gray-500 text-center">
@@ -771,7 +793,7 @@ export function ProjectDetailCard({
               </p>
             </div>
           )}
-          {!viewOnly && ctaMode === "apply-blocked-approved" && (
+          {showCtaNotice && ctaMode === "apply-blocked-approved" && (
             <div className="mt-2 flex w-full items-center justify-center gap-1">
               <CheckIcon className="text-teal-gray-500 h-4 w-4 shrink-0" />
               <p className="text-caption-2-regular text-teal-gray-500 text-center">
@@ -779,7 +801,7 @@ export function ProjectDetailCard({
               </p>
             </div>
           )}
-          {!viewOnly && ctaMode === "apply-blocked-part" && (
+          {showCtaNotice && ctaMode === "apply-blocked-part" && (
             <div className="mt-2 flex w-full items-center justify-center gap-1">
               <CheckIcon className="text-teal-gray-500 h-4 w-4 shrink-0" />
               <p className="text-caption-2-regular text-teal-gray-500 text-center">
@@ -787,7 +809,7 @@ export function ProjectDetailCard({
               </p>
             </div>
           )}
-          {!viewOnly && ctaMode === "apply-blocked-closed" && (
+          {showCtaNotice && ctaMode === "apply-blocked-closed" && (
             <div className="mt-2 flex w-full items-center justify-center gap-1">
               <CheckIcon className="text-teal-gray-500 h-4 w-4 shrink-0" />
               <p className="text-caption-2-regular text-teal-gray-500 text-center">
@@ -795,7 +817,7 @@ export function ProjectDetailCard({
               </p>
             </div>
           )}
-          {!viewOnly && ctaMode === "no-active-round" && (
+          {showCtaNotice && ctaMode === "no-active-round" && (
             <div className="mt-2 flex w-full items-center justify-center gap-1">
               <CheckIcon className="text-teal-gray-500 h-4 w-4 shrink-0" />
               <p className="text-caption-2-regular text-teal-gray-500 text-center">

--- a/src/features/project/list/ui/ProjectDetailCard.tsx
+++ b/src/features/project/list/ui/ProjectDetailCard.tsx
@@ -193,6 +193,13 @@ export function ProjectDetailCard({
   // me 의 유무로 보면 안 된다. 회원 조회는 비동기라 로그인 사용자도 첫 렌더에는
   // me 가 없어, 잠깐 게스트 화면이 스쳐 지나간다. 토큰 유무는 동기로 안다.
   const isGuest = !useAuthStore((s) => s.isAuthed)
+  // 게스트는 애초에 작성자·모집 현황 데이터를 못 받는다. 공개 목록은 데이터가
+  // 있어도 시안대로 같은 모양으로 접는다.
+  //
+  // 렌더뿐 아니라 아래 쿼리의 enabled 도 이 값이 정한다. 액션이 없는 화면인데
+  // 지원 권한·내 지원서·활성 차수를 받아 오면 쓰지도 않을 요청만 나간다.
+  // 게스트는 me 가 없어 자연히 막히지만 로그인 상태에서는 걸러지지 않는다.
+  const isSimpleCard = isGuest || publicView
   const addToast = useToastStore((s) => s.addToast)
   const userIsOperator = isOperator(me)
   const userIsPm = isCurrentTermPm(me)
@@ -207,6 +214,7 @@ export function ProjectDetailCard({
   })
   const shouldQueryApplicationWritePermission =
     !showEditCta &&
+    !isSimpleCard &&
     Number.isFinite(projectId) &&
     me !== undefined &&
     isApplicantView
@@ -254,7 +262,8 @@ export function ProjectDetailCard({
   const { data: myApplications, isError: isMyApplicationsError } = useQuery({
     queryKey: ["myApplications", activeGisuId],
     queryFn: () => getMyApplications(activeGisuId!),
-    enabled: activeGisuId != null && isApplicantView && me != null,
+    enabled:
+      activeGisuId != null && !isSimpleCard && isApplicantView && me != null,
   })
 
   const myChapterId = useMemo(() => {
@@ -363,7 +372,9 @@ export function ProjectDetailCard({
         return getActiveMatchingRound(myChapterId!)
       },
       enabled:
-        isApplicantView && (myChapterId != null || devMatchingRoundId != null),
+        !isSimpleCard &&
+        isApplicantView &&
+        (myChapterId != null || devMatchingRoundId != null),
       staleTime: 60 * 1000,
     })
 
@@ -438,9 +449,6 @@ export function ProjectDetailCard({
 
   const cover = data?.coverImage
   const showLogo = logo === "on"
-  // 게스트는 애초에 작성자·모집 현황 데이터를 못 받는다. 공개 목록은 데이터가
-  // 있어도 시안대로 같은 모양으로 접는다.
-  const isSimpleCard = isGuest || publicView
   // 시안 카드는 파트별 인원에서 끝난다. 액션도 그 아래 안내 문구도 두지 않는다.
   const showCtaNotice = !isSimpleCard && !viewOnly
   const shouldShowEditCta =
@@ -450,12 +458,14 @@ export function ProjectDetailCard({
     if (!detail) return
     trackEvent("project_detail_view", {
       project_id: projectId,
-      cta_mode: ctaMode,
+      // 액션이 없는 화면에서는 CTA 판정에 쓰는 쿼리를 아예 열지 않는다. 그
+      // 상태로 계산한 ctaMode 는 실제 사용자 상태와 다르므로 보내지 않는다.
+      cta_mode: isSimpleCard ? undefined : ctaMode,
       view_only: viewOnly,
       has_external_link: Boolean(detail.externalLink),
       has_application_form: Boolean(detail.applicationFormId),
     })
-  }, [detail, projectId, ctaMode, viewOnly])
+  }, [detail, projectId, ctaMode, viewOnly, isSimpleCard])
 
   if (isDetailLoading) {
     return <ProjectDetailCardLoading />

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -20,5 +20,5 @@ export const Route = createFileRoute("/projects/")({
 
 function ProjectsListRoute() {
   // 이 화면은 사이드바 없이 전폭이라 로그인 여부와 상관없이 3열이다.
-  return <MatchingProjectsListPage columns={3} />
+  return <MatchingProjectsListPage columns={3} publicView />
 }

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -11,7 +11,7 @@ export const Route = createFileRoute("/projects/")({
   head: () =>
     createMeta(
       "프로젝트 | UMC",
-      "UMC 에서 진행 중인 프로젝트를 학교·파트별로 확인할 수 있습니다.",
+      "지금까지 UMC 에서 만들어진 프로젝트를 한눈에 확인할 수 있습니다.",
       { canonical: `${SITE_URL}/projects` },
     ),
   validateSearch: validateProjectListSearch,

--- a/src/routes/projects/route.tsx
+++ b/src/routes/projects/route.tsx
@@ -35,7 +35,7 @@ function ProjectsLayout() {
   if (normalizedPathname === "/projects") {
     trail = ["홈", "프로젝트"]
     title = "프로젝트"
-    description = "UMC 에서 진행 중인 프로젝트를 확인할 수 있습니다."
+    description = "지금까지 UMC에서 만들어진 프로젝트를 소개하겠습니다!"
   } else if (normalizedPathname === "/projects/notice") {
     trail = ["리크루팅", "지원하기", "모집 공고"]
     title = "모집 공고"

--- a/src/routes/projects/route.tsx
+++ b/src/routes/projects/route.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/shared/config/applicantNavigation"
 import { useActiveGeneration } from "@/shared/hooks/useActiveGisu"
 import { toUmcGisuLabel } from "@/shared/lib/gisuLabel"
+import { cn } from "@/shared/lib/utils"
 import Footer from "@/widgets/footer/Footer"
 import RecruitingHeader from "@/widgets/navigation/header/RecruitingHeader"
 import { FlatSideBar } from "@/widgets/navigation/sidebar/FlatSideBar"
@@ -24,6 +25,7 @@ function ProjectsLayout() {
   const { data: generation } = useActiveGeneration()
   // 프로젝트 목록은 사이드바 없이 전폭으로 보여준다
   const showApplicantSideBar = isApplicantFlowPath(normalizedPathname)
+  const isProjectList = normalizedPathname === "/projects"
 
   // 프로젝트 목록은 지원하기 흐름이 아니라 독립 화면이라 상위 경로가 다르다.
   let trail: string[] = []
@@ -73,7 +75,14 @@ function ProjectsLayout() {
           />
         )}
         <div className="flex min-w-0 flex-1 flex-col">
-          <div className="min-h-200 px-8 pt-10">
+          <div
+            className={cn(
+              "min-h-200 px-8 pt-10",
+              // 프로젝트 목록은 시안이 1440 기준 고정 폭이다. 폭을 안 잡으면
+              // 넓은 화면에서 카드가 늘어나 348 카드 시안과 어긋난다.
+              isProjectList && "mx-auto w-full max-w-[1220px]",
+            )}
+          >
             <div className="flex flex-col gap-6.5 pl-3">
               <div className="flex h-5.5 items-center gap-1">
                 {trail.map((crumb, index) => (


### PR DESCRIPTION
## 📸 작업 내용

- 프로젝트 목록 UI 수정

## 🖥️ 구현화면
<img width="1427" height="625" alt="image" src="https://github.com/user-attachments/assets/0aacddea-ebc3-469b-a231-9e0c3772e494" />

## 🔗 연결된 이슈

- Closed #798 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 프로젝트 목록의 공개 보기에서 필터와 부가 정보를 숨기고 게스트용 카드로 표시합니다.
  * 공개 목록을 중앙 정렬된 3열 레이아웃으로 제공하며, 상세 모달에도 간소화된 표시를 적용합니다.

* **스타일**
  * 카드 내 콘텐츠 간격과 글꼴 스타일을 조정해 더 간결하고 읽기 쉬운 화면을 제공합니다.
  * 프로젝트 목록의 콘텐츠 영역 너비와 정렬을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->