### PR TITLE
style: 대시보드·히스토리 PageLabel 좌측 여백 누락 보정

### DIFF
--- a/src/routes/recruiting/dashboard/applications.tsx
+++ b/src/routes/recruiting/dashboard/applications.tsx
@@ -80,6 +80,7 @@ function RouteComponent() {
       ]}
       title="지원 현황"
       description="지부별, 학교별, 파트별 지원 현황을 실시간으로 확인합니다."
+      className="pl-3"
     />
   )
 

--- a/src/routes/recruiting/dashboard/evaluations.tsx
+++ b/src/routes/recruiting/dashboard/evaluations.tsx
@@ -60,6 +60,7 @@ function RouteComponent() {
       ]}
       title="평가 현황"
       description="지부별, 학교별, 파트별 평가 현황을 실시간으로 확인합니다."
+      className="pl-3"
     />
   )
 

--- a/src/routes/recruiting/history/archive.tsx
+++ b/src/routes/recruiting/history/archive.tsx
@@ -125,6 +125,7 @@ function RouteComponent() {
         ]}
         title="평가 이력"
         description="교내 회장단의 최종 평가 이력을 확인합니다."
+        className="pl-3"
       />
 
       <ChapterTabs


### PR DESCRIPTION
## 📸 작업 내용

- 대시보드·히스토리 PageLabel 좌측 여백 누락 보정


## 🖥️ 구현화면

<img width="1420" height="592" alt="image" src="https://github.com/user-attachments/assets/78dbfabc-852d-4f7c-81ef-bd92b18586c3" />


## 🔗 연결된 이슈

- Closed #804 

