### PR TITLE
✨ feat: 기수 선택 전역 연결과 기수 관리 페이지 신설

### DIFF
--- a/src/entities/organization/hooks/useSchoolChapterMap.ts
+++ b/src/entities/organization/hooks/useSchoolChapterMap.ts
@@ -5,22 +5,24 @@ import { getChaptersWithSchools } from "@/entities/organization/api/organization
 import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
 
 export interface SchoolChapterMapOptions {
+  gisuId?: number
   refetchInterval?: number | false
 }
 
 export function useSchoolChapterMap(options: SchoolChapterMapOptions = {}) {
-  const { data: gisuData } = useActiveGisu()
+  const { data: gisuData } = useActiveGisu({ enabled: options.gisuId == null })
 
-  const activeGisuId = gisuData?.gisuId ? Number(gisuData.gisuId) : undefined
+  const resolvedGisuId =
+    options.gisuId ?? (gisuData?.gisuId ? Number(gisuData.gisuId) : undefined)
 
   const {
     data: chaptersData,
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ["chaptersWithSchools", activeGisuId],
-    queryFn: () => getChaptersWithSchools(String(activeGisuId!)),
-    enabled: activeGisuId != null,
+    queryKey: ["chaptersWithSchools", resolvedGisuId],
+    queryFn: () => getChaptersWithSchools(String(resolvedGisuId!)),
+    enabled: resolvedGisuId != null,
     staleTime: 5 * 60 * 1000,
     refetchInterval: options.refetchInterval ?? false,
   })

--- a/src/features/auth/lib/logout.ts
+++ b/src/features/auth/lib/logout.ts
@@ -1,8 +1,10 @@
 import { useAuthStore } from "@/entities/member/store/authStore"
 import { clearLoginReturnTo } from "@/shared/lib/loginRedirect"
+import { useSelectedGisuStore } from "@/shared/model/useSelectedGisuStore"
 
 export function logout() {
   clearLoginReturnTo()
   useAuthStore.getState().clear()
+  useSelectedGisuStore.getState().clear()
   window.location.href = "/login"
 }

--- a/src/features/chapter/ui/ChapterManagePage.tsx
+++ b/src/features/chapter/ui/ChapterManagePage.tsx
@@ -60,10 +60,13 @@ export function ChapterManagePage() {
   const createChaptersBulkMutation = useCreateChaptersBulk()
   const updateSchoolMutation = useUpdateSchool()
   const { data: activeGisuId, isLoading: isGisuLoading } = useSelectedGisuId()
-  const { chapters: serverChapters, isLoading: isServerChaptersLoading } =
-    useSchoolChapterMap({
-      gisuId: activeGisuId ?? undefined,
-    })
+  const {
+    chapters: serverChapters,
+    isLoading: isServerChaptersLoading,
+    isError: isServerChaptersError,
+  } = useSchoolChapterMap({
+    gisuId: activeGisuId ?? undefined,
+  })
 
   const { data: allSchoolsData } = useQuery({
     queryKey: ["allSchools"],
@@ -109,7 +112,7 @@ export function ChapterManagePage() {
 
     setSelectedChipId(null)
 
-    if (isServerChaptersLoading) {
+    if (isServerChaptersLoading || isServerChaptersError) {
       setChapters(INITIAL_CHAPTERS)
       return
     }
@@ -125,7 +128,13 @@ export function ChapterManagePage() {
       })),
     )
     loadedGisuIdRef.current = activeGisuId
-  }, [activeGisuId, isServerChaptersLoading, serverChapters, setSelectedChipId])
+  }, [
+    activeGisuId,
+    isServerChaptersLoading,
+    isServerChaptersError,
+    serverChapters,
+    setSelectedChipId,
+  ])
 
   function handleDragStart(event: DragStartEvent) {
     const school = event.active.data.current
@@ -332,6 +341,17 @@ export function ChapterManagePage() {
   }
 
   async function handleSave() {
+    if (isServerChaptersError) {
+      addToast({
+        message: "지부 정보를 불러오지 못해 저장할 수 없습니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return
+    }
+
     const newChapters = chapters.filter((ch) => ch.id.startsWith("chapter-"))
     const existingChapters = chapters.filter(
       (ch) => !ch.id.startsWith("chapter-"),
@@ -478,6 +498,7 @@ export function ChapterManagePage() {
               variant="fill"
               className="w-fit rounded-[8px] px-3 py-1.5"
               onClick={handleSave}
+              disabled={isServerChaptersError}
             >
               저장하기
             </Button>
@@ -491,24 +512,32 @@ export function ChapterManagePage() {
 
             <div className="relative min-w-0 flex-1">
               <div className="absolute inset-0 flex flex-col gap-4 overflow-y-auto pr-1">
-                {chapters.map((chapter) => (
-                  <DroppableChapterBox
-                    key={chapter.id}
-                    chapter={chapter}
-                    selectedChipId={selectedChipId}
-                    onSelectChip={setSelectedChipId}
-                    onClear={() => handleClearChapter(chapter.id)}
-                    onDelete={() => handleDeleteChapter(chapter.id)}
-                    onUpdateName={(name) =>
-                      handleUpdateChapterName(chapter.id, name)
-                    }
-                  />
-                ))}
-                {chapters.length > 0 && (
-                  <div
-                    className="pointer-events-none h-[calc(100%-185px)] shrink-0"
-                    aria-hidden="true"
-                  />
+                {isServerChaptersError ? (
+                  <div className="text-body-1-medium text-teal-gray-400 py-12 text-center">
+                    지부 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
+                  </div>
+                ) : (
+                  <>
+                    {chapters.map((chapter) => (
+                      <DroppableChapterBox
+                        key={chapter.id}
+                        chapter={chapter}
+                        selectedChipId={selectedChipId}
+                        onSelectChip={setSelectedChipId}
+                        onClear={() => handleClearChapter(chapter.id)}
+                        onDelete={() => handleDeleteChapter(chapter.id)}
+                        onUpdateName={(name) =>
+                          handleUpdateChapterName(chapter.id, name)
+                        }
+                      />
+                    ))}
+                    {chapters.length > 0 && (
+                      <div
+                        className="pointer-events-none h-[calc(100%-185px)] shrink-0"
+                        aria-hidden="true"
+                      />
+                    )}
+                  </>
                 )}
               </div>
             </div>

--- a/src/features/chapter/ui/ChapterManagePage.tsx
+++ b/src/features/chapter/ui/ChapterManagePage.tsx
@@ -17,7 +17,7 @@ import { useUpdateSchool } from "@/entities/organization/hooks/useSchool"
 import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import ResetIcon from "@/shared/assets/icon/reset/ResetIcon"
-import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
+import { useSelectedGisuId } from "@/shared/hooks/useSelectedGisu"
 import { useChipAssignment } from "@/shared/lib/useChipAssignment"
 import { Button } from "@/shared/ui/Button"
 import { PageLabel } from "@/shared/ui/page-label/PageLabel"
@@ -59,8 +59,10 @@ export function ChapterManagePage() {
   const createChapterMutation = useCreateChapter()
   const createChaptersBulkMutation = useCreateChaptersBulk()
   const updateSchoolMutation = useUpdateSchool()
-  const { data: activeGisuId, isLoading: isGisuLoading } = useActiveGisuId()
-  const { chapters: serverChapters } = useSchoolChapterMap()
+  const { data: activeGisuId, isLoading: isGisuLoading } = useSelectedGisuId()
+  const { chapters: serverChapters } = useSchoolChapterMap({
+    gisuId: activeGisuId ?? undefined,
+  })
 
   const { data: allSchoolsData } = useQuery({
     queryKey: ["allSchools"],

--- a/src/features/chapter/ui/ChapterManagePage.tsx
+++ b/src/features/chapter/ui/ChapterManagePage.tsx
@@ -53,37 +53,22 @@ export function ChapterManagePage() {
     "waiting" | "assigned"
   >("waiting")
 
-  const isInitializedRef = useRef(false)
+  const loadedGisuIdRef = useRef<number | null>(null)
 
   const deleteChapterMutation = useDeleteChapter()
   const createChapterMutation = useCreateChapter()
   const createChaptersBulkMutation = useCreateChaptersBulk()
   const updateSchoolMutation = useUpdateSchool()
   const { data: activeGisuId, isLoading: isGisuLoading } = useSelectedGisuId()
-  const { chapters: serverChapters } = useSchoolChapterMap({
-    gisuId: activeGisuId ?? undefined,
-  })
+  const { chapters: serverChapters, isLoading: isServerChaptersLoading } =
+    useSchoolChapterMap({
+      gisuId: activeGisuId ?? undefined,
+    })
 
   const { data: allSchoolsData } = useQuery({
     queryKey: ["allSchools"],
     queryFn: getAllSchools,
   })
-
-  useEffect(() => {
-    if (isInitializedRef.current || !serverChapters) return
-    if (serverChapters.length > 0) {
-      const mappedChapters: ChapterData[] = serverChapters.map((ch) => ({
-        id: String(ch.chapterId),
-        name: ch.chapterName,
-        assignedSchools: ch.schools.map((s) => ({
-          id: String(s.schoolId),
-          name: s.schoolName,
-        })),
-      }))
-      setChapters(mappedChapters)
-      isInitializedRef.current = true
-    }
-  }, [serverChapters])
 
   useEffect(() => {
     if (!allSchoolsData?.schools) return
@@ -117,6 +102,30 @@ export function ChapterManagePage() {
   } = useChipAssignment<School>({
     onRemoveSelected: handleRemoveAssignedSchool,
   })
+
+  useEffect(() => {
+    if (activeGisuId == null) return
+    if (loadedGisuIdRef.current === activeGisuId) return
+
+    setSelectedChipId(null)
+
+    if (isServerChaptersLoading) {
+      setChapters(INITIAL_CHAPTERS)
+      return
+    }
+
+    setChapters(
+      serverChapters.map((ch) => ({
+        id: String(ch.chapterId),
+        name: ch.chapterName,
+        assignedSchools: ch.schools.map((s) => ({
+          id: String(s.schoolId),
+          name: s.schoolName,
+        })),
+      })),
+    )
+    loadedGisuIdRef.current = activeGisuId
+  }, [activeGisuId, isServerChaptersLoading, serverChapters, setSelectedChipId])
 
   function handleDragStart(event: DragStartEvent) {
     const school = event.active.data.current

--- a/src/features/curriculum/hooks/useCurriculumEditor.test.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.test.ts
@@ -22,8 +22,8 @@ vi.mock("@/entities/curriculum", () => ({
   deleteWeeklyCurriculum: vi.fn(),
 }))
 
-vi.mock("@/shared/hooks/useActiveGisu", () => ({
-  useActiveGisuId: () => ({ data: 1, isLoading: false }),
+vi.mock("@/shared/hooks/useSelectedGisu", () => ({
+  useSelectedGisuId: () => ({ data: 1, isLoading: false }),
 }))
 
 describe("useCurriculumEditor - temporary ID handleBlur", () => {

--- a/src/features/curriculum/hooks/useCurriculumEditor.ts
+++ b/src/features/curriculum/hooks/useCurriculumEditor.ts
@@ -19,7 +19,7 @@ import {
   updateCurriculum,
   updateWeeklyCurriculum,
 } from "@/entities/curriculum"
-import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
+import { useSelectedGisuId } from "@/shared/hooks/useSelectedGisu"
 import { useToastStore } from "@/shared/ui/toast/useToastStore"
 
 import {
@@ -164,7 +164,7 @@ export function useCurriculumEditor({
     useState<CurriculumItem[]>(initialCurriculums)
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const addToast = useToastStore((state) => state.addToast)
-  const { data: activeGisuId, isLoading: isGisuLoading } = useActiveGisuId()
+  const { data: activeGisuId, isLoading: isGisuLoading } = useSelectedGisuId()
 
   const pendingCurriculumPromisesRef = useRef<
     Map<string, Promise<number | string | null>>

--- a/src/features/curriculum/ui/CurriculumManagePage.tsx
+++ b/src/features/curriculum/ui/CurriculumManagePage.tsx
@@ -89,7 +89,11 @@ export function CurriculumManagePage() {
     }))
   }
 
+  const hasGisuChangedSince = (requestGisuId: number | null) =>
+    loadedGisuIdRef.current !== requestGisuId
+
   const handleDeleteItem = async (id: string): Promise<boolean> => {
+    const requestGisuId = loadedGisuIdRef.current
     const targetItem = (curriculumData[selectedPart] || []).find(
       (item) => item.id === id,
     )
@@ -117,16 +121,18 @@ export function CurriculumManagePage() {
         await deleteCurriculum(numericId)
       } catch {
         if (targetItem) {
-          setCurriculumData((prev) => {
-            const list = [...(prev[selectedPart] || [])]
-            const insertIndex = Math.min(targetIndex, list.length)
-            list.splice(insertIndex, 0, targetItem)
-            const renumbered = list.map((item, idx) => ({
-              ...item,
-              number: String(idx + 1).padStart(2, "0"),
-            }))
-            return { ...prev, [selectedPart]: renumbered }
-          })
+          if (!hasGisuChangedSince(requestGisuId)) {
+            setCurriculumData((prev) => {
+              const list = [...(prev[selectedPart] || [])]
+              const insertIndex = Math.min(targetIndex, list.length)
+              list.splice(insertIndex, 0, targetItem)
+              const renumbered = list.map((item, idx) => ({
+                ...item,
+                number: String(idx + 1).padStart(2, "0"),
+              }))
+              return { ...prev, [selectedPart]: renumbered }
+            })
+          }
           addToast({
             message: "커리큘럼 삭제에 실패했습니다.",
             color: "red",
@@ -173,13 +179,16 @@ export function CurriculumManagePage() {
       return
     }
 
+    const requestGisuId = loadedGisuIdRef.current
     const previousList = curriculumData[selectedPart] || []
 
     const rollbackState = () => {
-      setCurriculumData((prev) => ({
-        ...prev,
-        [selectedPart]: previousList,
-      }))
+      if (!hasGisuChangedSince(requestGisuId)) {
+        setCurriculumData((prev) => ({
+          ...prev,
+          [selectedPart]: previousList,
+        }))
+      }
       addToast({
         message: "커리큘럼 복원에 실패했습니다.",
         color: "red",
@@ -215,16 +224,20 @@ export function CurriculumManagePage() {
         return
       }
 
-      setCurriculumData((prev) => {
-        const list = prev[selectedPart] || []
-        const updated = list.map((c) =>
-          c.id === itemToRestore.id ? { ...c, id: String(newCurriculumId) } : c,
-        )
-        return {
-          ...prev,
-          [selectedPart]: updated,
-        }
-      })
+      if (!hasGisuChangedSince(requestGisuId)) {
+        setCurriculumData((prev) => {
+          const list = prev[selectedPart] || []
+          const updated = list.map((c) =>
+            c.id === itemToRestore.id
+              ? { ...c, id: String(newCurriculumId) }
+              : c,
+          )
+          return {
+            ...prev,
+            [selectedPart]: updated,
+          }
+        })
+      }
 
       if (itemToRestore.workbooks && itemToRestore.workbooks.length > 0) {
         for (const wb of itemToRestore.workbooks) {
@@ -243,17 +256,19 @@ export function CurriculumManagePage() {
             return
           }
 
-          setCurriculumData((prev) => {
-            const list = prev[selectedPart] || []
-            const updated = list.map((c) => {
-              if (c.id !== String(newCurriculumId)) return c
-              const updatedWbs = c.workbooks.map((w) =>
-                w.id === wb.id ? { ...w, id: String(createdWbId) } : w,
-              )
-              return { ...c, workbooks: updatedWbs }
+          if (!hasGisuChangedSince(requestGisuId)) {
+            setCurriculumData((prev) => {
+              const list = prev[selectedPart] || []
+              const updated = list.map((c) => {
+                if (c.id !== String(newCurriculumId)) return c
+                const updatedWbs = c.workbooks.map((w) =>
+                  w.id === wb.id ? { ...w, id: String(createdWbId) } : w,
+                )
+                return { ...c, workbooks: updatedWbs }
+              })
+              return { ...prev, [selectedPart]: updated }
             })
-            return { ...prev, [selectedPart]: updated }
-          })
+          }
         }
       }
     } catch {

--- a/src/features/curriculum/ui/CurriculumManagePage.tsx
+++ b/src/features/curriculum/ui/CurriculumManagePage.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/entities/curriculum"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
 import SettingIcon from "@/shared/assets/icon/setting/SettingIcon"
-import { useActiveGisuId } from "@/shared/hooks/useActiveGisu"
+import { useSelectedGisuId } from "@/shared/hooks/useSelectedGisu"
 import { Button } from "@/shared/ui/Button"
 import { PageLabel } from "@/shared/ui/page-label/PageLabel"
 import { useToastStore } from "@/shared/ui/toast/useToastStore"
@@ -31,7 +31,7 @@ export function CurriculumManagePage() {
   const [curriculumData, setCurriculumData] = useState(INITIAL_CURRICULUM_DATA)
   const [isSettingModalOpen, setIsSettingModalOpen] = useState(false)
   const addToast = useToastStore((state) => state.addToast)
-  const { data: activeGisuId, isLoading: isGisuLoading } = useActiveGisuId()
+  const { data: activeGisuId, isLoading: isGisuLoading } = useSelectedGisuId()
 
   // Default expand card 01 (design-1)
   const [expandedIds, setExpandedIds] = useState<Record<string, boolean>>({

--- a/src/features/curriculum/ui/CurriculumManagePage.tsx
+++ b/src/features/curriculum/ui/CurriculumManagePage.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "@tanstack/react-router"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
 import {
   createCurriculum,
@@ -32,6 +32,7 @@ export function CurriculumManagePage() {
   const [isSettingModalOpen, setIsSettingModalOpen] = useState(false)
   const addToast = useToastStore((state) => state.addToast)
   const { data: activeGisuId, isLoading: isGisuLoading } = useSelectedGisuId()
+  const loadedGisuIdRef = useRef<number | null>(null)
 
   // Default expand card 01 (design-1)
   const [expandedIds, setExpandedIds] = useState<Record<string, boolean>>({
@@ -42,6 +43,11 @@ export function CurriculumManagePage() {
     if (isGisuLoading || activeGisuId == null) return
 
     const currentGisuId = activeGisuId
+    if (loadedGisuIdRef.current !== currentGisuId) {
+      loadedGisuIdRef.current = currentGisuId
+      setCurriculumData({})
+    }
+
     let isSubscribed = true
     async function loadCurriculum() {
       try {
@@ -50,15 +56,22 @@ export function CurriculumManagePage() {
           gisuId: currentGisuId,
           part: apiPart,
         })
-        if (isSubscribed && overview && overview.curriculumId) {
-          const item = mapOverviewToCurriculumItem(overview, 0)
+        if (!isSubscribed) return
+        const items =
+          overview && overview.curriculumId
+            ? [mapOverviewToCurriculumItem(overview, 0)]
+            : []
+        setCurriculumData((prev) => ({
+          ...prev,
+          [selectedPart]: items,
+        }))
+      } catch {
+        if (isSubscribed) {
           setCurriculumData((prev) => ({
             ...prev,
-            [selectedPart]: [item],
+            [selectedPart]: [],
           }))
         }
-      } catch {
-        // Fallback to initial local mock data if api has no entry
       }
     }
     loadCurriculum()

--- a/src/features/gisu/api/gisuAdmin.ts
+++ b/src/features/gisu/api/gisuAdmin.ts
@@ -1,0 +1,27 @@
+import { api } from "@/shared/lib/axios"
+
+import type { ApiResponse } from "@/shared/lib/apiResponse"
+import type { components } from "@/types/api"
+
+export type GisuResponse = components["schemas"]["GisuResponse"]
+export type GisuPageResponse = components["schemas"]["GisuPageResponse"]
+export type CreateGisuRequest = components["schemas"]["CreateGisuRequest"]
+
+export async function getGisuList(params: {
+  page: number
+  size: number
+}): Promise<GisuPageResponse> {
+  const { data } = await api.get<ApiResponse<GisuPageResponse>>("/v1/gisu", {
+    params,
+  })
+  return data.result
+}
+
+export async function createGisu(body: CreateGisuRequest): Promise<number> {
+  const { data } = await api.post<ApiResponse<number>>("/v1/gisu", body)
+  return Number(data.result)
+}
+
+export async function activateGisu(gisuId: number): Promise<void> {
+  await api.post<ApiResponse<void>>(`/v1/gisu/${gisuId}/active`)
+}

--- a/src/features/gisu/hooks/useGisuAdmin.ts
+++ b/src/features/gisu/hooks/useGisuAdmin.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+
+import {
+  activateGisu,
+  createGisu,
+  getGisuList,
+} from "@/features/gisu/api/gisuAdmin"
+import { gisuKeys } from "@/shared/hooks/useActiveGisu"
+
+import type { CreateGisuRequest } from "@/features/gisu/api/gisuAdmin"
+
+const gisuListKey = ["gisu", "list"] as const
+
+export function useGisuList(params: { page: number; size: number }) {
+  return useQuery({
+    queryKey: [...gisuListKey, params],
+    queryFn: () => getGisuList(params),
+    staleTime: 30 * 1000,
+  })
+}
+
+export function useCreateGisu() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (body: CreateGisuRequest) => createGisu(body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: gisuListKey })
+    },
+  })
+}
+
+export function useActivateGisu() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (gisuId: number) => activateGisu(gisuId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: gisuListKey })
+      queryClient.invalidateQueries({ queryKey: gisuKeys.active })
+    },
+  })
+}

--- a/src/features/gisu/ui/GisuManagePage.tsx
+++ b/src/features/gisu/ui/GisuManagePage.tsx
@@ -1,0 +1,315 @@
+import { isAxiosError } from "axios"
+import { useMemo, useState } from "react"
+
+import {
+  useActivateGisu,
+  useCreateGisu,
+  useGisuList,
+} from "@/features/gisu/hooks/useGisuAdmin"
+import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
+import { Button } from "@/shared/ui/Button"
+import { InputBox } from "@/shared/ui/input/InputBox"
+import { CtaModal } from "@/shared/ui/modal/CtaModal"
+import { PageLabel } from "@/shared/ui/page-label/PageLabel"
+import { useToastStore } from "@/shared/ui/toast/useToastStore"
+
+import type { GisuResponse } from "@/features/gisu/api/gisuAdmin"
+
+const GISU_PAGE_SIZE = 50
+
+const dateInputClassName =
+  "border-teal-gray-200 shadow-inner-neutral-2 box-border h-11 w-full max-w-52 rounded-[12px] border bg-white px-4 text-gray-900 outline-none"
+
+export function GisuManagePage() {
+  const addToast = useToastStore((s) => s.addToast)
+
+  const { data: gisuPageData, isLoading } = useGisuList({
+    page: 0,
+    size: GISU_PAGE_SIZE,
+  })
+  const createGisuMutation = useCreateGisu()
+  const activateGisuMutation = useActivateGisu()
+
+  const [isCreating, setIsCreating] = useState(false)
+  const [generationInput, setGenerationInput] = useState("")
+  const [startDate, setStartDate] = useState("")
+  const [endDate, setEndDate] = useState("")
+  const [activationTarget, setActivationTarget] = useState<GisuResponse | null>(
+    null,
+  )
+
+  const sortedGisuList = useMemo(() => {
+    const content = gisuPageData?.content ?? []
+    return [...content].sort(
+      (a, b) => Number(b.generation) - Number(a.generation),
+    )
+  }, [gisuPageData])
+
+  const resetCreateForm = () => {
+    setGenerationInput("")
+    setStartDate("")
+    setEndDate("")
+    setIsCreating(false)
+  }
+
+  const handleCreate = async () => {
+    const generation = Number(generationInput)
+    if (!generationInput.trim() || Number.isNaN(generation) || generation < 1) {
+      addToast({
+        message: "기수 번호를 확인해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return
+    }
+    if (!startDate || !endDate) {
+      addToast({
+        message: "활동 기간을 입력해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return
+    }
+    if (startDate >= endDate) {
+      addToast({
+        message: "종료일은 시작일보다 빨라야 합니다.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      return
+    }
+
+    try {
+      await createGisuMutation.mutateAsync({
+        generation,
+        startAt: `${startDate}T00:00:00Z`,
+        endAt: `${endDate}T23:59:59Z`,
+      })
+      addToast({
+        message: `${generation}기가 생성됐습니다.`,
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+      resetCreateForm()
+    } catch (error) {
+      const status = isAxiosError(error) ? error.response?.status : undefined
+      addToast({
+        message:
+          status === 409
+            ? "이미 존재하는 기수입니다."
+            : "기수 생성에 실패했습니다. 잠시 후 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    }
+  }
+
+  const handleActivateConfirm = async () => {
+    if (!activationTarget) return
+    const target = activationTarget
+    setActivationTarget(null)
+
+    try {
+      await activateGisuMutation.mutateAsync(Number(target.gisuId))
+      addToast({
+        message: `${Number(target.generation)}기가 활성 기수로 변경됐습니다.`,
+        color: "primary",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    } catch {
+      addToast({
+        message: "활성 기수 변경에 실패했습니다. 잠시 후 다시 시도해주세요.",
+        color: "red",
+        variant: "deep",
+        type: "default",
+        duration: 3000,
+      })
+    }
+  }
+
+  const formatDate = (value?: string) => {
+    if (!value) return "-"
+    return value.slice(0, 10)
+  }
+
+  return (
+    <div className="flex w-full max-w-244 flex-col gap-8">
+      <PageLabel
+        breadcrumb={[
+          { id: "settings", label: "설정" },
+          { id: "gisu", label: "기수 관리" },
+        ]}
+        title="기수 관리"
+        description="UMC 기수를 생성하고 활성 기수를 관리합니다."
+        className="pl-3"
+      />
+
+      <div className="flex w-full flex-col gap-6">
+        <div className="flex w-full items-center justify-end">
+          <Button
+            size="m"
+            color="primary"
+            variant="fill"
+            onClick={() => setIsCreating((prev) => !prev)}
+            className="flex items-center gap-1 py-2.75 pr-3.5 pl-3"
+          >
+            <PlusIcon className="h-4 w-4" /> 기수 생성
+          </Button>
+        </div>
+
+        {isCreating && (
+          <div className="border-teal-gray-150 box-border flex w-full flex-col gap-6 rounded-[14px] border bg-white px-8 py-8.5">
+            <h2 className="text-heading-7-semibold text-teal-gray-900">
+              새 기수 생성
+            </h2>
+
+            <div className="flex w-full flex-col gap-3">
+              <div className="flex w-full items-center gap-6">
+                <label
+                  htmlFor="gisu-generation"
+                  className="text-body-1-medium text-teal-gray-600 w-18 shrink-0"
+                >
+                  기수 번호
+                </label>
+                <InputBox
+                  id="gisu-generation"
+                  value={generationInput}
+                  onChange={(e) =>
+                    setGenerationInput(e.target.value.replace(/\D/g, ""))
+                  }
+                  placeholder="11"
+                  className="w-full max-w-52"
+                />
+              </div>
+
+              <div className="flex w-full items-center gap-6">
+                <label
+                  htmlFor="gisu-start-date"
+                  className="text-body-1-medium text-teal-gray-600 w-18 shrink-0"
+                >
+                  시작일
+                </label>
+                <input
+                  id="gisu-start-date"
+                  type="date"
+                  value={startDate}
+                  onChange={(e) => setStartDate(e.target.value)}
+                  className={dateInputClassName}
+                />
+              </div>
+
+              <div className="flex w-full items-center gap-6">
+                <label
+                  htmlFor="gisu-end-date"
+                  className="text-body-1-medium text-teal-gray-600 w-18 shrink-0"
+                >
+                  종료일
+                </label>
+                <input
+                  id="gisu-end-date"
+                  type="date"
+                  value={endDate}
+                  onChange={(e) => setEndDate(e.target.value)}
+                  className={dateInputClassName}
+                />
+              </div>
+            </div>
+
+            <div className="flex items-center justify-end gap-3">
+              <Button
+                size="m"
+                color="neutral"
+                variant="weak"
+                onClick={resetCreateForm}
+                className="rounded-[10px]"
+              >
+                취소
+              </Button>
+              <Button
+                size="m"
+                color="primary"
+                variant="fill"
+                onClick={handleCreate}
+                disabled={createGisuMutation.isPending}
+                className="rounded-[10px]"
+              >
+                생성
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="text-body-1-medium text-teal-gray-400 py-12 text-center">
+            기수 정보를 불러오는 중입니다...
+          </div>
+        ) : sortedGisuList.length === 0 ? (
+          <div className="text-body-1-medium text-teal-gray-400 py-12 text-center">
+            등록된 기수가 없습니다.
+          </div>
+        ) : (
+          <div className="flex w-full flex-col gap-2">
+            {sortedGisuList.map((gisu) => (
+              <div
+                key={String(gisu.gisuId)}
+                className="border-teal-gray-150 box-border flex w-full items-center justify-between rounded-[14px] border bg-white px-6 py-5"
+              >
+                <div className="flex items-center gap-4">
+                  <span className="text-heading-7-semibold text-teal-gray-900">
+                    {Number(gisu.generation)}기
+                  </span>
+                  <span className="text-body-2-medium text-teal-gray-400">
+                    {formatDate(gisu.startAt)} ~ {formatDate(gisu.endAt)}
+                  </span>
+                </div>
+
+                {gisu.isActive ? (
+                  <span className="text-label-1-semibold rounded-full bg-teal-50 px-3 py-1.5 text-teal-600">
+                    활성
+                  </span>
+                ) : (
+                  <Button
+                    size="xs"
+                    color="primary"
+                    variant="weak"
+                    onClick={() => setActivationTarget(gisu)}
+                    disabled={activateGisuMutation.isPending}
+                    className="w-fit px-3"
+                  >
+                    활성화
+                  </Button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <CtaModal
+        open={activationTarget != null}
+        variant="warning"
+        title={`${activationTarget ? Number(activationTarget.generation) : ""}기를 활성 기수로 변경하시겠습니까?`}
+        content="활성 기수를 변경하면 서비스 전체에 즉시 반영됩니다."
+        cancelText="돌아가기"
+        confirmText="변경하기"
+        onOpenChange={(open) => {
+          if (!open) setActivationTarget(null)
+        }}
+        onCancel={() => setActivationTarget(null)}
+        onConfirm={handleActivateConfirm}
+      />
+    </div>
+  )
+}

--- a/src/features/gisu/ui/GisuManagePage.tsx
+++ b/src/features/gisu/ui/GisuManagePage.tsx
@@ -23,7 +23,11 @@ const dateInputClassName =
 export function GisuManagePage() {
   const addToast = useToastStore((s) => s.addToast)
 
-  const { data: gisuPageData, isLoading } = useGisuList({
+  const {
+    data: gisuPageData,
+    isLoading,
+    isError,
+  } = useGisuList({
     page: 0,
     size: GISU_PAGE_SIZE,
   })
@@ -254,6 +258,10 @@ export function GisuManagePage() {
         {isLoading ? (
           <div className="text-body-1-medium text-teal-gray-400 py-12 text-center">
             기수 정보를 불러오는 중입니다...
+          </div>
+        ) : isError ? (
+          <div className="text-body-1-medium text-teal-gray-400 py-12 text-center">
+            기수 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.
           </div>
         ) : sortedGisuList.length === 0 ? (
           <div className="text-body-1-medium text-teal-gray-400 py-12 text-center">

--- a/src/features/gisu/ui/GisuManagePage.tsx
+++ b/src/features/gisu/ui/GisuManagePage.tsx
@@ -76,7 +76,7 @@ export function GisuManagePage() {
     }
     if (startDate >= endDate) {
       addToast({
-        message: "종료일은 시작일보다 빨라야 합니다.",
+        message: "종료일은 시작일보다 늦어야 합니다.",
         color: "red",
         variant: "deep",
         type: "default",

--- a/src/features/recruiting/ui/ChapterTabs.tsx
+++ b/src/features/recruiting/ui/ChapterTabs.tsx
@@ -10,6 +10,7 @@ interface ChapterTabsProps {
   chapters?: Array<{ chapterId: string | number; chapterName: string } | string>
   allLabel?: string
   className?: string
+  gisuId?: number
 }
 
 export function ChapterTabs({
@@ -18,8 +19,9 @@ export function ChapterTabs({
   chapters: customChapters,
   allLabel = "전체",
   className,
+  gisuId,
 }: ChapterTabsProps) {
-  const { chapters: serverChapters } = useSchoolChapterMap()
+  const { chapters: serverChapters } = useSchoolChapterMap({ gisuId })
 
   const chapterOptions = useMemo(() => {
     if (customChapters && customChapters.length > 0) {

--- a/src/features/recruiting/ui/ChapterTabs.tsx
+++ b/src/features/recruiting/ui/ChapterTabs.tsx
@@ -25,17 +25,21 @@ export function ChapterTabs({
 
   const chapterOptions = useMemo(() => {
     if (customChapters && customChapters.length > 0) {
-      return customChapters.map((ch) =>
-        typeof ch === "string"
-          ? { value: ch, label: ch }
-          : { value: ch.chapterName, label: ch.chapterName },
-      )
+      return customChapters.map((ch) => {
+        const chapterName = typeof ch === "string" ? ch : ch.chapterName
+        return {
+          value: chapterName,
+          label: chapterName,
+          tooltipContent: chapterName,
+        }
+      })
     }
     if (serverChapters && serverChapters.length > 0) {
       return serverChapters.map(
         (ch: { chapterId: string | number; chapterName: string }) => ({
           value: ch.chapterName,
           label: ch.chapterName,
+          tooltipContent: ch.chapterName,
         }),
       )
     }

--- a/src/features/settings/ui/SchoolSortDropdown.tsx
+++ b/src/features/settings/ui/SchoolSortDropdown.tsx
@@ -7,11 +7,15 @@ import { DropdownItem } from "@/shared/ui/dropdown/DropdownItem"
 
 export const SCHOOL_SORT_OPTIONS = [
   { value: "name", label: "학교 이름 순" },
-  { value: "branch", label: "지부 순" },
   { value: "count", label: "인원 순" },
 ] as const
 
 export type SchoolSortOption = (typeof SCHOOL_SORT_OPTIONS)[number]["value"]
+
+export const SCHOOL_SORT_SERVER_VALUES: Record<SchoolSortOption, string> = {
+  name: "schoolName,asc",
+  count: "activeChallengerCount,desc",
+}
 
 interface SchoolSortDropdownProps {
   value: SchoolSortOption

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -77,6 +77,7 @@ import { Route as MatchingStatusRouteImport } from './routes/matching/status'
 import { Route as MatchingRoundsRouteImport } from './routes/matching/rounds'
 import { Route as MatchingNoticePublishRouteImport } from './routes/matching/notice-publish'
 import { Route as MatchingApplicationsRouteImport } from './routes/matching/applications'
+import { Route as ManageGisuRouteImport } from './routes/manage/gisu'
 import { Route as ManageChapterRouteImport } from './routes/manage/chapter'
 import { Route as LoginDefaultRouteImport } from './routes/login/default'
 import { Route as RecruitingEvaluationsRouteRouteImport } from './routes/recruiting/evaluations/route'
@@ -467,6 +468,11 @@ const MatchingApplicationsRoute = MatchingApplicationsRouteImport.update({
   path: '/applications',
   getParentRoute: () => MatchingRouteRoute,
 } as any)
+const ManageGisuRoute = ManageGisuRouteImport.update({
+  id: '/gisu',
+  path: '/gisu',
+  getParentRoute: () => ManageRouteRoute,
+} as any)
 const ManageChapterRoute = ManageChapterRouteImport.update({
   id: '/chapter',
   path: '/chapter',
@@ -709,6 +715,7 @@ export interface FileRoutesByFullPath {
   '/recruiting/evaluations': typeof RecruitingEvaluationsRouteRouteWithChildren
   '/login/default': typeof LoginDefaultRoute
   '/manage/chapter': typeof ManageChapterRoute
+  '/manage/gisu': typeof ManageGisuRoute
   '/matching/applications': typeof MatchingApplicationsRoute
   '/matching/notice-publish': typeof MatchingNoticePublishRouteWithChildren
   '/matching/rounds': typeof MatchingRoundsRoute
@@ -812,6 +819,7 @@ export interface FileRoutesByTo {
   '/recruiting-guide': typeof RecruitingGuideRoute
   '/login/default': typeof LoginDefaultRoute
   '/manage/chapter': typeof ManageChapterRoute
+  '/manage/gisu': typeof ManageGisuRoute
   '/matching/applications': typeof MatchingApplicationsRoute
   '/matching/notice-publish': typeof MatchingNoticePublishRouteWithChildren
   '/matching/rounds': typeof MatchingRoundsRoute
@@ -922,6 +930,7 @@ export interface FileRoutesById {
   '/recruiting/evaluations': typeof RecruitingEvaluationsRouteRouteWithChildren
   '/login/default': typeof LoginDefaultRoute
   '/manage/chapter': typeof ManageChapterRoute
+  '/manage/gisu': typeof ManageGisuRoute
   '/matching/applications': typeof MatchingApplicationsRoute
   '/matching/notice-publish': typeof MatchingNoticePublishRouteWithChildren
   '/matching/rounds': typeof MatchingRoundsRoute
@@ -1034,6 +1043,7 @@ export interface FileRouteTypes {
     | '/recruiting/evaluations'
     | '/login/default'
     | '/manage/chapter'
+    | '/manage/gisu'
     | '/matching/applications'
     | '/matching/notice-publish'
     | '/matching/rounds'
@@ -1137,6 +1147,7 @@ export interface FileRouteTypes {
     | '/recruiting-guide'
     | '/login/default'
     | '/manage/chapter'
+    | '/manage/gisu'
     | '/matching/applications'
     | '/matching/notice-publish'
     | '/matching/rounds'
@@ -1246,6 +1257,7 @@ export interface FileRouteTypes {
     | '/recruiting/evaluations'
     | '/login/default'
     | '/manage/chapter'
+    | '/manage/gisu'
     | '/matching/applications'
     | '/matching/notice-publish'
     | '/matching/rounds'
@@ -1839,6 +1851,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof MatchingApplicationsRouteImport
       parentRoute: typeof MatchingRouteRoute
     }
+    '/manage/gisu': {
+      id: '/manage/gisu'
+      path: '/gisu'
+      fullPath: '/manage/gisu'
+      preLoaderRoute: typeof ManageGisuRouteImport
+      parentRoute: typeof ManageRouteRoute
+    }
     '/manage/chapter': {
       id: '/manage/chapter'
       path: '/chapter'
@@ -2140,6 +2159,7 @@ const AdminRouteRouteWithChildren = AdminRouteRoute._addFileChildren(
 
 interface ManageRouteRouteChildren {
   ManageChapterRoute: typeof ManageChapterRoute
+  ManageGisuRoute: typeof ManageGisuRoute
   ManageIndexRoute: typeof ManageIndexRoute
   ManageCurriculumCreateRoute: typeof ManageCurriculumCreateRoute
   ManageCurriculumEditRoute: typeof ManageCurriculumEditRoute
@@ -2151,6 +2171,7 @@ interface ManageRouteRouteChildren {
 
 const ManageRouteRouteChildren: ManageRouteRouteChildren = {
   ManageChapterRoute: ManageChapterRoute,
+  ManageGisuRoute: ManageGisuRoute,
   ManageIndexRoute: ManageIndexRoute,
   ManageCurriculumCreateRoute: ManageCurriculumCreateRoute,
   ManageCurriculumEditRoute: ManageCurriculumEditRoute,

--- a/src/routes/manage/gisu.tsx
+++ b/src/routes/manage/gisu.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router"
+
+import { GisuManagePage } from "@/features/gisu/ui/GisuManagePage"
+
+export const Route = createFileRoute("/manage/gisu")({
+  component: GisuManagePage,
+})

--- a/src/routes/manage/route.tsx
+++ b/src/routes/manage/route.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, Outlet, redirect } from "@tanstack/react-router"
 import { isCentralAdmin } from "@/entities/member/model/identity"
 import { ensureMe } from "@/features/auth/lib/ensureMe"
 import { SETTINGS_SIDEBAR_ITEMS } from "@/shared/config/settingsNavigation"
-import { useActiveGeneration } from "@/shared/hooks/useActiveGisu"
+import { useSelectedGeneration } from "@/shared/hooks/useSelectedGisu"
 import { notifyAccessDenied } from "@/shared/lib/accessDenied"
 import { toUmcGisuLabel } from "@/shared/lib/gisuLabel"
 import Footer from "@/widgets/footer/Footer"
@@ -27,7 +27,7 @@ export const Route = createFileRoute("/manage")({
 })
 
 function ManageLayout() {
-  const { data: generation } = useActiveGeneration()
+  const { data: generation } = useSelectedGeneration()
 
   return (
     <main className="flex h-full min-h-screen w-full flex-col">

--- a/src/routes/manage/school/index.tsx
+++ b/src/routes/manage/school/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { isAxiosError } from "axios"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 
 import { useAdminSchoolsSummary } from "@/entities/organization/hooks/useSchool"
 import { useSchoolChapterMap } from "@/entities/organization/hooks/useSchoolChapterMap"
@@ -42,6 +42,15 @@ function SchoolManagePage() {
   const { data: selectedGisuIdData } = useSelectedGisuId()
   const selectedGisuId = selectedGisuIdData ?? undefined
   const { data: selectedGeneration } = useSelectedGeneration()
+
+  const loadedGisuIdRef = useRef(selectedGisuId)
+
+  useEffect(() => {
+    if (loadedGisuIdRef.current === selectedGisuId) return
+    loadedGisuIdRef.current = selectedGisuId
+    setSelectedChapter("all")
+    setCurrentPage(1)
+  }, [selectedGisuId])
 
   const { getChapterIdBySchool, getChapterIdByName } = useSchoolChapterMap({
     gisuId: selectedGisuId,

--- a/src/routes/manage/school/index.tsx
+++ b/src/routes/manage/school/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router"
+import { isAxiosError } from "axios"
 import { useMemo, useState } from "react"
 
 import { useAdminSchoolsSummary } from "@/entities/organization/hooks/useSchool"
@@ -8,11 +9,15 @@ import { SchoolCard } from "@/features/settings/ui/SchoolCard"
 import { SchoolPagination } from "@/features/settings/ui/SchoolPagination"
 import { SchoolSearchInput } from "@/features/settings/ui/SchoolSearchInput"
 import {
+  SCHOOL_SORT_SERVER_VALUES,
   SchoolSortDropdown,
   type SchoolSortOption,
 } from "@/features/settings/ui/SchoolSortDropdown"
 import PlusIcon from "@/shared/assets/icon/plus/PlusIcon"
-import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
+import {
+  useSelectedGeneration,
+  useSelectedGisuId,
+} from "@/shared/hooks/useSelectedGisu"
 import { Button } from "@/shared/ui/Button"
 import { PageLabel } from "@/shared/ui/page-label/PageLabel"
 
@@ -34,15 +39,13 @@ function SchoolManagePage() {
     setCurrentPage(1)
   }
 
-  const { data: activeGisuData } = useActiveGisu()
-  const activeGisuId = activeGisuData?.gisuId
-    ? Number(activeGisuData.gisuId)
-    : undefined
-  const activeGisuText = activeGisuData?.gisu
-    ? `${activeGisuData.gisu}기`
-    : "11기"
+  const { data: selectedGisuIdData } = useSelectedGisuId()
+  const selectedGisuId = selectedGisuIdData ?? undefined
+  const { data: selectedGeneration } = useSelectedGeneration()
 
-  const { getChapterIdBySchool, getChapterIdByName } = useSchoolChapterMap()
+  const { getChapterIdBySchool, getChapterIdByName } = useSchoolChapterMap({
+    gisuId: selectedGisuId,
+  })
 
   const chapterIdParam = useMemo(() => {
     if (selectedChapter === "all") return undefined
@@ -54,18 +57,25 @@ function SchoolManagePage() {
   const isChapterUnresolved =
     selectedChapter !== "all" && chapterIdParam === undefined
 
-  const { data: summaryData, isLoading: isSummaryLoading } =
-    useAdminSchoolsSummary({
-      gisuId: activeGisuId,
-      chapterId: chapterIdParam,
-      search: submittedSearchQuery.trim() || undefined,
-      page: currentPage - 1,
-      size: PAGE_SIZE,
-      sort: sortOption,
-      enabled: activeGisuId != null && !isChapterUnresolved,
-    })
+  const {
+    data: summaryData,
+    isLoading: isSummaryLoading,
+    isError: isSummaryError,
+    error: summaryError,
+  } = useAdminSchoolsSummary({
+    gisuId: selectedGisuId,
+    chapterId: chapterIdParam,
+    search: submittedSearchQuery.trim() || undefined,
+    page: currentPage - 1,
+    size: PAGE_SIZE,
+    sort: SCHOOL_SORT_SERVER_VALUES[sortOption],
+    enabled: selectedGisuId != null && !isChapterUnresolved,
+  })
 
   const isLoading = isSummaryLoading
+  const summaryErrorStatus = isAxiosError(summaryError)
+    ? summaryError.response?.status
+    : undefined
 
   const paginatedSchools = useMemo(() => {
     if (!summaryData?.content) return []
@@ -98,12 +108,17 @@ function SchoolManagePage() {
           { id: "school", label: "학교 관리" },
         ]}
         title="학교 관리"
-        description={`UMC ${activeGisuText} 소속의 학교 정보를 관리합니다.`}
+        description={
+          selectedGeneration != null
+            ? `UMC ${selectedGeneration}기 소속의 학교 정보를 관리합니다.`
+            : "소속 학교 정보를 관리합니다."
+        }
         className="pl-3"
       />
 
       <div className="flex w-full flex-col gap-6">
         <ChapterTabs
+          gisuId={selectedGisuId}
           value={selectedChapter}
           onValueChange={(val) => {
             setSelectedChapter(val)
@@ -148,6 +163,12 @@ function SchoolManagePage() {
         ) : isLoading ? (
           <div className="text-body-1-medium text-teal-gray-400 py-12 text-center">
             학교 정보를 불러오는 중입니다...
+          </div>
+        ) : isSummaryError ? (
+          <div className="text-body-1-medium text-teal-gray-400 py-12 text-center">
+            {summaryErrorStatus === 403
+              ? "선택한 기수의 학교 정보를 볼 권한이 없습니다. 해당 기수의 운영진만 조회할 수 있습니다."
+              : "학교 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요."}
           </div>
         ) : paginatedSchools.length === 0 ? (
           <div className="text-body-1-medium text-teal-gray-400 py-12 text-center">

--- a/src/shared/config/settingsNavigation.ts
+++ b/src/shared/config/settingsNavigation.ts
@@ -1,11 +1,18 @@
+import GoalIcon from "@/shared/assets/icon/goal/GoalIcon"
 import TeamIcon from "@/shared/assets/icon/people/TeamIcon"
 import SchoolIcon from "@/shared/assets/icon/school/SchoolIcon"
 import SettingIcon from "@/shared/assets/icon/setting/SettingIcon"
 
 import type { FlatNavItem } from "@/shared/config/navigation"
 
-/** 설정 영역은 대분류 없이 평면 3항목이다. */
+/** 설정 영역은 대분류 없이 평면 4항목이다. */
 export const SETTINGS_SIDEBAR_ITEMS: FlatNavItem[] = [
+  {
+    id: "settings-gisu",
+    title: "기수 관리",
+    to: "/manage/gisu",
+    icon: GoalIcon,
+  },
   {
     id: "settings-school",
     title: "학교 관리",

--- a/src/shared/hooks/useSelectedGisu.ts
+++ b/src/shared/hooks/useSelectedGisu.ts
@@ -1,0 +1,37 @@
+import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
+import { useSelectedGisuStore } from "@/shared/model/useSelectedGisuStore"
+
+interface SelectedGisuResult {
+  data: number | null
+  isLoading: boolean
+}
+
+export function useSelectedGisuId(): SelectedGisuResult {
+  const selected = useSelectedGisuStore((s) => s.selected)
+  const { data: activeGisu, isLoading } = useActiveGisu({
+    enabled: selected == null,
+  })
+
+  if (selected?.gisuId != null) {
+    return { data: Number(selected.gisuId), isLoading: false }
+  }
+  return {
+    data: activeGisu?.gisuId != null ? Number(activeGisu.gisuId) : null,
+    isLoading,
+  }
+}
+
+export function useSelectedGeneration(): SelectedGisuResult {
+  const selected = useSelectedGisuStore((s) => s.selected)
+  const { data: activeGisu, isLoading } = useActiveGisu({
+    enabled: selected == null,
+  })
+
+  if (selected?.generation != null) {
+    return { data: Number(selected.generation), isLoading: false }
+  }
+  return {
+    data: activeGisu?.generation != null ? Number(activeGisu.generation) : null,
+    isLoading,
+  }
+}

--- a/src/shared/model/useSelectedGisuStore.ts
+++ b/src/shared/model/useSelectedGisuStore.ts
@@ -1,0 +1,27 @@
+import { create } from "zustand"
+import { createJSONStorage, persist } from "zustand/middleware"
+
+export interface SelectedGisu {
+  gisuId: string
+  generation: number
+}
+
+interface SelectedGisuState {
+  selected: SelectedGisu | null
+  setSelected: (selected: SelectedGisu | null) => void
+  clear: () => void
+}
+
+export const useSelectedGisuStore = create<SelectedGisuState>()(
+  persist(
+    (set) => ({
+      selected: null,
+      setSelected: (selected) => set({ selected }),
+      clear: () => set({ selected: null }),
+    }),
+    {
+      name: "umc-selected-gisu",
+      storage: createJSONStorage(() => sessionStorage),
+    },
+  ),
+)

--- a/src/shared/ui/segment-button/SegmentButton.tsx
+++ b/src/shared/ui/segment-button/SegmentButton.tsx
@@ -1,6 +1,7 @@
 import { cva } from "class-variance-authority"
 
 import { cn } from "@/shared/lib/utils"
+import { Tooltip } from "@/shared/ui/tooltip/Tooltip"
 
 const buttonVariants = cva(
   "inline-flex h-9.5 shrink-0 cursor-pointer items-center overflow-clip rounded-xl transition-all",
@@ -50,6 +51,7 @@ export interface SegmentButtonItem {
   value: string
   label: string
   disabled?: boolean
+  tooltipContent?: string
 }
 
 interface SegmentButtonProps {
@@ -97,9 +99,29 @@ export function SegmentButton({
                 {index + 1}
               </span>
             )}
-            <span className={textVariants({ selected: isSelected })}>
-              {item.label}
-            </span>
+            {item.tooltipContent ? (
+              <Tooltip
+                content={item.tooltipContent}
+                size="small"
+                dark={true}
+                side="bottom"
+                hoverOnly
+                triggerClassName="block min-w-0 max-w-full"
+              >
+                <span
+                  className={cn(
+                    textVariants({ selected: isSelected }),
+                    "block max-w-full truncate",
+                  )}
+                >
+                  {item.label}
+                </span>
+              </Tooltip>
+            ) : (
+              <span className={textVariants({ selected: isSelected })}>
+                {item.label}
+              </span>
+            )}
           </button>
         )
       })}

--- a/src/widgets/navigation/header/ProfileDropdown.tsx
+++ b/src/widgets/navigation/header/ProfileDropdown.tsx
@@ -1,14 +1,16 @@
 import { useNavigate } from "@tanstack/react-router"
-import { useEffect, useRef, useState } from "react"
+import { useRef, useState } from "react"
 
 import { useMe } from "@/entities/member/hooks/useMe"
 import { isCentralStaff, isSuperAdmin } from "@/entities/member/model/identity"
 import { useAuthStore } from "@/entities/member/store/authStore"
 import { logout as apiLogout } from "@/features/auth/api/credentials"
 import { logout as localLogout } from "@/features/auth/lib/logout"
+import { useActiveGisu } from "@/shared/hooks/useActiveGisu"
 import { useClickOutside } from "@/shared/hooks/useClickOutside"
 import { toRoleTag } from "@/shared/lib/roleTagMapper"
 import { cn } from "@/shared/lib/utils"
+import { useSelectedGisuStore } from "@/shared/model/useSelectedGisuStore"
 import { TextButton } from "@/shared/ui/button/TextButton"
 import { RoleTagChip } from "@/shared/ui/chip/RoleTagChip"
 import { ProfileAvatar } from "@/shared/ui/profile/ProfileAvatar"
@@ -37,17 +39,11 @@ export function ProfileDropdown({
   const { data: me } = useMe()
   const canManageMembers = isSuperAdmin(me) || isCentralStaff(me)
 
-  // TODO: 기수 변경이 다른 화면에서도 쓰게 되면 URL 쿼리(?gisuId=)로 전환
-  const [selectedGisuId, setSelectedGisuId] = useState<string | null>(null)
+  const selectedGisu = useSelectedGisuStore((s) => s.selected)
+  const setSelectedGisu = useSelectedGisuStore((s) => s.setSelected)
+  const { data: activeGisu } = useActiveGisu()
 
-  // TODO: GET /api/v2/member/me 연동 후 challengerRecords → challengerHistory, record.gisu → record.generation 으로 교체
-  useEffect(() => {
-    if (selectedGisuId || !me?.challengerRecords?.length) return
-    const latest = [...me.challengerRecords].sort(
-      (a, b) => Number(b.gisuId) - Number(a.gisuId),
-    )[0]
-    if (latest) setSelectedGisuId(latest.gisuId)
-  }, [me, selectedGisuId, setSelectedGisuId])
+  const currentGisuId = selectedGisu?.gisuId ?? activeGisu?.gisuId ?? null
 
   useClickOutside(
     containerRef,
@@ -153,10 +149,14 @@ export function ProfileDropdown({
                       <GenerationListItem
                         key={record.challengerId}
                         generation={Number(record.gisu)}
-                        active={record.gisuId === selectedGisuId}
-                        // TODO: 클릭 시 기수 상태 변경
-                        // onClick={() => setSelectedGisuId(record.gisuId)}
-                        className="w-full cursor-default"
+                        active={String(record.gisuId) === String(currentGisuId)}
+                        onClick={() =>
+                          setSelectedGisu({
+                            gisuId: String(record.gisuId),
+                            generation: Number(record.gisu),
+                          })
+                        }
+                        className="w-full"
                       />
                     ))
                 ) : (

--- a/src/widgets/navigation/header/ProfileDropdown.tsx
+++ b/src/widgets/navigation/header/ProfileDropdown.tsx
@@ -176,7 +176,7 @@ export function ProfileDropdown({
           <div className="flex flex-col gap-1 px-1.5">
             {canManageMembers && (
               <TextButton
-                onClick={() => navigate({ to: "/admin" })}
+                onClick={() => navigate({ to: "/manage/gisu" })}
                 size="14"
                 className="h-6 w-15"
               >


### PR DESCRIPTION
## 📸 작업 내용

- 프로필 드롭다운의 기수 선택을 전역 상태(zustand + sessionStorage)로 연결해, 지부·커리큘럼 등 관리 화면이 선택한 기수 기준으로 조회되도록 했습니다.
- 운영진용 기수 관리 페이지(`/manage/gisu`)를 신설해 기수 목록 조회·생성·활성 기수 전환을 지원하고, 설정 네비게이션과 프로필 드롭다운에서 진입할 수 있게 연결했습니다.
- 학교 관리 목록의 정렬 값을 API 스펙(`정렬필드,방향`)에 맞게 변환해 정렬 변경 시 조회가 실패하던 문제를 고치고, 조회 실패 상태를 화면에 노출했습니다. API가 지원하지 않는 `지부 순` 옵션은 제거했습니다.
- 지부 탭의 긴 이름이 잘려 보이던 문제를 공용 `SegmentButton` 의 말줄임 + 호버 툴팁 처리로 해결했습니다.

## 🎞️ 주요 코드 설명

### 선택 기수 우선, 활성 기수 fallback

```TypeScript
export function useSelectedGisuId(): SelectedGisuResult {
  const selected = useSelectedGisuStore((s) => s.selected)
  const { data: activeGisu, isLoading } = useActiveGisu({
    enabled: selected == null,
  })

  if (selected?.gisuId != null) {
    return { data: Number(selected.gisuId), isLoading: false }
  }
  return {
    data: activeGisu?.gisuId != null ? Number(activeGisu.gisuId) : null,
    isLoading,
  }
}
```

- 각 화면이 "선택 기수가 있으면 그것, 없으면 활성 기수" 규칙을 매번 구현하지 않도록 훅 한 곳에 모았습니다.
- 선택 기수가 있을 때는 활성 기수 조회를 `enabled: false` 로 막아 불필요한 요청을 만들지 않습니다.
- id 는 문자열로 내려오므로 `Number()` 로 정규화해 비교/전달합니다.
- 선택 상태는 sessionStorage 에 보관하고, 로그아웃 시 초기화합니다.

### 정렬 값 서버 스펙 매핑

```TypeScript
export const SCHOOL_SORT_SERVER_VALUES: Record<SchoolSortOption, string> = {
  name: "schoolName,asc",
  count: "activeChallengerCount,desc",
}
```

- UI 라벨용 값과 API 전송 값을 분리해, 드롭다운 값이 그대로 요청에 실려 실패하던 문제를 막았습니다.

## 🔗 연결된 이슈

- Connected: #813, #814, #815, #816
- Closes #813
- Closes #814
- Closes #815
- Closes #816

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 기수 관리 화면에서 기수 목록 조회, 생성 및 활성화가 가능합니다.
  * 선택한 기수를 기준으로 학교·지부·챕터·커리큘럼 정보를 확인할 수 있습니다.
  * 설정 메뉴와 관리 경로에서 기수 관리로 이동할 수 있습니다.
* **개선 사항**
  * 선택한 기수 정보가 화면 간 유지되며, 로그아웃 시 초기화됩니다.
  * 학교 정렬에서 ‘지부 순’이 제거되고 이름·학교 수 정렬을 제공합니다.
  * 긴 챕터명은 툴팁으로 확인할 수 있습니다.
  * 학교 관리 화면의 권한 및 조회 오류 안내가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->