### PR TITLE
🐛 fix: 정적 랜딩 페이지 인증 의존성 제거

### DIFF
--- a/src/features/auth/api/terms.ts
+++ b/src/features/auth/api/terms.ts
@@ -1,4 +1,4 @@
-import { api } from "@/shared/lib/axios"
+import { publicApi } from "@/shared/lib/publicApi"
 
 import type { TermResponse, Terms, TermType } from "@/features/auth/model/types"
 import type { ApiResponse } from "@/shared/lib/apiResponse"
@@ -6,14 +6,14 @@ import type { ApiResponse } from "@/shared/lib/apiResponse"
 export async function getTermsByType(
   termType: TermType,
 ): Promise<TermResponse> {
-  const { data } = await api.get<ApiResponse<TermResponse>>(
+  const { data } = await publicApi.get<ApiResponse<TermResponse>>(
     `/v1/terms/type/${termType}`,
   )
   return data.result
 }
 
 export async function getTerms(): Promise<Terms> {
-  const { data } = await api.get<ApiResponse<Terms>>("/v1/terms")
+  const { data } = await publicApi.get<ApiResponse<Terms>>("/v1/terms")
 
   return data.result
 }

--- a/src/features/recruiting/api/recruitingApi.test.ts
+++ b/src/features/recruiting/api/recruitingApi.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { api } from "@/shared/lib/axios"
+import { publicApi } from "@/shared/lib/publicApi"
 
 import {
   addRoundEvaluator,
@@ -38,6 +39,16 @@ import type {
 
 vi.mock("@/shared/lib/axios", () => ({
   api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+vi.mock("@/shared/lib/publicApi", () => ({
+  publicApi: {
     get: vi.fn(),
     post: vi.fn(),
     put: vi.fn(),
@@ -304,10 +315,15 @@ describe("지원자 유형별 API", () => {
       answers: [],
     }
 
-    vi.mocked(api.post).mockResolvedValue({
-      data: { isSuccess: true, code: "COMMON200", message: "OK", result: created },
+    vi.mocked(publicApi.post).mockResolvedValue({
+      data: {
+        isSuccess: true,
+        code: "COMMON200",
+        message: "OK",
+        result: created,
+      },
     })
-    vi.mocked(api.put).mockResolvedValue({
+    vi.mocked(publicApi.put).mockResolvedValue({
       data: {
         isSuccess: true,
         code: "COMMON200",
@@ -323,16 +339,16 @@ describe("지원자 유형별 API", () => {
       applicationKey: "key-1",
     })
 
-    expect(api.post).toHaveBeenNthCalledWith(
+    expect(publicApi.post).toHaveBeenNthCalledWith(
       1,
       "/v1/recruiting/public/applications",
       draftBody,
     )
-    expect(api.put).toHaveBeenCalledWith(
+    expect(publicApi.put).toHaveBeenCalledWith(
       "/v1/recruiting/public/applications",
       updateBody,
     )
-    expect(api.post).toHaveBeenNthCalledWith(
+    expect(publicApi.post).toHaveBeenNthCalledWith(
       2,
       "/v1/recruiting/public/applications/submit",
       { email: "guest@example.com", applicationKey: "key-1" },

--- a/src/features/recruiting/api/recruitingApi.ts
+++ b/src/features/recruiting/api/recruitingApi.ts
@@ -1,4 +1,5 @@
 import { api } from "@/shared/lib/axios"
+import { publicApi } from "@/shared/lib/publicApi"
 
 import type { ApiResponse } from "@/shared/lib/apiResponse"
 
@@ -73,7 +74,7 @@ const APPLICATIONS_PAGE_SIZE = 100
 export async function getPublicRounds(
   params: PublicRoundsQuery,
 ): Promise<RecruitingRoundGroup[]> {
-  const { data } = await api.get<ApiResponse<RecruitingRoundGroup[]>>(
+  const { data } = await publicApi.get<ApiResponse<RecruitingRoundGroup[]>>(
     "/v1/recruiting/public/rounds",
     { params, paramsSerializer: { indexes: null } },
   )
@@ -432,7 +433,7 @@ export async function getFormStructure(
   applicationFormId: string,
   params: FormStructureQuery,
 ): Promise<RecruitingFormStructure> {
-  const { data } = await api.get<ApiResponse<RecruitingFormStructure>>(
+  const { data } = await publicApi.get<ApiResponse<RecruitingFormStructure>>(
     `/v1/recruiting/public/forms/${applicationFormId}/structure`,
     { params },
   )
@@ -452,10 +453,9 @@ export async function createApplicationDraft(
 export async function createAnonymousApplicationDraft(
   body: CreateAnonymousApplicationDraftBody,
 ): Promise<RecruitingApplicationCreated> {
-  const { data } = await api.post<ApiResponse<RecruitingApplicationCreated>>(
-    "/v1/recruiting/public/applications",
-    body,
-  )
+  const { data } = await publicApi.post<
+    ApiResponse<RecruitingApplicationCreated>
+  >("/v1/recruiting/public/applications", body)
   return data.result
 }
 
@@ -497,7 +497,7 @@ export async function getMyApplications(): Promise<
 export async function lookupAnonymousApplication(
   body: RecruitingApplicationCredentialRequest,
 ): Promise<RecruitingPublicApplicationResponse> {
-  const { data } = await api.post<
+  const { data } = await publicApi.post<
     ApiResponse<RecruitingPublicApplicationResponse>
   >("/v1/recruiting/public/applications/lookup", body)
   return data.result
@@ -507,7 +507,7 @@ export async function lookupAnonymousApplication(
 export async function updateAnonymousApplication(
   body: UpdateAnonymousApplicationRequest,
 ): Promise<RecruitingApplicationMutationResult> {
-  const { data } = await api.put<
+  const { data } = await publicApi.put<
     ApiResponse<RecruitingApplicationMutationResult>
   >("/v1/recruiting/public/applications", body)
   return data.result
@@ -517,7 +517,7 @@ export async function updateAnonymousApplication(
 export async function cancelAnonymousApplication(
   body: RecruitingApplicationCredentialRequest,
 ): Promise<RecruitingApplicationMutationResult> {
-  const { data } = await api.post<
+  const { data } = await publicApi.post<
     ApiResponse<RecruitingApplicationMutationResult>
   >("/v1/recruiting/public/applications/cancel", body)
   return data.result
@@ -527,7 +527,7 @@ export async function cancelAnonymousApplication(
 export async function submitAnonymousApplication(
   body: SubmitAnonymousApplicationRequest,
 ): Promise<RecruitingApplicationMutationResult> {
-  const { data } = await api.post<
+  const { data } = await publicApi.post<
     ApiResponse<RecruitingApplicationMutationResult>
   >("/v1/recruiting/public/applications/submit", body)
   return data.result

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from "@tanstack/react-router"
 
 import { AboutPage } from "@/features/about/ui/AboutPage"
 import { createMeta, SITE_URL } from "@/shared/seo"
-import RecruitingHeader from "@/widgets/navigation/header/RecruitingHeader"
+import PublicLandingHeader from "@/widgets/navigation/header/PublicLandingHeader"
 
 export const Route = createFileRoute("/about")({
   head: () =>
@@ -18,7 +18,7 @@ function AboutRoute() {
   return (
     <div className="about-landing relative">
       <div className="sticky top-0 z-50 -mb-20">
-        <RecruitingHeader tone="glass" />
+        <PublicLandingHeader />
       </div>
       <AboutPage />
     </div>

--- a/src/routes/recruiting-guide.tsx
+++ b/src/routes/recruiting-guide.tsx
@@ -2,7 +2,7 @@ import { createFileRoute } from "@tanstack/react-router"
 
 import { RecruitingGuidePage } from "@/features/about/ui/RecruitingGuidePage"
 import { createMeta, SITE_URL } from "@/shared/seo"
-import RecruitingHeader from "@/widgets/navigation/header/RecruitingHeader"
+import PublicLandingHeader from "@/widgets/navigation/header/PublicLandingHeader"
 
 export const Route = createFileRoute("/recruiting-guide")({
   head: () =>
@@ -18,7 +18,7 @@ function RecruitingGuideRoute() {
   return (
     <div className="relative">
       <div className="sticky top-0 z-50 -mb-20">
-        <RecruitingHeader tone="glass" />
+        <PublicLandingHeader />
       </div>
       <RecruitingGuidePage />
     </div>

--- a/src/shared/api/gisu.ts
+++ b/src/shared/api/gisu.ts
@@ -1,4 +1,4 @@
-import { api } from "@/shared/lib/axios"
+import { publicApi } from "@/shared/lib/publicApi"
 
 import type { ApiResponse } from "@/shared/lib/apiResponse"
 import type { components } from "@/types/api"
@@ -7,6 +7,6 @@ type ActiveGisuResponse = components["schemas"]["ActiveGisuResponse"]
 
 export async function getActiveGisu(): Promise<ActiveGisuResponse> {
   const { data } =
-    await api.get<ApiResponse<ActiveGisuResponse>>("/v1/gisu/active")
+    await publicApi.get<ApiResponse<ActiveGisuResponse>>("/v1/gisu/active")
   return data.result
 }

--- a/src/shared/api/terms.test.ts
+++ b/src/shared/api/terms.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { api } from "@/shared/lib/axios"
+import { publicApi } from "@/shared/lib/publicApi"
 
 import { getPublicTermByType } from "./terms"
 
-vi.mock("@/shared/lib/axios", () => ({
-  api: {
+vi.mock("@/shared/lib/publicApi", () => ({
+  publicApi: {
     get: vi.fn(),
   },
 }))
@@ -16,7 +16,7 @@ describe("getPublicTermByType", () => {
   })
 
   it("문자열 약관 ID를 숫자로 정규화한다", async () => {
-    vi.mocked(api.get).mockResolvedValueOnce({
+    vi.mocked(publicApi.get).mockResolvedValueOnce({
       data: {
         success: true,
         code: "COMMON200",
@@ -31,7 +31,7 @@ describe("getPublicTermByType", () => {
 
     const result = await getPublicTermByType("PRIVACY")
 
-    expect(api.get).toHaveBeenCalledWith("/v1/terms/type/PRIVACY")
+    expect(publicApi.get).toHaveBeenCalledWith("/v1/terms/type/PRIVACY")
     expect(result).toEqual({
       id: 1,
       link: "https://example.com/privacy",
@@ -41,7 +41,7 @@ describe("getPublicTermByType", () => {
   })
 
   it("숫자로 변환할 수 없는 약관 ID는 거부한다", async () => {
-    vi.mocked(api.get).mockResolvedValueOnce({
+    vi.mocked(publicApi.get).mockResolvedValueOnce({
       data: {
         success: true,
         code: "COMMON200",
@@ -56,7 +56,7 @@ describe("getPublicTermByType", () => {
   })
 
   it("빈 문자열 약관 ID는 거부한다", async () => {
-    vi.mocked(api.get).mockResolvedValueOnce({
+    vi.mocked(publicApi.get).mockResolvedValueOnce({
       data: {
         success: true,
         code: "COMMON200",
@@ -71,7 +71,7 @@ describe("getPublicTermByType", () => {
   })
 
   it("안전 정수 범위를 벗어난 약관 ID는 거부한다", async () => {
-    vi.mocked(api.get).mockResolvedValueOnce({
+    vi.mocked(publicApi.get).mockResolvedValueOnce({
       data: {
         success: true,
         code: "COMMON200",

--- a/src/shared/api/terms.ts
+++ b/src/shared/api/terms.ts
@@ -1,4 +1,4 @@
-import { api } from "@/shared/lib/axios"
+import { publicApi } from "@/shared/lib/publicApi"
 
 import type { ApiResponse } from "@/shared/lib/apiResponse"
 import type { TermType } from "@/shared/model/domain"
@@ -18,7 +18,7 @@ export interface PublicTermResponse {
 export async function getPublicTermByType(
   termType: TermType,
 ): Promise<PublicTermResponse> {
-  const { data } = await api.get<ApiResponse<RawPublicTermResponse>>(
+  const { data } = await publicApi.get<ApiResponse<RawPublicTermResponse>>(
     `/v1/terms/type/${termType}`,
   )
   const rawId = data.result.id

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -1,0 +1,69 @@
+import axios, { AxiosError } from "axios"
+
+import { trackApiRequest } from "@/shared/analytics"
+
+import type { AxiosInstance, InternalAxiosRequestConfig } from "axios"
+
+declare module "axios" {
+  interface InternalAxiosRequestConfig {
+    analyticsStartTime?: number
+  }
+}
+
+export function createApiClient(): AxiosInstance {
+  const client = axios.create({
+    baseURL: import.meta.env.VITE_API_BASE_URL,
+    timeout: 10000,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  })
+
+  client.interceptors.request.use((config) => {
+    config.analyticsStartTime = performance.now()
+    return config
+  })
+
+  client.interceptors.response.use(
+    (response) => {
+      trackAxiosResponse(response.config, response.status, true)
+      const body = response.data as { success?: boolean; message?: string }
+      if (body && typeof body === "object" && body.success === false) {
+        return Promise.reject(
+          new AxiosError(
+            body.message ?? "요청에 실패했습니다.",
+            AxiosError.ERR_BAD_RESPONSE,
+            response.config,
+            response.request,
+            response,
+          ),
+        )
+      }
+      return response
+    },
+    (error: unknown) => {
+      if (axios.isAxiosError(error)) {
+        trackAxiosResponse(error.config, error.response?.status, false)
+      }
+      return Promise.reject(error)
+    },
+  )
+
+  return client
+}
+
+function trackAxiosResponse(
+  config: InternalAxiosRequestConfig | undefined,
+  status: number | undefined,
+  success: boolean,
+) {
+  const startTime = config?.analyticsStartTime
+  if (startTime == null) return
+  trackApiRequest({
+    method: config?.method,
+    path: config?.url,
+    status,
+    durationMs: performance.now() - startTime,
+    success,
+  })
+}

--- a/src/shared/lib/axios.ts
+++ b/src/shared/lib/axios.ts
@@ -1,21 +1,12 @@
-import axios, { AxiosError } from "axios"
+import { isAxiosError } from "axios"
 
-import {
-  getCurrentPagePath,
-  trackApiRequest,
-  trackEvent,
-} from "@/shared/analytics"
+import { getCurrentPagePath, trackEvent } from "@/shared/analytics"
+import { createApiClient } from "@/shared/lib/apiClient"
 import { authBridge } from "@/shared/lib/authBridge"
 
-import type { AxiosRequestConfig, InternalAxiosRequestConfig } from "axios"
+import type { AxiosRequestConfig } from "axios"
 
 import type { ApiResponse } from "@/shared/lib/apiResponse"
-
-declare module "axios" {
-  interface InternalAxiosRequestConfig {
-    analyticsStartTime?: number
-  }
-}
 
 const AUTH_LOGIN_PATH = "/v1/auth/login"
 const TOKEN_RENEW_PATH = "/v1/auth/token/renew"
@@ -45,16 +36,9 @@ function isEmailVerificationRequest(url: string | undefined) {
   )
 }
 
-export const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
-  timeout: 10000,
-  headers: {
-    "Content-Type": "application/json",
-  },
-})
+export const api = createApiClient()
 
 api.interceptors.request.use((config) => {
-  config.analyticsStartTime = performance.now()
   if (isTokenRenewRequest(config.url)) {
     config.headers.delete("Authorization")
     return config
@@ -97,31 +81,15 @@ function terminateAuthentication(
 }
 
 api.interceptors.response.use(
-  (response) => {
-    trackAxiosResponse(response.config, response.status, true)
-    const body = response.data as { success?: boolean; message?: string }
-    if (body && typeof body === "object" && body.success === false) {
-      return Promise.reject(
-        new AxiosError(
-          body.message ?? "요청에 실패했습니다.",
-          AxiosError.ERR_BAD_RESPONSE,
-          response.config,
-          response.request,
-          response,
-        ),
-      )
-    }
-    return response
-  },
+  (response) => response,
   async (error) => {
-    const originalRequest = error.config as AxiosRequestConfig & {
-      _retry?: boolean
-    }
-    trackAxiosResponse(
-      originalRequest as InternalAxiosRequestConfig | undefined,
-      error.response?.status,
-      false,
-    )
+    if (!isAxiosError(error)) return Promise.reject(error)
+    const originalRequest = error.config as
+      | (AxiosRequestConfig & {
+          _retry?: boolean
+        })
+      | undefined
+    if (!originalRequest) return Promise.reject(error)
 
     if (
       error.response?.status !== 401 ||
@@ -186,19 +154,3 @@ api.interceptors.response.use(
     }
   },
 )
-
-function trackAxiosResponse(
-  config: InternalAxiosRequestConfig | undefined,
-  status: number | undefined,
-  success: boolean,
-) {
-  const startTime = config?.analyticsStartTime
-  if (startTime == null) return
-  trackApiRequest({
-    method: config?.method,
-    path: config?.url,
-    status,
-    durationMs: performance.now() - startTime,
-    success,
-  })
-}

--- a/src/shared/lib/publicApi.ts
+++ b/src/shared/lib/publicApi.ts
@@ -1,0 +1,3 @@
+import { createApiClient } from "./apiClient"
+
+export const publicApi = createApiClient()

--- a/src/widgets/navigation/header/PublicLandingHeader.tsx
+++ b/src/widgets/navigation/header/PublicLandingHeader.tsx
@@ -1,0 +1,125 @@
+import { Link, useLocation } from "@tanstack/react-router"
+import { useEffect, useState } from "react"
+
+import CloseIcon from "@/shared/assets/icon/close/CloseIcon"
+import HamburgerIcon from "@/shared/assets/icon/hamburger/HamburgerIcon"
+import UmcLogo from "@/shared/assets/icon/logo/UmcLogo"
+import {
+  getDisabledNavMessage,
+  HEADER_NAV_ITEMS,
+  isHeaderNavItemActive,
+} from "@/shared/config/headerNavPolicy"
+import { useIsWithinHeaderRecruitingWindow } from "@/shared/hooks/useHeaderRecruitingWindow"
+import {
+  buildLoginRedirectSearch,
+  getCurrentReturnTo,
+} from "@/shared/lib/loginRedirect"
+import { cn } from "@/shared/lib/utils"
+import { GlassRim } from "@/shared/ui/GlassRim"
+import { useToastStore } from "@/shared/ui/toast/useToastStore"
+
+import { GLASS_RIM_PILL } from "./headerTone"
+import { MobileMenuPanel } from "./MobileMenuPanel"
+import NavigationButton from "./NavigationButton"
+import { RecruitingStatusButton } from "./RecruitingStatusButton"
+
+import type { NavItem } from "./recruitingHeaderNav"
+
+const NAV_ITEMS: NavItem[] = HEADER_NAV_ITEMS
+
+export default function PublicLandingHeader() {
+  const { pathname } = useLocation()
+  const isRecruitingPeriod = useIsWithinHeaderRecruitingWindow()
+  const addToast = useToastStore((state) => state.addToast)
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  useEffect(() => setIsMenuOpen(false), [pathname])
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(min-width: 64rem)")
+    const sync = () => {
+      if (mediaQuery.matches) setIsMenuOpen(false)
+    }
+    sync()
+    mediaQuery.addEventListener("change", sync)
+    return () => mediaQuery.removeEventListener("change", sync)
+  }, [])
+
+  const notifyComingSoon = (item: NavItem) => {
+    addToast({
+      message: getDisabledNavMessage(item),
+      color: "primary",
+      variant: "deep",
+      type: "notice",
+      duration: 3000,
+    })
+  }
+
+  return (
+    <header className="relative z-50 flex h-20 min-h-20 w-full items-center justify-between overflow-visible bg-transparent">
+      <Link to="/" className="flex items-center pl-8 md:w-55 md:pl-10">
+        <UmcLogo className="h-5.5 w-17.5 text-white" />
+      </Link>
+
+      <nav
+        className={cn(
+          "absolute left-1/2 hidden -translate-x-1/2 items-center gap-1.5 rounded-full bg-[rgba(251,252,252,0.2)] p-1.5",
+          isMenuOpen ? "lg:flex" : "md:flex",
+        )}
+      >
+        <GlassRim radius={24} variant="pill" {...GLASS_RIM_PILL} />
+        {NAV_ITEMS.map((item) => (
+          <NavigationButton
+            key={item.label}
+            label={item.label}
+            to={item.to}
+            selected={isHeaderNavItemActive(pathname, item)}
+            disabled={item.disabled}
+            onClick={item.disabled ? () => notifyComingSoon(item) : undefined}
+            className="min-w-18 px-4.5"
+            tone="glass"
+          />
+        ))}
+      </nav>
+
+      <div className="flex items-center justify-end gap-4 pr-5.5 md:pr-8.5">
+        <button
+          type="button"
+          aria-expanded={isMenuOpen}
+          aria-label={isMenuOpen ? "메뉴 닫기" : "메뉴 열기"}
+          onClick={() => setIsMenuOpen((open) => !open)}
+          className="flex size-11.5 cursor-pointer items-center justify-center text-white lg:hidden"
+        >
+          {isMenuOpen ? (
+            <CloseIcon className="size-7.5" />
+          ) : (
+            <HamburgerIcon className="size-7.5" />
+          )}
+        </button>
+
+        <div className="hidden items-center gap-4 lg:flex">
+          <RecruitingStatusButton tone="glass" alwaysVisible />
+          {!isRecruitingPeriod && (
+            <Link
+              to="/login"
+              search={buildLoginRedirectSearch(getCurrentReturnTo())}
+              className="text-[16px] font-semibold tracking-[-0.32px] whitespace-nowrap text-white transition-colors hover:text-white/70"
+            >
+              로그인
+            </Link>
+          )}
+        </div>
+      </div>
+
+      {isMenuOpen && (
+        <MobileMenuPanel
+          items={NAV_ITEMS}
+          pathname={pathname}
+          showLogin={!isRecruitingPeriod}
+          onClose={() => setIsMenuOpen(false)}
+          onDisabledNav={notifyComingSoon}
+        />
+      )}
+    </header>
+  )
+}


### PR DESCRIPTION
## 📸 작업 내용

- 공개 요청을 인증 갱신·로그인 리다이렉트와 분리한 API 클라이언트를 추가했습니다.
- 모집·약관·기수 등 공개 API 호출을 공개 클라이언트로 전환했습니다.
- `/about`과 `/recruiting-guide`에 인증 상태를 읽지 않는 공개 랜딩 헤더를 적용했습니다.
- 인증이 필요한 API 요청은 기존 인증 클라이언트를 계속 사용하도록 경계를 유지했습니다.

검증 결과:
- `pnpm exec vitest run`: 115개 테스트 파일, 926개 테스트 통과
- `pnpm build`: 통과
- `pnpm lint`: 오류 0건, 기존 경고 14건
- `pnpm lint:boundaries`: 신규 위반 0건
- `/about`, `/recruiting-guide` 응답 상태 확인: 200

## 🎞️ 주요 코드 설명

- `createApiClient`로 공통 요청·응답 처리와 분석 추적을 공유하고, `publicApi`는 인증 인터셉터 없이 생성했습니다.
- 공개 랜딩 헤더는 메뉴·모집 상태·로그인 이동만 담당하며 인증 저장소나 사용자 조회에 의존하지 않습니다.

## 🔗 연결된 이슈

- Connected: #825
- Closes #825

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 로그인 없이 공개 모집 정보, 지원서, 약관 및 활성 모집 기간을 조회하고 지원할 수 있도록 개선했습니다.
  - 공개 페이지에 새로운 랜딩 헤더를 추가했습니다.
  - 현재 경로와 모집 상태에 맞는 메뉴, 로그인 링크, 모집 상태 안내를 제공합니다.
  - 모바일 메뉴 열기·닫기와 비활성 메뉴 안내를 지원합니다.

- **개선 사항**
  - `/about` 및 모집 안내 페이지의 헤더 표시를 통일했습니다.
  - API 요청 성공 여부와 처리 시간을 분석할 수 있도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->