### PR TITLE
fix: #806 디자인 QA 반영 (프로필 아바타, 파트칩, 지원서 목록 UI)

### DIFF
--- a/src/routes/projects/application/list.tsx
+++ b/src/routes/projects/application/list.tsx
@@ -111,14 +111,16 @@ function ApplicationListPage() {
         <p className="text-body-2-medium text-teal-gray-400">
           조회된 지원서가 없습니다.
         </p>
-        <Button
-          variant="weak"
-          color="neutral"
-          size="s"
-          onClick={handleResetVerification}
-        >
-          다른 지원서 확인하기
-        </Button>
+        {!isAuthed && (
+          <Button
+            variant="weak"
+            color="neutral"
+            size="s"
+            onClick={handleResetVerification}
+          >
+            다른 지원서 확인하기
+          </Button>
+        )}
       </div>
     )
   }

--- a/src/routes/projects/application/list.tsx
+++ b/src/routes/projects/application/list.tsx
@@ -107,17 +107,17 @@ function ApplicationListPage() {
 
   if (!application) {
     return (
-      <div className="flex w-full flex-col items-center justify-center gap-4 py-20">
-        <p className="text-body-1-medium text-teal-gray-500">
+      <div className="border-teal-gray-150 flex w-full flex-col items-center justify-center gap-2.5 rounded-[14px] border bg-white px-8 py-35">
+        <p className="text-body-2-medium text-teal-gray-400">
           조회된 지원서가 없습니다.
         </p>
         <Button
-          variant="fill"
+          variant="weak"
           color="neutral"
-          size="m"
+          size="s"
           onClick={handleResetVerification}
         >
-          다른 지원서 조회하기
+          다른 지원서 확인하기
         </Button>
       </div>
     )

--- a/src/shared/ui/chip/PartTagChip.tsx
+++ b/src/shared/ui/chip/PartTagChip.tsx
@@ -6,20 +6,20 @@ import { PART_TAG_LABEL } from "@/shared/model/domain"
 import type { PartTag } from "@/shared/model/domain"
 
 const partTagChipVariants = cva(
-  "inline-flex h-6 px-2.5 items-center justify-center rounded-[6px] py-0.5 text-label-2-medium text-teal-gray-800 shadow-drop-neutral-2",
+  "inline-flex h-6.5 px-2 items-center justify-center rounded-[6px] py-0.5 text-label-2-medium text-teal-gray-800 shadow-drop-neutral-2",
   {
     variants: {
       role: {
-        plan: "w-9",
-        design: "w-15",
-        web: "w-11.5",
-        ios: "w-10",
-        android: "w-16.5",
-        springboot: "w-22",
-        nodejs: "w-16.5",
-        pm: "w-9",
-        "mobile-pe": "w-22",
-        "web-pe": "w-20",
+        plan: "",
+        design: "",
+        web: "",
+        ios: "",
+        android: "",
+        springboot: "",
+        nodejs: "",
+        pm: "",
+        "mobile-pe": "",
+        "web-pe": "",
       },
       type: {
         default: "",

--- a/src/shared/ui/profile/ProfileAvatar.test.tsx
+++ b/src/shared/ui/profile/ProfileAvatar.test.tsx
@@ -49,13 +49,9 @@ describe("ProfileAvatar", () => {
     expect(screen.queryByAltText("사용자 프로필")).not.toBeInTheDocument()
   })
 
-  it("기본 상태에서 크기에 맞춰 프로필 아이콘을 배치한다", () => {
+  it("기본 상태에서 프로필 아이콘을 영역에 맞춰 표시한다", () => {
     const { container } = render(<ProfileAvatar size={100} />)
 
-    expect(container.querySelector("svg")).toHaveStyle({
-      width: "87px",
-      height: "87px",
-      top: "17.39px",
-    })
+    expect(container.querySelector("svg")).toHaveClass("size-full")
   })
 })

--- a/src/shared/ui/profile/ProfileAvatar.tsx
+++ b/src/shared/ui/profile/ProfileAvatar.tsx
@@ -22,8 +22,6 @@ export function ProfileAvatar({
   const isDefault = state === "default"
   const isFilled = state === "filled"
   const isHoverUpload = state === "hover-upload"
-  const profileIconSize = size === 100 ? 87 : size === 46 ? 40 : 36
-  const profileIconTop = size === 100 ? 17.39 : size === 46 ? 8 : 7
 
   return (
     <span
@@ -39,15 +37,7 @@ export function ProfileAvatar({
       {isFilled && src ? (
         <img src={src} alt={alt} className="size-full object-cover" />
       ) : isDefault ? (
-        <ProfileIcon
-          className="absolute left-1/2 -translate-x-1/2"
-          style={{
-            width: profileIconSize,
-            height: profileIconSize,
-            top: profileIconTop,
-          }}
-          aria-hidden="true"
-        />
+        <ProfileIcon className="size-full" aria-hidden="true" />
       ) : null}
     </span>
   )


### PR DESCRIPTION
## 📸 작업 내용

- 프로필 아바타 기본 아이콘의 위치 하단 쏠림 현상을 중앙 정렬로 수정하였습니다.
- 파트칩(`PartTagChip`) 컴포넌트의 고정 너비를 제거하고 적절한 크기 및 패딩(`h-6.5`, `px-2`)을 설정하였습니다.
- 지원서 목록에서 조회된 지원서가 없을 때의 Empty State 디자인을 개선하였습니다.
- 로그인한 사용자의 지원서 목록 화면에서 '다른 지원서 확인하기' 버튼을 숨기도록 분기 처리하였습니다.

## 🎞️ 주요 코드 설명

### 1. 프로필 아바타 기본 아이콘 중앙 정렬
`src/shared/ui/profile/ProfileAvatar.tsx`
```TypeScript
{isFilled && src ? (
  <img src={src} alt={alt} className="size-full object-cover" />
) : isDefault ? (
  <ProfileIcon className="size-full" aria-hidden="true" />
) : null}
```
- 기존 하드코딩된 inline style 오프셋을 제거하고 `size-full` 클래스를 적용하여 아이콘 중앙 정렬을 맞췄습니다.

### 2. 지원서 목록 비로그인 유저 버튼 분기 및 Empty State UI 개선
`src/routes/projects/application/list.tsx`
```TypeScript
if (!application) {
  return (
    <div className="border-teal-gray-150 flex w-full flex-col items-center justify-center gap-2.5 rounded-[14px] border bg-white px-8 py-35">
      <p className="text-body-2-medium text-teal-gray-400">
        조회된 지원서가 없습니다.
      </p>
      {!isAuthed && (
        <Button
          variant="weak"
          color="neutral"
          size="s"
          onClick={handleResetVerification}
        >
          다른 지원서 확인하기
        </Button>
      )}
    </div>
  )
}
```
- 로그인된 사용자(`isAuthed`)에게는 '다른 지원서 확인하기' 버튼을 숨기고, 비로그인 상태(`!isAuthed`)에서만 노출되도록 분기하였습니다.

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #806 