### PR TITLE
fix: 로그인 회원 지원서 자동 연동 및 목록 조회 UX 개선

### DIFF
--- a/src/features/recruiting/hooks/useApplyForm.ts
+++ b/src/features/recruiting/hooks/useApplyForm.ts
@@ -163,9 +163,11 @@ export function useApplyForm(
   return {
     round: location?.round ?? null,
     config,
-    isLoading: roundQuery.isLoading || structureQuery.isLoading,
+    isLoading: gisuQuery.isLoading || roundQuery.isLoading,
+    isStructureLoading: structureQuery.isLoading,
     isStructureFetching: structureQuery.isFetching,
-    isError: gisuQuery.isError || roundQuery.isError || structureQuery.isError,
+    isStructureError: structureQuery.isError,
+    isError: gisuQuery.isError || roundQuery.isError,
     // 조회는 됐는데 그 차수가 없는 경우. 잘못된 링크로 들어온 것이라
     // "잠시 후 다시 시도"로 안내하면 아무리 기다려도 달라지지 않는다.
     isNotFound: roundQuery.isSuccess && location == null,

--- a/src/features/recruiting/index.ts
+++ b/src/features/recruiting/index.ts
@@ -28,6 +28,13 @@ export {
   useUpdateAnonymousApplication,
 } from "./hooks/useAnonymousApplication"
 export { toApplicationSections } from "./model/applicationDetailMapper"
+export {
+  clearApplyDraft,
+  readApplyDraft,
+  readMemberApplicationRef,
+  writeApplyDraft,
+  writeMemberApplicationRef,
+} from "./model/applyDraftStorage"
 export { validateEvaluationDetailSearch } from "./model/evaluationDetailSearch"
 export {
   EVALUATION_STAGE_LABEL,

--- a/src/features/recruiting/model/applyDraftStorage.ts
+++ b/src/features/recruiting/model/applyDraftStorage.ts
@@ -22,6 +22,36 @@ function isDraftRef(value: unknown): value is ApplyDraftRef {
   )
 }
 
+function memberStorageKey(memberId: string) {
+  return `umc:recruiting:member:${memberId}`
+}
+
+export function readMemberApplicationRef(
+  memberId: string,
+): ApplyDraftRef | null {
+  if (!memberId) return null
+  try {
+    const raw = localStorage.getItem(memberStorageKey(memberId))
+    if (!raw) return null
+    const parsed: unknown = JSON.parse(raw)
+    return isDraftRef(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+export function writeMemberApplicationRef(
+  memberId: string,
+  draft: ApplyDraftRef,
+): void {
+  if (!memberId) return
+  try {
+    localStorage.setItem(memberStorageKey(memberId), JSON.stringify(draft))
+  } catch {
+    // 사생활 보호 모드처럼 저장이 막힌 환경에서도 작성 자체는 이어갈 수 있어야 한다.
+  }
+}
+
 export function readApplyDraft(
   roundId: string,
   memberId: string,
@@ -43,6 +73,9 @@ export function writeApplyDraft(
 ): void {
   try {
     localStorage.setItem(storageKey(roundId, memberId), JSON.stringify(draft))
+    if (memberId) {
+      writeMemberApplicationRef(memberId, draft)
+    }
   } catch {
     // 사생활 보호 모드처럼 저장이 막힌 환경에서도 작성 자체는 이어갈 수 있어야 한다.
   }

--- a/src/features/recruiting/ui/apply/RecruitingApplyPage.tsx
+++ b/src/features/recruiting/ui/apply/RecruitingApplyPage.tsx
@@ -175,12 +175,6 @@ export function RecruitingApplyPage({ roundId }: RecruitingApplyPageProps) {
       answers: toPayload(values),
     })
     setApplicationKey(draft.applicationKey)
-    if (isAnonymous && typeof window !== "undefined" && draft.applicationKey) {
-      sessionStorage.setItem("isApplicationVerified", "true")
-      sessionStorage.setItem("anonymousEmail", applicant.applicantEmail.trim())
-      sessionStorage.setItem("anonymousApplicationKey", draft.applicationKey)
-      getOrCreateAnonymousSessionId()
-    }
     return draft
   }
 

--- a/src/routes/projects/application/index.tsx
+++ b/src/routes/projects/application/index.tsx
@@ -23,8 +23,7 @@ export const Route = createFileRoute("/projects/application/")({
   beforeLoad: () => {
     if (typeof window !== "undefined") {
       const isAuthed = useAuthStore.getState().isAuthed
-      const isVerified = sessionStorage.getItem("isApplicationVerified")
-      if (isAuthed || isVerified === "true") {
+      if (isAuthed) {
         throw redirect({ to: "/projects/application/list" })
       }
     }

--- a/src/routes/projects/application/list.tsx
+++ b/src/routes/projects/application/list.tsx
@@ -1,10 +1,12 @@
 import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router"
 import { useMemo } from "react"
 
+import { useMe } from "@/entities/member/hooks/useMe"
 import { useAuthStore } from "@/entities/member/store/authStore"
 import {
   clearAnonymousApplicationSession,
   mapTrackToPartTag,
+  readMemberApplicationRef,
   RecruitingApplicationCard,
   useAnonymousApplicationQuery,
   useCancelAnonymousApplication,
@@ -34,13 +36,26 @@ export const Route = createFileRoute("/projects/application/list")({
 function ApplicationListPage() {
   const navigate = useNavigate()
   const isAuthed = useAuthStore((s) => s.isAuthed)
+  const { data: me } = useMe()
+  const memberId = me?.id ?? ""
+  const memberEmail = me?.email ?? null
 
-  const email =
-    !isAuthed && typeof window !== "undefined"
+  const memberAppRef = useMemo(
+    () => (isAuthed && memberId ? readMemberApplicationRef(memberId) : null),
+    [isAuthed, memberId],
+  )
+
+  const email = isAuthed
+    ? memberEmail
+    : typeof window !== "undefined"
       ? sessionStorage.getItem("anonymousEmail")
       : null
-  const applicationKey =
-    !isAuthed && typeof window !== "undefined"
+  const applicationKey = isAuthed
+    ? (memberAppRef?.applicationKey ??
+      (typeof window !== "undefined"
+        ? sessionStorage.getItem("anonymousApplicationKey")
+        : null))
+    : typeof window !== "undefined"
       ? sessionStorage.getItem("anonymousApplicationKey")
       : null
 
@@ -111,16 +126,14 @@ function ApplicationListPage() {
         <p className="text-body-2-medium text-teal-gray-400">
           조회된 지원서가 없습니다.
         </p>
-        {!isAuthed && (
-          <Button
-            variant="weak"
-            color="neutral"
-            size="s"
-            onClick={handleResetVerification}
-          >
-            다른 지원서 확인하기
-          </Button>
-        )}
+        <Button
+          variant="weak"
+          color="neutral"
+          size="s"
+          onClick={handleResetVerification}
+        >
+          다른 지원서 확인하기
+        </Button>
       </div>
     )
   }


### PR DESCRIPTION
## 📸 작업 내용

- **로그인 회원 지원서 연동**: 로그인된 사용자(`memberId`)가 임시 저장하거나 생성한 지원서 참조 정보(`applicationKey`)를 `localStorage`에 저장하여 목록 페이지에서 자동으로 연동 및 조회되도록 개선
- **지망 선택 모달 언마운트 방지**: 지원서 작성 중 트랙/파트 구조 API(`structureQuery`) 로딩·에러 상태로 인해 모달 전체가 언마운트되던 현상 방지 (`isLoading`/`isError` 분리)
- **익명 지원 세션 우회 로직 정리**: 작성 완료 시 `sessionStorage`에 남아있던 익명 지원자 우회용 세션 로직을 제거하고 라우터 진입 조건(`beforeLoad`) 정리

## 🎞️ 주요 코드 설명

### 1. 트랙/파트 구조 조회 상태 분리로 모달 언마운트 방지 (`useApplyForm.ts`)

```TypeScript
// src/features/recruiting/hooks/useApplyForm.ts
return {
  round: location?.round ?? null,
  config,
  isLoading: gisuQuery.isLoading || roundQuery.isLoading,
  isStructureLoading: structureQuery.isLoading,
  isStructureFetching: structureQuery.isFetching,
  isStructureError: structureQuery.isError,
  isError: gisuQuery.isError || roundQuery.isError,
}
```

- 모집 폼 전체 초기화 로딩(`gisuQuery`, `roundQuery`)과 선택 정보 조회를 위한 `structureQuery` 로딩·에러를 분리하여, 지망 변경 시 모달이 언마운트되는 현상을 방지했습니다.

### 2. 회원 지원서 참조 정보 저장 및 자동 조회 (`applyDraftStorage.ts`, `list.tsx`)

```TypeScript
// src/features/recruiting/model/applyDraftStorage.ts
export function writeMemberApplicationRef(
  memberId: string,
  draft: ApplyDraftRef,
): void {
  if (!memberId) return
  try {
    localStorage.setItem(memberStorageKey(memberId), JSON.stringify(draft))
  } catch {}
}
```

- 회원 ID별로 지원서 임시저장/제출 내역의 `applicationKey`를 로컬 스토리지에 기록하고, `list.tsx`에서 로그인 회원인 경우 해당 키를 통해 지원서를 자동으로 연결하여 보여줍니다.

## 🖥️ 구현화면

## 🔗 연결된 이슈

- Connected: #808 

## 💬 기타 더 이야기해볼 점