### PR TITLE
Bug: 드롭다운 UI 해결 및 세부 UI QA

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -358,4 +358,7 @@
   button:not(:disabled) {
     cursor: pointer;
   }
+  button {
+    appearance: none;
+  }
 }

--- a/src/features/recruiting/ui/RecruitmentDraftArchiveCard.tsx
+++ b/src/features/recruiting/ui/RecruitmentDraftArchiveCard.tsx
@@ -114,7 +114,7 @@ export function RecruitmentDraftArchiveCard({
   return (
     <section
       className={cn(
-        "border-teal-gray-200 flex w-full flex-col rounded-xl border bg-white px-3 pt-5 pb-8",
+        "border-teal-gray-100 flex w-full flex-col rounded-xl border bg-white px-3 pt-5 pb-8",
         className,
       )}
     >
@@ -138,8 +138,8 @@ export function RecruitmentDraftArchiveCard({
         {selectedSchool ? (
           <RecruitmentSchoolSection schoolName={selectedSchool}>
             {selectedSchoolPosts.length === 0 ? (
-              <div className="flex w-full items-center justify-center bg-white py-10">
-                <p className="text-body-2-regular text-teal-gray-400">
+              <div className="flex w-full items-center bg-white px-5 py-4.5">
+                <p className="text-body-2-medium text-teal-gray-400">
                   등록된 임시 보관글이 없습니다.
                 </p>
               </div>
@@ -164,8 +164,8 @@ export function RecruitmentDraftArchiveCard({
             ({ school, posts: schoolPosts }) => (
               <RecruitmentSchoolSection key={school} schoolName={school}>
                 {schoolPosts.length === 0 ? (
-                  <div className="flex w-full items-center justify-center bg-white py-10">
-                    <p className="text-body-2-regular text-teal-gray-400">
+                  <div className="flex w-full items-center bg-white px-5 py-4.5">
+                    <p className="text-body-2-medium text-teal-gray-400">
                       등록된 임시 보관글이 없습니다.
                     </p>
                   </div>

--- a/src/features/recruiting/ui/RecruitmentPostListCard.tsx
+++ b/src/features/recruiting/ui/RecruitmentPostListCard.tsx
@@ -179,8 +179,8 @@ export function RecruitmentPostListCard({
               return (
                 <RecruitmentSchoolSection key={school} schoolName={school}>
                   {schoolPosts.length === 0 ? (
-                    <div className="flex w-full items-center justify-center bg-white py-10">
-                      <p className="text-body-2-regular text-teal-gray-400">
+                    <div className="flex w-full items-center bg-white px-5 py-4.5">
+                      <p className="text-body-2-medium text-teal-gray-400">
                         {schoolHasPosts && recruitingOnly
                           ? "현재 모집 중인 공고가 없습니다."
                           : "등록된 모집 공고가 없습니다."}

--- a/src/features/recruiting/ui/RecruitmentSchoolSection.tsx
+++ b/src/features/recruiting/ui/RecruitmentSchoolSection.tsx
@@ -18,7 +18,7 @@ export function RecruitmentSchoolSection({
   return (
     <div className={cn("flex w-full flex-col items-start", className)}>
       <RecruitmentSchoolSectionLabel schoolName={schoolName} />
-      <div className="bg-teal-gray-150 flex w-full flex-col items-start overflow-hidden rounded-b-lg border-r border-b border-l border-teal-200 p-px [&>*:last-child]:rounded-b-[7px]">
+      <div className="bg-teal-gray-150 flex w-full flex-col items-start overflow-hidden rounded-b-lg border-r border-b border-l border-teal-200 pt-px [&>*:last-child]:rounded-b-[7px]">
         {children}
       </div>
     </div>

--- a/src/features/recruiting/ui/RecruitmentSchoolSectionLabel.tsx
+++ b/src/features/recruiting/ui/RecruitmentSchoolSectionLabel.tsx
@@ -12,7 +12,7 @@ export function RecruitmentSchoolSectionLabel({
   return (
     <div
       className={cn(
-        "flex items-center justify-between self-stretch rounded-t-lg border-t border-r border-l border-teal-300 bg-teal-100 py-2 pr-5 pl-7.5",
+        "flex items-center justify-between self-stretch rounded-t-xl border-t border-r border-l border-teal-300 bg-teal-100 px-6 py-2",
         className,
       )}
     >

--- a/src/features/recruiting/ui/RecruitmentStepper.tsx
+++ b/src/features/recruiting/ui/RecruitmentStepper.tsx
@@ -34,8 +34,8 @@ export function RecruitmentStepper({
             aria-current={isSelected ? "step" : undefined}
             onClick={() => onStepChange(idx)}
             className={cn(
-              "flex h-9.5 flex-1 items-center gap-2 rounded-xl py-1 pr-5 pl-3",
-              isSelected && "bg-white",
+              "flex h-9.5 flex-1 items-center gap-2 rounded-xl py-1 pr-5 pl-3 transition-colors",
+              isSelected ? "bg-white" : "hover:bg-teal-gray-50",
             )}
           >
             <span

--- a/src/features/recruiting/ui/create/RecruitmentBasicInfoForm.tsx
+++ b/src/features/recruiting/ui/create/RecruitmentBasicInfoForm.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import { useMe } from "@/entities/member/hooks/useMe"
 import { getChaptersWithSchools } from "@/entities/organization/api/organization"
 import { type Chapter, isChapter } from "@/entities/organization/model/chapters"
+import CheckIcon from "@/shared/assets/icon/check/CheckIcon"
 import DownChevronIcon from "@/shared/assets/icon/chevron/sidebar/DownChevronIcon"
 import InfoCircleIcon from "@/shared/assets/icon/infomation/InfoCircleIcon"
 import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
@@ -881,10 +882,10 @@ export function RecruitmentBasicInfoForm({
                 </div>
               ) : (
                 <div className="flex items-center gap-6">
-                  <span className="text-body-1-medium text-teal-gray-600 w-16 shrink-0">
+                  <span className="text-body-1-regular text-teal-gray-700 w-16 shrink-0">
                     지부 정보
                   </span>
-                  <span className="text-body-1-medium text-teal-500">
+                  <span className="text-body-1-medium text-teal-600">
                     {chapter}
                   </span>
                 </div>
@@ -892,14 +893,7 @@ export function RecruitmentBasicInfoForm({
 
               <div className="flex flex-col gap-2">
                 <div className="flex items-center gap-6">
-                  <span
-                    className={cn(
-                      "w-16 shrink-0",
-                      isSchoolEditable
-                        ? "text-body-1-regular text-teal-gray-700"
-                        : "text-body-1-medium text-teal-gray-600",
-                    )}
-                  >
+                  <span className="text-body-1-regular text-teal-gray-700 w-16 shrink-0">
                     모집 학교
                   </span>
                   {isSchoolEditable ? (
@@ -940,16 +934,19 @@ export function RecruitmentBasicInfoForm({
                       />
                     </div>
                   ) : (
-                    <span className="text-body-1-medium text-teal-500">
+                    <span className="text-body-1-medium text-teal-600">
                       {school}
                     </span>
                   )}
                 </div>
                 {/* 임시 메시지(시즌 미생성시)*/}
                 {isSeasonMissing && (
-                  <p className="text-body-2-medium pl-22 text-red-500">
-                    모집 시즌 생성 전입니다.
-                  </p>
+                  <div className="flex items-center gap-1 pl-22">
+                    <CheckIcon className="text-error-500 h-4 w-4 shrink-0" />
+                    <p className="text-body-2-medium text-error-500">
+                      모집 시즌 생성 전입니다.
+                    </p>
+                  </div>
                 )}
               </div>
 
@@ -1084,10 +1081,13 @@ export function RecruitmentBasicInfoForm({
                   * 꼬릿말 예시: 사본 1, 테스트 1, 디자인 파트
                 </p>
                 {isTitleTooLong && (
-                  <p className="text-body-2-medium pl-22 text-red-500">
-                    공고 제목은 {MAX_TITLE_LENGTH}자를 넘을 수 없습니다.
-                    꼬릿말을 줄여주세요.
-                  </p>
+                  <div className="flex items-center gap-1 pl-22">
+                    <CheckIcon className="text-error-500 h-4 w-4 shrink-0" />
+                    <p className="text-body-2-medium text-error-500">
+                      공고 제목은 {MAX_TITLE_LENGTH}자를 넘을 수 없습니다.
+                      꼬릿말을 줄여주세요.
+                    </p>
+                  </div>
                 )}
               </div>
             </div>


### PR DESCRIPTION
## 📸 작업 내용

> 작업한 내용을 두괄식으로 작성해주세요

-  노션 QA에 있는 디자인 세부 사항들 수정하였습니다.

## 🎞️ 주요 코드 설명

### 주제1

```TypeScript
/* src/app/app.css */
button {
  appearance: none;
}
```

- Tailwind v4 preflight가 iOS border-radius 버그를 피하려고 button에 appearance: button을 남겨두는데, 이 네이티브 appearance가 Safari에서 커스텀 padding/border-radius 위에 자체 여백을 덧그려서 드롭다운 리스트 항목 같은 컴포넌트의 패딩이 깨져 보였던 것 같습니다. 모든 버튼을 Tailwind 유틸리티로 직접 스타일링하는 프로젝트라 전역으로 appearance: none을 꺼서 해결하고자 했습니다.

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #802 

## 📚 참고자료

## 💬 기타 더 이야기해볼 점
